### PR TITLE
Fix: Remove sensitive information in internal and development build l…

### DIFF
--- a/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
+++ b/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
@@ -207,8 +207,6 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
     [self.cookieStorage setRequestHeaderFieldsOnRequest:request];
     [self setRequestHeaderFieldsWithLastKnownAccessToken:request];
     self.currentAccessTokenTask = [URLSession taskWithRequest:request bodyData:nil transportRequest:nil];
-    ZMLogInfo(@"----> Access token request: %@ %@ \n %@ \n %@", request.HTTPMethod, request.URL, request.allHTTPHeaderFields, request.HTTPBody);
-
     [self.backoff performBlock:^{
         [self.currentAccessTokenTask resume];
     }];
@@ -289,8 +287,6 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 
 - (BOOL)processAccessTokenResponse:(ZMTransportResponse *)response
 {
-    ZMLogInfo(@"<---- Access token response: %@", response);
-    
     BOOL needsToReRun = YES;
     BOOL didFail = NO;
     

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -445,8 +445,6 @@ static NSInteger const DefaultMaximumRequests = 6;
     URLRequest.HTTPBody = nil;
     [self.remoteMonitoring logWithRequest:URLRequest];
     ZMLogPublic(@"Request: %@", request.safeForLoggingDescription);
-    ZMLogInfo(@"----> Request: %@\n%@", URLRequest.allHTTPHeaderFields, request);
-
     NSURLSessionTask *task = [session taskWithRequest:URLRequest bodyData:(bodyData.length == 0) ? nil : bodyData transportRequest:request];
     return task;
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Log files stored on the file system of the iOS device contain sensitive data like access tokens

### Causes (Optional)

An attacker with elevated access to the device could extract this information.

### Solutions

As recommended storing log files is required for debugging purposes, sensitive data
like access tokens or private information like chat messages should be redacted.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
