### PR TITLE
fix: request loop on /users/handles query - FS-1769

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -101,20 +101,24 @@ public class SearchTask {
     /// Start the search task. Results will be sent to the result handlers
     /// added via the `onResult()` method.
     public func start() {
-        performLocalSearch()
-
-        performRemoteSearch()
-        performRemoteSearchForTeamUser()
+        // search services
         performRemoteSearchForServices()
 
-        performUserLookup()
+        // search People or groups
         performLocalLookup()
+        performLocalSearch()
+
+        // v1
+        performUserLookup()
+        performRemoteSearchForTeamUser()
+        // v2+
+        performRemoteSearch()
     }
 }
 
 extension SearchTask {
 
-    /// look up a user ID from contacts and teamMmebers locally. 
+    /// look up a user ID from contacts and teamMembers locally.
     private func performLocalLookup() {
          guard case .lookup(let userId) = task else { return }
 
@@ -269,7 +273,8 @@ extension SearchTask {
     func performUserLookup() {
         guard
             case .lookup(let userId) = task,
-            let apiVersion = BackendInfo.apiVersion
+            let apiVersion = BackendInfo.apiVersion,
+            apiVersion <= .v1
         else { return }
 
         tasksRemaining += 1
@@ -315,6 +320,7 @@ extension SearchTask {
     func performRemoteSearch() {
         guard
             let apiVersion = BackendInfo.apiVersion,
+            apiVersion >= .v2,
             case .search(let searchRequest) = task,
             !searchRequest.searchOptions.isDisjoint(with: [.directory, .teamMembers, .federated])
         else {
@@ -437,6 +443,7 @@ extension SearchTask {
     func performRemoteSearchForTeamUser() {
         guard
             let apiVersion = BackendInfo.apiVersion,
+            apiVersion <= .v1,
             case .search(let searchRequest) = task,
             searchRequest.searchOptions.contains(.directory)
         else { return }

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
@@ -25,6 +25,7 @@ extension IntegrationTest {
     @objc
     public func searchAndConnectToUser(withName name: String, searchQuery: String) {
         createSharedSearchDirectory()
+        self.overrideAPIVersion(.v2)
 
         let searchCompleted = expectation(description: "Search result arrived")
         let request = SearchRequest(query: searchQuery, searchOptions: [.directory])
@@ -39,6 +40,7 @@ extension IntegrationTest {
         }
 
         task?.start()
+        self.resetCurrentAPIVersion()
 
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertNotNil(searchResult)

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
@@ -25,6 +25,7 @@ extension IntegrationTest {
     @objc
     public func searchAndConnectToUser(withName name: String, searchQuery: String) {
         createSharedSearchDirectory()
+        // TODO: do test assertion on apiVersion and move currentApiVersion on caller
         self.overrideAPIVersion(.v2)
 
         let searchCompleted = expectation(description: "Search result arrived")
@@ -55,7 +56,9 @@ extension IntegrationTest {
     @objc
     public func searchForDirectoryUser(withName name: String, searchQuery: String) -> ZMSearchUser? {
         createSharedSearchDirectory()
-
+        // this only work for v2 and above
+        // TODO: do test assertion on apiVersion and move currentApiVersion on caller
+        setCurrentAPIVersion(.v2)
         let searchCompleted = expectation(description: "Search result arrived")
         let request = SearchRequest(query: searchQuery, searchOptions: [.directory])
         let task = sharedSearchDirectory?.perform(request)
@@ -72,7 +75,7 @@ extension IntegrationTest {
 
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssertNotNil(searchResult)
-
+        resetCurrentAPIVersion()
         return searchResult?.directory.first
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
@@ -764,6 +764,9 @@ extension IntegrationTest {
         setCurrentAPIVersion(.v0)
     }
 
+    func overrideAPIVersion(_ version: APIVersion) {
+        setCurrentAPIVersion(version)
+    }
 }
 
 // MARK: - Account Helper

--- a/wire-ios-sync-engine/Tests/Source/Integration/SearchTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SearchTests.swift
@@ -382,8 +382,9 @@ class SearchTests: IntegrationTest {
         }
 
         XCTAssertTrue(login())
-        guard let searchQuery = userName?.components(separatedBy: " ").last else { XCTFail(); return }
-        guard let user = searchForConnectedUser(withName: userName!, searchQuery: searchQuery) else { XCTFail(); return }
+        guard let userName = userName else { XCTFail("missing userName"); return }
+        guard let searchQuery = userName.components(separatedBy: " ").last else { XCTFail("searchQuery"); return }
+        guard let user = searchForConnectedUser(withName: userName, searchQuery: searchQuery) else { XCTFail("missing user"); return }
 
         // when
         mockTransportSession.resetReceivedRequests()
@@ -399,7 +400,7 @@ class SearchTests: IntegrationTest {
         XCTAssertEqual(requests.first?.method, .methodGET)
     }
 
-    func testThatItDownloadsV3PreviewAssetWhenOnlyV3AssetsArePrensentInSearchUserResponse_UnconnectedUser() {
+    func testThatItDownloadsV3PreviewAssetWhenOnlyV3AssetsArePresentInSearchUserResponse_UnconnectedUser() {
         // given
         var profileImageData: Data?
         var userName: String?
@@ -424,9 +425,9 @@ class SearchTests: IntegrationTest {
         XCTAssertEqual(searchUser.previewImageData, profileImageData)
 
         let requests = mockTransportSession.receivedRequests()
-        XCTAssertEqual(requests.count, 4)
-        XCTAssertEqual(requests[3].path, "/assets/v3/\(user4.previewProfileAssetIdentifier!)")
-        XCTAssertEqual(requests[3].method, .methodGET)
+        XCTAssertEqual(requests.count, 3)
+        XCTAssertEqual(requests[2].path, "/assets/v3/\(user4.previewProfileAssetIdentifier!)")
+        XCTAssertEqual(requests[2].method, .methodGET)
     }
 
     func testThatItDownloadsMediumAssetForSearchUserWhenAssetAndLegacyIdArePresentUsingV3() {
@@ -454,9 +455,9 @@ class SearchTests: IntegrationTest {
         }
 
         XCTAssertTrue(login())
-
-        guard let searchQuery = userName?.components(separatedBy: " ").last else { XCTFail(); return }
-        guard let searchUser = searchForDirectoryUser(withName: userName!, searchQuery: searchQuery) else { XCTFail(); return }
+        guard let userName = userName else { XCTFail("missing userName"); return }
+        guard let searchQuery = userName.components(separatedBy: " ").last else { XCTFail("missing searchQuery"); return }
+        guard let searchUser = searchForDirectoryUser(withName: userName, searchQuery: searchQuery) else { XCTFail("missing searchUser"); return }
         searchUser.requestPreviewProfileImage()
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -38,7 +38,7 @@ class SearchTaskTests: DatabaseTest {
             _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.uiMOC)
             uiMOC.saveOrRollback()
         }
-
+        BackendInfo.storage = UserDefaults(suiteName: UUID().uuidString)!
         setCurrentAPIVersion(.v0)
     }
 
@@ -46,6 +46,7 @@ class SearchTaskTests: DatabaseTest {
         self.teamIdentifier = nil
         self.mockTransportSession = nil
         resetCurrentAPIVersion()
+        BackendInfo.storage = UserDefaults.standard
         super.tearDown()
     }
 
@@ -809,6 +810,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItSendsASearchRequest() {
         // given
+        setCurrentAPIVersion(.v2)
         let request = SearchRequest(query: "Steve O'Hara & Söhne", searchOptions: [.directory])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -835,6 +837,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItEncodesAPlusCharacterInTheSearchURL() {
         // given
+        setCurrentAPIVersion(.v2)
         let request = SearchRequest(query: "foo+bar@example.com", searchOptions: [.directory])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -853,6 +856,7 @@ class SearchTaskTests: DatabaseTest {
         // "The characters slash ("/") and question mark ("?") may represent data within the query component."
 
         // given
+        setCurrentAPIVersion(.v2)
         let request = SearchRequest(query: "$&+,/:;=?@", searchOptions: [.directory])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -866,6 +870,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCallsCompletionHandlerForDirectorySearch() {
         // given
+        setCurrentAPIVersion(.v2)
         let resultArrived = expectation(description: "received result")
         let request = SearchRequest(query: "User", searchOptions: [.directory])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
@@ -889,6 +894,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItMakesRequestToFetchTeamMembershipMetadata() {
         // given
+        setCurrentAPIVersion(.v2)
         let request = SearchRequest(query: "User", searchOptions: [.directory, .teamMembers])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -912,6 +918,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCallsCompletionHandlerForTeamMemberDirectorySearch() {
         // given
+        setCurrentAPIVersion(.v2)
         let resultArrived = expectation(description: "received result")
         let request = SearchRequest(query: "User", searchOptions: [.directory, .teamMembers])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
@@ -1039,6 +1046,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItSendsAFederatedUserSearchRequest() throws {
         // given
+        setCurrentAPIVersion(.v3)
         let searchRequest = SearchRequest(query: "john@example.com", searchOptions: .federated)
         let task = SearchTask(request: searchRequest, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -1054,6 +1062,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCallsCompletionHandlerForFederatedUserSearch_WhenUserExists() {
         // given
+        setCurrentAPIVersion(.v3)
         let federatedDomain = "example.com"
         let resultArrived = expectation(description: "received result")
 
@@ -1083,6 +1092,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCallsCompletionHandlerForFederatedUserSearch_WhenUserDoesntExist() {
         // given
+        setCurrentAPIVersion(.v3)
         let resultArrived = expectation(description: "received result")
         mockTransportSession.federatedDomains = ["example.com"]
 
@@ -1143,6 +1153,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatLocalResultsIncludePreviousRemoteResults() {
         // given
+        setCurrentAPIVersion(.v2)
         let remoteResultArrived = expectation(description: "received remote result")
         _ = createConnectedUser(withName: "userA")
 
@@ -1198,6 +1209,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatTaskIsCompletedAfterRemoteResults() {
         // given
+        setCurrentAPIVersion(.v2)
         let remoteResultArrived = expectation(description: "received remote result")
         mockTransportSession.performRemoteChanges { (remoteChanges) in
             remoteChanges.insertUser(withName: "UserB")

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -819,7 +819,7 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/search/contacts?q=steve%20o'hara%20%26%20s%C3%B6hne&size=10")
+        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/v2/search/contacts?q=steve%20o'hara%20%26%20s%C3%B6hne&size=10")
     }
 
     func testThatItDoesNotSendASearchRequestIfSeachingLocally() {
@@ -846,7 +846,7 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/search/contacts?q=foo%2Bbar&domain=example.com&size=10")
+        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/v2/search/contacts?q=foo%2Bbar&domain=example.com&size=10")
     }
 
     func testThatItEncodesUnsafeCharactersInRequest() {
@@ -865,7 +865,7 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/search/contacts?q=$%26%2B,/:;%3D?&size=10")
+        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/v2/search/contacts?q=$%26%2B,/:;%3D?&size=10")
     }
 
     func testThatItCallsCompletionHandlerForDirectorySearch() {
@@ -912,8 +912,8 @@ class SearchTaskTests: DatabaseTest {
 
         // then
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 2)
-        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/search/contacts?q=user&size=10")
-        XCTAssertEqual(mockTransportSession.receivedRequests().last?.path, "/teams/\(teamIdentifier.transportString())/get-members-by-ids-using-post")
+        XCTAssertEqual(mockTransportSession.receivedRequests().first?.path, "/v2/search/contacts?q=user&size=10")
+        XCTAssertEqual(mockTransportSession.receivedRequests().last?.path, "/v2/teams/\(teamIdentifier.transportString())/get-members-by-ids-using-post")
     }
 
     func testThatItCallsCompletionHandlerForTeamMemberDirectorySearch() {
@@ -1057,7 +1057,7 @@ class SearchTaskTests: DatabaseTest {
         // then
         let request = try XCTUnwrap(mockTransportSession.receivedRequests().first)
         XCTAssertEqual(request.method, .methodGET)
-        XCTAssertEqual(request.path, "/search/contacts?q=john&domain=example.com&size=10")
+        XCTAssertEqual(request.path, "/v3/search/contacts?q=john&domain=example.com&size=10")
     }
 
     func testThatItCallsCompletionHandlerForFederatedUserSearch_WhenUserExists() {
@@ -1117,6 +1117,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatRemoteResultsIncludePreviousLocalResults() {
         // given
+        setCurrentAPIVersion(.v2)
         let localResultArrived = expectation(description: "received local result")
         let user = createConnectedUser(withName: "userA")
 

--- a/wire-ios-transport/Source/URLSession/RequestLoopDetection.swift
+++ b/wire-ios-transport/Source/URLSession/RequestLoopDetection.swift
@@ -36,7 +36,7 @@ import Foundation
     /// After this time, requests are purged from the list
     static let decayTimer : TimeInterval = 60 // 1 minute
     
-    /// Repeatition warning trigger threshold
+    /// Repetition warning trigger threshold
     /// If a request is repeated more than this number of times,
     /// it will trigger a warning
     static let repetitionTriggerThreshold = 20


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1769" title="FS-1769" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1769</a>  [iOS] Request loop alert when selecting +- 20 contacts in group creation flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While searching for users, we fire two requests:
```
/v3/users?handles=adcc8d04
/v3/search/contacts?q=adcc8d04&domain=...&size=10
```
The first one causes a request loop detection.
### Causes (Optional)

While typing the domain we will end up firing the same request for the exact handle.

The /users?handles is deprecated since version 2 along with GET /users, GET /users/by-handle in favor of POST /search/contacts.

### Solutions

Check APIVersion for each performXXX methods of SearchTask.

### Testing

#### Test Coverage (Optional)

- Updated current tests to use the correct apiVersion.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
