### PR TITLE
fix: crash when fetching local fingerprint

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -577,8 +577,11 @@ extension UserClient {
         return fingerprintData
     }
 
-    private func localFingerprint() -> Data? {
-        guard let proteusProvider = managedObjectContext?.proteusProvider else {
+    func localFingerprint(_ proteusProvider: ProteusProviding? = nil) -> Data? {
+        guard
+            let proteusProvider = proteusProvider ?? managedObjectContext?.proteusProvider,
+            proteusProvider.canPerform
+        else {
             return nil
         }
 

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -462,7 +462,7 @@ public extension UserClient {
             if client.remoteIdentifier == selfClient.remoteIdentifier {
                 client.fingerprint = client.localFingerprint()
                 if client.fingerprint == nil {
-                    zmLog.error("Cannot fetch local fingerprint for \(client)")
+                    zmLog.warn("Cannot fetch local fingerprint for \(client)")
                 }
             }
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Crash when fetching local fingerprint

### Causes

When fetching the list of clients of the self user, we may update the self client's fingerprint. 
There can be a case where we try to do that while we do not have an instance of the `ProteusService`, which will trigger a `fatalError`

### Solutions

Verify if the `ProteusService` is available before fetching the local fingerprint by using the `canPerform` method of `ProteusProvider`.
This will allow us to return `nil` for the fingerprint instead of crashing.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution


