### PR TITLE
chore: get file lock once when decrypting a batch of events FS-1580

### DIFF
--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -321,4 +321,13 @@ public final class ProteusService: ProteusServiceInterface {
             throw FingerprintError.failedToGetFingerprintFromPrekey
         }
     }
+
+    // MARK: - Batched operations
+
+    public func performBatchedOperations(_ block: () throws -> Void) rethrows {
+        try coreCrypto.perform { _ in
+            try block()
+        }
+    }
+
 }

--- a/wire-ios-data-model/Source/Proteus/ProteusServiceInterface.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusServiceInterface.swift
@@ -58,6 +58,13 @@ public protocol ProteusServiceInterface {
     func remoteFingerprint(forSession id: ProteusSessionID) throws -> String
     func fingerprint(fromPrekey prekey: String) throws -> String
 
+    /// Acquire safe Core Crypto access during across the lifetime of the given block.
+    ///
+    /// - Parameters:
+    ///   - block: A closure to perform some work needing safe Core Crypto access.
+
+    func performBatchedOperations(_ block: @escaping () throws -> Void) rethrows
+
 }
 
 public typealias IdPrekeyTuple = (id: UInt16, prekey: String)

--- a/wire-ios-data-model/Tests/MLS/MockCoreCrypto.swift
+++ b/wire-ios-data-model/Tests/MLS/MockCoreCrypto.swift
@@ -22,12 +22,16 @@ import CoreCryptoSwift
 
 class MockCoreCrypto: CoreCryptoProtocol, SafeCoreCryptoProtocol {
 
+    var performCount = 0
     func perform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T {
-        try block(self)
+        performCount += 1
+        return try block(self)
     }
 
+    var unsafePerformCount = 0
     func unsafePerform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T {
-        try block(self)
+        unsafePerformCount += 1
+        return try block(self)
     }
 
     // MARK: - mlsInit

--- a/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
+++ b/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
@@ -151,6 +151,20 @@ class ProteusServiceTests: XCTestCase {
         }
     }
 
+    // MARK: - Batched operations
+
+    func test_PerformBachedOperations() throws {
+        // Given
+        mockCoreCrypto.performCount = 0
+
+        // When
+        sut.performBatchedOperations {}
+
+        // Then
+        XCTAssertEqual(mockCoreCrypto.performCount, 1)
+        XCTAssertEqual(mockCoreCrypto.unsafePerformCount, 0)
+    }
+
 }
 
 // MARK: - Helpers

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -337,4 +337,19 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         }
     }
 
+    // MARK: - performBatchedOperations
+
+    public var performBatchedOperations_Invocations: [() throws -> Void] = []
+    public var performBatchedOperations_MockMethod: ((@escaping () throws -> Void) -> Void)?
+
+    public func performBatchedOperations(_ block: @escaping () throws -> Void) {
+        performBatchedOperations_Invocations.append(block)
+
+        guard let mock = performBatchedOperations_MockMethod else {
+            fatalError("no mock for `performBatchedOperations`")
+        }
+
+        mock(block)            
+    }
+
 }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -399,6 +399,15 @@ extension EventDecoderTest {
 
             // Mock
             self.syncMOC.proteusService = mockProteusService
+
+            mockProteusService.performBatchedOperations_MockMethod = { block in
+                do {
+                    try block()
+                } catch {
+                    XCTFail("an error was thrown: \(error)")
+                }
+            }
+
             mockProteusService.decryptDataForSession_MockMethod = { data, _ in
                 return (didCreateSession: false, decryptedData: data)
             }
@@ -410,6 +419,7 @@ extension EventDecoderTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // Then
+        XCTAssertEqual(mockProteusService.performBatchedOperations_Invocations.count, 1)
         XCTAssertEqual(mockProteusService.decryptDataForSession_Invocations.count, 1)
 
         // Cleanup

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockProteusServiceinterface.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockProteusServiceinterface.swift
@@ -323,4 +323,19 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         }
     }
 
+    // MARK: - performBatchedOperations
+
+    public var performBatchedOperations_Invocations: [() throws -> Void] = []
+    public var performBatchedOperations_MockMethod: ((@escaping () throws -> Void) -> Void)?
+
+    public func performBatchedOperations(_ block: @escaping () throws -> Void) {
+        performBatchedOperations_Invocations.append(block)
+
+        guard let mock = performBatchedOperations_MockMethod else {
+            fatalError("no mock for `performBatchedOperations`")
+        }
+
+        mock(block)
+    }
+
 }

--- a/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusServiceInterface.swift
+++ b/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusServiceInterface.swift
@@ -323,4 +323,19 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         }
     }
 
+    // MARK: - performBatchedOperations
+
+    public var performBatchedOperations_Invocations: [() throws -> Void] = []
+    public var performBatchedOperations_MockMethod: ((@escaping () throws -> Void) -> Void)?
+
+    public func performBatchedOperations(_ block: @escaping () throws -> Void) {
+        performBatchedOperations_Invocations.append(block)
+
+        guard let mock = performBatchedOperations_MockMethod else {
+            fatalError("no mock for `performBatchedOperations`")
+        }
+
+        mock(block)
+    }
+    
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In this PR we address a TODO from a previous PR for decrypting update events with core crypto. The existing flow with decrypting proteus events via Cryptobox was to first get safe access to cryptobox, then iterate through a batch of update events and decrypt them one by one. Finally, once the decrypted update events were stored in the database, the file lock on cryptobox was released.

While this exact behavior was not yet implemented when decrypting events via Core Crypto, we still had safe access to Core Crypto at the level we decrypt a single event. However, since it is possible that we may decrypt a large batch of events at one time, it may be inefficient to get the lock, encrypt one event, release the lock, get the lock, decrypt one more event, release the lock.... 100 or so times.

Instead, we should get the lock once, decrypt a batch of events, then release the lock. This PR introduces a way to achieve this by adding a new `ProteusService` method to ensure safe access to Core Crypto across the life time of a closure.


### Testing

#### Test Coverage

- updated `EventDecoder` tests to assert that `performBatchedOperations` is called
- added unit test to `ProteusServiceTests` asserting safe access to core crypto when invoking the `performBatchedOperations` method

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
