### PR TITLE
chore: enabled proteus via core crypto by default FS-1630

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -60,13 +60,48 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .deprecatedCallingUI:
             return "Turn on to use deprecated calling UI"
-
         }
     }
 
     public var isOn: Bool {
-        get { return Self.storage.bool(forKey: rawValue) }
-        set { Self.storage.set(newValue, forKey: rawValue) }
+        get {
+            return Self.storage.object(forKey: rawValue) as? Bool ?? defaultValue
+        }
+
+        set {
+            Self.storage.set(newValue, forKey: rawValue)
+        }
+    }
+
+    private var defaultValue: Bool {
+        switch self {
+        case .enableMLSSupport:
+            return false
+
+        case .showCreateMLSGroupToggle:
+            return false
+
+        case .proteusViaCoreCrypto:
+            return true
+
+        case .breakMyNotifications:
+            return false
+
+        case .nseV2:
+            return false
+
+        case .nseDebugging:
+            return false
+
+        case .nseDebugEntryPoint:
+            return false
+
+        case .useDevelopmentBackendAPI:
+            return false
+
+        case .deprecatedCallingUI:
+            return false
+        }
     }
 
     static public func clearAllFlags() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Refactor `DeveloperFlag` to allow specifying a default value.
- Make the default value for `proteusViaCoreCrypto` to be `true`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
