### PR TITLE
fix: loop login when 2fa input is wrong

### DIFF
--- a/wire-ios-sync-engine/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/wire-ios-sync-engine/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -316,6 +316,9 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 - (void)didFailLoginWithEmailBecauseVerificationCodeIsInvalid
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
+    if (self.isWaitingForLogin) {
+        self.isWaitingForLogin = NO;
+    }
     NSError *error = [NSError userSessionErrorWithErrorCode:ZMUserSessionInvalidEmailVerificationCode userInfo:nil];
     [self.delegate authenticationDidFail: error];
     ZMLogDebug(@"current phase: %lu", (unsigned long)self.currentPhase);

--- a/wire-ios-sync-engine/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
+++ b/wire-ios-sync-engine/Source/UnauthenticatedSession/ZMAuthenticationStatus.m
@@ -316,6 +316,8 @@ static NSString* ZMLogTag ZM_UNUSED = @"Authentication";
 - (void)didFailLoginWithEmailBecauseVerificationCodeIsInvalid
 {
     ZMLogDebug(@"%@", NSStringFromSelector(_cmd));
+    // This fixes a loop on /login with the wrong verification loop
+    // we break the state of currentPhase ZMAuthenticationPhaseLoginWithEmail
     if (self.isWaitingForLogin) {
         self.isWaitingForLogin = NO;
     }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Pre-Login/AuthenticationEmailFallbackErrorHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Pre-Login/AuthenticationEmailFallbackErrorHandler.swift
@@ -38,8 +38,10 @@ class AuthenticationEmailFallbackErrorHandler: AuthenticationEventHandler {
         // Handle the actions
         var actions: [AuthenticationCoordinatorAction] = [.hideLoadingView]
 
-        // Show a guidance dot if the user caused the failure
-        if error.userSessionErrorCode != .networkError {
+        if error.userSessionErrorCode == .invalidEmailVerificationCode {
+            actions.append(.executeFeedbackAction(.clearInputFields))
+        } else if error.userSessionErrorCode != .networkError {
+            // Show a guidance dot if the user caused the failure
             actions.append(.executeFeedbackAction(.showGuidanceDot))
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When entering a wrong 2FA code received from email, we're not able to re-enter a new code.

### Causes (Optional)

We're stuck in a state where we keep on sending login request with the wrong code.

### Solutions

* Break the loop of sending the request when we reach `didFailLoginWithEmailBecauseVerificationCodeIsInvalid` in order to enter a new code.
* Clear current input when code is wrong

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

* Connect to a backend with 2FA enabled via deeplink
* Login
* Enter wrong code
* Enter correct code

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
