### PR TITLE
fix: crash on api migration v2 to v3 - FS-1760

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/APIMigration/AccessTokenMigration.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/APIMigration/AccessTokenMigration.swift
@@ -40,10 +40,10 @@ class AccessTokenMigration: APIMigration, AccessTokenRenewalObserver {
     }
 
     func perform(with session: ZMUserSession, clientID: String) async throws {
-        try await perform(with: session, clientID: clientID)
+        try await perform(withTokenRenewer: session, clientID: clientID)
     }
 
-    func perform(with tokenRenewer: AccessTokenRenewing, clientID: String) async throws {
+    func perform(withTokenRenewer tokenRenewer: AccessTokenRenewing, clientID: String) async throws {
         logger.info("performing access token migration for clientID \(clientID)")
 
         tokenRenewer.setAccessTokenRenewalObserver(self)

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/AccessTokenMigrationTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/AccessTokenMigrationTests.swift
@@ -57,7 +57,7 @@ class AccessTokenMigrationTests: XCTestCase {
         tokenRenewer.shoudFail = false
 
         // When
-        try await sut.perform(with: tokenRenewer, clientID: clientID)
+        try await sut.perform(withTokenRenewer: tokenRenewer, clientID: clientID)
 
         // Then
         XCTAssertEqual(tokenRenewer.calls.setAccessTokenRenewalObserver.count, 1)
@@ -75,7 +75,7 @@ class AccessTokenMigrationTests: XCTestCase {
 
         // When / Then
         do {
-            try await sut.perform(with: tokenRenewer, clientID: clientID)
+            try await sut.perform(withTokenRenewer: tokenRenewer, clientID: clientID)
             XCTFail("expected an error")
         } catch let error as AccessTokenMigration.Error {
             XCTAssertEqual(error, .failedToRenewAccessToken)

--- a/wire-ios-system/Source/WireLogger.swift
+++ b/wire-ios-system/Source/WireLogger.swift
@@ -167,4 +167,6 @@ public extension WireLogger {
 
   static let updateEvent = WireLogger(tag: "update-event")
 
+  /// For logs related to performance
+  static let performance = WireLogger(tag: "performance")
 }

--- a/wire-ios/Wire-iOS/Sources/Helpers/PerformanceDebugger.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/PerformanceDebugger.swift
@@ -56,12 +56,14 @@ final class PerformanceDebugger {
 
         if elapsedTime > 16.7 {
             log.warn("Frame dropped after \(elapsedTime)s")
+            WireLogger.performance.warn("Frame dropped after \(elapsedTime)s")
         }
     }
 
     @objc
     private func handleMemoryWarning() {
         log.warn("Application did receive memory warning.")
+        WireLogger.performance.warn("Application did receive memory warning.")
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1760" title="FS-1760" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1760</a>  [iOS] App crash when having Wire open, locking the device, and re-opening the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When we update to a new build with different apiVersion from 2 to 3 for example, and we coem back to foreground, the app will crash.

### Causes (Optional)

The apiVersioning is triggered on `applicationWillEnterForeground` which checks for any migration to be performed like `AccessTokenMigration`. The `AccessTokenMigration` had two similar signatures from two different protocols

```
func perform(with session: ZMUserSession, clientID: String) async throws {

func perform(with tokenRenewer: AccessTokenRenewing, clientID: String) async throws {
```

And `ZMUserSession` implements `AccessTokenRenewing`. so the same method is called over and over since we don't cast the session as AccessTokenRenewing.

### Solutions

* Rename one of the `perform` method to avoid Out of memory crash.
* Log memory warnings to Datadog

### Testing

#### How to Test

* Log in with a build with apiVersion: v2
* Update the build with apiVersion: v3
* Put the app into background and put it back on foreground

Expected: It should not crash

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
