### PR TITLE
fix: classification banner hidden behind home bar FS-1763

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -30,7 +30,7 @@ class CallingActionsInfoViewController: UIViewController, UICollectionViewDelega
     private var participantsHeaderView = UIView()
     private let securityLevelView = SecurityLevelView()
     private var participantsHeaderLabel = DynamicFontLabel(fontSpec: .smallSemiboldFont, color: SemanticColors.Label.textSectionHeader)
-    private var actionsViewHeightConstraint: NSLayoutConstraint!
+    private(set) var actionsViewHeightConstraint: NSLayoutConstraint!
     var isIncomingCall: Bool = false
 
     let actionsView = CallingActionsView()
@@ -99,7 +99,7 @@ class CallingActionsInfoViewController: UIViewController, UICollectionViewDelega
         collectionView.bounces = true
         collectionView.delegate = self
         self.collectionView = collectionView
-        [actionsView, securityLevelView, participantsHeaderView, collectionView].forEach(stackView.addArrangedSubview)
+        [securityLevelView, actionsView, participantsHeaderView, collectionView].forEach(stackView.addArrangedSubview)
         CallParticipantsListCellConfiguration.prepare(collectionView)
         view.backgroundColor = SemanticColors.View.backgroundDefaultWhite
     }
@@ -130,7 +130,7 @@ class CallingActionsInfoViewController: UIViewController, UICollectionViewDelega
 
     func updateActionViewHeight() {
         guard UIDevice.current.twoDimensionOrientation.isLandscape else {
-            actionsViewHeightConstraint.constant =  isIncomingCall ? 250 : 128
+            actionsViewHeightConstraint.constant =  (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
             actionsView.verticalStackView.alignment = .fill
             return
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -41,17 +41,7 @@ class CallingBottomSheetViewController: BottomSheetContainerViewController {
     private let callDegradationController = CallDegradationController()
 
     var bottomSheetMinimalOffset: CGFloat {
-        var offset = 0.0
-        switch voiceChannel.state {
-        case .incoming:
-            offset = UIDevice.current.twoDimensionOrientation.isLandscape ? 128.0 : 250.0
-        default:
-            offset = 128.0
-        }
-        if case .established = callInfoConfiguration?.state, let configuration = callInfoConfiguration, configuration.classification != .none {
-            offset += SecurityLevelView.SecurityLevelViewHeight
-        }
-        return offset
+        return callingActionsInfoViewController.actionsViewHeightConstraint.constant
     }
 
     let callingActionsInfoViewController: CallingActionsInfoViewController

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/EstablishingCallStatusView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/EstablishingCallStatusView.swift
@@ -51,13 +51,19 @@ extension CallStatusViewState {
 }
 
 class EstablishingCallStatusView: UIView {
-    private let titleLabel = DynamicFontLabel(text: "",
-                                             fontSpec: .largeSemiboldFont,
-                                             color: SemanticColors.Label.textDefault)
-    private let callStateLabel = DynamicFontLabel(text: L10n.Localizable.Voice.Calling.title,
-                                                  fontSpec: .mediumRegularFont,
-                                                  color: SemanticColors.Label.textDefault)
-    private let securityLevelView = SecurityLevelView()
+
+    private let titleLabel = DynamicFontLabel(
+        text: "",
+        fontSpec: .largeSemiboldFont,
+        color: SemanticColors.Label.textDefault
+    )
+
+    private let callStateLabel = DynamicFontLabel(
+        text: L10n.Localizable.Voice.Calling.title,
+        fontSpec: .mediumRegularFont,
+        color: SemanticColors.Label.textDefault
+    )
+
     private let spaceView = UIView()
     private let profileImageView = UIImageView()
     private let stackView = UIStackView(axis: .vertical)
@@ -73,11 +79,11 @@ class EstablishingCallStatusView: UIView {
     }
 
     private func setupViews() {
-        [stackView, profileImageView, securityLevelView, spaceView].prepareForLayout()
+        [stackView, profileImageView, spaceView].prepareForLayout()
         stackView.alignment = .center
         stackView.spacing = 8
         addSubview(stackView)
-        [titleLabel, callStateLabel, securityLevelView, spaceView, profileImageView].forEach(stackView.addArrangedSubview)
+        [titleLabel, callStateLabel, spaceView, profileImageView].forEach(stackView.addArrangedSubview)
         profileImageView.layer.cornerRadius = 64.0
         profileImageView.layer.masksToBounds = true
         profileImageView.contentMode = .scaleAspectFill
@@ -92,8 +98,7 @@ class EstablishingCallStatusView: UIView {
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             profileImageView.widthAnchor.constraint(equalToConstant: 128.0),
             profileImageView.heightAnchor.constraint(equalToConstant: 128.0),
-            spaceView.heightAnchor.constraint(equalToConstant: spacerHeight),
-            securityLevelView.widthAnchor.constraint(equalTo: widthAnchor)
+            spaceView.heightAnchor.constraint(equalToConstant: spacerHeight)
         ])
     }
 
@@ -113,9 +118,6 @@ class EstablishingCallStatusView: UIView {
         profileImageView.isHidden = hidden
     }
 
-    func configureSecurityLevelView(with otherUsers: [UserType]) {
-        securityLevelView.configure(with: otherUsers)
-    }
 }
 
 // MARK: - Helper

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallViewController.swift
@@ -317,9 +317,6 @@ final class CallViewController: UIViewController {
         establishingCallStatusView.setProfileImage(hidden: configuration.mediaState.isSendingVideo)
         establishingCallStatusView.updateState(state: state)
         establishingCallStatusView.setTitle(title: configuration.title)
-        if let participants = voiceChannel.conversation?.participants as? [ZMUser] {
-            establishingCallStatusView.configureSecurityLevelView(with: participants)
-        }
         guard establishingCallStatusView.superview == nil else { return }
         establishingCallStatusView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(establishingCallStatusView)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
During a call, if the classification banner was shown, it was shown behind the iOS home bar at the bottom of the screen.

### Causes
The call actions view is a sheet that is partially visible and slides out to review all UI elements: call buttons, classification banner, then participant list.

When the sheet is only partially visible, it shows the call buttons and the classification banner, but doesn't take into account the safe area insets.

### Solutions
There are two different approaches I considered:

Extend the sheet a little further so that the bottom of the classification banner is snug against the safe area bottom margin: this didn't look good though because you could start to see the top of the participants list at the bottom of the screen.

![Wire 2023-03-31 at 2_05 PM](https://user-images.githubusercontent.com/28632506/229131124-670c2044-69b2-410c-aa31-7f8b491b327b.jpeg)

Instead, I opted to move the classification banner above the call actions: this looks better, but now it's possible to see two classification banners while the call is establishing. Therefore, I removed the banner from the establish call view so that only one banner is visible at a time. 
![Wire 2023-03-31 at 2_05 PM](https://user-images.githubusercontent.com/28632506/229131267-2be772f7-bc46-433e-9481-14114a03af16.jpeg)


### Testing

#### How to Test

- Start a call in a classified or unclassified conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
