### PR TITLE
fix: biometrics with EAR - FS-1826

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/ContextProvider+EncryptionAtRest.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/ContextProvider+EncryptionAtRest.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import LocalAuthentication
 
 public extension ContextProvider {
 
@@ -30,6 +31,8 @@ public extension ContextProvider {
         if enabled {
             try EncryptionKeys.deleteKeys(for: account)
             encryptionKeys = try EncryptionKeys.createKeys(for: account)
+            // force retrieve keys from keychain
+            encryptionKeys = try EncryptionKeys(account: account,  context: LAContext())
             storeEncryptionKeysInAllContexts(encryptionKeys: encryptionKeys)
         } else {
             encryptionKeys = try viewContext.getEncryptionKeys()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1826" title="FS-1826" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1826</a>  [iOS] Wire Bund Beta asks for biometrics while app is already open
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When generating the encryption keys, we don't keep an authenticated LAContext along with the privateKey, so each time we use the private key for decryption, iOS will try to authenticate via a new LAContext.

### Solutions

Retrieve the privateKey after we generate it so we have it with the authenticated context.

### Notes (Optional)

This will cause 2 successive prompt, one to generate and one for retrieving it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
