### PR TITLE
chore: bump avs to 9.2.2 FS-1732

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=9.1.13
+export APPSTORE_AVS_VERSION=9.2.2


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Bump avs to 9.2.2

### Issues

App crashes when starting or answering a call

### Causes (Optional)

Caused by the version of webrtc used by avs

### Solutions

Bump webrtc version in avs and update to avs 9.2.2 

