### PR TITLE
fix: crash when resetting session FS-1604

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -355,7 +355,7 @@ public class UserClient: ZMManagedObject, UserClientType {
             }
 
             // Delete session and fingerprint
-            try? self.deleteSession(context: syncMOC)
+            try? syncClient.deleteSession()
             syncClient.fingerprint = .none
 
             // Mark clients as needing to be refetched
@@ -656,10 +656,10 @@ public extension UserClient {
 
     /// Deletes the session between the selfClient and the given userClient
     /// If there is no session it does nothing
-    func deleteSession(context: NSManagedObjectContext? = nil) throws {
+    func deleteSession() throws {
         guard
             !isSelfClient(),
-            let context = context ?? managedObjectContext,
+            let context = managedObjectContext,
             let sessionID = proteusSessionID
         else {
             return


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes when resetting the session with another client.

### Causes

Resetting the session invokes a method to delete the proteus session for the other client. This method is called from the view context, so the code switches to the sync context to do the deletion. We also pass in the sync context to the delete method.

However, the delete session method is a method of the `UserClient`, and although we passed in the sync context, we were still trying to access other properties of the user client that may have been from the view context. This results in a crash because you can only access an object from the context it belongs to.

### Solutions

Don't pass in context to the delete session method. Instead, invoke the delete session method on the sync context instance of the user client.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
