### PR TITLE
fix: not receiving incoming call in background while in 1:1 call FS-1992

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -73,10 +73,10 @@ class EventProcessor: UpdateEventProcessor {
     /// - Returns: **True** if there are still more events to process
     @objc
     public func processEventsIfReady() -> Bool { // TODO jacob shouldn't be public
-        Self.logger.trace("process events if ready")
+        WireLogger.updateEvent.info("process events if ready")
 
         guard isReadyToProcessEvents else {
-            Self.logger.info("not ready to process events")
+            WireLogger.updateEvent.info("not ready to process events")
             return true
         }
 
@@ -94,6 +94,7 @@ class EventProcessor: UpdateEventProcessor {
 
     func processPendingCallEvents() throws {
         try syncContext.performGroupedAndWait { _ in
+            self.eventBuffer?.processAllEventsInBuffer()
             try self.processEvents(callEventsOnly: true)
         }
     }
@@ -140,6 +141,7 @@ class EventProcessor: UpdateEventProcessor {
     public func storeAndProcessUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
         storeUpdateEvents(updateEvents, ignoreBuffer: ignoreBuffer)
         _ = processEventsIfReady()
+        try? processPendingCallEvents()
     }
 
     private func processStoredUpdateEvents(

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -140,8 +140,11 @@ class EventProcessor: UpdateEventProcessor {
 
     public func storeAndProcessUpdateEvents(_ updateEvents: [ZMUpdateEvent], ignoreBuffer: Bool) {
         storeUpdateEvents(updateEvents, ignoreBuffer: ignoreBuffer)
-        _ = processEventsIfReady()
-        try? processPendingCallEvents()
+        if syncContext.isLocked {
+            try? processPendingCallEvents()
+        } else {
+            _ = processEventsIfReady()
+        }
     }
 
     private func processStoredUpdateEvents(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1992" title="FS-1992" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-1992</a>  [iOS] No callkit shows up for an incoming group call while in 1:1 call, when the app is in background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the app is in the background while in a 1:1 call and we receive an incoming call, the incoming call doesn't ring 

### Causes

Since we're in a 1:1 call, the app is active while in the background. When the incoming call is started, we receive the update event through the push channel, but we never end up processing it because the app is not considered to be ready to process events (because it's locked). 

### Solutions

After receiving and events from the push channel, add a step to process pending call events, which isn't dependent on the app being ready to process all events since we have access to the secondary private key
