### PR TITLE
fix: crash on call start FS-1767

### DIFF
--- a/avs-versions
+++ b/avs-versions
@@ -17,4 +17,4 @@
 # along with this program. If not, see http://www.gnu.org/licenses/.
 #
 
-export APPSTORE_AVS_VERSION=9.2.6
+export APPSTORE_AVS_VERSION=9.2.7


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App crashes on call start

### Causes (Optional)

Missing symbol for [UIDevice deviceType] .
The method is implemented in an extension of webrtc but somehow wasn't linked for simulator builds

### Solutions

Fixed by avs, so we just bump the version
