### PR TITLE
fix: login redirect - FS-1653

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
@@ -100,12 +100,13 @@ final class APIVersionResolver {
             BackendInfo.apiVersion = commonProductionVersions.max()
         }
 
+        let previousBackendDomain = BackendInfo.domain
         BackendInfo.domain = payload.domain
 
         let wasFederationEnabled = BackendInfo.isFederationEnabled
         BackendInfo.isFederationEnabled = payload.federation
 
-        if !wasFederationEnabled && BackendInfo.isFederationEnabled {
+        if previousBackendDomain == payload.domain && !wasFederationEnabled && BackendInfo.isFederationEnabled {
             delegate?.apiVersionResolverDetectedFederationHasBeenEnabled()
         }
 

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -201,10 +201,14 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             showDatabaseLoadingFailure(completion: completionBlock)
         case .migrating:
             showLaunchScreen(isLoading: true, completion: completionBlock)
-        case .unauthenticated(error: let error):
-            screenCurtain.delegate = nil
-            configureUnauthenticatedAppearance()
-            showUnauthenticatedFlow(error: error, completion: completionBlock)
+        case .unauthenticated(let error):
+            if error == NSError(code: .needsAuthenticationAfterMigration, userInfo: nil) {
+                authenticationCoordinator?.stateController.unwindState()
+            } else {
+                screenCurtain.delegate = nil
+                configureUnauthenticatedAppearance()
+                showUnauthenticatedFlow(error: error, completion: completionBlock)
+            }
         case .authenticated(completedRegistration: let completedRegistration):
             configureAuthenticatedAppearance()
             executeAuthenticatedBlocks()

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -201,14 +201,10 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             showDatabaseLoadingFailure(completion: completionBlock)
         case .migrating:
             showLaunchScreen(isLoading: true, completion: completionBlock)
-        case .unauthenticated(let error):
-            if error == NSError(code: .needsAuthenticationAfterMigration, userInfo: nil) {
-                authenticationCoordinator?.stateController.unwindState()
-            } else {
-                screenCurtain.delegate = nil
-                configureUnauthenticatedAppearance()
-                showUnauthenticatedFlow(error: error, completion: completionBlock)
-            }
+        case .unauthenticated(error: let error):
+            screenCurtain.delegate = nil
+            configureUnauthenticatedAppearance()
+            showUnauthenticatedFlow(error: error, completion: completionBlock)
         case .authenticated(completedRegistration: let completedRegistration):
             configureAuthenticatedAppearance()
             executeAuthenticatedBlocks()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When login in on a fresh install on a federated backend, the user gets redirected to landing screen and has to enter credentials twice to login.

This impacts also automated tests from QA.

### Causes (Optional)

There is a migration for Federated Backend needed as soon as possible once we get the response of apiVersioning and as the user is not authenticated yet, this produces a state transition to unauthenticated flow.

### Solutions

The migration is not needed when switching from different backend domain. We had some logic to do that.
### Testing

#### How to Test

Manual testing cases:
1. install app
2. open deeplink to dogfood env
3. login

### Notes (Optional)

There is one case which this PR does not handle yet:
1. user was authenticated on a not federated backend A
2. He tries to login to the same backend A but the backend become federated 
-> the user will have to relogin again (happens just once when the migration occurs)

This could be done on a second PR/ticket.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
