### PR TITLE
chore: Update the `setupObserver` method in NotificationEngine's Operation Loop to match Share Engine's `setupObserver` method

### DIFF
--- a/wire-ios-notification-engine/Sources/Synchronization/OperationLoop.swift
+++ b/wire-ios-notification-engine/Sources/Synchronization/OperationLoop.swift
@@ -96,19 +96,19 @@ public final class RequestGeneratorStore {
 
 
 final class RequestGeneratorObserver {
-    
+
     private let context : NSManagedObjectContext
     public var observedGenerator: ZMTransportRequestGenerator? = nil
-    
+
     init(context: NSManagedObjectContext) {
         self.context = context
     }
-    
+
     public func nextRequest() -> ZMTransportRequest? {
         guard let request = observedGenerator?() else { return nil }
         return request
     }
-    
+
 }
 
 final class OperationLoop : NSObject, RequestAvailableObserver {
@@ -121,7 +121,7 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
     private unowned let userContext: NSManagedObjectContext
     private let callBackQueue: OperationQueue
     private var tokens: [NSObjectProtocol] = []
-    
+
     public var changeClosure: ChangeClosure?
     public var requestAvailableClosure: RequestAvailableClosure?
 
@@ -129,11 +129,11 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
         self.userContext = userContext
         self.syncContext = syncContext
         self.callBackQueue = callBackQueue
-        
+
         super.init()
-        
+
         RequestAvailableNotification.addObserver(self)
-        
+
         tokens.append(setupObserver(for: userContext) { [weak self] (note, inserted, updated) in
             self?.userInterfaceContextDidSave(notification: note, insertedObjects: inserted, updatedObjects: updated)
         })
@@ -149,12 +149,12 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
 
     func setupObserver(for context: NSManagedObjectContext, onSave: @escaping SaveClosure) -> NSObjectProtocol {
         return NotificationCenter.default.addObserver(forName: .NSManagedObjectContextDidSave, object: context, queue: callBackQueue) { note in
-            if let insertedObjects = note.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>, let updatedObjects = note.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> {
-                onSave(note, insertedObjects, updatedObjects)
-            }
+            let insertedObjects = (note.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>) ?? Set<NSManagedObject>()
+            let updatedObjects = (note.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) ?? Set<NSManagedObject>()
+            onSave(note, insertedObjects, updatedObjects)
         }
     }
-    
+
     func merge(changes notification: Notification, intoContext context: NSManagedObjectContext) {
         let moc = notification.object as! NSManagedObjectContext
         let userInfo = moc.userInfo as NSDictionary as! [String: Any]
@@ -166,21 +166,21 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
             NotificationCenter.default.post(name: contextWasMergedNotification, object: context, userInfo: notification.userInfo)
         }
     }
-    
+
     func syncContextDidSave(notification: Notification, insertedObjects: Set<NSManagedObject>, updatedObjects: Set<NSManagedObject>) {
         merge(changes: notification, intoContext: userContext)
-        
+
         syncContext.performGroupedBlock {
             self.changeClosure?(Set(insertedObjects).union(updatedObjects))
         }
     }
-    
+
     func userInterfaceContextDidSave(notification: Notification, insertedObjects: Set<NSManagedObject>, updatedObjects: Set<NSManagedObject>) {
         merge(changes: notification, intoContext: syncContext)
-        
+
         let insertedObjectsIds = insertedObjects.map({ $0.objectID })
         let updatedObjectsIds  =  updatedObjects.map({ $0.objectID })
-        
+
         syncContext.performGroupedBlock {
             let insertedObjects = insertedObjectsIds.compactMap(self.syncContext.object)
             let updatedObjects = updatedObjectsIds.compactMap(self.syncContext.object)
@@ -188,7 +188,7 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
             self.changeClosure?(Set(insertedObjects).union(updatedObjects))
         }
     }
-    
+
     func newRequestsAvailable() {
         requestAvailableClosure?()
     }
@@ -199,11 +199,11 @@ final class RequestGeneratingOperationLoop {
 
     private let operationLoop: OperationLoop!
     private let callBackQueue: OperationQueue
-    
+
     private let requestGeneratorStore: RequestGeneratorStore
     private let requestGeneratorObserver: RequestGeneratorObserver
     private unowned let transportSession: ZMTransportSession
-    
+
 
     init(userContext: NSManagedObjectContext, syncContext: NSManagedObjectContext, callBackQueue: OperationQueue = .main, requestGeneratorStore: RequestGeneratorStore, transportSession: ZMTransportSession) {
         self.callBackQueue = callBackQueue
@@ -221,7 +221,7 @@ final class RequestGeneratingOperationLoop {
         requestGeneratorStore.changeTrackers.forEach {
             $0.objectsDidChange(changes)
         }
-        
+
         enqueueRequests()
     }
 
@@ -229,14 +229,14 @@ final class RequestGeneratingOperationLoop {
         transportSession.tearDown()
         requestGeneratorStore.tearDown()
     }
-    
+
     fileprivate func enqueueRequests() {
         var result : ZMTransportEnqueueResult
-        
+
         repeat {
             result = transportSession.attemptToEnqueueSyncRequest(generator: { [weak self] in self?.requestGeneratorObserver.nextRequest() })
         } while result.didGenerateNonNullRequest && result.didHaveLessRequestThanMax
-        
+
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we update the `setupObserver` method of the `OperationLoop` in `NotificationEngine` to match the same method of the `OperationLoop` in `ShareEngine`. That change came up because of changes Apple made in Core Data and iOS 16. More information can be found in this PR #95

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
