### PR TITLE
fix: Transparent View Controller Navigation Bars - IC - 58

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
@@ -38,36 +38,59 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
         createAndPresentParticipantsPopoverController(with: frame, from: view, contentViewController: profileViewController.wrapInNavigationController(setBackgroundColor: true))
     }
 
-    func conversationContentViewController(_ contentViewController: ConversationContentViewController, willDisplayActiveMediaPlayerFor message: ZMConversationMessage?) {
+    func conversationContentViewController(
+        _ contentViewController: ConversationContentViewController,
+        willDisplayActiveMediaPlayerFor message: ZMConversationMessage?
+    ) {
         conversationBarController.dismiss(bar: mediaBarViewController)
     }
 
-    func conversationContentViewController(_ contentViewController: ConversationContentViewController, didEndDisplayingActiveMediaPlayerFor message: ZMConversationMessage) {
+    func conversationContentViewController(
+        _ contentViewController: ConversationContentViewController,
+        didEndDisplayingActiveMediaPlayerFor message: ZMConversationMessage
+    ) {
         conversationBarController.present(bar: mediaBarViewController)
     }
 
-    func conversationContentViewController(_ contentViewController: ConversationContentViewController, didTriggerResending message: ZMConversationMessage) {
+    func conversationContentViewController(
+        _ contentViewController: ConversationContentViewController,
+        didTriggerResending message: ZMConversationMessage
+    ) {
         ZMUserSession.shared()?.enqueue({
             message.resend()
         })
     }
 
-    func conversationContentViewController(_ contentViewController: ConversationContentViewController, didTriggerEditing message: ZMConversationMessage) {
+    func conversationContentViewController(
+        _ contentViewController: ConversationContentViewController,
+        didTriggerEditing message: ZMConversationMessage
+    ) {
         guard message.textMessageData?.messageText != nil else { return }
 
         inputBarController.editMessage(message)
     }
 
-    func conversationContentViewController(_ contentViewController: ConversationContentViewController, didTriggerReplyingTo message: ZMConversationMessage) {
+    func conversationContentViewController(
+        _ contentViewController: ConversationContentViewController,
+        didTriggerReplyingTo message: ZMConversationMessage
+    ) {
         let replyComposingView = contentViewController.createReplyComposingView(for: message)
         inputBarController.reply(to: message, composingView: replyComposingView)
     }
 
-    func conversationContentViewController(_ controller: ConversationContentViewController, shouldBecomeFirstResponderWhenShowMenuFromCell cell: UIView) -> Bool {
+    func conversationContentViewController(
+        _ controller: ConversationContentViewController,
+        shouldBecomeFirstResponderWhenShowMenuFromCell cell: UIView
+    ) -> Bool {
         if inputBarController.inputBar.textView.isFirstResponder {
             inputBarController.inputBar.textView.overrideNextResponder = cell
 
-            NotificationCenter.default.addObserver(self, selector: #selector(menuDidHide(_:)), name: UIMenuController.didHideMenuNotification, object: nil)
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(menuDidHide(_:)),
+                name: UIMenuController.didHideMenuNotification,
+                object: nil
+            )
 
             return false
         }
@@ -75,7 +98,11 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
         return true
     }
 
-    func conversationContentViewController(_ contentViewController: ConversationContentViewController, performImageSaveAnimation snapshotView: UIView?, sourceRect: CGRect) {
+    func conversationContentViewController(
+        _ contentViewController: ConversationContentViewController,
+        performImageSaveAnimation snapshotView: UIView?,
+        sourceRect: CGRect
+    ) {
         if let snapshotView = snapshotView {
             view.addSubview(snapshotView)
         }
@@ -98,7 +125,10 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
         openConversationList()
     }
 
-    func conversationContentViewController(_ controller: ConversationContentViewController, presentGuestOptionsFrom sourceView: UIView) {
+    func conversationContentViewController(
+        _ controller: ConversationContentViewController,
+        presentGuestOptionsFrom sourceView: UIView
+    ) {
         guard conversation.conversationType == .group else {
             zmLog.error("Illegal Operation: Trying to show guest options for non-group conversation")
             return
@@ -110,21 +140,32 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
         presentParticipantsViewController(navigationController, from: sourceView)
     }
 
-    func conversationContentViewController(_ controller: ConversationContentViewController, presentServicesOptionFrom sourceView: UIView) {
+    func conversationContentViewController(
+        _ controller: ConversationContentViewController,
+        presentServicesOptionFrom sourceView: UIView
+    ) {
         guard conversation.conversationType == .group else {
             zmLog.error("Illegal Operation: Trying to show services options for non-group conversation")
             return
         }
 
         let groupDetailsViewController = GroupDetailsViewController(conversation: conversation)
-        let navigationController = groupDetailsViewController.wrapInNavigationController()
+        let navigationController = groupDetailsViewController.wrapInNavigationController(setBackgroundColor: true)
         groupDetailsViewController.presentServicesOptions(animated: false)
         presentParticipantsViewController(navigationController, from: sourceView)
     }
 
-    func conversationContentViewController(_ controller: ConversationContentViewController, presentParticipantsDetailsWithSelectedUsers selectedUsers: [UserType], from sourceView: UIView) {
+    func conversationContentViewController(
+        _ controller: ConversationContentViewController,
+        presentParticipantsDetailsWithSelectedUsers selectedUsers: [UserType],
+        from sourceView: UIView
+    ) {
         if let groupDetailsViewController = (participantsController as? UINavigationController)?.topViewController as? GroupDetailsViewController {
-                groupDetailsViewController.presentParticipantsDetails(with: conversation.sortedOtherParticipants, selectedUsers: selectedUsers, animated: false)
+                groupDetailsViewController.presentParticipantsDetails(
+                    with: conversation.sortedOtherParticipants,
+                    selectedUsers: selectedUsers,
+                    animated: false
+                )
         }
 
         if let participantsController = participantsController {
@@ -135,7 +176,10 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
 
 extension ConversationViewController {
 
-    func presentParticipantsViewController(_ viewController: UIViewController, from sourceView: UIView) {
+    func presentParticipantsViewController(
+        _ viewController: UIViewController,
+        from sourceView: UIView
+    ) {
         ConversationInputBarViewController.endEditingMessage()
         inputBarController.inputBar.textView.resignFirstResponder()
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -347,7 +347,7 @@ final class ZClientViewController: UIViewController {
     /// - Parameter conversation: conversation to open
     func openDetailScreen(for conversation: ZMConversation) {
         let controller = GroupDetailsViewController(conversation: conversation)
-        let navController = controller.wrapInNavigationController()
+        let navController = controller.wrapInNavigationController(setBackgroundColor: true)
         navController.modalPresentationStyle = .formSheet
 
         present(navController, animated: true)
@@ -657,7 +657,7 @@ final class ZClientViewController: UIViewController {
             viewController = profileViewController
         }
 
-        let navWrapperController: UINavigationController? = viewController?.wrapInNavigationController()
+        let navWrapperController: UINavigationController? = viewController?.wrapInNavigationController(setBackgroundColor: true)
         navWrapperController?.modalPresentationStyle = .formSheet
         if let aController = navWrapperController {
             present(aController, animated: true)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix a couple of navigation bars being transparent in certain scenarios where use would tap on `started using a new device` as shown in the screenshot below. 

![testy](https://user-images.githubusercontent.com/10944108/229466434-266a2bdd-3df7-498d-87b0-309e9875b31b.jpeg)

![Screenshot 2023-04-03 at 11 19 08](https://user-images.githubusercontent.com/10944108/229467331-ebad2e4a-c1b9-419d-a127-7d8ff74670fa.png)


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
