### PR TITLE
fix: avs race condition

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -80,7 +80,7 @@ extension WireCallCenterV3: ZMConversationObserver {
 extension WireCallCenterV3 {
 
     private func handleEvent(_ description: String, _ handlerBlock: @escaping () -> Void) {
-        Self.logger.trace("handle avs event: \(description)")
+        Self.logger.info("handle avs event: \(description)")
         zmLog.debug("Handle AVS event: \(description)")
 
         guard let context = self.uiMOC else {

--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -24,6 +24,7 @@ import avs
 public protocol VoIPPushManagerDelegate: AnyObject {
 
     func processIncomingRealVoIPPush(payload: [AnyHashable: Any], completion: @escaping () -> Void)
+    func processPendingCallEvents(accountID: UUID)
 
 }
 
@@ -173,6 +174,8 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
                 reason: .unanswered
             )
         }
+
+        delegate?.processPendingCallEvents(accountID: accountID)
     }
 
     private func processVoIPPush(

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+VoIPPushManagerDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+VoIPPushManagerDelegate.swift
@@ -61,6 +61,23 @@ extension SessionManager: VoIPPushManagerDelegate {
         })
     }
 
+    public func processPendingCallEvents(accountID: UUID) {
+        WireLogger.calling.info("process pending call events preemptively")
+
+        guard
+            let account = accountManager.account(with: accountID),
+            let activity = BackgroundActivityFactory.shared.startBackgroundActivity(withName: "processPendingCallEvents")
+        else {
+            WireLogger.calling.error("failed to process pending call events preemptively")
+            return
+        }
+
+        withSession(for: account) { session in
+            try? session.processPendingCallEvents()
+            BackgroundActivityFactory.shared.endBackgroundActivity(activity)
+        }
+    }
+
 }
 
 private extension VoIPPushPayload {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -631,6 +631,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
     }
 
     func processPendingCallEvents() throws {
+        WireLogger.updateEvent.info("process pending call events")
         try updateEventProcessor!.processPendingCallEvents()
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Perform call actions for an incoming CallKit call (e.g answer, reject) often fail or produce unexpected results.


### Causes
Before we perform the call action using AVS, we try to process pending call events so that AVS is update date and can perform the action we want to. But we only wait for all pending events to be passed to AVS before proceeding to use AVS, rather than waiting for AVS to call back to the app with new call states. As a result, for example, when we try to answer the call, our app doesn't think there is an incoming call because it hasn't yet received the incoming call state from AVS, so it actually tries to start a new call.

This is just one example but I'm sure there are more.

### Solutions
Try to process pending call events earlier so that by the time the user wants to perform an action AVS is already up to date. We can do this after reporting the call to CallKit.

### Testing

#### Test Coverage

Tested manually for now.

### Notes

There are still issues with AVS, but we'll try to address these separately.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
