### PR TITLE
fix: failing security tests

### DIFF
--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+MLSEncryptedPayloadGenerator.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+MLSEncryptedPayloadGenerator.swift
@@ -21,6 +21,19 @@ import Foundation
 
 final class ZMClientMessageTests_MLSEncryptedPayloadGenerator: BaseZMClientMessageTests {
 
+    override func setUp() {
+        DeveloperFlag.storage = UserDefaults(suiteName: UUID().uuidString)!
+        var flag = DeveloperFlag.proteusViaCoreCrypto
+        flag.isOn = false
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DeveloperFlag.storage = UserDefaults.standard
+    }
+
     let encryptionFunction: (Data) throws -> Data = {
         $0.zmSHA256Digest()
     }

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+OTR_Legacy.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+OTR_Legacy.swift
@@ -19,7 +19,22 @@
 import XCTest
 @testable import WireDataModel
 
-final class ClientMessageTests_OTR_Legacy: BaseZMClientMessageTests {}
+final class ClientMessageTests_OTR_Legacy: BaseZMClientMessageTests {
+
+    override func setUp() {
+        DeveloperFlag.storage = UserDefaults(suiteName: UUID().uuidString)!
+        var flag = DeveloperFlag.proteusViaCoreCrypto
+        flag.isOn = false
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        DeveloperFlag.storage = UserDefaults.standard
+    }
+
+}
 
 // MARK: - Payload creation
 extension ClientMessageTests_OTR_Legacy {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some tests including in the security tests paln were failing.

### Causes (Optional)

DeveloperFlag for proteus was not set correctly for some tests.

### Solutions

Set developerFlag on isolated UserDefaults instance so it does not impact other tests.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
