### PR TITLE
fix: Fingerprint for a self client FS-1556

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -586,7 +586,7 @@ extension UserClient {
         proteusProvider.perform(
             withProteusService: { proteusService in
                 do {
-                    let fingerprint = try proteusService.fingerprint()
+                    let fingerprint = try proteusService.localFingerprint()
                     fingerprintData = fingerprint.utf8Data
                 } catch {
                     zmLog.error("Cannot fetch local fingerprint for \(self)")

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -585,12 +585,8 @@ extension UserClient {
 
         proteusProvider.perform(
             withProteusService: { proteusService in
-                guard let sessionID = self.proteusSessionID else {
-                    return
-                }
-
                 do {
-                    let fingerprint = try proteusService.localFingerprint(forSession: sessionID)
+                    let fingerprint = try proteusService.fingerprint()
                     fingerprintData = fingerprint.utf8Data
                 } catch {
                     zmLog.error("Cannot fetch local fingerprint for \(self)")

--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -267,29 +267,17 @@ public final class ProteusService: ProteusServiceInterface {
     // MARK: - proteusFingerprint
 
     enum FingerprintError: Error {
-        case failedToGetFingerprint
         case failedToGetLocalFingerprint
         case failedToGetRemoteFingerprint
         case failedToGetFingerprintFromPrekey
         case prekeyNotBase64Encoded
     }
 
-    public func fingerprint() throws -> String {
-        logger.info("fetching fingerprint")
-
-        do {
-            return try coreCrypto.perform { try $0.proteusFingerprint() }
-        } catch {
-            logger.error("failed to fetch fingerprint: \(String(describing: error))")
-            throw FingerprintError.failedToGetFingerprint
-        }
-    }
-
-    public func localFingerprint(forSession id: ProteusSessionID) throws -> String {
+    public func localFingerprint() throws -> String {
         logger.info("fetching local fingerprint")
 
         do {
-            return try coreCrypto.perform { try $0.proteusFingerprintLocal(sessionId: id.rawValue) }
+            return try coreCrypto.perform { try $0.proteusFingerprint() }
         } catch {
             logger.error("failed to fetch local fingerprint: \(String(describing: error))")
             throw FingerprintError.failedToGetLocalFingerprint

--- a/wire-ios-data-model/Source/Proteus/ProteusServiceInterface.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusServiceInterface.swift
@@ -53,8 +53,7 @@ public protocol ProteusServiceInterface {
     func lastPrekey() throws -> String
     var lastPrekeyID: UInt16 { get }
     func generatePrekeys(start: UInt16, count: UInt16) throws -> [IdPrekeyTuple]
-    func fingerprint() throws -> String
-    func localFingerprint(forSession id: ProteusSessionID) throws -> String
+    func localFingerprint() throws -> String
     func remoteFingerprint(forSession id: ProteusSessionID) throws -> String
     func fingerprint(fromPrekey prekey: String) throws -> String
 

--- a/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -1321,7 +1321,7 @@ extension UserClientTests {
 
         self.syncMOC.performGroupedBlockAndWait {
             let mockProteusService = MockProteusServiceInterface()
-            mockProteusService.fingerprint_MockMethod = {
+            mockProteusService.localFingerprint_MockMethod = {
                 return localFingerprint
             }
             self.syncMOC.proteusService = mockProteusService

--- a/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -1321,7 +1321,7 @@ extension UserClientTests {
 
         self.syncMOC.performGroupedBlockAndWait {
             let mockProteusService = MockProteusServiceInterface()
-            mockProteusService.localFingerprintForSession_MockMethod = {_ in
+            mockProteusService.fingerprint_MockMethod = {
                 return localFingerprint
             }
             self.syncMOC.proteusService = mockProteusService

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -245,49 +245,26 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         }
     }
 
-    // MARK: - fingerprint
+    // MARK: - localFingerprint
 
-    public var fingerprint_Invocations: [Void] = []
-    public var fingerprint_MockError: Error?
-    public var fingerprint_MockMethod: (() throws -> String)?
-    public var fingerprint_MockValue: String?
+    public var localFingerprint_Invocations: [Void] = []
+    public var localFingerprint_MockError: Error?
+    public var localFingerprint_MockMethod: (() throws -> String)?
+    public var localFingerprint_MockValue: String?
 
-    public func fingerprint() throws -> String {
-        fingerprint_Invocations.append(())
+    public func localFingerprint() throws -> String {
+        localFingerprint_Invocations.append(())
 
-        if let error = fingerprint_MockError {
+        if let error = localFingerprint_MockError {
             throw error
         }
 
-        if let mock = fingerprint_MockMethod {
+        if let mock = localFingerprint_MockMethod {
             return try mock()
-        } else if let mock = fingerprint_MockValue {
+        } else if let mock = localFingerprint_MockValue {
             return mock
         } else {
             fatalError("no mock for `fingerprint`")
-        }
-    }
-
-    // MARK: - localFingerprint
-
-    public var localFingerprintForSession_Invocations: [ProteusSessionID] = []
-    public var localFingerprintForSession_MockError: Error?
-    public var localFingerprintForSession_MockMethod: ((ProteusSessionID) throws -> String)?
-    public var localFingerprintForSession_MockValue: String?
-
-    public func localFingerprint(forSession id: ProteusSessionID) throws -> String {
-        localFingerprintForSession_Invocations.append(id)
-
-        if let error = localFingerprintForSession_MockError {
-            throw error
-        }
-
-        if let mock = localFingerprintForSession_MockMethod {
-            return try mock(id)
-        } else if let mock = localFingerprintForSession_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `localFingerprintForSession`")
         }
     }
 

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockProteusServiceinterface.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockProteusServiceinterface.swift
@@ -231,49 +231,26 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         }
     }
 
-    // MARK: - fingerprint
+    // MARK: - localFingerprint
 
-    public var fingerprint_Invocations: [Void] = []
-    public var fingerprint_MockError: Error?
-    public var fingerprint_MockMethod: (() throws -> String)?
-    public var fingerprint_MockValue: String?
+    public var localFingerprint_Invocations: [Void] = []
+    public var localFingerprint_MockError: Error?
+    public var localFingerprint_MockMethod: (() throws -> String)?
+    public var localFingerprint_MockValue: String?
 
-    public func fingerprint() throws -> String {
-        fingerprint_Invocations.append(())
+    public func localFingerprint() throws -> String {
+        localFingerprint_Invocations.append(())
 
-        if let error = fingerprint_MockError {
+        if let error = localFingerprint_MockError {
             throw error
         }
 
-        if let mock = fingerprint_MockMethod {
+        if let mock = localFingerprint_MockMethod {
             return try mock()
-        } else if let mock = fingerprint_MockValue {
+        } else if let mock = localFingerprint_MockValue {
             return mock
         } else {
             fatalError("no mock for `fingerprint`")
-        }
-    }
-
-    // MARK: - localFingerprint
-
-    public var localFingerprintForSession_Invocations: [ProteusSessionID] = []
-    public var localFingerprintForSession_MockError: Error?
-    public var localFingerprintForSession_MockMethod: ((ProteusSessionID) throws -> String)?
-    public var localFingerprintForSession_MockValue: String?
-
-    public func localFingerprint(forSession id: ProteusSessionID) throws -> String {
-        localFingerprintForSession_Invocations.append(id)
-
-        if let error = localFingerprintForSession_MockError {
-            throw error
-        }
-
-        if let mock = localFingerprintForSession_MockMethod {
-            return try mock(id)
-        } else if let mock = localFingerprintForSession_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `localFingerprintForSession`")
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusServiceInterface.swift
+++ b/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusServiceInterface.swift
@@ -231,49 +231,26 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         }
     }
 
-    // MARK: - fingerprint
+    // MARK: - localFingerprint
 
-    public var fingerprint_Invocations: [Void] = []
-    public var fingerprint_MockError: Error?
-    public var fingerprint_MockMethod: (() throws -> String)?
-    public var fingerprint_MockValue: String?
+    public var localFingerprint_Invocations: [Void] = []
+    public var localFingerprint_MockError: Error?
+    public var localFingerprint_MockMethod: (() throws -> String)?
+    public var localFingerprint_MockValue: String?
 
-    public func fingerprint() throws -> String {
-        fingerprint_Invocations.append(())
+    public func localFingerprint() throws -> String {
+        localFingerprint_Invocations.append(())
 
-        if let error = fingerprint_MockError {
+        if let error = localFingerprint_MockError {
             throw error
         }
 
-        if let mock = fingerprint_MockMethod {
+        if let mock = localFingerprint_MockMethod {
             return try mock()
-        } else if let mock = fingerprint_MockValue {
+        } else if let mock = localFingerprint_MockValue {
             return mock
         } else {
             fatalError("no mock for `fingerprint`")
-        }
-    }
-
-    // MARK: - localFingerprint
-
-    public var localFingerprintForSession_Invocations: [ProteusSessionID] = []
-    public var localFingerprintForSession_MockError: Error?
-    public var localFingerprintForSession_MockMethod: ((ProteusSessionID) throws -> String)?
-    public var localFingerprintForSession_MockValue: String?
-
-    public func localFingerprint(forSession id: ProteusSessionID) throws -> String {
-        localFingerprintForSession_Invocations.append(id)
-
-        if let error = localFingerprintForSession_MockError {
-            throw error
-        }
-
-        if let mock = localFingerprintForSession_MockMethod {
-            return try mock(id)
-        } else if let mock = localFingerprintForSession_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `localFingerprintForSession`")
         }
     }
 


### PR DESCRIPTION
…ingerprint for the self client

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The user cannot see the fingerprint of their own device.

### Causes (Optional)

`proteusFingerprintLocal(sessionId: String)` doesn't send a fingerprint.

### Solutions

Jacob confirmed that we should use CoreCrypto's `proteusFingerprint()` method to get the fingerprint for the self client.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
