### PR TITLE
fix: [SQSERVICES-1856] Fix Delivery receipts not being sent

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -92,10 +92,6 @@ extension DeliveryReceiptRequestStrategy: ZMEventConsumer {
     }
 
     public func processEvents(_ events: [ZMUpdateEvent], liveEvents: Bool, prefetchResult: ZMFetchRequestBatchResult?) {
-
-    }
-
-    public func processEventsWhileInBackground(_ events: [ZMUpdateEvent]) {
         deliveryReceipts(for: events).forEach(sendDeliveryReceipt)
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
@@ -64,7 +64,7 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
             let event = self.createTextUpdateEvent(from: self.otherUser, in: self.oneToOneConversation)
 
             // when
-            self.sut.processEventsWhileInBackground([event])
+            self.sut.processEvents([event], liveEvents: Bool.random(), prefetchResult: nil)
 
             // then
             let request = try XCTUnwrap(self.sut.nextRequest(for: .v1))
@@ -78,7 +78,7 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
             let event = self.createTextUpdateEvent(from: self.otherUser, in: self.oneToOneConversation)
 
             // when
-            self.sut.processEventsWhileInBackground([event])
+            self.sut.processEvents([event], liveEvents: Bool.random(), prefetchResult: nil)
 
             // then
             let request = try XCTUnwrap(self.sut.nextRequest(for: .v0))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

https://wearezeta.atlassian.net/browse/SQSERVICES-1856
TL;DR what's the issue about? When the app goes into background and receives a push notification with a new message then 'delivered' status is not sent to the backend when the app becomes active again. 


### Causes (Optional)

The issue is caused by mixing older implementations of background refresh (fetch / sync) and the presence of a notification service extension. Specifically:
1. When a push notification arrives the extension performs sync with the backend (fetches all upstream events and decodes them) and stores them to the 'events store' (this happens in background)
2. When the app becomes foreground it performs a regular sync with the backend again
3. The `DeliveryReceiptRequestStrategy` was listening only for the events from the sync when becoming foreground. This sync however has 2 issues:
i. It's not configured together with notification service extension sync so it fetches the same events again that NSE already fetched, but when it comes to encryption this duplication causes the events to not being processed finally 
ii. now when the sync logic changed a bit there is a chance that listening only for the events from second point (becoming foreground sync) may miss some events that happened because of push notifications arrivals (I am not sure wjether we should rely on that anymore?)

### Solutions

- I've changed the `DeliveryReceiptRequestStrategy` to listen for all new events, not only those that happened while in the background 
- We should improve the 'becoming foreground' sync to know what was the last event fetched from the backend by notification service extension (missing Jira ticket) 

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Steps to reproduce:
- User A logs into any client (iOs, Android, Web)
- User B logs into iOS, has no other clients.
- User B puts the app into the background
- User A sends a 1-1 message to User B.
- User B sees the notification, opens the app and reads the message.

Actual result:
- The message never transitions to the delivered status for User A, even though User B has read it.

Expected result:
- After User B opens the app, the message should go to the delivered status.\


##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
