### PR TITLE
fix: repeated biometric prompts when EAR is forced FS-1993

### DIFF
--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -195,7 +195,8 @@ public class EARService: EARServiceInterface {
 
             do {
                 try self.deleteExistingKeys()
-                let databaseKey = try self.generateKeys()
+                try self.generateKeys()
+                let databaseKey = try self.fetchDecyptedDatabaseKey(context: LAContext())
 
                 if !skipMigration {
                     try context.migrateTowardEncryptionAtRest(databaseKey: databaseKey)
@@ -299,6 +300,7 @@ public class EARService: EARServiceInterface {
         try keyRepository.deleteDatabaseKey(description: databaseKeyDescription)
     }
 
+    @discardableResult
     func generateKeys() throws -> VolatileData {
         WireLogger.ear.info("generating new keys")
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+EncryptionAtRest.swift
@@ -79,7 +79,8 @@ extension ZMUserSession: UserSessionEncryptionAtRestInterface {
     /// database key.
 
     public var encryptMessagesAtRest: Bool {
-        return managedObjectContext.encryptMessagesAtRest
+        guard let context = coreDataStack?.viewContext else { return false }
+        return context.encryptMessagesAtRest
     }
 
     /// Whether the database is currently locked.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1993" title="FS-1993" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1993</a>  Multiple biometrics prompt after enabling EAR just after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
When logging in to a build that has EAR force enabled, then each time a new event is received the user is prompted for biometric authentication. If the user puts the app in the background and then foreground, the issue goes away.

### Causes
After enabling EAR we have the database key stored but not the private key, which is used to decrypt incoming events. When we decrypt an incoming event, we fetch the private key without a `LAContext`, and because the private key requires user presence, it will prompt for biometrics each time it is used.

This isn't a problem when EAR is not forced enabled, I'm not sure why.

### Solutions
After enabled EAR, fetch the private key with an instance of `LAContext`. This will result in a second biometric prompt when but not again when receiving new events. The second biometric prompt will authenticate the LAContext which is then reused.

### Testing

#### Test Coverage

- Updated unit tests to assert we refetch the key after enabling EAR.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
