### PR TITLE
chore: add developer flag for proteus via CoreCrypto FS-1513

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -284,6 +284,7 @@ extension GenericMessage {
             return nil
         }
 
+        // TODO: [John] use flag here
         let encryptionContext = selfClient.keysStore.encryptionContext
         var messageData: Data?
 

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient+Patches.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient+Patches.swift
@@ -32,6 +32,7 @@ extension UserClient {
                 return
         }
 
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { (session) in
             for client in allClients {
                 client.migrateSessionIdentifierFromV1IfNeeded(sessionDirectory: session)
@@ -49,6 +50,7 @@ extension UserClient {
                 return
         }
 
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { (session) in
             for client in allClients {
                 client.migrateSessionIdentifierFromV2IfNeeded(sessionDirectory: session)

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -320,6 +320,7 @@ public class UserClient: ZMManagedObject, UserClientType {
             return false
         }
         var hasSession = false
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { [weak self](sessionsDirectory) in
             guard let strongSelf = self, let sessionIdentifier = strongSelf.sessionIdentifier else {return}
             hasSession = sessionsDirectory.hasSession(for: sessionIdentifier)
@@ -447,6 +448,7 @@ public extension UserClient {
 
             // We could already set local fingerprint if user is self
             if client.remoteIdentifier == selfClient.remoteIdentifier {
+                // TODO: [John] use flag here
                 client.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                     client.fingerprint = sessionsDirectory.localFingerprint
                     if client.fingerprint == nil {
@@ -505,6 +507,7 @@ public extension UserClient {
             else { return }
 
             if syncSelfClient == syncClient {
+                // TODO: [John] use flag here
                 syncSelfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                     syncClient.fingerprint = sessionsDirectory.localFingerprint
                     syncMOC.saveOrRollback()
@@ -517,6 +520,7 @@ public extension UserClient {
                     syncMOC.saveOrRollback()
                 }
                 else {
+                    // TODO: [John] use flag here
                     syncSelfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                         syncClient.fingerprint = sessionsDirectory.fingerprint(for: sessionIdentifier)
                         if syncClient.fingerprint == nil {
@@ -587,6 +591,7 @@ public extension UserClient {
         guard let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient(), selfClient.sessionIdentifier != clientID
         else { return }
 
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { (sessionsDirectory) in
             sessionsDirectory.delete(clientID)
         }
@@ -600,6 +605,7 @@ public extension UserClient {
 
         var didEstablishSession = false
 
+        // TODO: [John] use flag here
         keysStore.encryptionContext.perform { (sessionsDirectory) in
 
             // Session is already established?
@@ -614,6 +620,7 @@ public extension UserClient {
         // if at the end of the block the session is still there. Just to be safe, I split the operations
         // in two separate `perform` blocks.
 
+        // TODO: [John] use flag here
         keysStore.encryptionContext.perform { (sessionsDirectory) in
             do {
                 try sessionsDirectory.createClientSession(sessionIdentifier, base64PreKeyString: preKey)
@@ -629,6 +636,7 @@ public extension UserClient {
 
     fileprivate func fetchFingerprint() -> Data? {
         var fingerprint: Data?
+        // TODO: [John] use flag here
         keysStore.encryptionContext.perform { [weak self] (sessionsDirectory) in
             guard let strongSelf = self, let sessionIdentifier = strongSelf.sessionIdentifier else { return }
             fingerprint = sessionsDirectory.fingerprint(for: sessionIdentifier)

--- a/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -135,6 +135,7 @@ final class UserClientTests: ZMBaseManagedObjectTest {
             let selfClient = self.createSelfClient(onMOC: self.syncMOC)
 
             var preKeys : [(id: UInt16, prekey: String)] = []
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                 preKeys = try! sessionsDirectory.generatePrekeys(0 ..< 2)
             })
@@ -167,6 +168,7 @@ final class UserClientTests: ZMBaseManagedObjectTest {
             // given
             let selfClient = self.createSelfClient(onMOC: self.syncMOC)
             var preKeys : [(id: UInt16, prekey: String)] = []
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                 preKeys = try! sessionsDirectory.generatePrekeys(0 ..< 2)
             })
@@ -289,6 +291,7 @@ final class UserClientTests: ZMBaseManagedObjectTest {
             let selfClient = self.createSelfClient(onMOC: self.syncMOC)
 
             var preKeys : [(id: UInt16, prekey: String)] = []
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                 preKeys = try! sessionsDirectory.generatePrekeys(0 ..< 2)
             })
@@ -304,6 +307,7 @@ final class UserClientTests: ZMBaseManagedObjectTest {
                     XCTFail("could not generate prekeys")
                     return }
 
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                 try! sessionsDirectory.createClientSession(otherClient.sessionIdentifier!, base64PreKeyString: preKey.prekey)
             })
@@ -639,6 +643,8 @@ extension UserClientTests {
             selfClient = self.createSelfClient(onMOC: self.syncMOC)
             selfClient.fingerprint = .none
 
+            // TODO: [John] use flag here
+
             self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { (sessionsDirectory) in
                 newFingerprint = sessionsDirectory.localFingerprint
             }
@@ -669,6 +675,7 @@ extension UserClientTests {
 
             var preKeys : [(id: UInt16, prekey: String)] = []
 
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform({ (sessionsDirectory) in
                 preKeys = try! sessionsDirectory.generatePrekeys(0 ..< 2)
             })
@@ -684,6 +691,7 @@ extension UserClientTests {
             client.user = otherUser
             client.remoteIdentifier = "badf00d"
 
+            // TODO: [John] use flag here
             self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { (sessionsDirectory) in
                 try! sessionsDirectory.createClientSession(client.sessionIdentifier!, base64PreKeyString: preKey.prekey)
             }
@@ -945,6 +953,7 @@ extension UserClientTests {
             otherClient.needsSessionMigration = true
 
             var preKeys : [(id: UInt16, prekey: String)] = []
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform { sessionsDirectory in
                 preKeys = try! sessionsDirectory.generatePrekeys(0 ..< 2)
             }
@@ -1000,6 +1009,7 @@ extension UserClientTests {
             otherClient.needsSessionMigration = true
 
             var preKeys : [(id: UInt16, prekey: String)] = []
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform { sessionsDirectory in
                 preKeys = try! sessionsDirectory.generatePrekeys(0 ..< 2)
             }

--- a/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.m
+++ b/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.m
@@ -251,6 +251,7 @@
         UserClient *selfClient = [ZMUser selfUserInContext:moc].selfClient;
         [self performPretendingUiMocIsSyncMoc:^{
             NSError *error;
+            // TODO: [John] use flag here
             NSString *key = [selfClient.keysStore lastPreKeyAndReturnError:&error];
             NOT_USED([selfClient establishSessionWithClient:userClient usingPreKey:key]);
         }];

--- a/wire-ios-data-model/Tests/Source/Utils/InvalidClientsRemovalTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/InvalidClientsRemovalTests.swift
@@ -74,6 +74,7 @@ class InvalidClientsRemovalTests: DiskDatabaseTest {
             // given
             let selfClient = self.createSelfClient(in: syncMOC)
             var preKeys : [(id: UInt16, prekey: String)] = []
+            // TODO: [John] use flag here
             selfClient.keysStore.encryptionContext.perform {
                 preKeys = try! $0.generatePrekeys(0 ..< 2)
             }

--- a/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
@@ -192,6 +192,7 @@ class LegacyPersistedDataPatchesTests: ZMBaseManagedObjectTest {
             newClient.user = newUser
             newClient.remoteIdentifier = "aabb2d32ab"
 
+            // TODO: [John] use flag here
             let otrURL = selfClient.keysStore.cryptoboxDirectory
             XCTAssertTrue(selfClient.establishSessionWithClient(newClient, usingPreKey: hardcodedPrekey))
             self.syncMOC.saveOrRollback()

--- a/wire-ios-request-strategy/Sources/Helpers/CryptoBoxUpdateEventsTests.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/CryptoBoxUpdateEventsTests.swift
@@ -90,6 +90,7 @@ class CryptoboxUpdateEventsTests: MessagingTestBase {
             let event = ZMUpdateEvent.eventsArray(from: wrapper as NSDictionary, source: .download)!.first!
 
             // WHEN
+            // TODO: [John] use flag here
             self.performIgnoringZMLogError {
                 self.selfClient.keysStore.encryptionContext.perform { session in
                     _ = session.decryptAndAddClient(event, in: self.syncMOC)
@@ -132,6 +133,7 @@ class CryptoboxUpdateEventsTests: MessagingTestBase {
             let event = ZMUpdateEvent.eventsArray(from: wrapper, source: .download)!.first!
 
             // When
+            // TODO: [John] use flag here
             self.performIgnoringZMLogError {
                 self.selfClient.keysStore.encryptionContext.perform { session in
                     _ = session.decryptAndAddClient(event, in: self.syncMOC)
@@ -174,6 +176,7 @@ class CryptoboxUpdateEventsTests: MessagingTestBase {
             let event = ZMUpdateEvent.eventsArray(from: wrapper, source: .download)!.first!
 
             // When
+            // TODO: [John] use flag here
             self.performIgnoringZMLogError {
                 self.selfClient.keysStore.encryptionContext.perform { session in
                     _ = session.decryptAndAddClient(event, in: self.syncMOC)

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -133,6 +133,7 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
         guard let selfClient = ZMUser.selfUser(in: context).selfClient() else {
             return
         }
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { (session) in
             session.purgeEncryptedPayloadCache()
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -567,6 +567,7 @@ extension FetchClientRequestStrategyTests {
             sessionIdentifier = EncryptionSessionIdentifier(userId: self.otherUser!.remoteIdentifier.uuidString, clientId: remoteIdentifier)
             self.otherUser.fetchUserClients()
             payload = [["id": remoteIdentifier, "class": "phone"]] as NSArray
+            // TODO: [John] use flag here
             self.selfClient.keysStore.encryptionContext.perform {
                 try! $0.createClientSession(sessionIdentifier, base64PreKeyString: self.selfClient.keysStore.lastPreKey()) // just a bogus key is OK
             }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
@@ -28,6 +28,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
     var mockApplicationStatus: MockApplicationStatus!
 
     var validPrekey: String {
+        // TODO: [John] use flag here
         return try! self.selfClient.keysStore.lastPreKey()
     }
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -113,6 +113,7 @@ extension EventDecoder {
         let publicKey = try? EncryptionKeys.publicKey(for: account)
         var decryptedEvents: [ZMUpdateEvent] = []
 
+        // TODO: [John] use flag here
         syncMOC.zm_cryptKeyStore.encryptionContext.perform { [weak self] (sessionsDirectory) -> Void in
             guard let `self` = self else { return }
 

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Encryption.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Encryption.swift
@@ -38,6 +38,7 @@ extension MessagingTestBase {
         var cypherText: Data?
         self.encryptionContext(for: sender).perform { (session) in
             if !session.hasSession(for: selfClient.sessionIdentifier!) {
+                // TODO: [John] use flag here
                 guard let lastPrekey = try? selfClient.keysStore.lastPreKey() else {
                     fatalError("Can't get prekey for self user")
                 }
@@ -72,6 +73,7 @@ extension MessagingTestBase {
             prekey = try! session.generateLastPrekey()
         }
 
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { (session) in
             try! session.createClientSession(client.sessionIdentifier!, base64PreKeyString: prekey!)
         }

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -167,6 +167,7 @@ extension MessagingTestBase {
         let event = ZMUpdateEvent.eventsArray(from: wrapper as NSDictionary, source: source)!.first!
 
         var decryptedEvent: ZMUpdateEvent?
+        // TODO: [John] use flag here
         self.selfClient.keysStore.encryptionContext.perform { session in
             decryptedEvent = session.decryptAndAddClient(event, in: self.syncMOC)
         }

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -87,6 +87,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
 
         let syncMOC = contextProvider.syncContext
         let strategies: [Any] = [
+            // TODO: [John] use flag here
             UserClientRequestStrategy(
                 clientRegistrationStatus: applicationStatusDirectory.clientRegistrationStatus,
                 clientUpdateStatus: applicationStatusDirectory.clientUpdateStatus,

--- a/wire-ios-sync-engine/Source/UserSession/NSManagedObject+EncryptionContext.swift
+++ b/wire-ios-sync-engine/Source/UserSession/NSManagedObject+EncryptionContext.swift
@@ -21,6 +21,8 @@ import WireDataModel
 
 extension NSManagedObjectContext {
 
+    // TODO: [John] use flag here
+
     @objc
     public func deleteAndCreateNewEncryptionContext() {
         zm_cryptKeyStore.deleteAndCreateNewBox()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+Debugging.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+Debugging.swift
@@ -203,6 +203,7 @@ private class DebugCommandLogEncryption: DebugCommandMixin {
         let subject = arguments[1]
 
         userSession.syncManagedObjectContext.perform {
+            // TODO: [John] use flag here
             guard let context = ZMUser
                 .selfUser(in: userSession.syncManagedObjectContext)
                 .selfClient()?.keysStore.encryptionContext else {
@@ -246,6 +247,7 @@ private class DebugCommandLogEncryption: DebugCommandMixin {
             EncryptionSessionIdentifier(string: $0)
         })
         userSession.syncManagedObjectContext.performAsync {
+            // TODO: [John] use flag here
             guard let context = ZMUser.selfUser(in: userSession.syncManagedObjectContext).selfClient()?.keysStore.encryptionContext
                 else {
                     return

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientEventConsumerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientEventConsumerTests.swift
@@ -247,6 +247,8 @@ class UserClientEventConsumerTests: RequestStrategyTestBase {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let existingClient = self.createSelfClient()
 
+            // TODO: [John] use flag here
+
             var fingerprint: Data?
             self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { (sessionsDirectory) in
                 fingerprint = sessionsDirectory.localFingerprint

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Encryption.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Encryption.swift
@@ -38,6 +38,7 @@ extension IntegrationTest {
         var cypherText: Data?
         self.encryptionContext(for: sender).perform { (session) in
             if !session.hasSession(for: selfClient.sessionIdentifier!) {
+                // TODO: [John] use flag here
                 guard let lastPrekey = try? selfClient.keysStore.lastPreKey() else {
                     fatalError("Can't get prekey for self user")
                 }
@@ -71,6 +72,7 @@ extension IntegrationTest {
             prekey = try! session.generateLastPrekey()
         }
 
+        // TODO: [John] use flag here
         selfClient.keysStore.encryptionContext.perform { (session) in
             try! session.createClientSession(client.sessionIdentifier!, base64PreKeyString: prekey!)
         }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -559,6 +559,7 @@ class CallingRequestStrategyTests: MessagingTest {
         client.remoteIdentifier = NSString.createAlphanumerical() as String
         client.user = user
 
+        // TODO: [John] use flag here
         XCTAssertTrue(userClient.establishSessionWithClient(client, usingPreKey: try! userClient.keysStore.lastPreKey()))
 
         return client

--- a/wire-ios/WireCommonComponents/DeveloperFlag.swift
+++ b/wire-ios/WireCommonComponents/DeveloperFlag.swift
@@ -23,6 +23,7 @@ public enum DeveloperFlag: String, CaseIterable {
     private static let storage = UserDefaults.applicationGroup
 
     case showCreateMLSGroupToggle
+    case proteusViaCoreCrypto
     case breakMyNotifications
     case nseV2
     case nseDebugging
@@ -34,6 +35,9 @@ public enum DeveloperFlag: String, CaseIterable {
         switch self {
         case .showCreateMLSGroupToggle:
             return "Turn on to show the MLS toggle when creating a new group."
+
+        case .proteusViaCoreCrypto:
+            return "Turn on to use CoreCrypto for proteus messaging."
 
         case .breakMyNotifications:
             return "Turn on to get your app in a state where it no longer receives notifications."


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Add a developer flag to use proteus via CoreCrypto
- Add todo markers to indicate everywhere Cryptobox is used, which may be places to use the new flag

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
