### PR TITLE
refactor: call event processing

### DIFF
--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEvent.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEvent.swift
@@ -133,12 +133,18 @@ public final class StoredUpdateEvent: NSManagedObject {
 
     static func nextEvents(
         _ context: NSManagedObjectContext,
-        batchSize: Int
+        batchSize: Int,
+        callEventsOnly: Bool
     ) -> [StoredUpdateEvent] {
         let fetchRequest = NSFetchRequest<StoredUpdateEvent>(entityName: self.entityName)
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: StoredUpdateEvent.SortIndexKey, ascending: true)]
         fetchRequest.fetchLimit = batchSize
         fetchRequest.returnsObjectsAsFaults = false
+
+        if callEventsOnly {
+            fetchRequest.predicate = NSPredicate(format: "%K == YES", #keyPath(StoredUpdateEvent.isCallEvent))
+        }
+
         let result = context.fetchOrAssert(request: fetchRequest)
         return result
     }
@@ -156,9 +162,10 @@ public final class StoredUpdateEvent: NSManagedObject {
     static func nextEventBatch(
         size: Int,
         privateKeys: EARPrivateKeys?,
-        context: NSManagedObjectContext
+        context: NSManagedObjectContext,
+        callEventsOnly: Bool
     ) -> EventBatch {
-        let storedEvents = nextEvents(context, batchSize: size)
+        let storedEvents = nextEvents(context, batchSize: size, callEventsOnly: callEventsOnly)
         return eventsFromStoredEvents(
             storedEvents,
             privateKeys: privateKeys

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEventTests.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEventTests.swift
@@ -323,7 +323,8 @@ class StoreUpdateEventTests: MessagingTestBase {
             // When we fetch a batch of events.
             let batch = StoredUpdateEvent.nextEvents(
                 self.eventMOC,
-                batchSize: 4
+                batchSize: 4,
+                callEventsOnly: false
             )
 
             // Then all the events are returned.
@@ -340,7 +341,8 @@ class StoreUpdateEventTests: MessagingTestBase {
             // When we fetch a batch of events.
             let batch = StoredUpdateEvent.nextEvents(
                 self.eventMOC,
-                batchSize: 3
+                batchSize: 3,
+                callEventsOnly: false
             )
 
             // Then they are returned in the correct order.
@@ -358,7 +360,8 @@ class StoreUpdateEventTests: MessagingTestBase {
             // When we fetch a small batch.
             let firstBatch = StoredUpdateEvent.nextEvents(
                 self.eventMOC,
-                batchSize: 2
+                batchSize: 2,
+                callEventsOnly: false
             )
 
             // Then the batch size is correct
@@ -368,7 +371,8 @@ class StoreUpdateEventTests: MessagingTestBase {
             firstBatch.forEach(self.eventMOC.delete)
             let secondBatch = StoredUpdateEvent.nextEvents(
                 self.eventMOC,
-                batchSize: 2
+                batchSize: 2,
+                callEventsOnly: false
             )
 
             // Then

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEventTests.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEventTests.swift
@@ -380,6 +380,23 @@ class StoreUpdateEventTests: MessagingTestBase {
         }
     }
 
+    func test_NextEvents_CallEventsOnly() throws {
+        try eventMOC.performAndWait {
+            // Given stored events (containing 1 call event)
+            let storedEvents = try self.createStoredEvents(encrypt: false).1
+
+            // When we fetch a batch
+            let batch = StoredUpdateEvent.nextEvents(
+                self.eventMOC,
+                batchSize: 2,
+                callEventsOnly: true
+            )
+
+            // Then we only get 1 event (call event)
+            XCTAssertEqual(batch, Array(storedEvents.dropFirst()))
+        }
+    }
+
     // MARK: - Highest index
 
     func test_HighestIndex() throws {

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/UpdateEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/UpdateEventProcessor.swift
@@ -29,5 +29,7 @@ public protocol UpdateEventProcessor: AnyObject {
 
     func processEventsIfReady() -> Bool
 
+    func processPendingCallEvents() throws
+
     var eventConsumers: [ZMEventConsumer] { get set }
 }

--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -31,7 +31,7 @@ protocol CallKitManagerDelegate: AnyObject {
         completionHandler: @escaping (Result<ZMConversation>) -> Void
     )
 
-    func lookupConversationAndSync(
+    func lookupConversationAndProcessPendingCallEvents(
         by handle: CallHandle,
         completionHandler: @escaping (Result<ZMConversation>) -> Void
     )
@@ -632,7 +632,7 @@ extension CallKitManager: CXProviderDelegate {
             return
         }
 
-        delegate.lookupConversationAndSync(by: call.handle) { [weak self] result in
+        delegate.lookupConversationAndProcessPendingCallEvents(by: call.handle) { [weak self] result in
             guard let `self` = self else {
                 action.fail()
                 return
@@ -702,7 +702,7 @@ extension CallKitManager: CXProviderDelegate {
             return
         }
 
-        delegate.lookupConversationAndSync(by: call.handle) { [weak self] result in
+        delegate.lookupConversationAndProcessPendingCallEvents(by: call.handle) { [weak self] result in
             guard let `self` = self else {
                 action.fail()
                 return

--- a/wire-ios-sync-engine/Source/Synchronization/ApplicationStatusDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/ApplicationStatusDirectory.swift
@@ -79,7 +79,7 @@ public final class ApplicationStatusDirectory: NSObject, ApplicationStatus {
         switch operationStatus.operationState {
         case .foreground:
             return .foreground
-        case .background, .backgroundPendingCall, .backgroundCall, .backgroundFetch, .backgroundTask:
+        case .background, .backgroundCall, .backgroundFetch, .backgroundTask:
             return .background
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -30,7 +30,6 @@ class EventProcessor: UpdateEventProcessor {
 
     let syncContext: NSManagedObjectContext
     let eventContext: NSManagedObjectContext
-    let operationStateProvider: OperationStateProvider
     let syncStatus: SyncStatus
     var eventBuffer: ZMUpdateEventsBuffer?
     let eventDecoder: EventDecoder
@@ -40,13 +39,14 @@ class EventProcessor: UpdateEventProcessor {
     public var eventConsumers: [ZMEventConsumer] = []
 
     var isReadyToProcessEvents: Bool {
-        switch operationStateProvider.operationState {
-        case .backgroundPendingCall:
-            return !syncStatus.isSyncingInBackground
+        // Only process events once we've finished fetching events.
+        guard !syncStatus.isSyncing else { return false }
 
-        default:
-            return !syncStatus.isSyncing && !syncContext.isLocked
-        }
+        // If the database is locked, then we won't be able to process events
+        // that require writes to the database.
+        guard !syncContext.isLocked else { return false }
+
+        return true
     }
 
     // MARK: Life Cycle
@@ -54,14 +54,12 @@ class EventProcessor: UpdateEventProcessor {
     init(
         storeProvider: CoreDataStack,
         syncStatus: SyncStatus,
-        operationStateProvider: OperationStateProvider,
         eventProcessingTracker: EventProcessingTrackerProtocol,
         earService: EARServiceInterface
     ) {
         self.syncContext = storeProvider.syncContext
         self.eventContext = storeProvider.eventContext
         self.syncStatus = syncStatus
-        self.operationStateProvider = operationStateProvider
         self.eventDecoder = EventDecoder(eventMOC: eventContext, syncMOC: syncContext)
         self.eventProcessingTracker = eventProcessingTracker
         self.earService = earService
@@ -72,31 +70,47 @@ class EventProcessor: UpdateEventProcessor {
 
     /// Process previously received events if we are ready to process events.
     ///
-    // - Returns: **True** if there are still more events to process
+    /// - Returns: **True** if there are still more events to process
     @objc
     public func processEventsIfReady() -> Bool { // TODO jacob shouldn't be public
         Self.logger.trace("process events if ready")
+
         guard isReadyToProcessEvents else {
             Self.logger.info("not ready to process events")
-            return  true
+            return true
         }
 
         eventBuffer?.processAllEventsInBuffer()
 
+        var hasMoreEventsToProcess = false
+        do {
+            try processEvents(callEventsOnly: false)
+        } catch {
+            hasMoreEventsToProcess = true
+        }
+
+        return hasMoreEventsToProcess
+    }
+
+    func processPendingCallEvents() throws {
+        try syncContext.performGroupedAndWait { _ in
+            try self.processEvents(callEventsOnly: true)
+        }
+    }
+
+    private func processEvents(callEventsOnly: Bool) throws {
         if syncContext.encryptMessagesAtRest {
             do {
                 Self.logger.info("trying to get EAR keys")
                 let privateKeys = try earService.fetchPrivateKeys()
-                processStoredUpdateEvents(with: privateKeys)
+                processStoredUpdateEvents(with: privateKeys, callEventsOnly: callEventsOnly)
             } catch {
                 Self.logger.error("failed to fetch EAR keys: \(String(describing: error))")
-                return true
+                throw error
             }
         } else {
-            processStoredUpdateEvents()
+            processStoredUpdateEvents(callEventsOnly: callEventsOnly)
         }
-
-        return false
     }
 
     public func storeUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
@@ -127,10 +141,16 @@ class EventProcessor: UpdateEventProcessor {
         _ = processEventsIfReady()
     }
 
-    private func processStoredUpdateEvents(with privateKeys: EARPrivateKeys? = nil) {
+    private func processStoredUpdateEvents(
+        with privateKeys: EARPrivateKeys? = nil,
+        callEventsOnly: Bool = false
+    ) {
         Self.logger.trace("process stored update events")
 
-        eventDecoder.processStoredEvents(with: privateKeys) { [weak self] (decryptedUpdateEvents) in
+        eventDecoder.processStoredEvents(
+            with: privateKeys,
+            callEventsOnly: callEventsOnly
+        ) { [weak self] (decryptedUpdateEvents) in
             Self.logger.info("decrypted update events: \(decryptedUpdateEvents.count)")
 
             guard let `self` = self else { return }

--- a/wire-ios-sync-engine/Source/UserSession/OperationStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/OperationStatus.swift
@@ -44,11 +44,6 @@ public enum SyncEngineOperationState: UInt, CustomStringConvertible {
 
     case background
 
-    /// The app was woken to process a call event fetched from
-    /// the notification service extension.
-
-    case backgroundPendingCall
-
     /// The app is active in the background with an ongoing call.
 
     case backgroundCall
@@ -69,9 +64,6 @@ public enum SyncEngineOperationState: UInt, CustomStringConvertible {
         switch self {
         case .background:
             return "background"
-
-        case .backgroundPendingCall:
-            return "backgroundPendingCall"
 
         case .backgroundCall:
             return "backgroundCall"
@@ -114,15 +106,8 @@ public class OperationStatus: NSObject {
         }
     }
 
-    var hasPendingCall = false {
-        didSet {
-            updateOperationState()
-        }
-    }
-
     public var hasOngoingCall = false {
         didSet {
-            hasPendingCall = false
             updateOperationState()
         }
     }
@@ -198,9 +183,6 @@ public class OperationStatus: NSObject {
 
     fileprivate var calculatedOperationState: SyncEngineOperationState {
         if isInBackground {
-            if hasPendingCall {
-                return .backgroundPendingCall
-            }
 
             if hasOngoingCall {
                 return .backgroundCall

--- a/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
@@ -176,12 +176,12 @@ class MockCallKitManagerDelegate: WireSyncEngine.CallKitManagerDelegate {
         }
     }
 
-    var lookupConversationAndSyncCalls: Int = 0
-    func lookupConversationAndSync(
-        by handle: CallHandle,
-        completionHandler: @escaping (Result<ZMConversation>) -> Void
-    ) {
-        lookupConversationAndSyncCalls += 1
+    var lookupConversationAndProcessPendingCallEventsCalls = 0
+    func lookupConversationAndProcessPendingCallEvents(
+        by handle: WireSyncEngine.CallHandle,
+        completionHandler: @escaping (WireUtilities.Result<ZMConversation>
+    ) -> Void) {
+        lookupConversationAndProcessPendingCallEventsCalls += 1
         lookupConversation(by: handle, completionHandler: completionHandler)
     }
 
@@ -964,7 +964,7 @@ class CallKitManagerTest: DatabaseTest {
 
     // MARK: - Call Rejection
 
-    func test_itSyncsBeforeRejectingCall() {
+    func test_itProcessesCallEventsBeforeRejectingCall() {
         // given
         let conversation = conversation()
         let otherUser = otherUser(moc: uiMOC)
@@ -982,7 +982,7 @@ class CallKitManagerTest: DatabaseTest {
         sut.provider(callKitProvider, perform: mockEndCallAction)
 
         // then
-        XCTAssertEqual(mockCallKitManagerDelegate.lookupConversationAndSyncCalls, 1)
+        XCTAssertEqual(mockCallKitManagerDelegate.lookupConversationAndProcessPendingCallEventsCalls, 1)
     }
 
     func test_itUnregistersCallAfterRejecting() {

--- a/wire-ios-sync-engine/Tests/Source/MockUpdateEventProcessor.swift
+++ b/wire-ios-sync-engine/Tests/Source/MockUpdateEventProcessor.swift
@@ -41,4 +41,8 @@ public class MockUpdateEventProcessor: NSObject, WireSyncEngine.UpdateEventProce
         storedEvents.append(contentsOf: updateEvents)
     }
 
+    public func processPendingCallEvents() throws {
+
+    }
+
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -25,7 +25,6 @@ class EventProcessorTests: MessagingTest {
 
     var sut: EventProcessor!
     var syncStatus: SyncStatus!
-    var operationStateProvider: MockOperationStateProvider!
     var syncStateDelegate: ZMSyncStateDelegate!
     var eventProcessingTracker: EventProcessingTracker!
     var mockEventsConsumers: [MockEventConsumer]!
@@ -49,12 +48,9 @@ class EventProcessorTests: MessagingTest {
         earService.fetchPublicKeys_MockError = MockError()
         earService.fetchPrivateKeys_MockError = MockError()
 
-        operationStateProvider = MockOperationStateProvider()
-
         sut = EventProcessor(
             storeProvider: coreDataStack,
             syncStatus: syncStatus,
-            operationStateProvider: operationStateProvider,
             eventProcessingTracker: eventProcessingTracker,
             earService: earService
         )
@@ -195,40 +191,12 @@ class EventProcessorTests: MessagingTest {
         )
     }
 
-    func test_IsReadyToProcessEvents_BackgroundPendingCall_IfNotSyncing() throws {
-        try assertIsReadyToProccessEvents(
-            expectation: true,
-            operationState: .backgroundPendingCall,
-            isSyncing: false
-        )
-    }
-
-    func test_IsReadyToProcessEvents_BackgroundPendingCall_EvenIfDBIsLocked() throws {
-        try assertIsReadyToProccessEvents(
-            expectation: true,
-            operationState: .backgroundPendingCall,
-            isDatabaseLocked: true
-        )
-    }
-
-    func test_IsNotReadyToProcessEvents_ForBackgroundPendingCall_IfSyncing() throws {
-        try assertIsReadyToProccessEvents(
-            expectation: false,
-            operationState: .backgroundPendingCall,
-            isSyncing: true
-        )
-    }
-
     private func assertIsReadyToProccessEvents(
         expectation: Bool,
-        operationState: SyncEngineOperationState = .foreground,
         isSyncing: Bool = false,
         isDatabaseLocked: Bool = false
     ) throws {
         // Given
-        operationStateProvider.operationState = operationState
-        XCTAssertEqual(sut.operationStateProvider.operationState, operationState)
-
         if isSyncing {
             syncStatus.currentSyncPhase = .fetchingMissedEvents
             syncStatus.pushChannelEstablishedDate = nil

--- a/wire-ios-sync-engine/Tests/Source/UserSession/OperationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/OperationStatusTests.swift
@@ -52,38 +52,6 @@ class OperationStatusTests: MessagingTest {
         XCTAssertEqual(sut.operationState, .background)
     }
 
-    func testOperationState_whenInBackgroundWithOngoingCall() {
-        // when
-        sut.isInBackground = true
-        sut.hasOngoingCall = true
-
-        // then
-        XCTAssertEqual(sut.operationState, .backgroundCall)
-    }
-
-    func testOperationState_whenInBackgroundWithPendingCall() {
-        // when
-        sut.isInBackground = true
-        sut.hasPendingCall = true
-
-        // then
-        XCTAssertEqual(sut.operationState, .backgroundPendingCall)
-    }
-
-    func testOperationState_BackgroundWithPendingCall_IsReset() {
-        // given
-        sut.isInBackground = true
-        sut.hasPendingCall = true
-        XCTAssertEqual(sut.operationState, .backgroundPendingCall)
-
-        // when
-        sut.hasOngoingCall = true
-
-        // then
-        XCTAssertFalse(sut.hasPendingCall)
-        XCTAssertEqual(sut.operationState, .backgroundCall)
-    }
-
     func testThatBackgroundTaskIsUpdatingOperationState() {
 
         // given


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?


**Processing call events** is a **necessary** step in the process of answering / rejecting calls we receive in the background. 

We trigger event processing by requesting a quick sync. To process the events, we also need to be _"ready"_ for processing. Which means we're **not currently syncing** and the **database is unlocked**.

In order to process call events while the database is locked, we changed the conditions for being _ready_ to process events. If the current state of the app was **in the background** and **pending a call** we would allow event processing. (we'd assume the only events to process were call events, which we're able to process while the app is locked thanks to secondary keys)

However, maintaining an accurate operation state is tricky and ended up not being reliable, which caused issues answering calls. 

To solve this, we stop requesting the quick sync to process all events. Instead we directly process call events that were stored by the NSE.




