### PR TITLE
chore: Disable `testThatItRendersCorrectlyShareViewController_Video_DarkMode` in `ShareViewControllerTests`

### DIFF
--- a/wire-ios/Wire-iOS Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios/Wire-iOS Tests/TestPlans/AllTests.xctestplan
@@ -42,7 +42,8 @@
     {
       "skippedTests" : [
         "SearchResultLabelTests",
-        "ShareViewControllerTests\/testThatItRendersCorrectlyShareViewController_Photos()"
+        "ShareViewControllerTests\/testThatItRendersCorrectlyShareViewController_Photos()",
+        "ShareViewControllerTests\/testThatItRendersCorrectlyShareViewController_Video_DarkMode()"
       ],
       "target" : {
         "containerPath" : "container:Wire-iOS.xcodeproj",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

That test has been flaky on CI that's why we're disabling it for now. I already created a [ticket](https://wearezeta.atlassian.net/browse/IC-152) to keep track of that test and fix it eventually

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
