### PR TITLE
fix: crash when session expires FS-1666

### DIFF
--- a/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
@@ -25,6 +25,7 @@ public protocol SafeCoreCryptoProtocol {
     func perform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T
     func unsafePerform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T
     func mlsInit(clientID: String) throws
+    func tearDown() throws
 }
 
 public class SafeCoreCrypto: SafeCoreCryptoProtocol {
@@ -35,6 +36,7 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
     private let coreCrypto: CoreCryptoProtocol
     private let safeContext: SafeFileContext
     private var didInitializeMLS = false
+    private let databasePath: String
 
     public convenience init(coreCryptoConfiguration config: CoreCryptoConfiguration) throws {
         guard let clientID = config.clientIDBytes else {
@@ -75,8 +77,13 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
 
     init(coreCrypto: CoreCryptoProtocol, databasePath: String) {
         self.coreCrypto = coreCrypto
+        self.databasePath = databasePath
         let directoryPathUrl = URL(fileURLWithPath: databasePath).deletingLastPathComponent()
         self.safeContext = SafeFileContext(fileURL: directoryPathUrl)
+    }
+
+    public func tearDown() throws {
+        _ = try FileManager.default.removeItem(atPath: databasePath)
     }
 
     public func perform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T {

--- a/wire-ios-data-model/Tests/MLS/MockCoreCrypto.swift
+++ b/wire-ios-data-model/Tests/MLS/MockCoreCrypto.swift
@@ -49,6 +49,12 @@ class MockSafeCoreCrypto: SafeCoreCryptoProtocol {
 
         try mock(clientID)
     }
+
+    var tearDownCount = 0
+    func tearDown() throws {
+        tearDownCount += 1
+    }
+
 }
 
 class MockCoreCrypto: CoreCryptoProtocol {

--- a/wire-ios-sync-engine/Source/UserSession/NSManagedObject+CryptoStack.swift
+++ b/wire-ios-sync-engine/Source/UserSession/NSManagedObject+CryptoStack.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,11 +22,16 @@ import WireDataModel
 extension NSManagedObjectContext {
 
     @objc
-    public func deleteAndCreateNewEncryptionContext() {
+    public func tearDownCryptoStack() {
         proteusProvider.perform(
             withProteusService: { _ in },
             withKeyStore: { keyStore in keyStore.deleteAndCreateNewBox() }
         )
+
+        proteusService = nil
+        mlsController = nil
+        try? coreCrypto?.tearDown()
+        coreCrypto = nil
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/NSManagedObject+EncryptionContext.swift
+++ b/wire-ios-sync-engine/Source/UserSession/NSManagedObject+EncryptionContext.swift
@@ -21,10 +21,12 @@ import WireDataModel
 
 extension NSManagedObjectContext {
 
-    // TODO: [John] use flag here
-
     @objc
     public func deleteAndCreateNewEncryptionContext() {
-        zm_cryptKeyStore.deleteAndCreateNewBox()
+        proteusProvider.perform(
+            withProteusService: { _ in },
+            withKeyStore: { keyStore in keyStore.deleteAndCreateNewBox() }
+        )
     }
+
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.m
+++ b/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.m
@@ -357,7 +357,7 @@ static NSString *ZMLogTag ZM_UNUSED = @"Authentication";
         [client deleteClientAndEndSession];
     }
     
-    [self.managedObjectContext deleteAndCreateNewEncryptionContext];
+    [self.managedObjectContext tearDownCryptoStack];
     [self invalidateCookieAndNotify];
 }
 

--- a/wire-ios-sync-engine/Tests/Source/MessagingTest+Swift.swift
+++ b/wire-ios-sync-engine/Tests/Source/MessagingTest+Swift.swift
@@ -55,8 +55,12 @@ extension MessagingTest {
     }
 
     @objc
-    public func setDefaultAPIVersion() {
+    public func setDefaults() {
         setCurrentAPIVersion(.v0)
+        BackendInfo.domain = "example.com"
+
+        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        proteusViaCoreCrypto.isOn = false
     }
 
     @objc

--- a/wire-ios-sync-engine/Tests/Source/MessagingTest.m
+++ b/wire-ios-sync-engine/Tests/Source/MessagingTest.m
@@ -123,7 +123,7 @@ static ZMReachability *sharedReachabilityMock = nil;
 - (void)setUp;
 {
     [super setUp];
-    [self setDefaultAPIVersion];
+    [self setDefaults];
     BackgroundActivityFactory.sharedFactory.activityManager = UIApplication.sharedApplication;
     [BackgroundActivityFactory.sharedFactory resume];
     

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 		549552541D645683004F21F6 /* AddressBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549552511D64567C004F21F6 /* AddressBookTests.swift */; };
 		549710081F6FF5C100026EDD /* NotificationInContext+UserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549710071F6FF5C100026EDD /* NotificationInContext+UserSession.swift */; };
 		5497100A1F6FFE9900026EDD /* ClientUpdateNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 549710091F6FFE9900026EDD /* ClientUpdateNotification.swift */; };
-		54973A361DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54973A351DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift */; };
+		54973A361DD48CAB007F8702 /* NSManagedObject+CryptoStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54973A351DD48CAB007F8702 /* NSManagedObject+CryptoStack.swift */; };
 		549815CD1A432BC700A7CE2E /* ZMBlacklistDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = F9FD798619EE742600D70FCD /* ZMBlacklistDownloader.m */; };
 		549815CE1A432BC700A7CE2E /* ZMBlacklistVerificator.m in Sources */ = {isa = PBXBuildFile; fileRef = F9FD798C19EE9B9A00D70FCD /* ZMBlacklistVerificator.m */; };
 		549815DC1A432BC700A7CE2E /* NSError+ZMUserSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E05F253192A50CC00F22D80 /* NSError+ZMUserSession.m */; };
@@ -965,7 +965,7 @@
 		549552511D64567C004F21F6 /* AddressBookTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookTests.swift; sourceTree = "<group>"; };
 		549710071F6FF5C100026EDD /* NotificationInContext+UserSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationInContext+UserSession.swift"; sourceTree = "<group>"; };
 		549710091F6FFE9900026EDD /* ClientUpdateNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientUpdateNotification.swift; sourceTree = "<group>"; };
-		54973A351DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+EncryptionContext.swift"; sourceTree = "<group>"; };
+		54973A351DD48CAB007F8702 /* NSManagedObject+CryptoStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+CryptoStack.swift"; sourceTree = "<group>"; };
 		549815931A43232400A7CE2E /* WireSyncEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireSyncEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		549815961A43232400A7CE2E /* WireSyncEngine-ios-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "WireSyncEngine-ios-Info.plist"; sourceTree = "<group>"; };
 		54991D571DEDCF2B007E282F /* AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
@@ -2041,7 +2041,7 @@
 				F992985A1BE1404D0058D42F /* ZMClientRegistrationStatus+Internal.h */,
 				F9FD167A1BDFCDAD00725F5C /* ZMClientRegistrationStatus.m */,
 				A9C02604266F5B4B002E542B /* ZMClientRegistrationStatus.swift */,
-				54973A351DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift */,
+				54973A351DD48CAB007F8702 /* NSManagedObject+CryptoStack.swift */,
 				163FB9982057E3F200E74F83 /* AuthenticationStatusProvider.swift */,
 				F9B171F51C0EF21100E6EEC6 /* ClientUpdateStatus.swift */,
 				166264732166093800300F45 /* CallEventStatus.swift */,
@@ -3442,7 +3442,7 @@
 				5E0EB1F421008C1900B5DC2B /* CompanyLoginRequester.swift in Sources */,
 				16A764611F3E0B0B00564F21 /* CallKitManager.swift in Sources */,
 				BF491CD11F03D7CF0055EE44 /* PermissionsDownloadRequestStrategy.swift in Sources */,
-				54973A361DD48CAB007F8702 /* NSManagedObject+EncryptionContext.swift in Sources */,
+				54973A361DD48CAB007F8702 /* NSManagedObject+CryptoStack.swift in Sources */,
 				165D3A3D1E1D60520052E654 /* ZMConversation+VoiceChannel.swift in Sources */,
 				EE1DEBC723D5F1F30087EE1F /* NSManagedObjectContext+TypingUsers.swift in Sources */,
 				EEE186B4259CC92D008707CA /* ZMUserSession+AppLock.swift in Sources */,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If the session expires (e.g the self client is deleted remotely), then the app will crash.

### Causes

When the self client is deleted, we try to delete the keystore, even if proteus via core crypto is enabled. The keystore doesn't exist, resulting in a crash.

### Solutions

Use `ProteusProvider` to access the keystore, and also tear down the crypto stack.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
