### PR TITLE
fix: Share Extension - Show an alert when an attachment exceeds the size limit of 25MB - SQSERVICES - 1788

### DIFF
--- a/wire-ios/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -315,8 +315,10 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
 
             case .error(let error):
                 WireLogger.shareExtension.error("progress event: error: \(error.localizedDescription)")
-                if let errorDescription = (error as? UnsentSendableError )?.errorDescription {
-                    let alert = UIAlertController.alertWithOKButton(title: nil, message: errorDescription)
+                if let errorDescription = (error as? UnsentSendableError)?.errorDescription {
+                    let alert = UIAlertController.alertWithOKButton(title: nil, message: errorDescription) { _ in
+                        self.extensionContext?.completeRequest(returningItems: [])
+                    }
 
                     self.present(alert, animated: true) {
                         self.popConfigurationViewController()

--- a/wire-ios/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -163,9 +163,9 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
 
     private func recreateSharingSession(account: Account?) throws {
         guard let applicationGroupIdentifier = Bundle.main.applicationGroupIdentifier,
-            let hostBundleIdentifier = Bundle.main.hostBundleIdentifier,
-            let accountIdentifier = account?.userIdentifier
-            else { return }
+              let hostBundleIdentifier = Bundle.main.hostBundleIdentifier,
+              let accountIdentifier = account?.userIdentifier
+        else { return }
 
         let legacyConfig = AppLockController.LegacyConfig.fromBundle()
 
@@ -461,7 +461,7 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
     private func presentChooseConversation() {
         requireLocalAuthenticationIfNeeded { [weak self] in
             guard let `self` = self,
-                self.localAuthenticationStatus == .granted else { return }
+                  self.localAuthenticationStatus == .granted else { return }
 
             self.showChooseConversation()
         }
@@ -561,7 +561,7 @@ extension ShareExtensionViewController {
 
             DispatchQueue.main.async {
                 if case .granted = result, let context = context as? LAContext {
-                  try? self.sharingSession?.unlockDatabase(with: context)
+                    try? self.sharingSession?.unlockDatabase(with: context)
                 }
 
                 self.authenticationEvaluated(with: result, completion: completion)

--- a/wire-ios/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/wire-ios/Wire-iOS Share Extension/UnsentSendable.swift
@@ -234,10 +234,6 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
                     return completion()
                 }
 
-                if url?.fileSize > AccountManager.fileSizeLimitInBytes {
-                    weakSelf.error = .fileSizeTooBig
-                    return completion()
-                }
                 weakSelf.prepareAsFileData(name: url?.lastPathComponent, completion: completion)
             }
         } else if typePass {
@@ -291,11 +287,22 @@ class UnsentFileSendable: UnsentSendableBase, UnsentSendable {
             }
 
             if let data = data as? Data {
+                guard data.count <= AccountManager.fileSizeLimitInBytes else {
+                    self?.error = .fileSizeTooBig
+                    return completion()
+                }
+
                 self?.prepareForSending(withUTI: UTIString,
                                         name: name,
                                         data: data,
                                         completion: prepareColsure)
             } else if let dataURL = data as? URL {
+
+                guard dataURL.fileSize ?? .max <= AccountManager.fileSizeLimitInBytes else {
+                    self?.error = .fileSizeTooBig
+                    return completion()
+                }
+
                 self?.prepareForSending(withUTI: UTIString,
                                         name: name,
                                         dataURL: dataURL,

--- a/wire-ios/Wire-iOS Share Extension/UnsentSendable.swift
+++ b/wire-ios/Wire-iOS Share Extension/UnsentSendable.swift
@@ -54,7 +54,7 @@ extension UnsentSendableError: LocalizedError {
     }
 }
 
-/// This protocol defines the basic methods that an Object needes to conform to 
+/// This protocol defines the basic methods that an Object needes to conform to
 /// in order to be prepared and sent. A consumer should ask the objects if they need to perform
 /// perparation operations and call `prepare` before calling `send`.
 protocol UnsentSendable {
@@ -159,7 +159,7 @@ final class UnsentImageSendable: UnsentSendableBase, UnsentSendable {
             // Tries to load the content from local URL...
 
             if let cfUrl = (url as? URL) as CFURL?,
-                let imageSource = CGImageSourceCreateWithURL(cfUrl, nil) {
+               let imageSource = CGImageSourceCreateWithURL(cfUrl, nil) {
                 let options: [NSString: Any] = [
                     kCGImageSourceThumbnailMaxPixelSize: longestDimension,
                     kCGImageSourceCreateThumbnailFromImageAlways: true,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix an issue where we would try and send an attachment over 25 MB but it would eventually fail since we have a size limit. So instead of trying to send it, we show an alert that we can't send an attachment over 25 MB. 

In addition to that we dismiss the Share Extension when user taps OK on the alert. That was also something that it was missing and fixed with this PR.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
