### PR TITLE
fix: use custom engine for non proxy based websockets (SQSERVICES-1794)

### DIFF
--- a/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
@@ -119,7 +119,7 @@ class StarscreamPushChannel: NSObject, PushChannelType {
         connectionRequest.setValue("\(accessToken.type) \(accessToken.token)", forHTTPHeaderField: "Authorization")
 
         let certificatePinning = StarscreamCertificatePinning(environment: environment)
-        webSocket = WebSocket(request: connectionRequest, certPinner: certificatePinning, useCustomEngine: false)
+        webSocket = WebSocket(request: connectionRequest, certPinner: certificatePinning, useCustomEngine: environment.proxy == nil)
         webSocket?.delegate = self
 
         if let proxySettings = environment.proxy {


### PR DESCRIPTION

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This is a Workaround to reintroduce the previous behavior of the WebSockets for non-proxy based connections (see also https://wearezeta.atlassian.net/browse/SQSERVICES-1794)

### Solutions

Using the old custom implementation based on the current configuration resolves this issue for regular usage.

### Testing

#### How to Test

Test that the application still works in both operating modes and receives real time updates through the websocket.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
