### PR TITLE
fix: biometrics required when processing each event

### DIFF
--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -341,8 +341,17 @@ public class EARService: EARServiceInterface {
         }
     }
 
-    private func fetchPrimaryPrivateKey() throws -> SecKey {
-        return try keyRepository.fetchPrivateKey(description: primaryPrivateKeyDescription)
+    private func fetchPrimaryPrivateKey(context: LAContext? = nil) throws -> SecKey {
+        if let context = context {
+            let authenticatedKeyDescription = PrivateEARKeyDescription.primaryKeyDescription(
+                accountID: accountID,
+                context: context
+            )
+
+            return try keyRepository.fetchPrivateKey(description: authenticatedKeyDescription)
+        } else {
+            return try keyRepository.fetchPrivateKey(description: primaryPrivateKeyDescription)
+        }
     }
 
     private func fetchSecondaryPrivateKey() throws -> SecKey {
@@ -352,7 +361,7 @@ public class EARService: EARServiceInterface {
     // MARK: - Database key
 
     private func fetchDecyptedDatabaseKey(context: LAContext) throws -> VolatileData {
-        let privateKey = try fetchPrimaryPrivateKey()
+        let privateKey = try fetchPrimaryPrivateKey(context: context)
         let encryptedDatabaseKeyData = try fetchEncryptedDatabaseKey()
         let databaseKeyData = try keyEncryptor.decryptDatabaseKey(
             encryptedDatabaseKeyData,

--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -371,6 +371,7 @@ public class EARService: EARServiceInterface {
     public func lockDatabase() {
         WireLogger.ear.info("locking database")
         setDatabaseKeyInAllContexts(nil)
+        keyRepository.clearCache()
     }
 
     public func unlockDatabase(context: LAContext) throws {

--- a/wire-ios-data-model/Source/Utilis/EAR/PrivateEARKeyDescription.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/PrivateEARKeyDescription.swift
@@ -31,8 +31,7 @@ public class PrivateEARKeyDescription: BaseEARKeyDescription, KeychainItemProtoc
     init(
         accountID: UUID,
         label: String,
-        context: LAContextProtocol? = nil,
-        prompt: String? = nil
+        context: LAContextProtocol? = nil
     ) {
         super.init(
             accountID: accountID,
@@ -54,8 +53,6 @@ public class PrivateEARKeyDescription: BaseEARKeyDescription, KeychainItemProtoc
         if let context = context, canUseContext {
             getQuery[kSecUseAuthenticationContext] = context
             getQuery[kSecUseAuthenticationUI] = kSecUseAuthenticationUISkip
-        } else if let prompt = prompt {
-            getQuery[kSecUseOperationPrompt] = prompt
         }
     }
 
@@ -74,14 +71,12 @@ extension PrivateEARKeyDescription {
 
     static func primaryKeyDescription(
         accountID: UUID,
-        context: LAContext? = nil,
-        authenticationPrompt: String? = nil
+        context: LAContext? = nil
     ) -> PrivateEARKeyDescription {
         return PrivateEARKeyDescription(
             accountID: accountID,
             label: "primary-private",
-            context: context,
-            prompt: authenticationPrompt
+            context: context
         )
     }
 

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -492,6 +492,9 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
             syncMOC.databaseKey = databaseKey
         }
 
+        // Mock
+        keyRepository.clearCache_MockMethod = { }
+
         // When
         sut.lockDatabase()
 
@@ -501,6 +504,8 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         syncMOC.performAndWait {
             XCTAssertNil(syncMOC.databaseKey)
         }
+
+        XCTAssertEqual(keyRepository.clearCache_Invocations.count, 1)
     }
 
     // MARK: - Unlock database

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -263,6 +263,21 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
         try mock(description)            
     }
 
+    // MARK: - clearCache
+
+    public var clearCache_Invocations: [Void] = []
+    public var clearCache_MockMethod: (() -> Void)?
+
+    public func clearCache() {
+        clearCache_Invocations.append(())
+
+        guard let mock = clearCache_MockMethod else {
+            fatalError("no mock for `clearCache`")
+        }
+
+        mock()            
+    }
+
 }
 public class MockEARServiceInterface: EARServiceInterface {
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Biometric authentication is required whenever the app receives an update event. 


### Causes
Update events are stored encrypted by the public keys, and fetched decrypted by the private keys. While the app is in the foreground, both primary and secondary private keys are available, however the primary key requires biometric authentication. Each time the key is used, it will ask for authentication, unless an authenticated LAContext is attached to the key. 

The problem is two fold: first we weren't attaching the authenticated context to the key, and secondly we aren't keeping a reference to the fetched key, so we refetch the key repeatedly without a context.

### Solutions

- Fetch the private key with LAContext
- Cache the keys, clear the cache when the DB is locked.

### Testing

#### Test Coverage

- Unit test asserting we clear the cache when locking the db


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
