### PR TITLE
refactor: migrate to ear secondary keys FS-1782

### DIFF
--- a/wire-ios-data-model/Source/Utilis/EAR/DatabaseEARKeyDescription.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/DatabaseEARKeyDescription.swift
@@ -42,8 +42,7 @@ public class DatabaseEARKeyDescription: BaseEARKeyDescription, KeychainItemProto
 
         baseQuery = [
             kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: id,
-            kSecReturnData: true
+            kSecAttrAccount: id
         ]
     }
 

--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -161,7 +161,6 @@ public class EARService: EARServiceInterface {
         }
 
         do {
-            try deleteSecondaryKeys()
             let secondaryKeys = try generateSecondaryKeys()
             try storeSecondaryPublicKey(secondaryKeys.publicKey)
         } catch {

--- a/wire-ios-data-model/Source/Utilis/EAR/PrivateEARKeyDescription.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/PrivateEARKeyDescription.swift
@@ -75,7 +75,7 @@ extension PrivateEARKeyDescription {
     ) -> PrivateEARKeyDescription {
         return PrivateEARKeyDescription(
             accountID: accountID,
-            label: "primary-private",
+            label: "private",
             context: context
         )
     }

--- a/wire-ios-data-model/Source/Utilis/EAR/PublicEARKeyDescription.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/PublicEARKeyDescription.swift
@@ -42,8 +42,7 @@ public class PublicEARKeyDescription: BaseEARKeyDescription, KeychainItemProtoco
 
         baseQuery = [
             kSecClass: kSecClassKey,
-            kSecAttrApplicationTag: tag,
-            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+            kSecAttrApplicationTag: tag
         ]
     }
 
@@ -58,6 +57,7 @@ public class PublicEARKeyDescription: BaseEARKeyDescription, KeychainItemProtoco
     func setQuery<T>(value: T) -> [CFString: Any] {
         var query = baseQuery
         query[kSecValueRef] = value
+        query[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlock
         return query
     }
 
@@ -68,7 +68,7 @@ extension PublicEARKeyDescription {
     static func primaryKeyDescription(accountID: UUID) -> PublicEARKeyDescription {
         return PublicEARKeyDescription(
             accountID: accountID,
-            label: "primary-public"
+            label: "public"
         )
     }
 

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -136,16 +136,10 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         // Given
         uiMOC.encryptMessagesAtRest = true
         keyRepository.fetchPublicKeyDescription_MockError = EarKeyRepositoryFailure.keyNotFound
-        keyRepository.deletePublicKeyDescription_MockMethod = { _ in }
-        keyRepository.deletePrivateKeyDescription_MockMethod = { _ in }
         keyRepository.storePublicKeyDescriptionKey_MockMethod = { _, _ in }
 
         // When
         sut = createSUT(canPerformMigration: true)
-
-        // Then we deleted secondary keys (for good measure)
-        XCTAssertEqual(keyRepository.deletePublicKeyDescription_Invocations.count, 1)
-        XCTAssertEqual(keyRepository.deletePrivateKeyDescription_Invocations.count, 1)
 
         // Then we stored a new public key
         XCTAssertEqual(keyRepository.storePublicKeyDescriptionKey_Invocations.count, 1)

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -271,7 +271,8 @@ public class ZMUserSession: NSObject {
                 coreDataStack.viewContext,
                 coreDataStack.syncContext,
                 coreDataStack.searchContext
-            ]
+            ],
+            canPerformKeyMigration: true
         )
 
         super.init()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1782" title="FS-1782" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-1782</a>  [iOS] Migration path for new encryption keys
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We introduced new secondary keys to the EAR implementation. These keys are created when EAR is turned on, but not for existing users who already have EAR enabled and upgrade the to the new implementation.

### Solutions

When launching the app, we check if EAR is enabled and the secondary public key does not exist. If this is the case, we will generate the secondary keys.

Checking that EAR is enabled ensures we don't generate the keys if not needed. Checking that the keys don't exist ensure we don't delete and overwrite existing keys (such as on subsequent launches).

### Testing

#### Test Coverage

- EARService tests to we migrate, we don't migrate if keys already exist, and we don't migrate if EAR is disabled.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
