### PR TITLE
fix: adding user system message - FS-1623

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
@@ -511,3 +511,41 @@ extension Payload.UpdateConversationMLSWelcome {
     }
 
 }
+
+extension Payload.ConversationEvent where T == Payload.UpdateConverationMemberJoin {
+
+    func process(in context: NSManagedObjectContext, originalEvent: ZMUpdateEvent) {
+        guard
+            let conversation = fetchOrCreateConversation(in: context)
+        else {
+            Logging.eventProcessing.error("Member join update missing conversation, aborting...")
+            return
+        }
+
+        if let usersAndRoles = data.users?.map({ $0.fetchUserAndRole(in: context, conversation: conversation)! }) {
+            let selfUser = ZMUser.selfUser(in: context)
+            let users = Set(usersAndRoles.map { $0.0 })
+            let newUsers = !users.subtracting(conversation.localParticipants).isEmpty
+
+            if users.contains(selfUser) || newUsers {
+                // TODO jacob refactor to append method on conversation
+                _ = ZMSystemMessage.createOrUpdate(from: originalEvent, in: context)
+            }
+
+            conversation.addParticipantsAndUpdateConversationState(usersAndRoles: usersAndRoles)
+        } else if let users = data.userIDs?.map({ ZMUser.fetchOrCreate(with: $0, domain: nil, in: context)}) {
+            // NOTE: legacy code path for backwards compatibility with servers without role support
+
+            let users = Set(users)
+            let selfUser = ZMUser.selfUser(in: context)
+
+            if !users.isSubset(of: conversation.localParticipantsExcludingSelf) || users.contains(selfUser) {
+                // TODO jacob refactor to append method on conversation
+                _ = ZMSystemMessage.createOrUpdate(from: originalEvent, in: context)
+            }
+            conversation.addParticipantsAndUpdateConversationState(users: users, role: nil)
+        }
+
+    }
+
+}

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -107,60 +107,10 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
     typealias MemberJoinPayload = Payload.ConversationEvent<Payload.UpdateConverationMemberJoin>
 
     func processMemberJoin(payload: MemberJoinPayload, originalEvent: ZMUpdateEvent) {
-        context.performAndWait {
-            guard
-                let conversation = self.fetchOrCreateConversation(id: payload.id, qualifiedID: payload.qualifiedID, in: self.context)
-            else {
-                Logging.eventProcessing.warn("Member join update missing conversation, aborting...")
-                return
-            }
-
-            if let usersAndRoles = payload.data.users?.map({ $0.fetchUserAndRole(in: self.context, conversation: conversation)! }) {
-                let selfUser = ZMUser.selfUser(in: self.context)
-                let users = Set(usersAndRoles.map { $0.0 })
-                let newUsers = !users.subtracting(conversation.localParticipants).isEmpty
-
-                if users.contains(selfUser) || newUsers {
-                    // TODO jacob refactor to append method on conversation
-                    _ = ZMSystemMessage.createOrUpdate(from: originalEvent, in: self.context)
-                }
-
-                if users.contains(selfUser) {
-                    self.updateMLSStatus(for: conversation, context: self.context)
-                }
-
-                conversation.addParticipantsAndUpdateConversationState(usersAndRoles: usersAndRoles)
-            } else if let users = payload.data.userIDs?.map({ ZMUser.fetchOrCreate(with: $0, domain: nil, in: self.context)}) {
-                // NOTE: legacy code path for backwards compatibility with servers without role support
-                let users = Set(users)
-                let selfUser = ZMUser.selfUser(in: self.context)
-
-                if !users.isSubset(of: conversation.localParticipantsExcludingSelf) || users.contains(selfUser) {
-                    // TODO jacob refactor to append method on conversation
-                    _ = ZMSystemMessage.createOrUpdate(from: originalEvent, in: self.context)
-                }
-                conversation.addParticipantsAndUpdateConversationState(users: users, role: nil)
-            }
-        }
+        payload.process(in: context, originalEvent: originalEvent)
 
         // MLS specific sync
-        syncConversationIfNeeded(qualifiedID: payload.qualifiedID, in: context) {
-            guard
-                let conversation = self.fetchOrCreateConversation(id: payload.id, qualifiedID: payload.qualifiedID, in: self.context)
-            else {
-                Logging.eventProcessing.warn("Member join update missing conversation, aborting...")
-                return
-            }
-
-            if let usersAndRoles = payload.data.users?.map({ $0.fetchUserAndRole(in: self.context, conversation: conversation)! }) {
-                let selfUser = ZMUser.selfUser(in: self.context)
-                let users = Set(usersAndRoles.map { $0.0 })
-
-                if users.contains(selfUser) {
-                    self.updateMLSStatus(for: conversation, context: self.context)
-                }
-            }
-        }
+        syncConversationForMLSStatus(payload: payload)
     }
 
     func fetchOrCreateConversation(id: UUID?, qualifiedID: QualifiedID?, in context: NSManagedObjectContext) -> ZMConversation? {
@@ -168,21 +118,36 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
         return ZMConversation.fetchOrCreate(with: conversationID, domain: qualifiedID?.domain, in: context)
     }
 
-    private func syncConversationIfNeeded(
-        qualifiedID: QualifiedID?,
+    private func syncConversationForMLSStatus(payload: MemberJoinPayload) {
+        // If this is an MLS conversation, we need to fetch some metadata in order to process
+        // the welcome message. We expect that all MLS conversations have qualified IDs.
+        guard let qualifiedID = payload.qualifiedID else { return }
+
+        syncConversation(qualifiedID: qualifiedID, in: context) {
+            guard
+                let conversation = self.fetchOrCreateConversation(id: payload.id, qualifiedID: payload.qualifiedID, in: self.context)
+            else {
+                Logging.eventProcessing.warn("Member join update missing conversation, aborting...")
+                return
+            }
+
+            if let usersAndRoles = payload.data.users?.map({ $0.fetchUserAndRole(in: self.context, conversation: conversation)! }) {
+                let selfUser = ZMUser.selfUser(in: self.context)
+                let users = Set(usersAndRoles.map { $0.0 })
+
+                if users.contains(selfUser) {
+                    self.updateMLSStatus(for: conversation, context: self.context)
+                }
+            }
+        }
+    }
+
+    private func syncConversation(
+        qualifiedID: QualifiedID,
         in context: NSManagedObjectContext,
         then block: @escaping () -> Void
     ) {
-        // If this is an MLS conversation, we need to fetch some metadata in order to process
-        // the welcome message. We expect that all MLS conversations have qualified IDs.
-        if let qualifiedID = qualifiedID {
-            conversationService.syncConversation(qualifiedID: qualifiedID) {
-                context.performAndWait {
-                    block()
-                }
-            }
-
-        } else {
+        conversationService.syncConversation(qualifiedID: qualifiedID) {
             context.performAndWait {
                 block()
             }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

System message showing user has been added to the conversation is not shown on Federated group
### Causes (Optional)

We sync the conversation with backend before the add message logic (comparing users from payload and locally) because of some metadata we need for mls.

### Solutions

Synchronise the conversation (getting the metadata) after checking the users logic.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Adding a member from another backend to a federated group on dogfood env for example.
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
