### PR TITLE
fix: stuck on remove device screen FS-2017

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Device Configuration/DeviceConfigurationEventHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Device Configuration/DeviceConfigurationEventHandler.swift
@@ -23,8 +23,6 @@ class DeviceConfigurationEventHandler: AuthenticationEventHandler {
     weak var statusProvider: AuthenticationStatusProvider?
 
     func handleEvent(currentStep: AuthenticationFlowStep, context: Void) -> [AuthenticationCoordinatorAction]? {
-        guard case .configureDevice = currentStep else { return nil }
-
         if statusProvider?.sharedUserSession?.hasCompletedInitialSync == true {
             return [.hideLoadingView, postAction]
         } else {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Device Configuration/DeviceConfigurationEventHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Device Configuration/DeviceConfigurationEventHandler.swift
@@ -23,10 +23,18 @@ class DeviceConfigurationEventHandler: AuthenticationEventHandler {
     weak var statusProvider: AuthenticationStatusProvider?
 
     func handleEvent(currentStep: AuthenticationFlowStep, context: Void) -> [AuthenticationCoordinatorAction]? {
-        if statusProvider?.sharedUserSession?.hasCompletedInitialSync == true {
-            return [.hideLoadingView, postAction]
-        } else {
-            return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
+        // We normally expect the current step to be `configureDevice`, but in some cases
+        // it also happens to be `deleteClient` so we handle in this case as well.
+        switch currentStep {
+        case .configureDevice, .deleteClient:
+            if statusProvider?.sharedUserSession?.hasCompletedInitialSync == true {
+                return [.hideLoadingView, postAction]
+            } else {
+                return [.transition(.pendingInitialSync(next: nil), mode: .normal)]
+            }
+
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-2017" title="FS-2017" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />FS-2017</a>  [iOS] stuck on remove device screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
If I log in to C1 build and already have the max number of clients, after deleting one of my clients I get stuck on the "delete client" screen.

### Causes
C1 builds have EAR enabled by default, so immediately after deleting a device we register a new client and then enable EAR via the `configureDevicePermissions` action. When EAR is enabled (after biometric authentication), we invoke the `deviceConfigurationComplete` event. 

The handler for this event was checking that the current step is still `configureDevice`, however it is not. The current step was unwound to the previous step `.deleteClient` because the navigation stack changed (not sure why... maybe because of the biometric authentication). Since the current step changed, the event handler didn't do anything, and the whole flow got stuck.

### Solutions
Remove the condition to handle the event while in the `configureDevice` step.

### Testing

#### Test Coverage

Tested manually

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
