### PR TITLE
fix: request loop when searching users FS-1769

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchRequest.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchRequest.swift
@@ -22,24 +22,45 @@ import WireDataModel
 public struct SearchOptions: OptionSet {
     public let rawValue: Int
 
-    /// Users you are connected to via connection request
+    /// Users you are connected to via connection request.
+
     public static let contacts = SearchOptions(rawValue: 1 << 0)
-    /// Users found in your address book
+
+    /// Users found in your address book.
+
     public static let addressBook = SearchOptions(rawValue: 1 << 1)
-    /// Users which are a member of the same team as you
+
+    /// Users which are a member of the same team as you.
+
     public static let teamMembers = SearchOptions(rawValue: 1 << 2)
-    /// Exclude team members which aren't in an active conversation with you
+
+    /// Exclude team members which aren't in an active conversation with you.
+
     public static let excludeNonActiveTeamMembers = SearchOptions(rawValue: 1 << 3)
-    /// Exclude team members with the role .partner which aren't in an active conversation with you
+
+    /// Exclude team members with the role .partner which aren't in an active conversation with you.
+
     public static let excludeNonActivePartners = SearchOptions(rawValue: 1 << 4)
-    /// Users from the public directory
+
+    /// Users from the public directory.
+
     public static let directory = SearchOptions(rawValue: 1 << 5)
-    /// Group conversations you are or were a participant of
+
+    /// Group conversations you are or were a participant of.
+
     public static let conversations = SearchOptions(rawValue: 1 << 6)
-    /// Services which are enabled in your team
+
+    /// Services which are enabled in your team.
+
     public static let services = SearchOptions(rawValue: 1 << 7)
-    /// Users from federated servers
+
+    /// Users from federated servers.
+
     public static let federated = SearchOptions(rawValue: 1 << 8)
+
+    /// Only search the local database.
+
+    public static let localResultsOnly = SearchOptions(rawValue: 1 << 9)
 
     public init(rawValue: Int) {
         self.rawValue = rawValue

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -322,6 +322,7 @@ extension SearchTask {
             let apiVersion = BackendInfo.apiVersion,
             apiVersion >= .v2,
             case .search(let searchRequest) = task,
+            !searchRequest.searchOptions.contains(.localResultsOnly),
             !searchRequest.searchOptions.isDisjoint(with: [.directory, .teamMembers, .federated])
         else {
             return
@@ -445,6 +446,7 @@ extension SearchTask {
             let apiVersion = BackendInfo.apiVersion,
             apiVersion <= .v1,
             case .search(let searchRequest) = task,
+            !searchRequest.searchOptions.contains(.localResultsOnly),
             searchRequest.searchOptions.contains(.directory)
         else { return }
 
@@ -533,6 +535,7 @@ extension SearchTask {
         guard
             let apiVersion = BackendInfo.apiVersion,
             case .search(let searchRequest) = task,
+            !searchRequest.searchOptions.contains(.localResultsOnly),
             searchRequest.searchOptions.contains(.services)
         else { return }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -280,7 +280,7 @@ final class SearchResultsViewController: UIViewController {
     }
 
     func searchForLocalUsers(withQuery query: String) {
-        self.performSearch(query: query, options: [.contacts, .teamMembers])
+        self.performSearch(query: query, options: [.contacts, .teamMembers, .localResultsOnly])
     }
 
     func searchForServices(withQuery query: String) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1769" title="FS-1769" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1769</a>  [iOS] Request loop alert when selecting +- 20 contacts in group creation flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When adding creating a new group, if I quickly select about 20 participants, I'll see a request loop at `/contacts/search`.

### Causes

Every time we select a participant we trigger a remote search, which is the same every time. If we do this fast enough and frequent enough, we'll (falsely) trigger the request loop detector. The request is triggered because the selecting a user adds a token to the search bar which then triggers a search.

### Solutions

We shouldn't be performing a remote search when we intend to only do a local search, so I've added a new search option to restrict search results from the local database only. This option is used to ensure we don't make any remote searches when we don't want them.

### Testing

#### Test Coverage

- Unit tests to assert we don't make remote request when we only want local results only.

### Notes

The search logic is quick complicated and not easy to reason about, so I've opted for the simplest and lowest risk solution. Certainly we could make this much nicer, given more extensive refactoring.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
