### PR TITLE
fix: compilation errors relating to keystore

### DIFF
--- a/wire-ios-request-strategy/Sources/Helpers/EventDecoderDecryptionTestsTests.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/EventDecoderDecryptionTestsTests.swift
@@ -103,7 +103,7 @@ class EventDecoderDecryptionTests: MessagingTestBase {
             // WHEN
             // TODO: [John] use flag here
             self.performIgnoringZMLogError {
-                self.selfClient.keysStore.encryptionContext.perform { session in
+                self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { session in
                     _ = sut.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
                         try session.decryptData(encryptedData, for: sessionID.mapToEncryptionSessionID())
                     }
@@ -149,7 +149,7 @@ class EventDecoderDecryptionTests: MessagingTestBase {
             // When
             // TODO: [John] use flag here
             self.performIgnoringZMLogError {
-                self.selfClient.keysStore.encryptionContext.perform { session in
+                self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { session in
                     _ = sut.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
                         try session.decryptData(encryptedData, for: sessionID.mapToEncryptionSessionID())
                     }
@@ -195,7 +195,7 @@ class EventDecoderDecryptionTests: MessagingTestBase {
             // When
             // TODO: [John] use flag here
             self.performIgnoringZMLogError {
-                self.selfClient.keysStore.encryptionContext.perform { session in
+                self.syncMOC.zm_cryptKeyStore.encryptionContext.perform { session in
                     _ = sut.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
                         try session.decryptData(encryptedData, for: sessionID.mapToEncryptionSessionID())
                     }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -130,11 +130,11 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
     }
 
     fileprivate func purgeEncryptedPayloadCache() {
-        guard let selfClient = ZMUser.selfUser(in: context).selfClient() else {
+        guard let keyStore = context.zm_cryptKeyStore else {
             return
         }
-        // TODO: [John] use flag here
-        selfClient.keysStore.encryptionContext.perform { (session) in
+
+        keyStore.encryptionContext.perform { (session) in
             session.purgeEncryptedPayloadCache()
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -568,8 +568,8 @@ extension FetchClientRequestStrategyTests {
             self.otherUser.fetchUserClients()
             payload = [["id": remoteIdentifier, "class": "phone"]] as NSArray
             // TODO: [John] use flag here
-            self.selfClient.keysStore.encryptionContext.perform {
-                try! $0.createClientSession(sessionIdentifier, base64PreKeyString: self.selfClient.keysStore.lastPreKey()) // just a bogus key is OK
+            self.syncMOC.zm_cryptKeyStore.encryptionContext.perform {
+                try! $0.createClientSession(sessionIdentifier, base64PreKeyString: self.syncMOC.zm_cryptKeyStore.lastPreKey()) // just a bogus key is OK
             }
         }
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.2))

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
@@ -29,7 +29,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
 
     var validPrekey: String {
         // TODO: [John] use flag here
-        return try! self.selfClient.keysStore.lastPreKey()
+        return try! self.syncMOC.zm_cryptKeyStore.lastPreKey()
     }
 
     override func setUp() {

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Encryption.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Encryption.swift
@@ -39,7 +39,7 @@ extension MessagingTestBase {
         self.encryptionContext(for: sender).perform { (session) in
             if !session.hasSession(for: selfClient.sessionIdentifier!) {
                 // TODO: [John] use flag here
-                guard let lastPrekey = try? selfClient.keysStore.lastPreKey() else {
+                guard let lastPrekey = try? syncMOC.zm_cryptKeyStore.lastPreKey() else {
                     fatalError("Can't get prekey for self user")
                 }
                 try! session.createClientSession(selfClient.sessionIdentifier!, base64PreKeyString: lastPrekey)
@@ -74,7 +74,7 @@ extension MessagingTestBase {
         }
 
         // TODO: [John] use flag here
-        selfClient.keysStore.encryptionContext.perform { (session) in
+        syncMOC.zm_cryptKeyStore.encryptionContext.perform { (session) in
             try! session.createClientSession(client.sessionIdentifier!, base64PreKeyString: prekey!)
         }
     }

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -213,7 +213,7 @@ extension MessagingTestBase {
                 return (didCreateNewSession: result.didCreateSession, decryptedData: result.decryptedData)
             }
         } else {
-            selfClient.keysStore.encryptionContext.perform { session in
+            syncMOC.zm_cryptKeyStore.encryptionContext.perform { session in
                 decryptedEvent = eventDecoder.decryptProteusEventAndAddClient(
                     event,
                     in: self.syncMOC

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Encryption.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Encryption.swift
@@ -39,7 +39,7 @@ extension IntegrationTest {
         self.encryptionContext(for: sender).perform { (session) in
             if !session.hasSession(for: selfClient.sessionIdentifier!) {
                 // TODO: [John] use flag here
-                guard let lastPrekey = try? selfClient.keysStore.lastPreKey() else {
+                guard let lastPrekey = try? userSession!.syncContext.zm_cryptKeyStore.lastPreKey() else {
                     fatalError("Can't get prekey for self user")
                 }
                 try! session.createClientSession(selfClient.sessionIdentifier!, base64PreKeyString: lastPrekey)
@@ -73,7 +73,7 @@ extension IntegrationTest {
         }
 
         // TODO: [John] use flag here
-        selfClient.keysStore.encryptionContext.perform { (session) in
+        userSession!.syncContext.zm_cryptKeyStore.encryptionContext.perform { (session) in
             try! session.createClientSession(client.sessionIdentifier!, base64PreKeyString: prekey!)
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -561,7 +561,7 @@ class CallingRequestStrategyTests: MessagingTest {
         client.user = user
 
         // TODO: [John] use flag here
-        XCTAssertTrue(userClient.establishSessionWithClient(client, usingPreKey: try! userClient.keysStore.lastPreKey()))
+        XCTAssertTrue(userClient.establishSessionWithClient(client, usingPreKey: try! syncMOC.zm_cryptKeyStore.lastPreKey()))
 
         return client
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Several compiler issues because the keystore was removed from the user client.

### Solutions

Get the keystore from the sync context instead.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
