### PR TITLE
fix: biometric event block - FS-1826

### DIFF
--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -353,15 +353,6 @@ public final class ProteusService: ProteusServiceInterface {
                 throw MigrationError.failedToMigrateData
             }
         }
-
-    // MARK: - Batched operations
-
-    public func performBatchedOperations(_ block: () throws -> Void) rethrows {
-        try coreCrypto.perform { _ in
-            try block()
-        }
-    }
-
 }
 
 private extension CoreCryptoProtocol {

--- a/wire-ios-data-model/Source/Proteus/ProteusServiceInterface.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusServiceInterface.swift
@@ -65,13 +65,6 @@ public protocol ProteusServiceInterface {
     func fingerprint(fromPrekey prekey: String) throws -> String
     func migrateCryptoboxSessions(at url: URL) throws
 
-    /// Acquire safe Core Crypto access during across the lifetime of the given block.
-    ///
-    /// - Parameters:
-    ///   - block: A closure to perform some work needing safe Core Crypto access.
-
-    func performBatchedOperations(_ block: @escaping () throws -> Void) rethrows
-
 }
 
 public typealias IdPrekeyTuple = (id: UInt16, prekey: String)

--- a/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
+++ b/wire-ios-data-model/Tests/Proteus/ProteusServiceTests.swift
@@ -250,20 +250,6 @@ class ProteusServiceTests: XCTestCase {
         }
     }
 
-    // MARK: - Batched operations
-
-    func test_PerformBachedOperations() throws {
-        // Given
-        mockSafeCoreCrypto.performCount = 0
-
-        // When
-        sut.performBatchedOperations {}
-
-        // Then
-        XCTAssertEqual(mockSafeCoreCrypto.performCount, 1)
-        XCTAssertEqual(mockSafeCoreCrypto.unsafePerformCount, 0)
-    }
-
 }
 
 // MARK: - Helpers

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -483,19 +483,4 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
         try mock(url)            
     }
 
-    // MARK: - performBatchedOperations
-
-    public var performBatchedOperations_Invocations: [() throws -> Void] = []
-    public var performBatchedOperations_MockMethod: ((@escaping () throws -> Void) -> Void)?
-
-    public func performBatchedOperations(_ block: @escaping () throws -> Void) {
-        performBatchedOperations_Invocations.append(block)
-
-        guard let mock = performBatchedOperations_MockMethod else {
-            fatalError("no mock for `performBatchedOperations`")
-        }
-
-        mock(block)            
-    }
-
 }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -400,14 +400,6 @@ extension EventDecoderTest {
             // Mock
             self.syncMOC.proteusService = mockProteusService
 
-            mockProteusService.performBatchedOperations_MockMethod = { block in
-                do {
-                    try block()
-                } catch {
-                    XCTFail("an error was thrown: \(error)")
-                }
-            }
-
             mockProteusService.decryptDataForSession_MockMethod = { data, _ in
                 return (didCreateSession: false, decryptedData: data)
             }
@@ -419,7 +411,6 @@ extension EventDecoderTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // Then
-        XCTAssertEqual(mockProteusService.performBatchedOperations_Invocations.count, 1)
         XCTAssertEqual(mockProteusService.decryptDataForSession_Invocations.count, 1)
 
         // Cleanup

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockProteusServiceinterface.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockProteusServiceinterface.swift
@@ -339,20 +339,4 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
 
         try mock(url)
     }
-
-    // MARK: - performBatchedOperations
-
-    public var performBatchedOperations_Invocations: [() throws -> Void] = []
-    public var performBatchedOperations_MockMethod: ((@escaping () throws -> Void) -> Void)?
-
-    public func performBatchedOperations(_ block: @escaping () throws -> Void) {
-        performBatchedOperations_Invocations.append(block)
-
-        guard let mock = performBatchedOperations_MockMethod else {
-            fatalError("no mock for `performBatchedOperations`")
-        }
-
-        mock(block)
-    }
-
 }

--- a/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusServiceInterface.swift
+++ b/wire-ios-sync-engine/Tests/Source/Core Crypto/MockProteusServiceInterface.swift
@@ -339,20 +339,4 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
 
         try mock(url)
     }
-
-    // MARK: - performBatchedOperations
-
-    public var performBatchedOperations_Invocations: [() throws -> Void] = []
-    public var performBatchedOperations_MockMethod: ((@escaping () throws -> Void) -> Void)?
-
-    public func performBatchedOperations(_ block: @escaping () throws -> Void) {
-        performBatchedOperations_Invocations.append(block)
-
-        guard let mock = performBatchedOperations_MockMethod else {
-            fatalError("no mock for `performBatchedOperations`")
-        }
-
-        mock(block)
-    }
-
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1826" title="FS-1826" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1826</a>  [iOS] Wire Bund Beta asks for biometrics while app is already open
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When receiving an event with EAR enabled, we get stuck on AppLock screen while trying to decrypt the events

### Causes (Optional)

Looking at the logs, we acquire the lock for corecrypto but never succeed to release it.

### Solutions

Remove performOperationsInBatch so the acquire/release of lock does not last long, this seems to be the solution to not have the blocked app. Let's see if that impact performance in the future.


### How to test

1. fresh install on device
2. login on staging or any backend
3. enable face id or touch id
4. put app in background
5. make a connection request on web for example
6. put app in foreground

Actual Result:

Biometric prompt goes through but we're stuck on black/shield screen

Expected Result:

Biometric prompt goes through, we see the conversations list

### Note

We'll have to double check if that relates/impacts FS-1826

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
