### PR TITLE
fix: can't receive incoming CallKit calls for group conversations FS-1892

### DIFF
--- a/wire-ios-request-strategy/Sources/Notifications/CallEventContent.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/CallEventContent.swift
@@ -44,7 +44,7 @@ public struct CallEventContent: Decodable {
 
     /// Caller Id.
 
-    let callerIdString: String
+    let callerIdString: String?
 
     public let resp: Bool
 
@@ -75,7 +75,7 @@ public struct CallEventContent: Decodable {
     // MARK: - Methods
 
     public var callerID: UUID? {
-        return UUID(uuidString: callerIdString)
+        return callerIdString.flatMap(UUID.init)
     }
 
     public var callState: LocalNotificationType.CallState? {

--- a/wire-ios-request-strategy/Sources/Notifications/CallEventContentTests.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/CallEventContentTests.swift
@@ -29,16 +29,19 @@ class CallEventContentTests: XCTestCase {
 
     private func eventData(
         type: String,
-        callerID: UUID = .create(),
+        callerID: UUID? = .create(),
         isVideo: Bool = false,
         resp: Bool = false
     ) -> Data {
-        let json: [String: Any] = [
+        var json: [String: Any] = [
             "type": type,
-            "src_userid": callerID.uuidString,
             "resp": resp,
             "props": ["videosend": "\(isVideo)"]
         ]
+
+        if let callerID = callerID?.uuidString {
+            json["src_userid"] = callerID
+        }
 
         return try! JSONSerialization.data(withJSONObject: json, options: [])
     }
@@ -60,6 +63,21 @@ class CallEventContentTests: XCTestCase {
     }
 
     // MARK: - Tests
+
+    func test_initWithoutCallerID() throws {
+        let data = eventData(
+            type: "FOO",
+            callerID: nil,
+            isVideo: false,
+            resp: false
+        )
+
+        // When
+        let sut = CallEventContent(from: data, with: decoder)
+
+        // Then
+        XCTAssertNotNil(sut)
+    }
 
     func test_isRemoteMute() throws {
         try given(type: "REMOTEMUTE") { sut in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1892" title="FS-1892" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1892</a>  [iOS] Can't receive incoming CallKit calls for group conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
If a group call (not the same as a conference call) is started in a conversation with the self user while their app is in the background, then they will not be aware of it.

### Causes 
Once we've fetched the event in the notification service extension, we check to see if it is a call event. If we can decode the event payload into a call event structure, then we will proceed to report the incoming call, otherwise we ignore it.

While we can correctly decode incoming conference calls, we can't decode incoming group calls because `src_userid` field is missing.

### Solutions
We don't actually need to always have this field, so just make it optional.


### Testing

#### Test Coverage

- Added unit test

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
