### PR TITLE
fix: core crypto key errors in NSE FS-1613

### DIFF
--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -49,14 +49,16 @@ public class CoreCryptoConfigProvider {
 
     public func createFullConfiguration(
         sharedContainerURL: URL,
-        selfUser: ZMUser
+        selfUser: ZMUser,
+        createKeyIfNeeded: Bool
     ) throws -> CoreCryptoConfiguration {
 
         let qualifiedClientID = try clientID(of: selfUser)
 
         let initialConfig = try createInitialConfiguration(
             sharedContainerURL: sharedContainerURL,
-            userID: selfUser.remoteIdentifier
+            userID: selfUser.remoteIdentifier,
+            createKeyIfNeeded: createKeyIfNeeded
         )
 
         return CoreCryptoConfiguration(
@@ -68,7 +70,8 @@ public class CoreCryptoConfigProvider {
 
     public func createInitialConfiguration(
         sharedContainerURL: URL,
-        userID: UUID
+        userID: UUID,
+        createKeyIfNeeded: Bool
     ) throws -> (path: String, key: String) {
 
         let accountDirectory = CoreDataStack.accountDataFolder(
@@ -80,7 +83,7 @@ public class CoreCryptoConfigProvider {
         let coreCryptoDirectory = accountDirectory.appendingPathComponent("corecrypto")
 
         do {
-            let key = try coreCryptoKeyProvider.coreCryptoKey()
+            let key = try coreCryptoKeyProvider.coreCryptoKey(createIfNeeded: createKeyIfNeeded)
             return (
                 path: coreCryptoDirectory.path,
                 key: key.base64EncodedString()

--- a/wire-ios-data-model/Tests/MLS/CoreCryptoConfigProviderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CoreCryptoConfigProviderTests.swift
@@ -31,7 +31,7 @@ class MockCoreCryptoKeyProvider: CoreCryptoKeyProvider {
 
     var coreCryptoKeyMock: CoreCryptoKeyMock?
 
-    override func coreCryptoKey() throws -> Data {
+    override func coreCryptoKey(createIfNeeded: Bool) throws -> Data {
         guard let mock = coreCryptoKeyMock else { throw MockError.unmockedMethodCalled }
         return try mock()
     }
@@ -70,7 +70,8 @@ class CoreCryptoConfigProviderTests: ZMConversationTestsBase {
             // WHEN
             let configuration = try self.sut.createInitialConfiguration(
                 sharedContainerURL: OtrBaseTest.sharedContainerURL,
-                userID: selfUser.remoteIdentifier
+                userID: selfUser.remoteIdentifier,
+                createKeyIfNeeded: true
             )
 
             // THEN
@@ -96,7 +97,8 @@ class CoreCryptoConfigProviderTests: ZMConversationTestsBase {
             // WHEN
             let configuration = try self.sut.createFullConfiguration(
                 sharedContainerURL: OtrBaseTest.sharedContainerURL,
-                selfUser: selfUser
+                selfUser: selfUser,
+                createKeyIfNeeded: true
             )
 
             // THEN
@@ -119,7 +121,8 @@ class CoreCryptoConfigProviderTests: ZMConversationTestsBase {
                 // WHEN
                 _ = try sut.createFullConfiguration(
                     sharedContainerURL: OtrBaseTest.sharedContainerURL,
-                    selfUser: selfUser
+                    selfUser: selfUser,
+                    createKeyIfNeeded: true
                 )
             }
         }
@@ -143,7 +146,8 @@ class CoreCryptoConfigProviderTests: ZMConversationTestsBase {
                 // WHEN
                 _ = try sut.createFullConfiguration(
                     sharedContainerURL: OtrBaseTest.sharedContainerURL,
-                    selfUser: selfUser
+                    selfUser: selfUser,
+                    createKeyIfNeeded: true
                 )
             }
         }

--- a/wire-ios-data-model/Tests/MLS/CoreCryptoKeyProviderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CoreCryptoKeyProviderTests.swift
@@ -1,0 +1,73 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireDataModel
+import XCTest
+
+class CoreCryptoKeyProviderTests: XCTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+        try? KeychainManager.deleteItem(CoreCryptoKeychainItem())
+    }
+
+    // MARK: Fetching & creating key
+
+    func test_itFetchesCoreCryptoKey() throws {
+        // GIVEN
+        let sut = CoreCryptoKeyProvider()
+
+        let item = CoreCryptoKeychainItem()
+        let expectedKey = try KeychainManager.generateKey(numberOfBytes: 32)
+        try KeychainManager.storeItem(item, value: expectedKey)
+
+        // WHEN
+        let key = try sut.coreCryptoKey(createIfNeeded: false)
+
+        // THEN
+        XCTAssertEqual(key, expectedKey)
+    }
+
+    func test_itDoesntCreateCoreCryptoKey_WhenNotNeeded() {
+        // GIVEN
+        let sut = CoreCryptoKeyProvider()
+
+        // WHEN
+        XCTAssertThrowsError(try sut.coreCryptoKey(createIfNeeded: false))
+
+        // THEN
+        XCTAssertNil(try? KeychainManager.fetchItem(CoreCryptoKeychainItem()))
+    }
+
+    func test_itCreatesCoreCryptoKey_WhenNeeded() throws {
+        // GIVEN
+        let sut = CoreCryptoKeyProvider()
+
+        // WHEN
+        let key = try sut.coreCryptoKey(createIfNeeded: true)
+
+        // THEN
+        XCTAssertNotNil(key)
+
+        let storedKey: Data? = try? KeychainManager.fetchItem(CoreCryptoKeychainItem())
+        XCTAssertNotNil(storedKey)
+        XCTAssertEqual(key, storedKey)
+    }
+
+}

--- a/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
@@ -180,7 +180,7 @@ class LegacyPersistedDataPatchesTests: ZMBaseManagedObjectTest {
         XCTAssertFalse(patchApplied, "Version: \(Bundle(for: ZMUser.self).infoDictionary!["CFBundleShortVersionString"] as! String)")
     }
 
-    func testThatItMigratesClientsSessionIdentifiers() {
+    func testThatItMigratesClientsSessionIdentifiers() throws {
 
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
@@ -213,7 +213,8 @@ class LegacyPersistedDataPatchesTests: ZMBaseManagedObjectTest {
             LegacyPersistedDataPatch.applyAll(in: self.syncMOC, fromVersion: "0.0.0")
 
             // THEN
-            let readData = try! Data(contentsOf: newSession)
+            let readData = try? Data(contentsOf: newSession)
+            XCTAssertNotNil(readData)
             XCTAssertEqual(readData, previousData)
             XCTAssertFalse(FileManager.default.fileExists(atPath: oldSession.path))
             XCTAssertTrue(FileManager.default.fileExists(atPath: newSession.path))

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		63709F652993E7A600577D4B /* libcore_crypto_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 63709F642993E7A600577D4B /* libcore_crypto_ffi.a */; };
 		63709F6B2994108700577D4B /* CoreCrypto in Frameworks */ = {isa = PBXBuildFile; productRef = 63709F6A2994108700577D4B /* CoreCrypto */; };
 		63709F6D2994108700577D4B /* LibCoreCrypto in Frameworks */ = {isa = PBXBuildFile; productRef = 63709F6C2994108700577D4B /* LibCoreCrypto */; };
+		6374562229C3323D001D1A33 /* CoreCryptoKeyProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6374562129C3323D001D1A33 /* CoreCryptoKeyProviderTests.swift */; };
 		6388054A240EA8990043B641 /* ZMClientMessageTests+Composite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63880548240EA8950043B641 /* ZMClientMessageTests+Composite.swift */; };
 		638805652410FE920043B641 /* ButtonState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638805642410FE920043B641 /* ButtonState.swift */; };
 		63AFE2D6244F49A90003F619 /* GenericMessage+MessageCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFE2D5244F49A90003F619 /* GenericMessage+MessageCapable.swift */; };
@@ -1136,6 +1137,7 @@
 		6354BDF42747BD9600880D50 /* ZMConversationTests+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+Federation.swift"; sourceTree = "<group>"; };
 		63709F632993E70B00577D4B /* CoreCrypto */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = CoreCrypto; sourceTree = "<group>"; };
 		63709F642993E7A600577D4B /* libcore_crypto_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcore_crypto_ffi.a; path = CoreCrypto/lib/libcore_crypto_ffi.a; sourceTree = "<group>"; };
+		6374562129C3323D001D1A33 /* CoreCryptoKeyProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoKeyProviderTests.swift; sourceTree = "<group>"; };
 		63880548240EA8950043B641 /* ZMClientMessageTests+Composite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Composite.swift"; sourceTree = "<group>"; };
 		63880556240FFE7A0043B641 /* zmessaging2.80.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.80.0.xcdatamodel; sourceTree = "<group>"; };
 		638805642410FE920043B641 /* ButtonState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonState.swift; sourceTree = "<group>"; };
@@ -2177,6 +2179,7 @@
 				EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */,
 				EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */,
 				63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */,
+				6374562129C3323D001D1A33 /* CoreCryptoKeyProviderTests.swift */,
 				63FACD55291BC598003AB25D /* MLSClientIdTests.swift */,
 			);
 			path = MLS;
@@ -3980,6 +3983,7 @@
 				BFE764431ED5AAE500C65C3E /* ZMConversation+TeamsTests.swift in Sources */,
 				F14B9C6F212DB467004B6D7D /* ZMBaseManagedObjectTest+Helpers.swift in Sources */,
 				16626508217F4E0B00300F45 /* GenericMessageTests+Hashing.swift in Sources */,
+				6374562229C3323D001D1A33 /* CoreCryptoKeyProviderTests.swift in Sources */,
 				F9A708441CAEEB7500C2F5FE /* ZMConnectionTests.m in Sources */,
 				F9FD75761E2E79BF00B4558B /* ConversationListObserverTests.swift in Sources */,
 				BF3493EB1EC34C0B00B0C314 /* TeamTests.swift in Sources */,

--- a/wire-ios-notification-engine/Sources/CoreCrypto/NotificationSession+CoreCrypto.swift
+++ b/wire-ios-notification-engine/Sources/CoreCrypto/NotificationSession+CoreCrypto.swift
@@ -37,7 +37,8 @@ extension NotificationSession {
             do {
                 let configuration = try provider.createFullConfiguration(
                     sharedContainerURL: sharedContainerURL,
-                    selfUser: .selfUser(in: syncContext)
+                    selfUser: .selfUser(in: syncContext),
+                    createKeyIfNeeded: false
                 )
 
                 let safeCoreCrypto = try SafeCoreCrypto(coreCryptoConfiguration: configuration)

--- a/wire-ios-notification-engine/WireNotificationEngineTests/NotificationSessionTests+CryptoStack.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/NotificationSessionTests+CryptoStack.swift
@@ -21,6 +21,7 @@ import XCTest
 import Foundation
 import WireUtilities
 import WireTransport
+import WireDataModel
 
 class NotificationSessionTests_CryptoStack: BaseTest {
 
@@ -28,6 +29,11 @@ class NotificationSessionTests_CryptoStack: BaseTest {
     private var mlsFlag = DeveloperFlag.enableMLSSupport
 
     // MARK: - Life cycle
+
+    override class func setUp() {
+        super.setUp()
+        createCoreCryptoKeyIfNeeded()
+    }
 
     override func setUp() {
         super.setUp()
@@ -41,6 +47,13 @@ class NotificationSessionTests_CryptoStack: BaseTest {
         mlsFlag.isOn = false
         BackendInfo.apiVersion = nil
         super.tearDown()
+    }
+
+    // MARK: - Key generation
+
+    class func createCoreCryptoKeyIfNeeded() {
+        let keyProvider = CoreCryptoKeyProvider()
+        _ = try? keyProvider.coreCryptoKey(createIfNeeded: true)
     }
 
     // MARK: - Tests

--- a/wire-ios-share-engine/Sources/CoreCrypto/SharingSession+CoreCrypto.swift
+++ b/wire-ios-share-engine/Sources/CoreCrypto/SharingSession+CoreCrypto.swift
@@ -40,7 +40,8 @@ extension SharingSession {
             do {
                 let configuration = try provider.createFullConfiguration(
                     sharedContainerURL: sharedContainerURL,
-                    selfUser: .selfUser(in: syncContext)
+                    selfUser: .selfUser(in: syncContext),
+                    createKeyIfNeeded: false
                 )
 
                 let safeCoreCrypto = try SafeCoreCrypto(coreCryptoConfiguration: configuration)
@@ -54,7 +55,7 @@ extension SharingSession {
                 if DeveloperFlag.enableMLSSupport.isOn, syncContext.mlsController == nil {
                     syncContext.mlsController = MLSEncryptionController(coreCrypto: safeCoreCrypto)
                 }
-                
+
                 WireLogger.coreCrypto.info("success: setup crypto stack")
             } catch {
                 WireLogger.coreCrypto.error("fail: setup crypto stack: \(String(describing: error))")

--- a/wire-ios-share-engine/WireShareEngineTests/SharingSessionTests+CryptoStack.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/SharingSessionTests+CryptoStack.swift
@@ -31,6 +31,11 @@ class SharingSessionTestsCryptoStack: BaseTest {
 
     // MARK: - Life cycle
 
+    override class func setUp() {
+        super.setUp()
+        createCoreCryptoKeyIfNeeded()
+    }
+
     override func setUp() {
         super.setUp()
         proteusFlag.isOn = false
@@ -43,6 +48,13 @@ class SharingSessionTestsCryptoStack: BaseTest {
         mlsFlag.isOn = false
         BackendInfo.apiVersion = nil
         super.tearDown()
+    }
+
+    // MARK: - Key generation
+
+    class func createCoreCryptoKeyIfNeeded() {
+        let keyProvider = CoreCryptoKeyProvider()
+        _ = try? keyProvider.coreCryptoKey(createIfNeeded: true)
     }
 
     // MARK: - Tests

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+CoreCrypto.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+CoreCrypto.swift
@@ -49,7 +49,8 @@ extension ZMUserSession {
             do {
                 let configuration = try provider.createInitialConfiguration(
                     sharedContainerURL: sharedContainerURL,
-                    userID: userID
+                    userID: userID,
+                    createKeyIfNeeded: true
                 )
 
                 let coreCrypto = try SafeCoreCrypto(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Decrypting events in the NSE while the phone is locked with a passcode is causing a crash due to the proteus service being nil.

### Causes 

The reason the proteus service is nil is because we're not able to fetch the core crypto key from the keychain in order to create an instance of core crypto.

Fetching the core crypto key doesn't work because when the key is created we do not specify a value for the `kSecAttrAccessible` attribute. Since none is specified, it defaults to `kSecAttrAccessibleWhenUnlocked`. That means once we try to fetch the key from the keychain while the device is locked, we will fail, since it's only accessible when the device is unlocked.

### Solutions

Set `kSecAttrAccessibleAfterFirstUnlock` as the value for the `kSecAttrAccessible` attribute when creating / fetching the key.

**Note:** keychain items are not cleared on app uninstallation. So we need to add some logic to delete the existing keychain item and recreate a new one with the correct accessibility attribute. This only affects us internally, we would remove this migration logic before releasing.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
