### PR TITLE
fix: crash when setting up crypto stack in NSE FS-1631

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -547,16 +547,16 @@ public extension UserClient {
 
 extension UserClient {
 
-    private func remoteFingerprint() -> Data? {
+    func remoteFingerprint(_ proteusProvider: ProteusProviding? = nil) -> Data? {
         guard
-            let proteusProvider = managedObjectContext?.proteusProvider,
+            let proteusProvider = proteusProvider ?? managedObjectContext?.proteusProvider,
             proteusProvider.canPerform,
             let sessionID = proteusSessionID
         else {
             return nil
         }
 
-        var fingerprintData: Data? = nil
+        var fingerprintData: Data?
 
         proteusProvider.perform(
             withProteusService: { proteusService in

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -550,6 +550,7 @@ extension UserClient {
     private func remoteFingerprint() -> Data? {
         guard
             let proteusProvider = managedObjectContext?.proteusProvider,
+            proteusProvider.canPerform,
             let sessionID = proteusSessionID
         else {
             return nil
@@ -581,7 +582,7 @@ extension UserClient {
             return nil
         }
 
-        var fingerprintData: Data? = nil
+        var fingerprintData: Data?
 
         proteusProvider.perform(
             withProteusService: { proteusService in

--- a/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
@@ -29,6 +29,7 @@ public protocol ProteusProviding {
         withKeyStore keyStoreBlock: KeyStorePerformBlock<T>
     ) rethrows -> T
 
+    var canPerform: Bool { get }
 }
 
 public class ProteusProvider: ProteusProviding {
@@ -65,6 +66,13 @@ public class ProteusProvider: ProteusProviding {
         } else {
             fatal("can't access any proteus cryptography service")
         }
+    }
+
+    public var canPerform: Bool {
+        let canUseProteusService = proteusViaCoreCrypto && context.proteusService != nil
+        let canUseKeyStore = !proteusViaCoreCrypto && context.zm_cryptKeyStore != nil
+
+        return canUseProteusService || canUseKeyStore
     }
 
 }

--- a/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -1247,7 +1247,7 @@ extension UserClientTests {
 
 extension UserClientTests {
 
-    func test_GivenDeveloperFlagproteusViaCoreCryptoEnabled_itUsesCoreKrypto() {
+    func test_GivenDeveloperFlagProteusViaCoreCryptoEnabled_ItUsesCoreKrypto() {
         // GIVEN
         let context = self.syncMOC
         var mockMethodCalled = false
@@ -1282,7 +1282,7 @@ extension UserClientTests {
         }
     }
 
-    func test_GivenDeveloperFlagproteusViaCoreCryptoDisabled_itUsesCryptoBox() {
+    func test_GivenDeveloperFlagProteusViaCoreCryptoDisabled_ItUsesCryptoBox() {
         // GIVEN
         let context = self.syncMOC
         var resultOfMethod = false
@@ -1324,7 +1324,7 @@ extension UserClientTests {
         }
     }
 
-    func test_itLoadsLocalFingerprintForSelfClient_proteusViaCoreCryptoFlagEnabled() {
+    func test_itLoadsLocalFingerprintForSelfClient_ProteusViaCoreCryptoFlagEnabled() {
 
         // GIVEN
         var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
@@ -1360,7 +1360,38 @@ extension UserClientTests {
         proteusViaCoreCrypto.isOn = false
     }
 
-    func test_itLoadsRemoteFingerprintForOtherClient_proteusViaCoreCryptoFlagEnabled() {
+    func test_itDoesntLoadRemoteFingerprint_IfProteusProviderCantPerform_ProteusViaCoreCryptoFlagEnabled() {
+        // GIVEN
+        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        proteusViaCoreCrypto.isOn = true
+
+        let mockProteusService = MockProteusServiceInterface()
+        mockProteusService.remoteFingerprintForSession_MockMethod = { _ in return "" }
+
+        let mockProvider = MockProteusProvider(
+            mockProteusService: mockProteusService,
+            mockKeyStore: spyForTests(),
+            useProteusService: true
+        )
+        mockProvider.mockCanPerform = false
+
+        syncMOC.performAndWait {
+            let user = createUser(in: syncMOC)
+            let sut = createClient(for: user, createSessionWithSelfUser: false, onMOC: syncMOC)
+            sut.fingerprint = .none
+
+            // WHEN
+            _ = sut.remoteFingerprint(mockProvider)
+
+            // THEN
+            XCTAssertTrue(mockProteusService.remoteFingerprintForSession_Invocations.isEmpty)
+        }
+
+        // Cleanup
+        proteusViaCoreCrypto.isOn = false
+    }
+
+    func test_itLoadsRemoteFingerprintForOtherClient_ProteusViaCoreCryptoFlagEnabled() {
         // GIVEN
         var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
         proteusViaCoreCrypto.isOn = true

--- a/wire-ios-data-model/Tests/Source/Utils/MockProteusProvider.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/MockProteusProvider.swift
@@ -45,4 +45,9 @@ class MockProteusProvider: ProteusProviding {
             return try keyStoreBlock(mockKeyStore)
         }
     }
+
+    var mockCanPerform = true
+    var canPerform: Bool {
+        return mockCanPerform
+    }
 }

--- a/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusProvider.swift
+++ b/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusProvider.swift
@@ -47,4 +47,8 @@ class MockProteusProvider: ProteusProviding {
         }
     }
 
+    var mockCanPerform = true
+    var canPerform: Bool {
+        return mockCanPerform
+    }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes, setting up the crypto stack in the notification service extension will crash.

### Causes 

Setting up core crypto involves fetching the self user client to generate a qualified client id. When fetched, `awakeFromFetch` will be called, and if `nil`, the client's fingerprint will be set. However, in order to get the fingerprint we need an instance of the `ProteusService`, which doesn't exist at this point. As a result, the `ProteusProvider` will crash intentionally.

**Note**: the fingerprint may not always be nil

### Solutions

Added a `canPerform` api to the `ProteusProvider` to verify wether or not we are ready to perform crypto operations 

### Testing

#### Test Coverage 

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
