### PR TITLE
fix: RC build fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,7 +185,7 @@ platform :ios do
         sh "cp ../wire-ios/Configuration/Appfile ."
 
         deliver(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
+            api_key: ENV['APPSTORE_CONNECT_KEY'],
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             submit_for_review: false,
             automatic_release: false,
@@ -206,7 +206,7 @@ platform :ios do
 
 
         upload_to_testflight(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
+            api_key: ENV['APPSTORE_CONNECT_KEY'],
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             skip_waiting_for_build_processing: true
         )
@@ -215,7 +215,7 @@ platform :ios do
     desc "Create a new version but not submit for review. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane create_version app_version:X.XX"
     lane :create_version do |options|
         deliver(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],    
+            api_key: ENV['APPSTORE_CONNECT_KEY'],    
             app_version: options[:app_version],
             submit_for_review: false,
             automatic_release: false,
@@ -230,7 +230,7 @@ platform :ios do
     desc "Submit for review with release note. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane submit_review app_version:X.XX"
     lane :submit_review do |options|
         deliver(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
+            api_key: ENV['APPSTORE_CONNECT_KEY'],
             app_version: options[:app_version],
             submit_for_review: true,
             automatic_release: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,24 @@ opt_out_usage
 default_platform(:ios)
 
 platform :ios do
+    before_all do |lane|
+        lanes_with_api_key = [:upload_app_store, :upload_testflight, :create_version, :submit_review]
+        if lanes_with_api_key.include?(lane)
+            create_api_key
+        end
+    end
+
+    lane :create_api_key do
+        @api_key ||= app_store_connect_api_key(
+          key_id: ENV['KEY_ID'],
+          issuer_id: ENV['KEY_ID_ISSUER'],
+          key_filepath: ENV['KEY_FILE_PATH'],
+          duration: 1200, # optional(maximum 1200)
+          in_house: false # optional but may be required if using match / sigh
+        )
+    end
+    
+
     desc "Fetch dependencies"
     lane :prepare do |options|
         xcode_version = options[:xcode_version]
@@ -185,7 +203,7 @@ platform :ios do
         sh "cp ../wire-ios/Configuration/Appfile ."
 
         deliver(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
+            api_key: @api_key,
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             submit_for_review: false,
             automatic_release: false,
@@ -206,7 +224,7 @@ platform :ios do
 
 
         upload_to_testflight(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
+            api_key: @api_key,
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             skip_waiting_for_build_processing: true
         )
@@ -215,7 +233,7 @@ platform :ios do
     desc "Create a new version but not submit for review. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane create_version app_version:X.XX"
     lane :create_version do |options|
         deliver(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],    
+            api_key: @api_key,
             app_version: options[:app_version],
             submit_for_review: false,
             automatic_release: false,
@@ -230,7 +248,7 @@ platform :ios do
     desc "Submit for review with release note. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane submit_review app_version:X.XX"
     lane :submit_review do |options|
         deliver(
-            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
+            api_key: @api_key,
             app_version: options[:app_version],
             submit_for_review: true,
             automatic_release: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,6 +185,7 @@ platform :ios do
         sh "cp ../wire-ios/Configuration/Appfile ."
 
         deliver(
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             submit_for_review: false,
             automatic_release: false,
@@ -205,6 +206,7 @@ platform :ios do
 
 
         upload_to_testflight(
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             skip_waiting_for_build_processing: true
         )
@@ -213,6 +215,7 @@ platform :ios do
     desc "Create a new version but not submit for review. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane create_version app_version:X.XX"
     lane :create_version do |options|
         deliver(
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],    
             app_version: options[:app_version],
             submit_for_review: false,
             automatic_release: false,
@@ -227,6 +230,7 @@ platform :ios do
     desc "Submit for review with release note. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane submit_review app_version:X.XX"
     lane :submit_review do |options|
         deliver(
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
             app_version: options[:app_version],
             submit_for_review: true,
             automatic_release: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -539,7 +539,7 @@ class Build
             prefix = "AVS:#{@avs_version}-"
         end
         if rc_build
-            version = IO.foreach('../Wire-iOS/Resources/Configuration/Version.xcconfig').grep(/WIRE_SHORT_VERSION/).first.split(" = ")[1].chomp
+            version = IO.foreach('../wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig').grep(/WIRE_SHORT_VERSION/).first.split(" = ")[1].chomp
             prefix = "#{version}-"
         end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -185,7 +185,7 @@ platform :ios do
         sh "cp ../wire-ios/Configuration/Appfile ."
 
         deliver(
-            api_key: ENV['APPSTORE_CONNECT_KEY'],
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             submit_for_review: false,
             automatic_release: false,
@@ -206,7 +206,7 @@ platform :ios do
 
 
         upload_to_testflight(
-            api_key: ENV['APPSTORE_CONNECT_KEY'],
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
             ipa: "#{build.artifact_path(with_filename: true)}.ipa",
             skip_waiting_for_build_processing: true
         )
@@ -215,7 +215,7 @@ platform :ios do
     desc "Create a new version but not submit for review. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane create_version app_version:X.XX"
     lane :create_version do |options|
         deliver(
-            api_key: ENV['APPSTORE_CONNECT_KEY'],    
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],    
             app_version: options[:app_version],
             submit_for_review: false,
             automatic_release: false,
@@ -230,7 +230,7 @@ platform :ios do
     desc "Submit for review with release note. Usage: Create release_note.txt in fastlane/metadata/en-US & de-DE folders. Then call $fastlane submit_review app_version:X.XX"
     lane :submit_review do |options|
         deliver(
-            api_key: ENV['APPSTORE_CONNECT_KEY'],
+            api_key_path: ENV['APPSTORE_CONNECT_KEY'],
             app_version: options[:app_version],
             submit_for_review: true,
             automatic_release: false,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some part of fastlane script was not updated since moving to monorepo. Extra info for RC build

### Solutions

This PR fixes the path to the version.xcconfig

#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
