### PR TITLE
fix: crash when decoding events FS-1631

### DIFF
--- a/wire-ios-data-model/Source/Proteus/ProteusError+CBox.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusError+CBox.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireCryptobox
+
+public extension ProteusError {
+
+    init?(cboxResult: CBoxResult) {
+        switch cboxResult {
+        case CBOX_STORAGE_ERROR:
+            self = .storageError
+
+        case CBOX_SESSION_NOT_FOUND:
+            self = .sessionNotFound
+
+        case CBOX_DECODE_ERROR:
+            self = .decodeError
+
+        case CBOX_REMOTE_IDENTITY_CHANGED:
+            self = .remoteIdentityChanged
+
+        case CBOX_INVALID_SIGNATURE:
+            self = .invalidSignature
+
+        case CBOX_INVALID_MESSAGE:
+            self = .invalidMessage
+
+        case CBOX_DUPLICATE_MESSAGE:
+            self = .duplicateMessage
+
+        case CBOX_TOO_DISTANT_FUTURE:
+            self = .tooDistantFuture
+
+        case CBOX_OUTDATED_MESSAGE:
+            self = .outdatedMessage
+
+        case CBOX_IDENTITY_ERROR:
+            self = .identityError
+
+        case CBOX_PREKEY_NOT_FOUND:
+            self = .prekeyNotFound
+
+        case CBOX_PANIC:
+            self = .panic
+
+        default:
+            return nil
+        }
+    }
+
+}

--- a/wire-ios-data-model/Source/Proteus/ProteusError.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusError.swift
@@ -46,7 +46,7 @@ public enum ProteusError: Int, Error, Equatable {
 
     case remoteIdentityChanged
 
-    /// The signature of a decrypte message is invalid.
+    /// The signature of a decrypted message is invalid.
     ///
     /// The message being decrypted is incomplete or has otherwise been tampered with.
 
@@ -82,12 +82,12 @@ public enum ProteusError: Int, Error, Equatable {
     /// A message is too old.
     ///
     /// The message being decrypted is unreasonably old and cannot be decrypted
-    /// any logner due to the key material no longer being availble. The message
+    /// any longer due to the key material no longer being available. The message
     /// should be dropped.
 
     case outdatedMessage
 
-    /// A CBox has been openend with an incomplete or mismatching identiy using
+    /// A CBox has been opened with an incomplete or mismatching identity using
     /// 'CryptoBox.openWith'.
 
     case identityError

--- a/wire-ios-data-model/Source/Proteus/ProteusError.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusError.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public enum ProteusError: Error {
+public enum ProteusError: Error, Equatable {
 
     case storageError
     case sessionNotFound
@@ -32,9 +32,13 @@ public enum ProteusError: Error {
     case identityError
     case prekeyNotFound
     case panic
+    case unknown(code: UInt32)
 
-    init?(code: Int) {
+    init?(code: UInt32) {
         switch code {
+        case 0:
+            return nil
+
         case 501:
             self = .storageError
 
@@ -72,7 +76,7 @@ public enum ProteusError: Error {
             self = .panic
 
         default:
-            return nil
+            self = .unknown(code: code)
         }
     }
 

--- a/wire-ios-data-model/Source/Proteus/ProteusError.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusError.swift
@@ -1,0 +1,80 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public enum ProteusError: Error {
+
+    case storageError
+    case sessionNotFound
+    case decodeError
+    case remoteIdentityChanged
+    case invalidSignature
+    case invalidMessage
+    case duplicateMessage
+    case tooDistantFuture
+    case outdatedMessage
+    case identityError
+    case prekeyNotFound
+    case panic
+
+    init?(code: Int) {
+        switch code {
+        case 501:
+            self = .storageError
+
+        case 102:
+            self = .sessionNotFound
+
+        case 3, 301, 302, 303:
+            self = .decodeError
+
+        case 204:
+            self = .remoteIdentityChanged
+
+        case 206, 207, 210:
+            self = .invalidSignature
+
+        case 200, 201, 202, 205, 213:
+            self = .invalidMessage
+
+        case 209:
+            self = .duplicateMessage
+
+        case 211, 212:
+            self = .tooDistantFuture
+
+        case 208:
+            self = .outdatedMessage
+
+        case 300:
+            self = .identityError
+
+        case 101:
+            self = .prekeyNotFound
+
+        case 5:
+            self = .panic
+
+        default:
+            return nil
+        }
+    }
+
+}
+

--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -159,9 +159,9 @@ public final class ProteusService: ProteusServiceInterface {
 
     // MARK: - proteusDecrypt
 
-    enum DecryptionError: Error {
-        case failedToDecryptData
-        case failedToEstablishSessionFromMessage
+    enum DecryptionError: Error, Equatable {
+        case failedToDecryptData(ProteusError?)
+        case failedToEstablishSessionFromMessage(ProteusError?)
     }
 
     public func decrypt(
@@ -173,31 +173,36 @@ public final class ProteusService: ProteusServiceInterface {
         if sessionExists(id: id) {
             logger.info("session exists, decrypting...")
 
-            do {
-                let decryptedBytes = try coreCrypto.perform { try $0.proteusDecrypt(
-                    sessionId: id.rawValue,
-                    ciphertext: data.bytes
-                )}
-
-                return (didCreateSession: false, decryptedData: decryptedBytes.data)
-            } catch {
-                logger.error("failed to decrypt data: \(String(describing: error))")
-                throw DecryptionError.failedToDecryptData
+            let decryptedBytes: Bytes = try coreCrypto.perform {
+                do {
+                    return try $0.proteusDecrypt(
+                        sessionId: id.rawValue,
+                        ciphertext: data.bytes
+                    )
+                } catch {
+                    logger.error("failed to decrypt data: \(error.localizedDescription)")
+                    throw DecryptionError.failedToDecryptData($0.lastProteusError)
+                }
             }
+
+            return (didCreateSession: false, decryptedData: decryptedBytes.data)
+
         } else {
             logger.info("session doesn't exist, creating one then decrypting message...")
 
-            do {
-                let decryptedBytes = try coreCrypto.perform { try $0.proteusSessionFromMessage(
-                    sessionId: id.rawValue,
-                    envelope: data.bytes
-                )}
-
-                return (didCreateSession: true, decryptedData: decryptedBytes.data)
-            } catch {
-                logger.error("failed to establish session from message: \(String(describing: error))")
-                throw DecryptionError.failedToEstablishSessionFromMessage
+            let decryptedBytes: Bytes = try coreCrypto.perform {
+                do {
+                    return try $0.proteusSessionFromMessage(
+                        sessionId: id.rawValue,
+                        envelope: data.bytes
+                    )
+                } catch {
+                    logger.error("failed to establish session from message: \(String(describing: error))")
+                    throw DecryptionError.failedToEstablishSessionFromMessage($0.lastProteusError)
+                }
             }
+
+            return (didCreateSession: true, decryptedData: decryptedBytes.data)
         }
     }
 
@@ -333,6 +338,14 @@ public final class ProteusService: ProteusServiceInterface {
         try coreCrypto.perform { _ in
             try block()
         }
+    }
+
+}
+
+private extension CoreCryptoProtocol {
+
+    var lastProteusError: ProteusError? {
+        return ProteusError(code: proteusLastErrorCode())
     }
 
 }

--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -159,9 +159,21 @@ public final class ProteusService: ProteusServiceInterface {
 
     // MARK: - proteusDecrypt
 
-    enum DecryptionError: Error, Equatable {
-        case failedToDecryptData(ProteusError?)
-        case failedToEstablishSessionFromMessage(ProteusError?)
+    public enum DecryptionError: Error, Equatable {
+
+        case failedToDecryptData(ProteusError)
+        case failedToEstablishSessionFromMessage(ProteusError)
+
+        public var proteusError: ProteusError {
+            switch self {
+            case .failedToDecryptData(let proteusError):
+                return proteusError
+
+            case .failedToEstablishSessionFromMessage(let proteusError):
+                return proteusError
+            }
+        }
+
     }
 
     public func decrypt(
@@ -344,8 +356,8 @@ public final class ProteusService: ProteusServiceInterface {
 
 private extension CoreCryptoProtocol {
 
-    var lastProteusError: ProteusError? {
-        return ProteusError(code: proteusLastErrorCode())
+    var lastProteusError: ProteusError {
+        return ProteusError(proteusCode:  proteusLastErrorCode())
     }
 
 }

--- a/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
+++ b/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
@@ -87,12 +87,16 @@ class ProteusServiceTests: XCTestCase {
             return true
         }
 
+        mockCoreCrypto.mockProteusLastErrorCode = {
+            return 209
+        }
+
         mockCoreCrypto.mockProteusDecrypt = { _, _ in
             throw MockError()
         }
 
         // Then
-        assertItThrows(error: ProteusService.DecryptionError.failedToDecryptData) {
+        assertItThrows(error: ProteusService.DecryptionError.failedToDecryptData(.duplicateMessage)) {
             // When
             _ = try sut.decrypt(
                 data: encryptedData,
@@ -140,12 +144,16 @@ class ProteusServiceTests: XCTestCase {
             return false
         }
 
+        mockCoreCrypto.mockProteusLastErrorCode = {
+            return 209
+        }
+
         mockCoreCrypto.mockProteusSessionFromMessage = { _, _ in
             throw MockError()
         }
 
         // Then
-        assertItThrows(error: ProteusService.DecryptionError.failedToEstablishSessionFromMessage) {
+        assertItThrows(error: ProteusService.DecryptionError.failedToEstablishSessionFromMessage(.duplicateMessage)) {
             // When
             _ = try sut.decrypt(
                 data: encryptedData,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -552,12 +552,14 @@
 		EEBACDA925B9C47E000210AC /* AppLockController.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBACDA825B9C47E000210AC /* AppLockController.Config.swift */; };
 		EEBACDAB25B9C4B0000210AC /* AppLockAuthenticationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBACDAA25B9C4B0000210AC /* AppLockAuthenticationResult.swift */; };
 		EEBF69ED28A2724800195771 /* ZMConversationTests+MLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBF69EC28A2724800195771 /* ZMConversationTests+MLS.swift */; };
+		EEBFA2E829D1D94B0004E8B4 /* ProteusError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBFA2E729D1D94B0004E8B4 /* ProteusError.swift */; };
 		EEC3BC742888403000BFDC35 /* MockCoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */; };
 		EEC3BC76288855C000BFDC35 /* MockMLSActionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */; };
 		EEC47ED627A81EF60020B599 /* Feature+ClassifiedDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC47ED527A81EF60020B599 /* Feature+ClassifiedDomains.swift */; };
 		EEC8064E28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */; };
 		EEC80B3629B0AD8100099727 /* NSManagedObjectContext+ProteusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B3529B0AD8100099727 /* NSManagedObjectContext+ProteusProvider.swift */; };
 		EEC80B5C29B611CA00099727 /* PersistedDataPatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B5B29B611CA00099727 /* PersistedDataPatch.swift */; };
+		EECCF10429D1BC7B000C0BF3 /* ProteusError+CBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECCF10329D1BC7B000C0BF3 /* ProteusError+CBox.swift */; };
 		EECFAA3826D52EB700D9E100 /* Feature.SelfDeletingMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECFAA3726D52EB700D9E100 /* Feature.SelfDeletingMessages.swift */; };
 		EEDA9C0E2510F3D5003A5B27 /* ZMConversation+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDA9C0D2510F3D5003A5B27 /* ZMConversation+EncryptionAtRest.swift */; };
 		EEDA9C1225121277003A5B27 /* NSManagedObjectContextTests+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDA9C1125121277003A5B27 /* NSManagedObjectContextTests+EncryptionAtRest.swift */; };
@@ -1421,12 +1423,14 @@
 		EEBACDA825B9C47E000210AC /* AppLockController.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockController.Config.swift; sourceTree = "<group>"; };
 		EEBACDAA25B9C4B0000210AC /* AppLockAuthenticationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLockAuthenticationResult.swift; sourceTree = "<group>"; };
 		EEBF69EC28A2724800195771 /* ZMConversationTests+MLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationTests+MLS.swift"; sourceTree = "<group>"; };
+		EEBFA2E729D1D94B0004E8B4 /* ProteusError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusError.swift; sourceTree = "<group>"; };
 		EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoreCrypto.swift; sourceTree = "<group>"; };
 		EEC3BC75288855C000BFDC35 /* MockMLSActionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSActionsProvider.swift; sourceTree = "<group>"; };
 		EEC47ED527A81EF60020B599 /* Feature+ClassifiedDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Feature+ClassifiedDomains.swift"; sourceTree = "<group>"; };
 		EEC8064D28CF4C2D00DD58E9 /* MockStaleMLSKeyDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStaleMLSKeyDetector.swift; sourceTree = "<group>"; };
 		EEC80B3529B0AD8100099727 /* NSManagedObjectContext+ProteusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+ProteusProvider.swift"; sourceTree = "<group>"; };
 		EEC80B5B29B611CA00099727 /* PersistedDataPatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedDataPatch.swift; sourceTree = "<group>"; };
+		EECCF10329D1BC7B000C0BF3 /* ProteusError+CBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProteusError+CBox.swift"; sourceTree = "<group>"; };
 		EECFAA3726D52EB700D9E100 /* Feature.SelfDeletingMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.SelfDeletingMessages.swift; sourceTree = "<group>"; };
 		EEDA9C0D2510F3D5003A5B27 /* ZMConversation+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		EEDA9C1125121277003A5B27 /* NSManagedObjectContextTests+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContextTests+EncryptionAtRest.swift"; sourceTree = "<group>"; };
@@ -1988,6 +1992,8 @@
 				63B1333729A503D000009D84 /* ProteusServiceInterface.swift */,
 				63B1333829A503D000009D84 /* ProteusService.swift */,
 				63B1337229A798C800009D84 /* ProteusProvider.swift */,
+				EEBFA2E729D1D94B0004E8B4 /* ProteusError.swift */,
+				EECCF10329D1BC7B000C0BF3 /* ProteusError+CBox.swift */,
 				EE032B2F29A62CA600E1DDF3 /* ProteusSessionID.swift */,
 				EE032B3029A62CA600E1DDF3 /* ProteusSessionID+Mapping.swift */,
 			);
@@ -3640,6 +3646,7 @@
 				5E36B45E21CA5BBA00B7063B /* UnverifiedCredentials.swift in Sources */,
 				EE04084E28CA85B2009E4B8D /* Date+Helpers.swift in Sources */,
 				F9B71F091CB264DF001DB03F /* ZMConversationList.m in Sources */,
+				EEBFA2E829D1D94B0004E8B4 /* ProteusError.swift in Sources */,
 				55C40BCE22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift in Sources */,
 				EE5E2C1926DFC67900C3928A /* MessageDestructionTimeoutValue.swift in Sources */,
 				5EFE9C0A2126BF9D007932A6 /* ZMPropertyNormalizationResult.m in Sources */,
@@ -3770,6 +3777,7 @@
 				EE032B3129A62CA600E1DDF3 /* ProteusSessionID.swift in Sources */,
 				63B1336E29A503D100009D84 /* StaleMLSKeyMaterialDetector.swift in Sources */,
 				63B1336229A503D100009D84 /* CoreCryptoKeyProvider.swift in Sources */,
+				EECCF10429D1BC7B000C0BF3 /* ProteusError+CBox.swift in Sources */,
 				16D68E971CEF2EC4003AB9E0 /* ZMFileMetadata.swift in Sources */,
 				BF421B2D1EF3F91D0079533A /* Team+Patches.swift in Sources */,
 				547E664B1F750E4A008CB1FA /* ZMConnection+Notification.swift in Sources */,

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+Proteus.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+Proteus.swift
@@ -90,7 +90,8 @@ extension EventDecoder {
             return nil
 
         } catch {
-            fatalError("Unknown error in decrypting payload, \(error)")
+            fail(error: nil)
+            return nil
         }
 
         // New client discovered?

--- a/wire-ios-system/Source/WireLogger.swift
+++ b/wire-ios-system/Source/WireLogger.swift
@@ -155,8 +155,12 @@ public extension WireLogger {
   /// For logs related to any mls related flow.
   static let shareExtension = WireLogger(tag: "share-extension")
 
-    /// For logs related to messaging flow.
+  /// For logs related to messaging flow.
 
-    static let messaging = WireLogger(tag: "messaging")
+  static let messaging = WireLogger(tag: "messaging")
+
+  /// For logs related to update events
+
+  static let updateEvent = WireLogger(tag: "update-event")
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
During event decoding, if core crypto throws an error the app will crash.

### Causes
We were catching `CBoxResult`s, but would fatal error all other errors.

### Solutions
- Use Core Cryptos `lastProteusError` to detect if there was an error.
- Convert this error to `ProteusError`.
- Catch `ProteusError`, handle it just like we do for `CBoxResult`.

### Testing

#### Test Coverage

- Updated `ProteusService` tests to assert it throws the `ProteusError`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
