### PR TITLE
fix: The position of the subtitle in the `ConversationTitleView`

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
@@ -48,20 +48,7 @@ class TitleView: UIView, DynamicTypeCapable {
     private func createConstraints() {
         [titleButton, stackView, subtitleLabel].prepareForLayout()
 
-//        if subtitleLabel.isHidden {
-//            stackView.fitIn(view: self)
-//        } else {
-//            stackView.fitIn(view: self, insets: UIEdgeInsets(top: 0, left: 0, bottom: -10, right: 0))
-//        }
-        NSLayoutConstraint.activate([
-
-            subtitleLabel.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: -5)
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
-
+        stackView.fitIn(view: self)
     }
 
     private func createViews() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
@@ -48,7 +48,20 @@ class TitleView: UIView, DynamicTypeCapable {
     private func createConstraints() {
         [titleButton, stackView, subtitleLabel].prepareForLayout()
 
-        stackView.fitIn(view: self)
+//        if subtitleLabel.isHidden {
+//            stackView.fitIn(view: self)
+//        } else {
+//            stackView.fitIn(view: self, insets: UIEdgeInsets(top: 0, left: 0, bottom: -10, right: 0))
+//        }
+        NSLayoutConstraint.activate([
+
+            subtitleLabel.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: -5)
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+
     }
 
     private func createViews() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -65,7 +65,6 @@ final class ConversationRootViewController: UIViewController {
         conversationController.didMove(toParent: self)
 
         conversation.refreshDataIfNeeded()
-
         configure()
     }
 
@@ -78,6 +77,8 @@ final class ConversationRootViewController: UIViewController {
         guard let conversationViewController = self.conversationViewController else {
             return
         }
+        navHeight = navBarContainer.view.heightAnchor.constraint(equalToConstant: 44)
+        setupNavigationBarHeight()
 
         self.view.backgroundColor = SemanticColors.View.backgroundDefault
 
@@ -98,6 +99,7 @@ final class ConversationRootViewController: UIViewController {
             navBarContainer.view.topAnchor.constraint(equalTo: networkStatusViewController.view.bottomAnchor),
             navBarContainer.view.leftAnchor.constraint(equalTo: view.leftAnchor),
             navBarContainer.view.rightAnchor.constraint(equalTo: view.rightAnchor),
+            navHeight!,
 
             contentView.leftAnchor.constraint(equalTo: view.leftAnchor),
             contentView.rightAnchor.constraint(equalTo: view.rightAnchor),
@@ -142,6 +144,21 @@ final class ConversationRootViewController: UIViewController {
 
     func scroll(to message: ZMConversationMessage) {
         conversationViewController?.scroll(to: message)
+    }
+
+    func setupNavigationBarHeight() {
+        let orientation = UIWindow.interfaceOrientation ?? .unknown
+        let deviceType = UIDevice.current.userInterfaceIdiom
+
+        if let conversationVC = conversationViewController?.conversation,
+           conversationVC.conversationType == .oneOnOne,
+           let user = conversationVC.connectedUserType,
+           user.isFederated {
+            navHeight?.constant = 50
+        } else {
+            navHeight?.constant = 44
+        }
+
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -25,6 +25,8 @@ final class ConversationRootViewController: UIViewController {
     let navBarContainer: UINavigationBarContainer
     fileprivate var contentView = UIView()
     var navHeight: NSLayoutConstraint?
+    private var navBarHeightForFederatedUsers: CGFloat = 50
+    private var defaultNavBarHeight: CGFloat = 40
     var networkStatusBarHeight: NSLayoutConstraint?
 
     /// for NetworkStatusViewDelegate
@@ -147,16 +149,14 @@ final class ConversationRootViewController: UIViewController {
     }
 
     func setupNavigationBarHeight() {
-        let orientation = UIWindow.interfaceOrientation ?? .unknown
-        let deviceType = UIDevice.current.userInterfaceIdiom
 
         if let conversationVC = conversationViewController?.conversation,
            conversationVC.conversationType == .oneOnOne,
            let user = conversationVC.connectedUserType,
            user.isFederated {
-            navHeight?.constant = 50
+            navHeight?.constant = navBarHeightForFederatedUsers
         } else {
-            navHeight?.constant = 44
+            navHeight?.constant = defaultNavBarHeight
         }
 
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -29,7 +29,7 @@ final class ConversationRootViewController: UIViewController {
     let navBarContainer: UINavigationBarContainer
     fileprivate var contentView = UIView()
     private var navBarHeightForFederatedUsers: CGFloat = 50
-    private var defaultNavBarHeight: CGFloat = 40
+    private var defaultNavBarHeight: CGFloat = 44
     var navHeight: NSLayoutConstraint?
     var networkStatusBarHeight: NSLayoutConstraint?
 
@@ -114,7 +114,7 @@ final class ConversationRootViewController: UIViewController {
         guard let conversationViewController = self.conversationViewController else {
             return
         }
-        navHeight = navBarContainer.view.heightAnchor.constraint(equalToConstant: 44)
+        navHeight = navBarContainer.view.heightAnchor.constraint(equalToConstant: defaultNavBarHeight)
         setupNavigationBarHeight()
 
         guard let navigationBarHeight = navHeight else {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -29,6 +29,8 @@ final class ConversationRootViewController: UIViewController {
     let navBarContainer: UINavigationBarContainer
     fileprivate var contentView = UIView()
     private var navBarHeightForFederatedUsers: CGFloat = 50
+    // This value is coming from UINavigationBarContainer. swift file
+    // where the value for the navigation bar height is set to 44.
     private var defaultNavBarHeight: CGFloat = 44
     var navHeight: NSLayoutConstraint?
     var networkStatusBarHeight: NSLayoutConstraint?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -19,14 +19,18 @@
 import UIKit
 import WireSyncEngine
 
+// MARK: - ConversationRootViewController
+
 // This class wraps the conversation content view controller in order to display the navigation bar on the top
 final class ConversationRootViewController: UIViewController {
 
+    // MARK: - Properties
+
     let navBarContainer: UINavigationBarContainer
     fileprivate var contentView = UIView()
-    var navHeight: NSLayoutConstraint?
     private var navBarHeightForFederatedUsers: CGFloat = 50
     private var defaultNavBarHeight: CGFloat = 40
+    var navHeight: NSLayoutConstraint?
     var networkStatusBarHeight: NSLayoutConstraint?
 
     /// for NetworkStatusViewDelegate
@@ -35,6 +39,8 @@ final class ConversationRootViewController: UIViewController {
     fileprivate let networkStatusViewController: NetworkStatusViewController = NetworkStatusViewController()
 
     fileprivate(set) weak var conversationViewController: ConversationViewController?
+
+    // MARK: - Init
 
     init(conversation: ZMConversation,
          message: ZMConversationMessage?,
@@ -74,6 +80,8 @@ final class ConversationRootViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // MARK: - Override methods
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -144,13 +152,13 @@ final class ConversationRootViewController: UIViewController {
         navBarContainer.navigationBar.pushItem(conversationViewController.navigationItem, animated: false)
     }
 
+    // MARK: - Methods
 
     func scroll(to message: ZMConversationMessage) {
         conversationViewController?.scroll(to: message)
     }
 
     func setupNavigationBarHeight() {
-
         if let conversationVC = conversationViewController?.conversation,
            conversationVC.conversationType == .oneOnOne,
            let user = conversationVC.connectedUserType,
@@ -163,20 +171,27 @@ final class ConversationRootViewController: UIViewController {
     }
 }
 
+// MARK: - NetworkStatusBarDelegate
+
 extension ConversationRootViewController: NetworkStatusBarDelegate {
     var bottomMargin: CGFloat {
         return 0
     }
 
-    func showInIPad(networkStatusViewController: NetworkStatusViewController, with orientation: UIInterfaceOrientation) -> Bool {
+    func showInIPad(
+        networkStatusViewController: NetworkStatusViewController,
+        with orientation: UIInterfaceOrientation
+    ) -> Bool {
         // always show on iPad for any orientation in regular mode
         return true
     }
 }
 
+// MARK: - ZMConversation extension
+
 extension ZMConversation {
 
-    /// Check if the conversation data is out of date, and in case update it. 
+    /// Check if the conversation data is out of date, and in case update it.
     /// This in an opportunistic update of the data, with an on-demand strategy.
     /// Whenever the conversation is opened by the user, we check if anything is missing.
     fileprivate func refreshDataIfNeeded() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -75,6 +75,33 @@ final class ConversationRootViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        shouldAnimateNetworkStatusView = true
+        navBarContainer.navigationBar.accessibilityElementsHidden = false
+        conversationViewController?.view.accessibilityElementsHidden = false
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        navBarContainer.navigationBar.accessibilityElementsHidden = true
+        conversationViewController?.view.accessibilityElementsHidden = true
+    }
+
+    private var child: UIViewController? {
+        return conversationViewController?.contentViewController
+    }
+
+    override var childForStatusBarStyle: UIViewController? {
+        return child
+    }
+
+    override var childForStatusBarHidden: UIViewController? {
+        return child
+    }
+
     func configure() {
         guard let conversationViewController = self.conversationViewController else {
             return
@@ -117,32 +144,6 @@ final class ConversationRootViewController: UIViewController {
         navBarContainer.navigationBar.pushItem(conversationViewController.navigationItem, animated: false)
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        shouldAnimateNetworkStatusView = true
-        navBarContainer.navigationBar.accessibilityElementsHidden = false
-        conversationViewController?.view.accessibilityElementsHidden = false
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        navBarContainer.navigationBar.accessibilityElementsHidden = true
-        conversationViewController?.view.accessibilityElementsHidden = true
-    }
-
-    private var child: UIViewController? {
-        return conversationViewController?.contentViewController
-    }
-
-    override var childForStatusBarStyle: UIViewController? {
-        return child
-    }
-
-    override var childForStatusBarHidden: UIViewController? {
-        return child
-    }
 
     func scroll(to message: ZMConversationMessage) {
         conversationViewController?.scroll(to: message)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -117,6 +117,10 @@ final class ConversationRootViewController: UIViewController {
         navHeight = navBarContainer.view.heightAnchor.constraint(equalToConstant: 44)
         setupNavigationBarHeight()
 
+        guard let navigationBarHeight = navHeight else {
+            return
+        }
+
         self.view.backgroundColor = SemanticColors.View.backgroundDefault
 
         self.addToSelf(navBarContainer)
@@ -136,7 +140,7 @@ final class ConversationRootViewController: UIViewController {
             navBarContainer.view.topAnchor.constraint(equalTo: networkStatusViewController.view.bottomAnchor),
             navBarContainer.view.leftAnchor.constraint(equalTo: view.leftAnchor),
             navBarContainer.view.rightAnchor.constraint(equalTo: view.rightAnchor),
-            navHeight!,
+            navigationBarHeight,
 
             contentView.leftAnchor.constraint(equalTo: view.leftAnchor),
             contentView.rightAnchor.constraint(equalTo: view.rightAnchor),


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix the position of the subtitle in ConversationTitleView. Before those changes, the subtitle would be cut off. So we fix the issue by changing the height of the navigation bar based on certain conditions. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
