### PR TITLE
fix: conversation type for connection requests FS-1764

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
@@ -86,21 +86,29 @@ extension Payload.Conversation {
         }
     }
 
-    func updateOrCreateOneToOneConversation(in context: NSManagedObjectContext,
-                                            serverTimestamp: Date,
-                                            source: Source) {
+    func updateOrCreateOneToOneConversation(
+        in context: NSManagedObjectContext,
+        serverTimestamp: Date,
+        source: Source
+    ) {
 
-        guard let conversationID = id ?? qualifiedID?.uuid,
-              let rawConversationType = type else {
-                  Logging.eventProcessing.error("Missing conversation or type in 1:1 conversation payload, aborting...")
-                  return
-              }
+        guard
+            let conversationID = id ?? qualifiedID?.uuid,
+            let rawConversationType = type
+        else {
+            Logging.eventProcessing.error("Missing conversation or type in 1:1 conversation payload, aborting...")
+            return
+        }
 
         let conversationType = BackendConversationType.clientConversationType(rawValue: rawConversationType)
 
-        guard let otherMember = members?.others.first, let otherUserID = otherMember.id ?? otherMember.qualifiedID?.uuid else {
+        guard
+            let otherMember = members?.others.first,
+            let otherUserID = otherMember.id ?? otherMember.qualifiedID?.uuid
+        else {
             let conversation = ZMConversation.fetch(with: conversationID, domain: qualifiedID?.domain, in: context)
-            conversation?.conversationType = conversationType
+            // TODO: use conversation type from the backend once it returns the correct value
+            conversation?.conversationType = self.conversationType(for: conversation, from: conversationType)
             conversation?.needsToBeUpdatedFromBackend = false
             return
         }
@@ -118,7 +126,9 @@ extension Payload.Conversation {
 
         conversation.remoteIdentifier = conversationID
         conversation.domain = BackendInfo.isFederationEnabled ? qualifiedID?.domain : nil
-        conversation.conversationType = conversationType
+
+        // TODO: use conversation type from the backend once it returns the correct value
+        conversation.conversationType = self.conversationType(for: conversation, from: conversationType)
 
         updateMetadata(for: conversation, context: context)
         updateMembers(for: conversation, context: context)
@@ -187,6 +197,22 @@ extension Payload.Conversation {
                 // Slow synced conversations should be considered read from the start
                 conversation.lastReadServerTimeStamp = conversation.lastModifiedDate
             }
+        }
+    }
+
+    // There is a bug in the backend where the conversation type is not correct for
+    // connection requests across federated backends. Instead of returning `.connection` type,
+    // it returns `oneOnOne.
+    // We fix this temporarily on our side by checking the connection status of the conversation.
+    private func conversationType(for conversation: ZMConversation?, from type: ZMConversationType) -> ZMConversationType {
+        guard let conversation = conversation else {
+            return type
+        }
+
+        if conversation.connection?.status == .sent {
+            return .connection
+        } else {
+            return type
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Opening an outgoing federated connection request opens the conversation view, although the remote user didn't accept the connection request yet.

<img src=https://user-images.githubusercontent.com/6436181/229165926-dce25f90-09f0-433a-ab4e-a224afad0c46.PNG width=300 />

### Causes

When fetching the conversation linked to the connection request, the backend returns an erroneous conversation type. The `type` is `oneOnOne` instead of `connection`.

We see the "cancel request" button and archive icon at the bottom because its visibility depends on the status of the connection request, while the conversation input view and call buttons visibility depend on the conversation type.

### Solutions

When processing the backend response, verify the connection status of the conversation and change the conversation type to `connection` is the connection status is `sent`.

Note that this is a workaround and that the real solution is for the backend to return the right conversation type.


