### PR TITLE
chore: move `DeveloperFlag` to utilities

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public enum DeveloperFlag: String, CaseIterable {
 
-    private static let storage = UserDefaults.applicationGroup
+    public static var storage = UserDefaults.standard
 
     case showCreateMLSGroupToggle
     case breakMyNotifications
@@ -65,14 +65,6 @@ public enum DeveloperFlag: String, CaseIterable {
         allCases.forEach {
             storage.set(nil, forKey: $0.rawValue)
         }
-    }
-
-}
-
-public extension DeveloperFlag {
-
-    static var isUpdatedCallingUI: Bool {
-        return !(DeveloperFlag.deprecatedCallingUI.isOn || AutomationHelper.sharedHelper.deprecatedCallingUI)
     }
 
 }

--- a/wire-ios-utilities/WireUtilities.xcodeproj/project.pbxproj
+++ b/wire-ios-utilities/WireUtilities.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		5EE020C7214A9FC5001669F0 /* ZMAtomicInteger.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EE020C5214A9FC5001669F0 /* ZMAtomicInteger.m */; };
 		6323786A2508D34D00AD4346 /* Array+Shift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632378692508D34D00AD4346 /* Array+Shift.swift */; };
 		6323786C2508D51C00AD4346 /* ArrayShiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6323786B2508D51C00AD4346 /* ArrayShiftTests.swift */; };
+		63DFEAD129A3845600FCA830 /* DeveloperFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFEAD029A3845600FCA830 /* DeveloperFlag.swift */; };
 		7C358075231E534600D994FD /* ZMAccentColorValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C358072231E524A00D994FD /* ZMAccentColorValidatorTests.m */; };
 		7C35807A231E5DA000D994FD /* ZMEmailAddressValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C358077231E5D9300D994FD /* ZMEmailAddressValidatorTests.m */; };
 		7C35807F231E5F5B00D994FD /* ZMPhoneNumberValidatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C35807C231E5ED300D994FD /* ZMPhoneNumberValidatorTests.m */; };
@@ -333,6 +334,7 @@
 		5EE020C5214A9FC5001669F0 /* ZMAtomicInteger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMAtomicInteger.m; sourceTree = "<group>"; };
 		632378692508D34D00AD4346 /* Array+Shift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Shift.swift"; sourceTree = "<group>"; };
 		6323786B2508D51C00AD4346 /* ArrayShiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayShiftTests.swift; sourceTree = "<group>"; };
+		63DFEAD029A3845600FCA830 /* DeveloperFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperFlag.swift; sourceTree = "<group>"; };
 		7C358072231E524A00D994FD /* ZMAccentColorValidatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMAccentColorValidatorTests.m; sourceTree = "<group>"; };
 		7C358077231E5D9300D994FD /* ZMEmailAddressValidatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMEmailAddressValidatorTests.m; sourceTree = "<group>"; };
 		7C35807C231E5ED300D994FD /* ZMPhoneNumberValidatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMPhoneNumberValidatorTests.m; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 				632378692508D34D00AD4346 /* Array+Shift.swift */,
 				EE16270F250BA12900D35062 /* VolatileData.swift */,
 				A9C6EDE326B32E9D007F61C5 /* UTIHelper.swift */,
+				63DFEAD029A3845600FCA830 /* DeveloperFlag.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1024,6 +1027,7 @@
 				5E4BC1BC2189E6A400A8682E /* AnyProperty.swift in Sources */,
 				7C8BFFE722FD612900B3C8A5 /* ZMPhoneNumberValidator.swift in Sources */,
 				54CA313B1B74F36B00B820C0 /* Sets.swift in Sources */,
+				63DFEAD129A3845600FCA830 /* DeveloperFlag.swift in Sources */,
 				D5D65A13207631A100D7F3C3 /* NSManagedObjectContext+PerformGrouped.swift in Sources */,
 				A9CDCDC4237D9A14008A9BC6 /* UIColor+Mixing.swift in Sources */,
 				87ECBDD51E78457C00596836 /* ExtremeCombiningCharactersValidator.swift in Sources */,

--- a/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
@@ -23,6 +23,7 @@ import WireNotificationEngine
 import WireCommonComponents
 import WireDataModel
 import WireSyncEngine
+import WireUtilities
 import UIKit
 import CallKit
 

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -19,6 +19,7 @@
 import Foundation
 import WireCommonComponents
 import UserNotifications
+import WireUtilities
 #if DATADOG_IMPORT
 import Datadog
 #endif

--- a/wire-ios/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import Wire
 import SnapshotTesting
-import WireCommonComponents
+import WireUtilities
 
 struct MockCallGridViewControllerInput: CallGridViewControllerInput, Equatable {
     var isConnected: Bool = true

--- a/wire-ios/Wire-iOS Tests/Calling/CallInfoRootViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallInfoRootViewControllerSnapshotTests.swift
@@ -17,7 +17,7 @@
 
 import SnapshotTesting
 import XCTest
-import WireCommonComponents
+import WireUtilities
 @testable import Wire
 
 final class CallInfoViewControllerSnapshotTests: ZMSnapshotTestCase {

--- a/wire-ios/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallInfoRootViewControllerTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import Wire
 import SnapshotTesting
-import WireCommonComponents
+import WireUtilities
 
 final class CallInfoRootViewControllerTests: ZMSnapshotTestCase {
 

--- a/wire-ios/Wire-iOS Tests/Calling/CallParticipantsListViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallParticipantsListViewControllerTests.swift
@@ -19,7 +19,7 @@
 import Foundation
 import SnapshotTesting
 import XCTest
-import WireCommonComponents
+import WireUtilities
 @testable import Wire
 
 final class CallParticipantsListHelper {

--- a/wire-ios/Wire-iOS Tests/UserCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserCellTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import WireCommonComponents
+import WireUtilities
 @testable import Wire
 
 final class UserCellTests: ZMSnapshotTestCase {

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -536,6 +536,7 @@
 		63B9F5B825E7D7190059020D /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B9F5B725E7D7190059020D /* ToastView.swift */; };
 		63CE88A42506A83300E457C7 /* OrientationDeltaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CE88A32506A83300E457C7 /* OrientationDeltaTests.swift */; };
 		63D17D6B268E142100B0CC4F /* MockCallGridViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D17D6A268E142000B0CC4F /* MockCallGridViewControllerDelegate.swift */; };
+		63DFEAD329A3885600FCA830 /* DeveloperFlag+Calling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DFEAD229A3885600FCA830 /* DeveloperFlag+Calling.swift */; };
 		63E128B726208BAD009D9AF2 /* CallGridHintNotificationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E128B626208BAD009D9AF2 /* CallGridHintNotificationLabel.swift */; };
 		63E128BB26208DDC009D9AF2 /* CallGridEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E128BA26208DDC009D9AF2 /* CallGridEvent.swift */; };
 		63F239352694A151000BFFC6 /* Array+Prefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D17D70268F52A300B0CC4F /* Array+Prefix.swift */; };
@@ -1371,7 +1372,6 @@
 		EEE455E828B2E210005ACD74 /* AccessAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455E728B2E210005ACD74 /* AccessAPIClient.swift */; };
 		EEE455EB28B2E470005ACD74 /* NetworkPrimitives.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455EA28B2E470005ACD74 /* NetworkPrimitives.swift */; };
 		EEE455EE28B2E4CE005ACD74 /* NotificationsAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE455ED28B2E4CE005ACD74 /* NotificationsAPIClient.swift */; };
-		EEE5D981287E1CDA004E2D2B /* DeveloperFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE5D980287E1CDA004E2D2B /* DeveloperFlag.swift */; };
 		EEE60E2C2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE60E2B2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift */; };
 		EEE81E9223E028EA00A1D035 /* TopPeopleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9123E028EA00A1D035 /* TopPeopleCell.swift */; };
 		EEE81E9423E0467F00A1D035 /* TopPeopleLineCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE81E9323E0467F00A1D035 /* TopPeopleLineCollectionViewController.swift */; };
@@ -2423,6 +2423,7 @@
 		63CE88A32506A83300E457C7 /* OrientationDeltaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationDeltaTests.swift; sourceTree = "<group>"; };
 		63D17D6A268E142000B0CC4F /* MockCallGridViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCallGridViewControllerDelegate.swift; sourceTree = "<group>"; };
 		63D17D70268F52A300B0CC4F /* Array+Prefix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Prefix.swift"; sourceTree = "<group>"; };
+		63DFEAD229A3885600FCA830 /* DeveloperFlag+Calling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeveloperFlag+Calling.swift"; sourceTree = "<group>"; };
 		63E128B626208BAD009D9AF2 /* CallGridHintNotificationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallGridHintNotificationLabel.swift; sourceTree = "<group>"; };
 		63E128BA26208DDC009D9AF2 /* CallGridEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallGridEvent.swift; sourceTree = "<group>"; };
 		63F2398D269F242B000BFFC6 /* VideoGridPresentationMode+CallActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VideoGridPresentationMode+CallActions.swift"; sourceTree = "<group>"; };
@@ -3337,7 +3338,6 @@
 		EEE455E728B2E210005ACD74 /* AccessAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessAPIClient.swift; sourceTree = "<group>"; };
 		EEE455EA28B2E470005ACD74 /* NetworkPrimitives.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPrimitives.swift; sourceTree = "<group>"; };
 		EEE455ED28B2E4CE005ACD74 /* NotificationsAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsAPIClient.swift; sourceTree = "<group>"; };
-		EEE5D980287E1CDA004E2D2B /* DeveloperFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperFlag.swift; sourceTree = "<group>"; };
 		EEE60E2B2179D99100D03346 /* GroupDetailsNotificationOptionsCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupDetailsNotificationOptionsCellTests.swift; sourceTree = "<group>"; };
 		EEE81E9123E028EA00A1D035 /* TopPeopleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPeopleCell.swift; sourceTree = "<group>"; };
 		EEE81E9323E0467F00A1D035 /* TopPeopleLineCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPeopleLineCollectionViewController.swift; sourceTree = "<group>"; };
@@ -6907,6 +6907,7 @@
 				BFE41870209C8AFD00503C7C /* CallInfoConfiguration+Debug.swift */,
 				635BAFE5262DB34400B986A4 /* Array+CallParticipant.swift */,
 				D36E027729374EEA006C3E5A /* NSLayoutConstraint+Helper.swift */,
+				63DFEAD229A3885600FCA830 /* DeveloperFlag+Calling.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -7831,7 +7832,6 @@
 				E9EBE0D128194F2D0058C793 /* FontScheme.swift */,
 				E9EBE0D328194F890058C793 /* FontScheme+DynamicType.swift */,
 				E9EBE0D8281958BE0058C793 /* FontSpec.swift */,
-				EEE5D980287E1CDA004E2D2B /* DeveloperFlag.swift */,
 			);
 			path = WireCommonComponents;
 			sourceTree = "<group>";
@@ -8748,6 +8748,7 @@
 				EF6777062073C6C20062F122 /* OfflineBar.swift in Sources */,
 				068500C726B9A33000721F80 /* SimpleVideoMessageRestrictionView.swift in Sources */,
 				BFFD439E1DE47FFA00505C8C /* UIView+RightToLeft.swift in Sources */,
+				63DFEAD329A3885600FCA830 /* DeveloperFlag+Calling.swift in Sources */,
 				1661C71F21A71F15003DCE1C /* ConversationAudioMessageCell.swift in Sources */,
 				872B3283209B208D005AC615 /* CallTopOverlayController.swift in Sources */,
 				5EF7BA63221ADF5500815625 /* ProfileDetailsViewController.swift in Sources */,
@@ -9884,7 +9885,6 @@
 				EF3B26DC2370585700245701 /* AppCenter.swift in Sources */,
 				A98370BC2488101500515687 /* URL+FileSize.swift in Sources */,
 				E9EBE0D228194F2D0058C793 /* FontScheme.swift in Sources */,
-				EEE5D981287E1CDA004E2D2B /* DeveloperFlag.swift in Sources */,
 				5E3E1B732260DA200053AC59 /* StyleKitIcons.generated.swift in Sources */,
 				F15650C621DD0C5500210504 /* CGFloat+Hairline.swift in Sources */,
 				F15650A321DCF63300210504 /* FilePreviewGenerator.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -52,6 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let pushTokenService = PushTokenService()
 
     private var launchOperations: [LaunchSequenceOperation] = [
+        DeveloperFlagOperation(),
         BackendEnvironmentOperation(),
         TrackingOperation(),
         AppCenterOperation(),
@@ -122,7 +123,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         voIPPushManager.registerForVoIPPushes()
-
         ZMSLog.switchCurrentLogToPrevious()
 
         zmLog.info("application:didFinishLaunchingWithOptions START \(String(describing: launchOptions)) (applicationState = \(application.applicationState.rawValue))")

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperFlags/DeveloperFlagsView.swift
@@ -17,7 +17,7 @@
 //
 
 import SwiftUI
-import WireCommonComponents
+import WireUtilities
 
 @available(iOS 14, *)
 struct DeveloperFlagsView: View {

--- a/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -32,6 +32,13 @@ protocol LaunchSequenceOperation {
     func execute()
 }
 
+// MARK: - DeveloperFlagOperation
+final class DeveloperFlagOperation: LaunchSequenceOperation {
+    func execute() {
+        DeveloperFlag.storage = .applicationGroup
+    }
+}
+
 // MARK: - BackendEnvironmentOperation
 final class BackendEnvironmentOperation: LaunchSequenceOperation {
     func execute() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionIconType.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/CallActionIconType.swift
@@ -19,6 +19,7 @@
 import Foundation
 import UIKit
 import WireCommonComponents
+import WireUtilities
 
 enum CallActionIconType: IconLabelButtonInput {
     case microphone

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantDetailView.swift
@@ -19,6 +19,7 @@
 import Foundation
 import UIKit
 import WireCommonComponents
+import WireUtilities
 
 final class CallParticipantDetailsView: RoundedBlurView {
     private let nameLabel: UILabel

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/Grid/GridView.swift
@@ -17,7 +17,7 @@
 //
 
 import UIKit
-import WireCommonComponents
+import WireUtilities
 
 protocol GridViewDelegate: AnyObject {
     func gridView(_ gridView: GridView, didChangePageTo page: Int)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/RoundedPageIndicator.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/RoundedPageIndicator.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import UIKit
-import WireCommonComponents
+import WireUtilities
 
 class RoundedPageIndicator: RoundedBlurView {
     private let selectedPageIndicator = UIImage.circle(filled: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/BitRateLabel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallInfoViewController/BitRateLabel.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import UIKit
-import WireCommonComponents
+import WireUtilities
 
 enum BitRateStatus: String {
     case constant

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Helper/DeveloperFlag+Calling.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Helper/DeveloperFlag+Calling.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,14 +18,12 @@
 
 import Foundation
 import WireUtilities
+import WireCommonComponents
 
-@available(iOS 14, *)
-final class DeveloperFlagsViewModel: ObservableObject {
+extension DeveloperFlag {
 
-    // MARK: - State
-
-    var flags = DeveloperFlag.allCases.sorted {
-        $0.rawValue < $1.rawValue
+    static var isUpdatedCallingUI: Bool {
+        return !(DeveloperFlag.deprecatedCallingUI.isOn || AutomationHelper.sharedHelper.deprecatedCallingUI)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Thumbnail/PinnableThumbnailViewController.swift
@@ -17,7 +17,7 @@
 //
 
 import UIKit
-import WireCommonComponents
+import WireUtilities
 
 final class PinnableThumbnailViewController: UIViewController {
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Move `DeveloperFlag` to utilities 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
