### PR TITLE
fix: appIcon directory for prepare build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -585,7 +585,7 @@ class Build
         end
         # Loop over all icons in the iconset
         processed = 0
-        Dir.glob("../#{iconset_location}/*.png") do |image|
+        Dir.glob("../wire-ios/#{iconset_location}/*.png") do |image|
             width = %x( identify -format %w #{image} )
             image_height = %x( identify -format %h #{image} )
             height = Integer(image_height) / 4.0


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app icon does not get the build info on RC builds

### Causes (Optional)

Path as changed since mono-repo move.

### Solutions

Fix the path

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
