### PR TITLE
feat: Remove the mandatory usage of keystore usage from ProteusMessageSync.

### DIFF
--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -130,13 +130,14 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
     }
 
     fileprivate func purgeEncryptedPayloadCache() {
-        guard let keyStore = context.zm_cryptKeyStore else {
-            return
-        }
-
-        keyStore.encryptionContext.perform { (session) in
-            session.purgeEncryptedPayloadCache()
-        }
+        context.proteusProvider.perform(
+            withProteusService: { _ in },
+            withKeyStore: { keyStore in
+                keyStore.encryptionContext.perform { (session) in
+                    session.purgeEncryptedPayloadCache()
+                }
+            }
+        )
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We try to use CryptoBox method to purge the encrypted payload cache if the `proteusViaCoreCrypto` flag is enabled. This causes a crash after the migration.

### Solutions

 Use `proteusProvider` and provide an empty block for the CoreCrypto case.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
