### PR TITLE
feat: switch backend from developer menu FS-1654

### DIFF
--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		010497E12940F5DE0046124D /* AuthenticationShowCustomBackendInfoHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010497E02940F5DE0046124D /* AuthenticationShowCustomBackendInfoHandler.swift */; };
 		0119F3D029969CEA006AE3A8 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE9A857529896B4D00064A9C /* CrashReporter.xcframework */; };
 		014C81BE29BB6BC600258FF8 /* ConversationListViewController+ConversationListTabBarControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6E9FEF231D4CDF000B7785 /* ConversationListViewController+ConversationListTabBarControllerDelegate.swift */; };
+		017ABBBA299541F50004C243 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E56CA37428588C4F00CD2045 /* Colors.xcassets */; };
+		017ABBBB299542BA0004C243 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F1FDF2C521ADA3F000E037A1 /* Images.xcassets */; };
 		01E29C8C2996A2710024E1A7 /* CrashReporter.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE9A857529896B4D00064A9C /* CrashReporter.xcframework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		01E29C8D2996A2710024E1A7 /* Datadog.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE82971229719FC400F12CAA /* Datadog.xcframework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		01E29C8E2996A2710024E1A7 /* DatadogCrashReporting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE9A857A29896CDA00064A9C /* DatadogCrashReporting.xcframework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -1214,6 +1216,8 @@
 		EE01D08725ADA3D5001DB205 /* AppLockModule.Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE01D08225ADA3D5001DB205 /* AppLockModule.Router.swift */; };
 		EE01D08825ADA3D5001DB205 /* AppLockModule.Interactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE01D08325ADA3D5001DB205 /* AppLockModule.Interactor.swift */; };
 		EE01D08925ADA3D5001DB205 /* AppLockModule.View.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE01D08425ADA3D5001DB205 /* AppLockModule.View.swift */; };
+		EE08ADED29C8862800B6C14D /* SwitchBackendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE08ADEC29C8862800B6C14D /* SwitchBackendView.swift */; };
+		EE08ADEF29C8863000B6C14D /* SwitchBackendViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE08ADEE29C8863000B6C14D /* SwitchBackendViewModel.swift */; };
 		EE09DE6025B24B2000B515F0 /* AppLockModuleRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09DE5E25B24B2000B515F0 /* AppLockModuleRouterTests.swift */; };
 		EE0DE1CD21B172BF00CF3C4E /* ConversationCreateGuestsSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0DE1CC21B172BF00CF3C4E /* ConversationCreateGuestsSectionController.swift */; };
 		EE118C012031D1C300BC68D6 /* MarkdownTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE118BFF2031D17000BC68D6 /* MarkdownTextViewTests.swift */; };
@@ -3202,6 +3206,8 @@
 		EE01D08225ADA3D5001DB205 /* AppLockModule.Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModule.Router.swift; sourceTree = "<group>"; };
 		EE01D08325ADA3D5001DB205 /* AppLockModule.Interactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModule.Interactor.swift; sourceTree = "<group>"; };
 		EE01D08425ADA3D5001DB205 /* AppLockModule.View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModule.View.swift; sourceTree = "<group>"; };
+		EE08ADEC29C8862800B6C14D /* SwitchBackendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBackendView.swift; sourceTree = "<group>"; };
+		EE08ADEE29C8863000B6C14D /* SwitchBackendViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBackendViewModel.swift; sourceTree = "<group>"; };
 		EE09DE5E25B24B2000B515F0 /* AppLockModuleRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockModuleRouterTests.swift; sourceTree = "<group>"; };
 		EE0DE1CC21B172BF00CF3C4E /* ConversationCreateGuestsSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCreateGuestsSectionController.swift; sourceTree = "<group>"; };
 		EE118BFF2031D17000BC68D6 /* MarkdownTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextViewTests.swift; sourceTree = "<group>"; };
@@ -7191,6 +7197,15 @@
 			path = "App Lock";
 			sourceTree = "<group>";
 		};
+		EE08ADEB29C8860600B6C14D /* SwitchBackend */ = {
+			isa = PBXGroup;
+			children = (
+				EE08ADEC29C8862800B6C14D /* SwitchBackendView.swift */,
+				EE08ADEE29C8863000B6C14D /* SwitchBackendViewModel.swift */,
+			);
+			path = SwitchBackend;
+			sourceTree = "<group>";
+		};
 		EE2DF75C2875E29F0028ECA2 /* PreferredAPIVersion */ = {
 			isa = PBXGroup;
 			children = (
@@ -7239,6 +7254,7 @@
 				EE742AB7284DE66400A6B5F3 /* DeveloperToolsViewModel.swift */,
 				EECA90A8287449D10024B301 /* DeveloperFlags */,
 				EE2DF75C2875E29F0028ECA2 /* PreferredAPIVersion */,
+				EE08ADEB29C8860600B6C14D /* SwitchBackend */,
 			);
 			path = DeveloperTools;
 			sourceTree = "<group>";
@@ -9234,6 +9250,7 @@
 				5E0F75C02268A0D7006C991E /* UIBarButtonItem+StyleKit.swift in Sources */,
 				5E8FFC1421EF3F9B0052DF03 /* BackupRestoreController.swift in Sources */,
 				6305206224FFEF9600ED295A /* OrientableView.swift in Sources */,
+				EE08ADEF29C8863000B6C14D /* SwitchBackendViewModel.swift in Sources */,
 				87C539561E8E516400084F94 /* BoundsAwareFlowLayout.swift in Sources */,
 				D5D89782201A25E000FAF69C /* Analytics+Services.swift in Sources */,
 				5E35F7802183131400D3F4FE /* ConversationLinkAttachmentCell.swift in Sources */,
@@ -9324,6 +9341,7 @@
 				EF2F6DA320ED11D2007B6D70 /* UIColor+Accent.swift in Sources */,
 				061275DE26F304CB006E8D4C /* DragInteractionRestrictionTextView.swift in Sources */,
 				5EBBE97121878D09008BC1B7 /* ConversationMessageToolboxCell.swift in Sources */,
+				EE08ADED29C8862800B6C14D /* SwitchBackendView.swift in Sources */,
 				8775BF1E2007CFB200A8AD93 /* UIControlBlockAPI.swift in Sources */,
 				EF1A461E21ADACF50009B6B9 /* RightIconDetailsCell.swift in Sources */,
 				5EE73BF3212323C70032986D /* RegistrationCredentialsVerifiedEventHandler.swift in Sources */,

--- a/wire-ios/Wire-iOS/Resources/Settings.bundle/Root.plist
+++ b/wire-ios/Wire-iOS/Resources/Settings.bundle/Root.plist
@@ -51,32 +51,6 @@
 			<false/>
 		</dict>
 		<dict>
-			<key>Titles</key>
-			<array>
-				<string>Production</string>
-				<string>Staging</string>
-				<string>Anta (Federated)</string>
-				<string>Bella (Federated)</string>
-				<string>Chala (Federated)</string>
-			</array>
-			<key>Values</key>
-			<array>
-				<string>production</string>
-				<string>staging</string>
-				<string>anta</string>
-				<string>bella</string>
-				<string>chala</string>
-			</array>
-			<key>Type</key>
-			<string>PSMultiValueSpecifier</string>
-			<key>Title</key>
-			<string>Backend (Logout before switching)</string>
-			<key>Key</key>
-			<string>ZMBackendEnvironmentType</string>
-			<key>DefaultValue</key>
-			<string>production</string>
-		</dict>
-		<dict>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 			<key>Title</key>

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -128,18 +128,7 @@ final class DeveloperToolsViewModel: ObservableObject {
             ]
         ))
 
-        sections.append(Section(
-            header: "Backend info",
-            items: [
-                .text(TextItem(title: "Name", value: backendName)),
-                .text(TextItem(title: "Domain", value: backendDomain)),
-                .text(TextItem(title: "API version", value: apiVersion)),
-                .destination(DestinationItem(title: "Preferred API version", makeView: {
-                    AnyView(PreferredAPIVersionView(viewModel: PreferredAPIVersionViewModel()))
-                })),
-                .text(TextItem(title: "Is federation enabled?", value: isFederationEnabled))
-            ]
-        ))
+        sections.append(backendInfoSection)
 
         if let selfUser = selfUser {
             sections.append(Section(
@@ -174,6 +163,37 @@ final class DeveloperToolsViewModel: ObservableObject {
                 ]
             ))
         }
+    }
+
+    private lazy var backendInfoSection: Section = {
+        let header = "Backend info"
+        var items = [Item]()
+
+        items.append(.text(TextItem(title: "Name", value: backendName)))
+
+        if canSwitchBackend {
+            items.append(.destination(DestinationItem(title: "Switch backend", makeView: {
+                AnyView(SwitchBackendView(viewModel: SwitchBackendViewModel()))
+            })))
+        }
+
+        items.append(.text(TextItem(title: "Domain", value: backendDomain)))
+        items.append(.text(TextItem(title: "API version", value: apiVersion)))
+        items.append(.destination(DestinationItem(title: "Preferred API version", makeView: {
+            AnyView(PreferredAPIVersionView(viewModel: PreferredAPIVersionViewModel()))
+        })))
+
+        items.append(.text(TextItem(title: "Is federation enabled?", value: isFederationEnabled)))
+
+        return Section(
+            header: header,
+            items: items
+        )
+    }()
+
+    private var canSwitchBackend: Bool {
+        guard let sessionManager = SessionManager.shared else { return false }
+        return sessionManager.canSwitchBackend() == nil
     }
 
     // MARK: - Events

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendView.swift
@@ -47,11 +47,8 @@ struct SwitchBackendView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onTapGesture {
             viewModel.handleEvent(.itemTapped(item))
-        }.alert(isPresented: $viewModel.isAlertPresented) {
-            Alert(
-                title: Text(""),
-                message: Text(viewModel.alertMessage)
-            )
+        }.alert(item: $viewModel.alertItem) { alertItem in
+            Alert(title: Text(""), message: Text(alertItem.message))
         }
 
     }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendView.swift
@@ -1,0 +1,69 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+
+@available(iOS 14, *)
+struct SwitchBackendView: View {
+
+    // MARK: - Properties
+
+    @StateObject
+    var viewModel: SwitchBackendViewModel
+
+    // MARK: - Views
+
+    var body: some View {
+        List(viewModel.items, rowContent: itemView(for:))
+            .navigationTitle("Switch backend")
+            .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func itemView(for item: SwitchBackendViewModel.Item) -> some View {
+        HStack {
+            Text(item.title)
+            Spacer()
+
+            if viewModel.selectedItemID == item.id {
+                Image(systemName: "checkmark")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onTapGesture {
+            viewModel.handleEvent(.itemTapped(item))
+        }.alert(isPresented: $viewModel.isAlertPresented) {
+            Alert(
+                title: Text(""),
+                message: Text(viewModel.alertMessage)
+            )
+        }
+
+    }
+}
+
+// MARK: - Previews
+
+@available(iOS 14, *)
+struct SwitchBackendView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        SwitchBackendView(viewModel: SwitchBackendViewModel())
+    }
+
+}

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendViewModel.swift
@@ -1,0 +1,93 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireTransport
+
+@available(iOS 14, *)
+final class SwitchBackendViewModel: ObservableObject {
+
+    // MARK: - Models
+
+    struct Item: Identifiable {
+
+        let id = UUID()
+        let title: String
+        let value: EnvironmentType
+
+    }
+
+    enum Event {
+
+        case itemTapped(Item)
+
+    }
+
+    // MARK: - State
+
+    let items: [Item]
+
+    @Published
+    var selectedItemID: Item.ID
+
+    @Published
+    var isAlertPresented = false
+
+    @Published
+    var alertMessage = ""
+
+    // MARK: - Life cycle
+
+    init() {
+        items = [
+            Item(title: "Production", value: .production),
+            Item(title: "Staging", value: .staging),
+            Item(title: "Anta", value: .anta),
+            Item(title: "Bella", value: .bella),
+            Item(title: "Chala", value: .chala)
+        ]
+
+        let selectedType = BackendEnvironment.shared.environmentType.value
+
+        // Initial selection
+        let selectedItem = items.first { item in
+            item.value == selectedType
+        }!
+
+        selectedItemID = selectedItem.id
+    }
+
+    // MARK: - Events
+
+    func handleEvent(_ event: Event) {
+        switch event {
+        case let .itemTapped(item):
+            selectedItemID = item.id
+
+            if let environment = BackendEnvironment(type: item.value) {
+                BackendEnvironment.shared = environment
+                alertMessage = "Backend switched! Please restart the app"
+                isAlertPresented = true
+            } else {
+                alertMessage = "Failed to switch backend"
+                isAlertPresented = true
+            }
+        }
+    }
+
+}

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/SwitchBackend/SwitchBackendViewModel.swift
@@ -46,10 +46,14 @@ final class SwitchBackendViewModel: ObservableObject {
     var selectedItemID: Item.ID
 
     @Published
-    var isAlertPresented = false
+    var alertItem: AlertItem?
 
-    @Published
-    var alertMessage = ""
+    struct AlertItem: Identifiable {
+
+        let id = UUID()
+        let message: String
+
+    }
 
     // MARK: - Life cycle
 
@@ -81,11 +85,9 @@ final class SwitchBackendViewModel: ObservableObject {
 
             if let environment = BackendEnvironment(type: item.value) {
                 BackendEnvironment.shared = environment
-                alertMessage = "Backend switched! Please restart the app"
-                isAlertPresented = true
+                alertItem = AlertItem(message: "Backend switched! Please restart the app")
             } else {
-                alertMessage = "Failed to switch backend"
-                isAlertPresented = true
+                alertItem = AlertItem(message: "Failed to switch backend")
             }
         }
     }

--- a/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -28,11 +28,9 @@ extension BackendEnvironment {
         if let typeOverride = AutomationHelper.sharedHelper.backendEnvironmentTypeOverride() {
             environmentType = EnvironmentType(stringValue: typeOverride)
         }
-        guard let environment = BackendEnvironment(
-            userDefaults: .applicationGroupCombinedWithStandard,
-            configurationBundle: .backendBundle,
-            environmentType: environmentType
-        ) else {
+
+        guard let environment = BackendEnvironment(type: environmentType) else {
+            WireLogger.environment.critical("failed to initialize environment")
             fatalError("Malformed backend configuration data")
         }
         return environment
@@ -44,4 +42,13 @@ extension BackendEnvironment {
             zmsLog.debug("Shared backend environment did change to: \(shared.title)")
         }
     }
+
+    public convenience init?(type: EnvironmentType?) {
+        self.init(
+            userDefaults: .applicationGroupCombinedWithStandard,
+            configurationBundle: .backendBundle,
+            environmentType: type
+        )
+    }
+
 }

--- a/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -30,7 +30,6 @@ extension BackendEnvironment {
         }
 
         guard let environment = BackendEnvironment(type: environmentType) else {
-            WireLogger.environment.critical("failed to initialize environment")
             fatalError("Malformed backend configuration data")
         }
         return environment


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Switch backends from the iPhone > Settings > Wire > Switch backend works fine for the main app target, but not for the extensions. As soon as a push notification is received, the user gets logged out when the app is brought to the foreground.


### Causes
The backend switch from the app settings is tied to the user defaults, but it doesn't appear to save them in the application group user defaults. When either of the extensions is loaded, it fails to read the backend override and will default to production. The access token can't be fetched, and as a result, the cookie is deleted. When the main app goes to the foreground, it finds no cookie and logs the user out.

### Solutions
Remove the backend switch from the app settings, and create a new switch in the developer menu.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
