### PR TITLE
fix: input bar buttons still present when file sharing restriction is enabled FS-1729

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/UIButton+RoundedCorners.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/UIButton+RoundedCorners.swift
@@ -27,6 +27,11 @@ extension UIButton {
         case bottom
     }
 
+    func removeRoundedCorners() {
+        layer.cornerRadius = 0
+        clipsToBounds = false
+    }
+
     func roundCorners(edge: Edge, radius: CGFloat = 0) {
         layer.cornerRadius = radius
         clipsToBounds = true

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -155,7 +155,12 @@ final class InputBarButtonsView: UIView {
 
         guard bounds.size.width >= minButtonWidth * 2 else { return }
 
-        // Drop existing constraints
+        defer {
+            showRow(0, animated: true)
+        }
+
+        buttonInnerContainer.removeSubviews()
+
         buttons.forEach {
             $0.roundCorners(edge: .leading)
             $0.roundCorners(edge: .trailing)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -157,33 +157,35 @@ final class InputBarButtonsView: UIView {
             return
         }
 
+        // Reset the container.
         buttonInnerContainer.removeSubviews()
 
+        // Reset the buttons.
         for button in buttons {
-            button.roundCorners(edge: .leading)
-            button.roundCorners(edge: .trailing)
+            button.removeRoundedCorners()
             button.removeFromSuperview()
             buttonInnerContainer.addSubview(button)
         }
 
-        let ratio = floorf(Float(bounds.width / minButtonWidth))
-        let numberOfButtons = Int(ratio)
-        multilineLayout = numberOfButtons < buttons.count
+        // Distribute buttons over rows.
+        let maxNumberOfButtonsPerRow = Int(floorf(Float(bounds.width / minButtonWidth)))
+        let isMultilineLayout = buttons.count > maxNumberOfButtonsPerRow
 
-        let (firstRow, secondRow): ([UIButton], [UIButton])
+        let firstRow, secondRow: [UIButton]
 
-        expandRowButton.isHidden = !multilineLayout
-
-        if multilineLayout {
+        if isMultilineLayout {
             firstRow = buttons.prefix(customButtonCount) + [expandRowButton]
             secondRow = [UIButton](buttons.suffix(buttons.count - customButtonCount))
             buttonRowHeight.constant = constants.buttonsBarHeight * 2
+            expandRowButton.isHidden = false
         } else {
             firstRow = buttons
             secondRow = []
             buttonRowHeight.constant = constants.buttonsBarHeight
+            expandRowButton.isHidden = true
         }
 
+        // Round buttons.
         firstRow.first?.roundCorners(edge: .leading, radius: 12)
         firstRow.last?.roundCorners(edge: .trailing, radius: 12)
         secondRow.first?.roundCorners(edge: .leading, radius: 12)
@@ -204,7 +206,7 @@ final class InputBarButtonsView: UIView {
             return
         }
 
-        let filled = secondRow.count == numberOfButtons
+        let filled = secondRow.count == maxNumberOfButtonsPerRow
         let referenceButton = firstRow.count > 1 ? firstRow[1] : firstRow[0]
 
         constraints.append(contentsOf: constrainRowOfButtons(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBarButtonsView.swift
@@ -151,25 +151,23 @@ final class InputBarButtonsView: UIView {
     }
 
     private func layoutAndConstrainButtonRows() {
-        let minButtonWidth: CGFloat = constants.minimumButtonWidth(forWidth: bounds.width)
+        let minButtonWidth = constants.minimumButtonWidth(forWidth: bounds.width)
 
-        guard bounds.size.width >= minButtonWidth * 2 else { return }
-
-        defer {
-            showRow(0, animated: true)
+        guard bounds.size.width >= minButtonWidth * 2 else {
+            return
         }
 
         buttonInnerContainer.removeSubviews()
 
-        buttons.forEach {
-            $0.roundCorners(edge: .leading)
-            $0.roundCorners(edge: .trailing)
-            $0.removeFromSuperview()
-            buttonInnerContainer.addSubview($0)
+        for button in buttons {
+            button.roundCorners(edge: .leading)
+            button.roundCorners(edge: .trailing)
+            button.removeFromSuperview()
+            buttonInnerContainer.addSubview(button)
         }
 
         let ratio = floorf(Float(bounds.width / minButtonWidth))
-        let numberOfButtons: Int = Int(ratio)
+        let numberOfButtons = Int(ratio)
         multilineLayout = numberOfButtons < buttons.count
 
         let (firstRow, secondRow): ([UIButton], [UIButton])
@@ -190,22 +188,31 @@ final class InputBarButtonsView: UIView {
         firstRow.last?.roundCorners(edge: .trailing, radius: 12)
         secondRow.first?.roundCorners(edge: .leading, radius: 12)
 
-        var constraints = constrainRowOfButtons(firstRow,
-                                                inset: 0,
-                                                rowIsFull: true,
-                                                referenceButton: .none)
+        var constraints = constrainRowOfButtons(
+            firstRow,
+            inset: 0,
+            rowIsFull: true,
+            referenceButton: .none
+        )
 
         defer {
             NSLayoutConstraint.activate(constraints)
+            showRow(0, animated: true)
         }
 
-        guard !secondRow.isEmpty else { return }
+        guard !secondRow.isEmpty else {
+            return
+        }
 
         let filled = secondRow.count == numberOfButtons
         let referenceButton = firstRow.count > 1 ? firstRow[1] : firstRow[0]
 
-        constraints.append(contentsOf: constrainRowOfButtons(secondRow, inset: constants.buttonsBarHeight, rowIsFull: filled, referenceButton: referenceButton)
-        )
+        constraints.append(contentsOf: constrainRowOfButtons(
+            secondRow,
+            inset: constants.buttonsBarHeight,
+            rowIsFull: filled,
+            referenceButton: referenceButton
+        ))
 
         setupAccessibility()
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When file sharing restrictions is enabled by a team admin, sometimes the user can still see some input bar buttons that allow sharing files (such as the sketch and camera button).

### Causes

When the feature is enabled, we update the input bar buttons. But this only updates the constraints and doesn't actually remove the buttons that should no longer be visible. Most of the time you don't see the left over buttons due to the missing constraints, but they are still there.

### Solutions

Remove all buttons in the input bar button container, then add again only the necessary ones. Additionally, show the first row if needed.

### Testing

#### How to Test

1. Log in to a team account, navigate to a conversation.
2. Team admin enables file sharing restrictions.
3. Observe that only the necessary buttons are in the view hierarchy (use the view debugger) 


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
