### PR TITLE
fix: Alert when device isn't connected to the internet during login - ACC - 432

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -674,7 +674,7 @@ extension AuthenticationCoordinator {
         activateNetworkSessions { [weak self] error in
             guard error == nil else {
                 self?.sessionManager.removeProxyCredentials()
-                self?.showAlertWithGeneralError()
+                self?.showAlertWithNoInternetConnectionError()
                 return
             }
             action()
@@ -828,12 +828,12 @@ extension AuthenticationCoordinator {
         stateController.unwindState()
     }
 
-    private func showAlertWithGeneralError() {
-        typealias Alert = L10n.Localizable.Credentials.GeneralError.Alert
+    private func showAlertWithNoInternetConnectionError() {
+        typealias Alert = L10n.Localizable.SystemStatusBar.NoInternet
 
         executeActions(
             [.presentAlert(.init(title: Alert.title,
-                                 message: Alert.message,
+                                 message: Alert.explanation,
                                  actions: [.ok]))]
         )
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we update the alert we show when during login the device **isn't connected to the internet**. Before that change we would show an alert about the credentials being wrong. But that wasn't the proper alert to show. 

So now for the alert title we have:

`No Internet`

For description we have:

`There seems to be a problem with your Internet connection. Please make sure it's working.`

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
