### PR TITLE
fix: accessibility label for qa

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/CustomBackendView.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/CustomBackendView.swift
@@ -25,6 +25,7 @@ final class CustomBackendView: UIView {
                                      fontSpec: .headerSemiboldFont,
                                      color: SemanticColors.Label.textSectionHeader)
         label.textAlignment = .right
+        label.accessibilityIdentifier = "Backend domain"
         return label
     }()
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The label for backend domain endpoint changes accessibility id whenever the domain changes.

### Solutions

Set a static accessibility id to help QA for regression tests.

### Testing

### Attachments (Optional)

![Simulator Screen Shot - iPhone 8 - 2023-03-23 at 13 02 05](https://user-images.githubusercontent.com/254198/227198326-ce463013-ca1f-4402-b8ec-06c6abf09606.png)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
