### PR TITLE
fix: call not ringing when already in a call on lock screen FS-1920

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -807,18 +807,6 @@ extension CallKitManager: CXProviderDelegate {
 
 extension CallKitManager: WireCallCenterCallStateObserver, WireCallCenterMissedCallObserver {
 
-    private var shouldHandleCallStates: Bool {
-        switch (requirePushTokenType, application.applicationState) {
-        case (.standard, .background):
-            // Processing call states in the background wiLl interfere with
-            // CallKit calls triggered from the NSE.
-            return false
-
-        default:
-            return true
-        }
-    }
-
     public func callCenterDidChange(
         callState: CallState,
         conversation: ZMConversation,
@@ -827,11 +815,6 @@ extension CallKitManager: WireCallCenterCallStateObserver, WireCallCenterMissedC
         previousCallState: CallState?
     ) {
         logger.info("received new call state: \(callState)")
-
-        guard shouldHandleCallStates else {
-            logger.info("not handling call state: app state is \(String(describing: application.applicationState))")
-            return
-        }
 
         switch callState {
         case .incoming(let hasVideo, let shouldRing, degraded: _):

--- a/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
@@ -806,7 +806,7 @@ class CallKitManagerTest: DatabaseTest {
         XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
     }
 
-    func testThatItIgnoresNewIncomingCall_v3_Unfectched_conversation() {
+    func testThatItIgnoresNewIncomingCall_v3_Unfetched_conversation() {
         // given
         let conversation = self.conversation()
         conversation.needsToBeUpdatedFromBackend = true
@@ -817,6 +817,25 @@ class CallKitManagerTest: DatabaseTest {
 
         // then
         XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
+    }
+
+    func testThatItIgnoresIncomingCall_IfItWasAlreadyReported() {
+        // given
+        let conversation = conversation()
+        let otherUser = otherUser(moc: uiMOC)
+
+        // report the call a first time
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: nil, previousCallState: nil)
+
+        // when
+        sut.callCenterDidChange(callState: .incoming(video: false, shouldRing: true, degraded: false), conversation: conversation, caller: otherUser, timestamp: nil, previousCallState: nil)
+
+        // then
+        // we verify it was only reported once
+        XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 1)
         XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
         XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
         XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 0)
@@ -903,6 +922,27 @@ class CallKitManagerTest: DatabaseTest {
 
         // then
         XCTAssertEqual(self.callKitProvider.lastEndedReason, .answeredElsewhere)
+    }
+
+    func test_itIgnoresCallEnded_IfItWasAlreadyReported() {
+        // given
+        let conversation = conversation()
+        let otherUser = otherUser(moc: uiMOC)
+        sut.requestStartCall(in: conversation, video: false)
+
+        // report the call is terminating a first time
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversation: conversation, caller: otherUser, timestamp: nil, previousCallState: nil)
+
+        // when
+        sut.callCenterDidChange(callState: .terminating(reason: .normal), conversation: conversation, caller: otherUser, timestamp: nil, previousCallState: nil)
+
+        // then
+        XCTAssertEqual(self.callKitProvider.timesReportNewIncomingCallCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallConnectedAtCalled, 0)
+        XCTAssertEqual(self.callKitProvider.timesReportOutgoingCallStartedConnectingCalled, 0)
+        // we verify that it was only reported once
+        XCTAssertEqual(self.callKitProvider.timesReportCallEndedAtCalled, 1)
+        XCTAssertEqual(self.callKitProvider.lastEndedReason, .remoteEnded)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1920" title="FS-1920" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1920</a>  [iOS] Incoming group call doesn't ring while already in a 1:1 call while the screen is locked
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user is in a call while on the Lock Screen, and a second call is incoming, the call doesn't ring / show up on the screen

### Causes 

Since we're already on a call, Wire is active despite being in the background. As a result, it syncs the events and processes other incoming call events.
However, the `CallKitManager` filters out call state updates if Wire is in the background, because we want to avoid interference with the NSE eventually reporting call state updates.

### Solutions

We don't need to filter out call states when in the background, as long as we avoid reporting call events more than once.

### Testing

#### Test Coverage 

- [x] Added unit tests to ensure we don't process the same call events more than once

#### How to Test

1. Be on the Lock Screen (with Wire in the background)
2. Accept a 1:1 call (while on lock screen)
3. Receive a group call (while on lock screen)

Expected: the second call rings and appears on the screen as incoming
