### PR TITLE
chore: rename MLSController to MLSService

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+MLSService.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+MLSService.swift
@@ -21,17 +21,17 @@ import CoreCryptoSwift
 
 extension NSManagedObjectContext {
 
-    private static let mlsControllerUserInfoKey = "MLSControllerUserInfoKey"
+    private static let mlsServiceUserInfoKey = "MLSServiceUserInfoKey"
 
-    public var mlsController: MLSControllerProtocol? {
+    public var mlsService: MLSServiceInterface? {
         get {
-            precondition(zm_isSyncContext, "MLSController should only be accessed on the sync context")
-            return userInfo[Self.mlsControllerUserInfoKey] as? MLSControllerProtocol
+            precondition(zm_isSyncContext, "MLSService should only be accessed on the sync context")
+            return userInfo[Self.mlsServiceUserInfoKey] as? MLSServiceInterface
         }
 
         set {
-            precondition(zm_isSyncContext, "MLSController should only be accessed on the sync context")
-            userInfo[Self.mlsControllerUserInfoKey] = newValue
+            precondition(zm_isSyncContext, "MLSService should only be accessed on the sync context")
+            userInfo[Self.mlsServiceUserInfoKey] = newValue
         }
     }
 

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -170,14 +170,14 @@ extension ZMConversation {
         case .mls:
             Logging.mls.info("adding \(participants.count) participants to conversation (\(String(describing: qualifiedID)))")
 
-            var mlsController: MLSControllerProtocol?
+            var mlsService: MLSServiceInterface?
 
             context.zm_sync.performAndWait {
-                mlsController = context.zm_sync.mlsController
+                mlsService = context.zm_sync.mlsService
             }
 
             guard
-                let mlsController = mlsController,
+                let mlsService = mlsService,
                 let groupID = mlsGroupID?.base64EncodedString,
                 let mlsGroupID = MLSGroupID(base64Encoded: groupID)
             else {
@@ -194,7 +194,7 @@ extension ZMConversation {
 
             Task {
                 do {
-                    try await mlsController.addMembersToConversation(with: mlsUsers, for: mlsGroupID)
+                    try await mlsService.addMembersToConversation(with: mlsUsers, for: mlsGroupID)
 
                     context.perform {
                         completion(.success(()))
@@ -251,14 +251,14 @@ extension ZMConversation {
         case (.mls, false):
             Logging.mls.info("removing participant from conversation (\(String(describing: qualifiedID)))")
 
-            var mlsController: MLSControllerProtocol?
+            var mlsService: MLSServiceInterface?
 
             context.zm_sync.performAndWait {
-                mlsController = context.zm_sync.mlsController
+                mlsService = context.zm_sync.mlsService
             }
 
             guard
-                let mlsController = mlsController,
+                let mlsService = mlsService,
                 let groupID = mlsGroupID,
                 let userID = user.qualifiedID
             else {
@@ -270,7 +270,7 @@ extension ZMConversation {
             Task {
                 do {
                     let clientIDs = try await provider.fetchUserClients(for: userID, in: context.notificationContext)
-                    try await mlsController.removeMembersFromConversation(with: clientIDs, for: groupID)
+                    try await mlsService.removeMembersFromConversation(with: clientIDs, for: groupID)
 
                     context.perform {
                         completion(.success(()))

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -21,9 +21,9 @@ import XCTest
 import CoreCryptoSwift
 @testable import WireDataModel
 
-class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
+class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
-    var sut: MLSController!
+    var sut: MLSService!
     var mockCoreCrypto: MockCoreCrypto!
     var mockSafeCoreCrypto: MockSafeCoreCrypto!
     var mockMLSActionExecutor: MockMLSActionExecutor!
@@ -50,7 +50,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
             return 100
         }
 
-        sut = MLSController(
+        sut = MLSService(
             context: uiMOC,
             coreCrypto: mockSafeCoreCrypto,
             mlsActionExecutor: mockMLSActionExecutor,
@@ -104,7 +104,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         )
     }
 
-    // MARK: - MLSControllerDelegate
+    // MARK: - mlsServiceDelegate
 
     var pendingProposalCommitExpectations = [MLSGroupID: XCTestExpectation]()
     var keyMaterialUpdatedExpectation: XCTestExpectation?
@@ -112,11 +112,11 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
     // Since SUT may schedule timers to commit pending proposals, we create expectations
     // and fulfill them when SUT informs us the commit was made.
 
-    func mlsControllerDidCommitPendingProposal(for: MLSGroupID) {
+    func mlsServiceDidCommitPendingProposal(for: MLSGroupID) {
         pendingProposalCommitExpectations[groupID]?.fulfill()
     }
 
-    func mlsControllerDidUpdateKeyMaterialForAllGroups() {
+    func mlsServiceDidUpdateKeyMaterialForAllGroups() {
         keyMaterialUpdatedExpectation?.fulfill()
     }
 
@@ -137,7 +137,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         })
 
         // When
-        let sut = MLSController(
+        let sut = MLSService(
             context: uiMOC,
             coreCrypto: mockSafeCoreCrypto,
             conversationEventProcessor: mockConversationEventProcessor,
@@ -154,7 +154,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
 
     // MARK: - Message Encryption
 
-    typealias EncryptionError = MLSController.MLSMessageEncryptionError
+    typealias EncryptionError = MLSService.MLSMessageEncryptionError
 
     func test_Encrypt_IsSuccessful() {
         do {
@@ -202,7 +202,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
 
     // MARK: - Message Decryption
 
-    typealias DecryptionError = MLSController.MLSMessageDecryptionError
+    typealias DecryptionError = MLSService.MLSMessageDecryptionError
 
     func test_Decrypt_ThrowsFailedToConvertMessageToBytes() {
         syncMOC.performAndWait {
@@ -353,7 +353,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         }
 
         // when / then
-        assertItThrows(error: MLSController.MLSGroupCreationError.failedToCreateGroup) {
+        assertItThrows(error: MLSService.MLSGroupCreationError.failedToCreateGroup) {
             try sut.createGroup(for: groupID)
         }
 
@@ -486,7 +486,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         }
 
         // when / then
-        await assertItThrows(error: MLSController.MLSAddMembersError.noMembersToAdd) {
+        await assertItThrows(error: MLSService.MLSAddMembersError.noMembersToAdd) {
             try await sut.addMembersToConversation(with: [], for: mlsGroupID)
         }
     }
@@ -506,7 +506,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         // No mock for claiming key packages.
 
         // Then
-        await assertItThrows(error: MLSController.MLSAddMembersError.failedToClaimKeyPackages) {
+        await assertItThrows(error: MLSService.MLSAddMembersError.failedToClaimKeyPackages) {
             // When
             try await sut.addMembersToConversation(with: mlsUser, for: mlsGroupID)
         }
@@ -657,7 +657,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         }
 
         // When / Then
-        await assertItThrows(error: MLSController.MLSRemoveParticipantsError.noClientsToRemove) {
+        await assertItThrows(error: MLSService.MLSRemoveParticipantsError.noClientsToRemove) {
             try await sut.removeMembersFromConversation(with: [], for: mlsGroupID)
         }
     }
@@ -1287,7 +1287,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         keyMaterialUpdatedExpectation = expectation
 
         // When
-        let sut = MLSController(
+        let sut = MLSService(
             context: uiMOC,
             coreCrypto: mockSafeCoreCrypto,
             mlsActionExecutor: mockMLSActionExecutor,
@@ -1375,7 +1375,7 @@ class MLSControllerTests: ZMConversationTestsBase, MLSControllerDelegate {
         }
 
         // When
-        let sut = MLSController(
+        let sut = MLSService(
             context: uiMOC,
             coreCrypto: mockSafeCoreCrypto,
             mlsActionExecutor: mockMLSActionExecutor,

--- a/wire-ios-data-model/Tests/MLS/MockMLSService.swift
+++ b/wire-ios-data-model/Tests/MLS/MockMLSService.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-class MockMLSController: MLSControllerProtocol {
+class MockMLSService: MLSServiceInterface {
 
     // MARK: - Types
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -638,9 +638,9 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
     func test_RemoveUser_FromMLSConversation() {
         syncMOC.performAndWait {
             // GIVEN
-            // set mock MLSController
-            let mockMLSController = MockMLSController()
-            syncMOC.mlsController = mockMLSController
+            // set mock mlsService
+            let mockMLSService = MockMLSService()
+            syncMOC.mlsService = mockMLSService
 
             // create conversation
             let conversation = ZMConversation.insertNewObject(in: syncMOC)
@@ -680,7 +680,7 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
 
             XCTAssertEqual(expectedClientIDs.count, 2)
 
-            mockMLSController.removeMembersMock = { clientIDs, groupID in
+            mockMLSService.removeMembersMock = { clientIDs, groupID in
                 XCTAssertEqual(groupID, expectedGroupID)
                 XCTAssertEqual(clientIDs, expectedClientIDs)
                 removeMemberExpectation.fulfill()
@@ -697,9 +697,9 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
     func test_RemoveSelfUser_FromMLSConversation() {
         syncMOC.performAndWait {
             // GIVEN
-            // set mock MLSController
-            let mockMLSController = MockMLSController()
-            syncMOC.mlsController = mockMLSController
+            // set mock mlsService
+            let mockMLSService = MockMLSService()
+            syncMOC.mlsService = mockMLSService
 
             // mock action handler
             let mockActionHandler = MockActionHandler<RemoveParticipantAction>(
@@ -726,11 +726,11 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
                 return []
             }
 
-            // expect that we dont call MLSController
+            // expect that we dont call mlsService
             let removeMembersExpectation = XCTestExpectation(description: "Remove Members Not Called")
             removeMembersExpectation.isInverted = true
 
-            mockMLSController.removeMembersMock = { _, _ in
+            mockMLSService.removeMembersMock = { _, _ in
                 removeMembersExpectation.fulfill()
             }
 

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 		63B1335929A503D100009D84 /* MLSGroupID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1333D29A503D000009D84 /* MLSGroupID.swift */; };
 		63B1335A29A503D100009D84 /* MLSActionExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1333E29A503D000009D84 /* MLSActionExecutor.swift */; };
 		63B1335B29A503D100009D84 /* MLSQualifiedClientID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1333F29A503D000009D84 /* MLSQualifiedClientID.swift */; };
-		63B1335C29A503D100009D84 /* MLSController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1334029A503D000009D84 /* MLSController.swift */; };
+		63B1335C29A503D100009D84 /* MLSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1334029A503D000009D84 /* MLSService.swift */; };
 		63B1335D29A503D100009D84 /* CommitBundle+Protobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1334129A503D000009D84 /* CommitBundle+Protobuf.swift */; };
 		63B1335E29A503D100009D84 /* BackendMLSPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1334229A503D000009D84 /* BackendMLSPublicKeys.swift */; };
 		63B1335F29A503D100009D84 /* MessageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1334329A503D000009D84 /* MessageProtocol.swift */; };
@@ -335,7 +335,7 @@
 		63D41E6F24573F420076826F /* ZMConversationTests+SelfConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D41E6E24573F420076826F /* ZMConversationTests+SelfConversation.swift */; };
 		63D41E7124597E420076826F /* GenericMessage+Flags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D41E7024597E420076826F /* GenericMessage+Flags.swift */; };
 		63D9A19E282AA0050074C20C /* NSManagedObjectContext+Federation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D9A19D282AA0050074C20C /* NSManagedObjectContext+Federation.swift */; };
-		63DA335E286C9CF000818C3C /* NSManagedObjectContext+MLSController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA335D286C9CF000818C3C /* NSManagedObjectContext+MLSController.swift */; };
+		63DA335E286C9CF000818C3C /* NSManagedObjectContext+MLSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA335D286C9CF000818C3C /* NSManagedObjectContext+MLSService.swift */; };
 		63DA3373286CA43300818C3C /* ZMConversation+MLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DA3372286CA43300818C3C /* ZMConversation+MLS.swift */; };
 		63DA33AF28746CCF00818C3C /* store2-103-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 63DA33AE28746CC100818C3C /* store2-103-0.wiredatabase */; };
 		63E21AE2291E92780084A942 /* FetchUserClientsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E21AE1291E92770084A942 /* FetchUserClientsAction.swift */; };
@@ -475,11 +475,11 @@
 		E90AAE34279719D8003C7DB0 /* store2-98-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = E90AAE33279719D8003C7DB0 /* store2-98-0.wiredatabase */; };
 		E97A542827B122D80009DCCF /* AccessRoleMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97A542727B122D80009DCCF /* AccessRoleMigrationTests.swift */; };
 		E9C7DD9B27B533D000FB9AE8 /* AccessRoleMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C7DD9A27B533D000FB9AE8 /* AccessRoleMappingTests.swift */; };
+		EE002F222878345C0027D63A /* store2-104-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE002F212878345C0027D63A /* store2-104-0.wiredatabase */; };
 		EE032B3129A62CA600E1DDF3 /* ProteusSessionID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE032B2F29A62CA600E1DDF3 /* ProteusSessionID.swift */; };
 		EE032B3229A62CA600E1DDF3 /* ProteusSessionID+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE032B3029A62CA600E1DDF3 /* ProteusSessionID+Mapping.swift */; };
 		EE032B3629A62CD600E1DDF3 /* ProteusServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE032B3529A62CD600E1DDF3 /* ProteusServiceTests.swift */; };
 		EE04084E28CA85B2009E4B8D /* Date+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE04084D28CA85B2009E4B8D /* Date+Helpers.swift */; };
-		EE002F222878345C0027D63A /* store2-104-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE002F212878345C0027D63A /* store2-104-0.wiredatabase */; };
 		EE09EEB1255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09EEB0255959F000919A6B /* ZMUserTests+AnalyticsIdentifier.swift */; };
 		EE128A66286DE31200558550 /* UserClient+MLSPublicKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE128A65286DE31200558550 /* UserClient+MLSPublicKeys.swift */; };
 		EE128A68286DE35F00558550 /* CodableHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE128A67286DE35F00558550 /* CodableHelpers.swift */; };
@@ -538,8 +538,8 @@
 		EE8DA96D2954A03800F58B79 /* WireLinkPreview.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE8DA96C2954A03800F58B79 /* WireLinkPreview.framework */; };
 		EE8DA9702954A03E00F58B79 /* WireImages.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE8DA96F2954A03E00F58B79 /* WireImages.framework */; };
 		EE980FB22834EB3A00CC6B9F /* store2-100-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = EE980FB12834EB3A00CC6B9F /* store2-100-0.wiredatabase */; };
-		EE98878E28882BFF002340D2 /* MLSControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98878D28882BFF002340D2 /* MLSControllerTests.swift */; };
-		EE98879228882C8F002340D2 /* MockMLSController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98879128882C8F002340D2 /* MockMLSController.swift */; };
+		EE98878E28882BFF002340D2 /* MLSServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98878D28882BFF002340D2 /* MLSServiceTests.swift */; };
+		EE98879228882C8F002340D2 /* MockMLSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98879128882C8F002340D2 /* MockMLSService.swift */; };
 		EE997A1425062295008336D2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A1325062295008336D2 /* Logging.swift */; };
 		EE997A16250629DC008336D2 /* ZMMessage+ProcessingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE997A15250629DC008336D2 /* ZMMessage+ProcessingError.swift */; };
 		EE9AD9162696F01700DD5F51 /* FeatureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9AD9152696F01700DD5F51 /* FeatureService.swift */; };
@@ -1158,7 +1158,7 @@
 		63B1333D29A503D000009D84 /* MLSGroupID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSGroupID.swift; sourceTree = "<group>"; };
 		63B1333E29A503D000009D84 /* MLSActionExecutor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSActionExecutor.swift; sourceTree = "<group>"; };
 		63B1333F29A503D000009D84 /* MLSQualifiedClientID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSQualifiedClientID.swift; sourceTree = "<group>"; };
-		63B1334029A503D000009D84 /* MLSController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSController.swift; sourceTree = "<group>"; };
+		63B1334029A503D000009D84 /* MLSService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MLSService.swift; sourceTree = "<group>"; };
 		63B1334129A503D000009D84 /* CommitBundle+Protobuf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommitBundle+Protobuf.swift"; sourceTree = "<group>"; };
 		63B1334229A503D000009D84 /* BackendMLSPublicKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendMLSPublicKeys.swift; sourceTree = "<group>"; };
 		63B1334329A503D000009D84 /* MessageProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageProtocol.swift; sourceTree = "<group>"; };
@@ -1190,7 +1190,7 @@
 		63D41E7024597E420076826F /* GenericMessage+Flags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Flags.swift"; sourceTree = "<group>"; };
 		63D5654528B4C45100BDFB49 /* zmessaging2.105.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.105.0.xcdatamodel; sourceTree = "<group>"; };
 		63D9A19D282AA0050074C20C /* NSManagedObjectContext+Federation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Federation.swift"; sourceTree = "<group>"; };
-		63DA335D286C9CF000818C3C /* NSManagedObjectContext+MLSController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+MLSController.swift"; sourceTree = "<group>"; };
+		63DA335D286C9CF000818C3C /* NSManagedObjectContext+MLSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+MLSService.swift"; sourceTree = "<group>"; };
 		63DA3372286CA43300818C3C /* ZMConversation+MLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+MLS.swift"; sourceTree = "<group>"; };
 		63DA33AD28746BD200818C3C /* zmessaging2.103.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.103.0.xcdatamodel; sourceTree = "<group>"; };
 		63DA33AE28746CC100818C3C /* store2-103-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-103-0.wiredatabase"; sourceTree = "<group>"; };
@@ -1415,8 +1415,8 @@
 		EE8DA96F2954A03E00F58B79 /* WireImages.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireImages.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE980FB02834EA3200CC6B9F /* zmessaging2.100.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.100.0.xcdatamodel; sourceTree = "<group>"; };
 		EE980FB12834EB3A00CC6B9F /* store2-100-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-100-0.wiredatabase"; sourceTree = "<group>"; };
-		EE98878D28882BFF002340D2 /* MLSControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSControllerTests.swift; sourceTree = "<group>"; };
-		EE98879128882C8F002340D2 /* MockMLSController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSController.swift; sourceTree = "<group>"; };
+		EE98878D28882BFF002340D2 /* MLSServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSServiceTests.swift; sourceTree = "<group>"; };
+		EE98879128882C8F002340D2 /* MockMLSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSService.swift; sourceTree = "<group>"; };
 		EE997A1325062295008336D2 /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		EE997A15250629DC008336D2 /* ZMMessage+ProcessingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+ProcessingError.swift"; sourceTree = "<group>"; };
 		EE9AD9152696F01700DD5F51 /* FeatureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureService.swift; sourceTree = "<group>"; };
@@ -2028,7 +2028,7 @@
 				63B1333D29A503D000009D84 /* MLSGroupID.swift */,
 				63B1333E29A503D000009D84 /* MLSActionExecutor.swift */,
 				63B1333F29A503D000009D84 /* MLSQualifiedClientID.swift */,
-				63B1334029A503D000009D84 /* MLSController.swift */,
+				63B1334029A503D000009D84 /* MLSService.swift */,
 				63B1334129A503D000009D84 /* CommitBundle+Protobuf.swift */,
 				63B1334229A503D000009D84 /* BackendMLSPublicKeys.swift */,
 				63B1334329A503D000009D84 /* MessageProtocol.swift */,
@@ -2214,14 +2214,14 @@
 		EE98879028882C6D002340D2 /* MLS */ = {
 			isa = PBXGroup;
 			children = (
-				EE98878D28882BFF002340D2 /* MLSControllerTests.swift */,
+				EE98878D28882BFF002340D2 /* MLSServiceTests.swift */,
 				EE84226F28EC353900B80FE5 /* MLSActionExecutorTests.swift */,
 				63123BCB291BBB79009A5179 /* MLSQualifiedClientIdTests.swift */,
 				0189815429A66B0800B52510 /* SafeCoreCryptoTests.swift */,
 				EEDE7DB628EC1618007DC6A3 /* MockMLSActionExecutor.swift */,
 				EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */,
 				EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */,
-				EE98879128882C8F002340D2 /* MockMLSController.swift */,
+				EE98879128882C8F002340D2 /* MockMLSService.swift */,
 				EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */,
 				EEC3BC732888403000BFDC35 /* MockCoreCrypto.swift */,
 				01A2D62E2A153118000EFC9C /* MockSafeCoreCrypto.swift */,
@@ -2351,7 +2351,7 @@
 				0630E4B5257F888600C75BFB /* NSManagedObjectContext+AppLock.swift */,
 				16AD86B91F75426C00E4C797 /* NSManagedObjectContext+NotificationContext.swift */,
 				163C92A92630A80400F8DC14 /* NSManagedObjectContext+SelfUser.swift */,
-				63DA335D286C9CF000818C3C /* NSManagedObjectContext+MLSController.swift */,
+				63DA335D286C9CF000818C3C /* NSManagedObjectContext+MLSService.swift */,
 				EE9B9F562993E57900A257BC /* NSManagedObjectContext+ProteusService.swift */,
 				EEC80B3529B0AD8100099727 /* NSManagedObjectContext+ProteusProvider.swift */,
 				EE9B9F5829964F6A00A257BC /* NSManagedObjectContext+CoreCrypto.swift */,
@@ -3629,7 +3629,7 @@
 				63B1335829A503D100009D84 /* Bytes+Random.swift in Sources */,
 				16460A46206544B00096B616 /* PersistentMetadataKeys.swift in Sources */,
 				5E67168E2174B9AF00522E61 /* LoginCredentials.swift in Sources */,
-				63DA335E286C9CF000818C3C /* NSManagedObjectContext+MLSController.swift in Sources */,
+				63DA335E286C9CF000818C3C /* NSManagedObjectContext+MLSService.swift in Sources */,
 				CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */,
 				63B1336529A503D100009D84 /* SendMLSMessageAction.swift in Sources */,
 				EEAAD75A252C6D2700E6A44E /* UnreadMessages.swift in Sources */,
@@ -3953,7 +3953,7 @@
 				EEAAD75C252C6DAE00E6A44E /* ModifiedObjects.swift in Sources */,
 				EE5E2C1526DFC31900C3928A /* MessageDestructionTimeoutType.swift in Sources */,
 				F991CE1B1CB561B0004D8465 /* ZMAddressBookContact.m in Sources */,
-				63B1335C29A503D100009D84 /* MLSController.swift in Sources */,
+				63B1335C29A503D100009D84 /* MLSService.swift in Sources */,
 				2BB20770292B787000FB6468 /* PatchApplicator.swift in Sources */,
 				87EFA3AC210F52C6004DFA53 /* ZMConversation+LastMessages.swift in Sources */,
 				F9C877091E000C9D00792613 /* AssetCollection.swift in Sources */,
@@ -4124,7 +4124,7 @@
 				F14FA377221DB05B005E7EF5 /* MockBackgroundActivityManager.swift in Sources */,
 				544034341D6DFE8500860F2D /* ZMAddressBookContactTests.swift in Sources */,
 				F920AE3B1E3B844E001BC14F /* SearchUserObserverCenterTests.swift in Sources */,
-				EE98879228882C8F002340D2 /* MockMLSController.swift in Sources */,
+				EE98879228882C8F002340D2 /* MockMLSService.swift in Sources */,
 				F9B71FA81CB2BF37001DB03F /* ZMConversationTests+Validation.m in Sources */,
 				F9B71FA11CB2BF37001DB03F /* ZMConversation+Testing.m in Sources */,
 				1600D944267BC5A100970F99 /* ZMManagedObjectFetchingTests.swift in Sources */,
@@ -4224,7 +4224,7 @@
 				EEB121AE2A175C9500E74D39 /* LastEventIDRepositoryTests.swift in Sources */,
 				EE2BA00925CB3DE7001EB606 /* InvalidFeatureRemovalTests.swift in Sources */,
 				63123BCC291BBB7A009A5179 /* MLSQualifiedClientIdTests.swift in Sources */,
-				EE98878E28882BFF002340D2 /* MLSControllerTests.swift in Sources */,
+				EE98878E28882BFF002340D2 /* MLSServiceTests.swift in Sources */,
 				BFE3A96E1ED301020024A05B /* ZMConversationListTests+Teams.swift in Sources */,
 				16C391E2214BD438003AB3AD /* MentionTests.swift in Sources */,
 				F991CE191CB55E95004D8465 /* ZMSearchUserTests.m in Sources */,

--- a/wire-ios-notification-engine/Sources/CoreCrypto/MLSDecryptionService.swift
+++ b/wire-ios-notification-engine/Sources/CoreCrypto/MLSDecryptionService.swift
@@ -21,7 +21,7 @@ import WireDataModel
 import CoreData
 import CoreCryptoSwift
 
-class MLSDecryptionController: MLSControllerProtocol {
+class MLSDecryptionService: MLSServiceInterface {
 
     // MARK: - Properties
 
@@ -37,7 +37,7 @@ class MLSDecryptionController: MLSControllerProtocol {
 
     // MARK: - Methods
 
-    // TODO: Avoid this code duplication from `MLSController`
+    // TODO: Avoid this code duplication from `mlsService`
 
     public enum MLSMessageDecryptionError: Error {
 
@@ -86,7 +86,7 @@ class MLSDecryptionController: MLSControllerProtocol {
         return MLSClientID(data: senderClientID.data)?.clientID
     }
 
-    // TODO: Avoid this code duplication from `MLSController`
+    // TODO: Avoid this code duplication from `mlsService`
 
     func scheduleCommitPendingProposals(groupID: MLSGroupID, at commitDate: Date) {
         guard let context = context else {

--- a/wire-ios-notification-engine/Sources/CoreCrypto/NotificationSession+CoreCrypto.swift
+++ b/wire-ios-notification-engine/Sources/CoreCrypto/NotificationSession+CoreCrypto.swift
@@ -49,8 +49,8 @@ extension NotificationSession {
                     syncContext.proteusService = ProteusService(coreCrypto: safeCoreCrypto)
                 }
 
-                if DeveloperFlag.enableMLSSupport.isOn, syncContext.mlsController == nil {
-                    syncContext.mlsController = MLSDecryptionController(
+                if DeveloperFlag.enableMLSSupport.isOn, syncContext.mlsService == nil {
+                    syncContext.mlsService = MLSDecryptionService(
                         context: syncContext,
                         coreCrypto: safeCoreCrypto
                     )
@@ -64,14 +64,14 @@ extension NotificationSession {
     }
 
     private var shouldSetupCryptoStack: Bool {
-        return shouldSetupProteusService || shouldSetupMLSController
+        return shouldSetupProteusService || shouldSetupMLSService
     }
 
     private var shouldSetupProteusService: Bool {
         return DeveloperFlag.proteusViaCoreCrypto.isOn
     }
 
-    private var shouldSetupMLSController: Bool {
+    private var shouldSetupMLSService: Bool {
         return DeveloperFlag.enableMLSSupport.isOn && (BackendInfo.apiVersion ?? .v0) >= .v2
     }
 

--- a/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697129C2497CAC200C32169 /* PushNotificationStrategy.swift */; };
 		630A582B29AF9CB800E26C4D /* NotificationSessionTests+CryptoStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A582A29AF9CB800E26C4D /* NotificationSessionTests+CryptoStack.swift */; };
 		630A582D29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */; };
-		630A584829B10E3800E26C4D /* MLSDecryptionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A584729B10E3800E26C4D /* MLSDecryptionControllerTests.swift */; };
+		630A584829B10E3800E26C4D /* MLSDecryptionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A584729B10E3800E26C4D /* MLSDecryptionServiceTests.swift */; };
 		630A584A29B1182C00E26C4D /* MockCoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A584929B1182C00E26C4D /* MockCoreCrypto.swift */; };
 		EE0BA28A29D59B1D004E93B5 /* NotificationSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */; };
 		EE0BA28C29D5B975004E93B5 /* MockCryptoboxMigrationManagerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0BA28B29D5B975004E93B5 /* MockCryptoboxMigrationManagerInterface.swift */; };
@@ -26,7 +26,7 @@
 		EE668BC62954BA4C00D939E7 /* WireRequestStrategy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE668BC52954BA4C00D939E7 /* WireRequestStrategy.framework */; };
 		EE761669299E60C9005DB75F /* WireNotificationEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 067ECB3A2487A93D00701956 /* WireNotificationEngine.framework */; };
 		EEC80B3A29B5FE0B00099727 /* NotificationSession+CoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B3829B5FDEC00099727 /* NotificationSession+CoreCrypto.swift */; };
-		EEC80B3B29B5FE0F00099727 /* MLSDecryptionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B3929B5FDEC00099727 /* MLSDecryptionController.swift */; };
+		EEC80B3B29B5FE0F00099727 /* MLSDecryptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B3929B5FDEC00099727 /* MLSDecryptionService.swift */; };
 		EEC80B4329B6053200099727 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B4229B6053200099727 /* AppDelegate.swift */; };
 		EEC80B4529B6053200099727 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B4429B6053200099727 /* SceneDelegate.swift */; };
 		EEC80B4729B6053200099727 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC80B4629B6053200099727 /* ViewController.swift */; };
@@ -93,7 +93,7 @@
 		06BD1D3B2487B01C002F82A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		630A582A29AF9CB800E26C4D /* NotificationSessionTests+CryptoStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationSessionTests+CryptoStack.swift"; sourceTree = "<group>"; };
 		630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNotificationSessionTests.swift; sourceTree = "<group>"; };
-		630A584729B10E3800E26C4D /* MLSDecryptionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSDecryptionControllerTests.swift; sourceTree = "<group>"; };
+		630A584729B10E3800E26C4D /* MLSDecryptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSDecryptionServiceTests.swift; sourceTree = "<group>"; };
 		630A584929B1182C00E26C4D /* MockCoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCoreCrypto.swift; sourceTree = "<group>"; };
 		EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSessionTests.swift; sourceTree = "<group>"; };
 		EE0BA28B29D5B975004E93B5 /* MockCryptoboxMigrationManagerInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCryptoboxMigrationManagerInterface.swift; sourceTree = "<group>"; };
@@ -104,7 +104,7 @@
 		EE67F6FB296F09A0001D7C88 /* WireTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE761665299E60C9005DB75F /* WireNotificationEngineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WireNotificationEngineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EEC80B3829B5FDEC00099727 /* NotificationSession+CoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationSession+CoreCrypto.swift"; sourceTree = "<group>"; };
-		EEC80B3929B5FDEC00099727 /* MLSDecryptionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSDecryptionController.swift; sourceTree = "<group>"; };
+		EEC80B3929B5FDEC00099727 /* MLSDecryptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSDecryptionService.swift; sourceTree = "<group>"; };
 		EEC80B4029B6053200099727 /* WireNotificationEngineTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WireNotificationEngineTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EEC80B4229B6053200099727 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EEC80B4429B6053200099727 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -262,7 +262,7 @@
 				630A582A29AF9CB800E26C4D /* NotificationSessionTests+CryptoStack.swift */,
 				EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */,
 				630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */,
-				630A584729B10E3800E26C4D /* MLSDecryptionControllerTests.swift */,
+				630A584729B10E3800E26C4D /* MLSDecryptionServiceTests.swift */,
 				630A584929B1182C00E26C4D /* MockCoreCrypto.swift */,
 				015C22DC2A1566EB009119CA /* MockSafeCoreCrypto.swift */,
 				EE0BA28B29D5B975004E93B5 /* MockCryptoboxMigrationManagerInterface.swift */,
@@ -274,7 +274,7 @@
 			isa = PBXGroup;
 			children = (
 				EEC80B3829B5FDEC00099727 /* NotificationSession+CoreCrypto.swift */,
-				EEC80B3929B5FDEC00099727 /* MLSDecryptionController.swift */,
+				EEC80B3929B5FDEC00099727 /* MLSDecryptionService.swift */,
 			);
 			path = CoreCrypto;
 			sourceTree = "<group>";
@@ -441,7 +441,7 @@
 				067ECB602487ABF700701956 /* AppDelegate.swift in Sources */,
 				EE32460228229FDF00F2A84A /* AuthenticationStatus.swift in Sources */,
 				EE32460028229F6B00F2A84A /* ClientRegistrationStatus.swift in Sources */,
-				EEC80B3B29B5FE0F00099727 /* MLSDecryptionController.swift in Sources */,
+				EEC80B3B29B5FE0F00099727 /* MLSDecryptionService.swift in Sources */,
 				EEC80B3A29B5FE0B00099727 /* NotificationSession+CoreCrypto.swift in Sources */,
 				069712912497B96E00C32169 /* OperationLoop.swift in Sources */,
 				0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */,
@@ -459,7 +459,7 @@
 				630A582D29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift in Sources */,
 				630A582B29AF9CB800E26C4D /* NotificationSessionTests+CryptoStack.swift in Sources */,
 				015C22DD2A1566EB009119CA /* MockSafeCoreCrypto.swift in Sources */,
-				630A584829B10E3800E26C4D /* MLSDecryptionControllerTests.swift in Sources */,
+				630A584829B10E3800E26C4D /* MLSDecryptionServiceTests.swift in Sources */,
 				630A584A29B1182C00E26C4D /* MockCoreCrypto.swift in Sources */,
 				EE0BA28C29D5B975004E93B5 /* MockCryptoboxMigrationManagerInterface.swift in Sources */,
 			);

--- a/wire-ios-notification-engine/WireNotificationEngineTests/MLSDecryptionServiceTests.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/MLSDecryptionServiceTests.swift
@@ -23,9 +23,9 @@ import WireTesting
 import CoreCryptoSwift
 @testable import WireNotificationEngine
 
-class MLSDecryptionControllerTests: BaseTest {
+class MLSDecryptionServiceTests: BaseTest {
 
-    var sut: MLSDecryptionController!
+    var sut: MLSDecryptionService!
     var mockCoreCrypto: MockCoreCrypto!
     var mockSafeCoreCrypto: MockSafeCoreCrypto!
     var syncMOC: NSManagedObjectContext!
@@ -39,7 +39,7 @@ class MLSDecryptionControllerTests: BaseTest {
         mockCoreCrypto = MockCoreCrypto()
         mockSafeCoreCrypto = MockSafeCoreCrypto(coreCrypto: mockCoreCrypto)
 
-        sut = MLSDecryptionController(
+        sut = MLSDecryptionService(
             context: syncMOC,
             coreCrypto: mockSafeCoreCrypto
         )
@@ -55,7 +55,7 @@ class MLSDecryptionControllerTests: BaseTest {
 
     // MARK: - Decryption
 
-    typealias DecryptionError = MLSDecryptionController.MLSMessageDecryptionError
+    typealias DecryptionError = MLSDecryptionService.MLSMessageDecryptionError
 
     func test_Decrypt_ThrowsFailedToConvertMessageToBytes() {
         syncMOC.performAndWait {

--- a/wire-ios-notification-engine/WireNotificationEngineTests/NotificationSessionTests+CryptoStack.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/NotificationSessionTests+CryptoStack.swift
@@ -64,7 +64,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -72,7 +72,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
         _ = try createNotificationSession()
 
         // THEN
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNotNil(context.proteusService)
         XCTAssertNotNil(context.coreCrypto)
     }
@@ -83,7 +83,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -91,7 +91,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
         _ = try createNotificationSession()
 
         // THEN
-        XCTAssertNotNil(context.mlsController)
+        XCTAssertNotNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNotNil(context.coreCrypto)
     }
@@ -103,7 +103,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -111,7 +111,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
         _ = try createNotificationSession()
 
         // THEN
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
     }
@@ -124,7 +124,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -132,7 +132,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
         _ = try createNotificationSession()
 
         // THEN
-        XCTAssertNotNil(context.mlsController)
+        XCTAssertNotNil(context.mlsService)
         XCTAssertNotNil(context.proteusService)
         XCTAssertNotNil(context.coreCrypto)
     }
@@ -144,7 +144,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -152,7 +152,7 @@ class NotificationSessionTests_CryptoStack: BaseTest {
         _ = try createNotificationSession()
 
         // THEN
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
     }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.Transcoder.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.Transcoder.swift
@@ -87,14 +87,14 @@ extension MLSMessageSync {
                 return nil
             }
 
-            guard let mlsController = context.mlsController else {
-                Logging.mls.warn("failed to encrypt message: MLSController is missing.")
+            guard let mlsService = context.mlsService else {
+                Logging.mls.warn("failed to encrypt message: mlsService is missing.")
                 return nil
             }
 
             do {
                 return try message.encryptForTransport { messageData in
-                    let encryptedBytes = try mlsController.encrypt(message: messageData.bytes, for: groupID)
+                    let encryptedBytes = try mlsService.encrypt(message: messageData.bytes, for: groupID)
                     return encryptedBytes.data
                 }
             } catch let error {

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.swift
@@ -62,7 +62,7 @@ class MLSMessageSync<Message: MLSMessage>: NSObject, ZMContextChangeTrackerSourc
     }
 
     func sync(_ message: Message, completion: @escaping EntitySyncHandler) {
-        guard let mlsController = context.mlsController else {
+        guard let mlsService = context.mlsService else {
             Logging.mls.info("not syncing message b/c no mls controller")
             return
         }
@@ -75,7 +75,7 @@ class MLSMessageSync<Message: MLSMessage>: NSObject, ZMContextChangeTrackerSourc
         Task {
             do {
                 Logging.mls.info("preemptively commiting pending proposals before sending message in group (\(groupID))")
-                try await mlsController.commitPendingProposals(in: groupID)
+                try await mlsService.commitPendingProposals(in: groupID)
             } catch {
                 Logging.mls.info("failed: preemptively commiting pending proposals before sending message in group (\(groupID)): \(String(describing: error))")
             }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSyncTests.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSyncTests.swift
@@ -22,13 +22,13 @@ import XCTest
 final class MLSMessageSyncTests: MessagingTestBase {
 
     var sut: MLSMessageSync<MockOTREntity>!
-    var mockMLSController: MockMLSController!
+    var mockMLSService: MockMLSService!
     var mockMessage: MockOTREntity!
 
     override func setUp() {
         super.setUp()
         sut = MLSMessageSync(context: syncMOC)
-        mockMLSController = MockMLSController()
+        mockMLSService = MockMLSService()
         mockMessage = MockOTREntity(
             messageData: Data([1, 2, 3]),
             conversation: groupConversation,
@@ -38,13 +38,13 @@ final class MLSMessageSyncTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             self.groupConversation.mlsGroupID = MLSGroupID([1, 2, 3])
             self.groupConversation.messageProtocol = .mls
-            self.syncMOC.mlsController = self.mockMLSController
+            self.syncMOC.mlsService = self.mockMLSService
         }
     }
 
     override func tearDown() {
         sut = nil
-        mockMLSController = nil
+        mockMLSService = nil
         mockMessage = nil
         super.tearDown()
     }
@@ -70,7 +70,7 @@ final class MLSMessageSyncTests: MessagingTestBase {
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
 
         // Then it preemptively commits pending proposals.
-        XCTAssertEqual(self.mockMLSController.calls.commitPendingProposalsInGroup, [MLSGroupID([1, 2, 3])])
+        XCTAssertEqual(self.mockMLSService.calls.commitPendingProposalsInGroup, [MLSGroupID([1, 2, 3])])
     }
 
     // MARK: - Request generation

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSyncTests.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSyncTests.swift
@@ -75,7 +75,7 @@ final class MessageSyncTests: MessagingTestBase {
             // Given
             self.groupConversation.messageProtocol = .mls
             self.groupConversation.mlsGroupID = MLSGroupID([1, 2, 3])
-            self.syncMOC.mlsController = MockMLSController()
+            self.syncMOC.mlsService = MockMLSService()
 
             let message = MockOTREntity(
                 conversation: self.groupConversation,

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 class MLSEventProcessorTests: MessagingTestBase {
 
-    var mlsControllerMock: MockMLSController!
+    var mlsServiceMock: MockMLSService!
     var conversation: ZMConversation!
     var domain = "example.com"
     let groupIdString = "identifier".data(using: .utf8)!.base64EncodedString()
@@ -29,8 +29,8 @@ class MLSEventProcessorTests: MessagingTestBase {
     override func setUp() {
         super.setUp()
         syncMOC.performGroupedBlockAndWait {
-            self.mlsControllerMock = MockMLSController()
-            self.syncMOC.mlsController = self.mlsControllerMock
+            self.mlsServiceMock = MockMLSService()
+            self.syncMOC.mlsService = self.mlsServiceMock
             self.conversation = ZMConversation.insertNewObject(in: self.syncMOC)
             self.conversation.mlsGroupID = MLSGroupID(self.groupIdString.base64EncodedBytes!)
             self.conversation.domain = self.domain
@@ -39,7 +39,7 @@ class MLSEventProcessorTests: MessagingTestBase {
     }
 
     override func tearDown() {
-        mlsControllerMock = nil
+        mlsServiceMock = nil
         conversation = nil
         super.tearDown()
     }
@@ -50,7 +50,7 @@ class MLSEventProcessorTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // Given
             let message = "welcome message"
-            self.mlsControllerMock.groupID = self.conversation.mlsGroupID
+            self.mlsServiceMock.groupID = self.conversation.mlsGroupID
             self.conversation.mlsStatus = .pendingJoin
             XCTAssertEqual(self.conversation.mlsStatus, .pendingJoin)
 
@@ -58,7 +58,7 @@ class MLSEventProcessorTests: MessagingTestBase {
             MLSEventProcessor.shared.process(welcomeMessage: message, in: self.syncMOC)
 
             // Then
-            XCTAssertEqual(message, self.mlsControllerMock.processedWelcomeMessage)
+            XCTAssertEqual(message, self.mlsServiceMock.processedWelcomeMessage)
             XCTAssertEqual(self.conversation.mlsStatus, .ready)
         }
     }
@@ -122,8 +122,8 @@ class MLSEventProcessorTests: MessagingTestBase {
             )
 
             // Then
-            XCTAssertEqual(self.mlsControllerMock.groupsPendingJoin.count, 1)
-            XCTAssertEqual(self.mlsControllerMock.groupsPendingJoin.first, self.conversation.mlsGroupID)
+            XCTAssertEqual(self.mlsServiceMock.groupsPendingJoin.count, 1)
+            XCTAssertEqual(self.mlsServiceMock.groupsPendingJoin.first, self.conversation.mlsGroupID)
         }
     }
 
@@ -149,8 +149,8 @@ class MLSEventProcessorTests: MessagingTestBase {
             )
 
             // Then
-            XCTAssertEqual(mlsControllerMock.calls.wipeGroup.count, 1)
-            XCTAssertEqual(mlsControllerMock.calls.wipeGroup.first, groupID)
+            XCTAssertEqual(mlsServiceMock.calls.wipeGroup.count, 1)
+            XCTAssertEqual(mlsServiceMock.calls.wipeGroup.first, groupID)
         }
     }
 
@@ -167,7 +167,7 @@ class MLSEventProcessorTests: MessagingTestBase {
             )
 
             // Then
-            XCTAssertEqual(mlsControllerMock.calls.wipeGroup.count, 0)
+            XCTAssertEqual(mlsServiceMock.calls.wipeGroup.count, 0)
         }
     }
 
@@ -185,7 +185,7 @@ class MLSEventProcessorTests: MessagingTestBase {
             )
 
             // Then
-            XCTAssertTrue(self.mlsControllerMock.groupsPendingJoin.isEmpty)
+            XCTAssertTrue(self.mlsServiceMock.groupsPendingJoin.isEmpty)
         }
     }
 
@@ -199,7 +199,7 @@ class MLSEventProcessorTests: MessagingTestBase {
             // Given
             self.conversation.mlsStatus = originalValue
             self.conversation.messageProtocol = mockMessageProtocol
-            self.mlsControllerMock.hasWelcomeMessageBeenProcessed = mockHasWelcomeMessageBeenProcessed
+            self.mlsServiceMock.hasWelcomeMessageBeenProcessed = mockHasWelcomeMessageBeenProcessed
 
             // When
             MLSEventProcessor.shared.updateConversationIfNeeded(

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -390,8 +390,8 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
             Logging.mls.info("resetting `mlsStatus` to `ready` b/c self client is creator")
             newConversation.mlsStatus = .ready
 
-            guard let mlsController = managedObjectContext.mlsController else {
-                Logging.mls.warn("failed to create mls group: MLSController doesn't exist")
+            guard let mlsService = managedObjectContext.mlsService else {
+                Logging.mls.warn("failed to create mls group: mlsService doesn't exist")
                 return
             }
 
@@ -401,7 +401,7 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
             }
 
             do {
-                try mlsController.createGroup(for: groupID)
+                try mlsService.createGroup(for: groupID)
             } catch let error {
                 Logging.mls.error("failed to create mls group: \(String(describing: error))")
                 return
@@ -411,7 +411,7 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
 
             Task {
                 do {
-                    try await mlsController.addMembersToConversation(with: users, for: groupID)
+                    try await mlsService.addMembersToConversation(with: users, for: groupID)
                 } catch let error {
                     Logging.mls.error("failed to add members to new mls group: \(String(describing: error))")
                     return

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
@@ -348,8 +348,8 @@ class ConversationRequestStrategyTests: MessagingTestBase {
     func testThatMLSGroupIsCreated() {
         self.syncMOC.performGroupedBlockAndWait {
             // given
-            let mlsController = MockMLSController()
-            self.syncMOC.mlsController = mlsController
+            let mlsService = MockMLSService()
+            self.syncMOC.mlsService = mlsService
 
             let id = UUID.create()
             let qualifiedID = QualifiedID(uuid: id, domain: self.owningDomain)
@@ -390,9 +390,9 @@ class ConversationRequestStrategyTests: MessagingTestBase {
             )
 
             // then
-            XCTAssertEqual(mlsController.createGroupCalls.count, 1)
+            XCTAssertEqual(mlsService.createGroupCalls.count, 1)
 
-            let createGroupCall = mlsController.createGroupCalls.element(atIndex: 0)
+            let createGroupCall = mlsService.createGroupCalls.element(atIndex: 0)
             XCTAssertEqual(createGroupCall, self.groupConversation.mlsGroupID)
             XCTAssertEqual(self.groupConversation.mlsStatus, .ready)
         }

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
@@ -19,10 +19,10 @@
 import Foundation
 import WireDataModel
 
-class MockMLSController: MLSControllerProtocol {
+class MockMLSService: MLSServiceInterface {
 
     var mockDecryptResult: MLSDecryptResult?
-    var mockDecryptionError: MLSController.MLSMessageDecryptionError?
+    var mockDecryptionError: MLSService.MLSMessageDecryptionError?
     var calls = Calls()
 
     struct Calls {

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -179,7 +179,7 @@
 		5E9EA4E02243C6B200D401B2 /* LinkAttachmentsPreprocessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9EA4DF2243C6B200D401B2 /* LinkAttachmentsPreprocessorTests.swift */; };
 		631216392881D10100FF9A56 /* ZMUpdateEvent+Payload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631216382881D10100FF9A56 /* ZMUpdateEvent+Payload.swift */; };
 		633B396A2891890600208124 /* ZMUpdateEvent+Decryption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B39692891890500208124 /* ZMUpdateEvent+Decryption.swift */; };
-		633B396C2892D53300208124 /* MockMLSController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B396B2892D53300208124 /* MockMLSController.swift */; };
+		633B396C2892D53300208124 /* MockMLSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633B396B2892D53300208124 /* MockMLSService.swift */; };
 		6397F6E228F447F800298DB1 /* SendCommitBundleActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397F6E128F447F800298DB1 /* SendCommitBundleActionHandler.swift */; };
 		6397F6E628F6DD8B00298DB1 /* SendCommitBundleActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397F6E528F6DD8B00298DB1 /* SendCommitBundleActionHandlerTests.swift */; };
 		63CC83B12859D488008549AD /* ClaimMLSKeyPackageActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CC83B02859D488008549AD /* ClaimMLSKeyPackageActionHandler.swift */; };
@@ -255,8 +255,8 @@
 		EEE0EDB12858906500BBEE29 /* MLSRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0EDB02858906500BBEE29 /* MLSRequestStrategy.swift */; };
 		EEE0EE0528591D3200BBEE29 /* OptionalString+NonEmptyValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0EE0328591D2C00BBEE29 /* OptionalString+NonEmptyValue.swift */; };
 		EEE0EE0728591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0EE0628591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift */; };
-		EEE46E5428C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */; };
 		EEE30BB02A0046E3001A0B38 /* UserDefaults+Reset.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE30BAF2A0046E3001A0B38 /* UserDefaults+Reset.swift */; };
+		EEE46E5428C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */; };
 		F14B7AEA222009BA00458624 /* UserRichProfileRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */; };
 		F14B7AEC222009C200458624 /* UserRichProfileRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */; };
 		F154EDC71F447B6C00CB8184 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F154EDC61F447B6C00CB8184 /* AppDelegate.swift */; };
@@ -600,7 +600,7 @@
 		5E9EA4DF2243C6B200D401B2 /* LinkAttachmentsPreprocessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAttachmentsPreprocessorTests.swift; sourceTree = "<group>"; };
 		631216382881D10100FF9A56 /* ZMUpdateEvent+Payload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUpdateEvent+Payload.swift"; sourceTree = "<group>"; };
 		633B39692891890500208124 /* ZMUpdateEvent+Decryption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUpdateEvent+Decryption.swift"; sourceTree = "<group>"; };
-		633B396B2892D53300208124 /* MockMLSController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSController.swift; sourceTree = "<group>"; };
+		633B396B2892D53300208124 /* MockMLSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSService.swift; sourceTree = "<group>"; };
 		6397F6E128F447F800298DB1 /* SendCommitBundleActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCommitBundleActionHandler.swift; sourceTree = "<group>"; };
 		6397F6E528F6DD8B00298DB1 /* SendCommitBundleActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCommitBundleActionHandlerTests.swift; sourceTree = "<group>"; };
 		63CC83B02859D488008549AD /* ClaimMLSKeyPackageActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimMLSKeyPackageActionHandler.swift; sourceTree = "<group>"; };
@@ -674,8 +674,8 @@
 		EEE0EDB02858906500BBEE29 /* MLSRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSRequestStrategy.swift; sourceTree = "<group>"; };
 		EEE0EE0328591D2C00BBEE29 /* OptionalString+NonEmptyValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OptionalString+NonEmptyValue.swift"; sourceTree = "<group>"; };
 		EEE0EE0628591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDownloadRequestFactoryTests.swift; sourceTree = "<group>"; };
-		EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMTransportResponse+ErrorInfo.swift"; sourceTree = "<group>"; };
 		EEE30BAF2A0046E3001A0B38 /* UserDefaults+Reset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Reset.swift"; sourceTree = "<group>"; };
+		EEE46E5328C5EE48005F48D7 /* ZMTransportResponse+ErrorInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMTransportResponse+ErrorInfo.swift"; sourceTree = "<group>"; };
 		F14B7AE9222009BA00458624 /* UserRichProfileRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategy.swift; sourceTree = "<group>"; };
 		F14B7AEB222009C200458624 /* UserRichProfileRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRichProfileRequestStrategyTests.swift; sourceTree = "<group>"; };
 		F154EDC41F447B6C00CB8184 /* WireRequestStrategyTestHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WireRequestStrategyTestHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -921,7 +921,7 @@
 			children = (
 				06ADF693264B467E002E0C7A /* MockAnalytics.swift */,
 				63DA33A9286F343A00818C3C /* MockMLSEventProcessor.swift */,
-				633B396B2892D53300208124 /* MockMLSController.swift */,
+				633B396B2892D53300208124 /* MockMLSService.swift */,
 				EE30CAAF29ACAE1600A332B1 /* MockProteusServiceinterface.swift */,
 			);
 			path = Mocks;
@@ -2072,7 +2072,7 @@
 				1621D2651D75C750007108C2 /* ZMLocallyModifiedObjectSetTests.m in Sources */,
 				06474DA624B4B1EA002C695D /* EventDecoderTest.swift in Sources */,
 				06CDDEA3282E9E9800F9360F /* RemovePushTokenActionHandlerTests.swift in Sources */,
-				633B396C2892D53300208124 /* MockMLSController.swift in Sources */,
+				633B396C2892D53300208124 /* MockMLSService.swift in Sources */,
 				EEDE7DAD28EAE538007DC6A3 /* ConversationEventProcessorTests.swift in Sources */,
 				068084982563B7310047899C /* FeatureConfigRequestStrategyTests.swift in Sources */,
 				168D7BBC26F330DE00789960 /* MessagingTest+Payloads.swift in Sources */,

--- a/wire-ios-share-engine/Sources/CoreCrypto/MLSEncryptionService.swift
+++ b/wire-ios-share-engine/Sources/CoreCrypto/MLSEncryptionService.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireDataModel
 import CoreCryptoSwift
 
-class MLSEncryptionController: MLSControllerProtocol {
+class MLSEncryptionService: MLSServiceInterface {
 
     private let coreCrypto: SafeCoreCryptoProtocol
 

--- a/wire-ios-share-engine/Sources/CoreCrypto/SharingSession+CoreCrypto.swift
+++ b/wire-ios-share-engine/Sources/CoreCrypto/SharingSession+CoreCrypto.swift
@@ -52,8 +52,8 @@ extension SharingSession {
                     syncContext.proteusService = ProteusService(coreCrypto: safeCoreCrypto)
                 }
 
-                if DeveloperFlag.enableMLSSupport.isOn, syncContext.mlsController == nil {
-                    syncContext.mlsController = MLSEncryptionController(coreCrypto: safeCoreCrypto)
+                if DeveloperFlag.enableMLSSupport.isOn, syncContext.mlsService == nil {
+                    syncContext.mlsService = MLSEncryptionService(coreCrypto: safeCoreCrypto)
                 }
 
                 WireLogger.coreCrypto.info("success: setup crypto stack")
@@ -65,14 +65,14 @@ extension SharingSession {
     }
 
     private var shouldSetupCryptoStack: Bool {
-        return shouldSetupProteusService || shouldSetupMLSController
+        return shouldSetupProteusService || shouldSetupMLSService
     }
 
     private var shouldSetupProteusService: Bool {
         return DeveloperFlag.proteusViaCoreCrypto.isOn
     }
 
-    private var shouldSetupMLSController: Bool {
+    private var shouldSetupMLSService: Bool {
         return DeveloperFlag.enableMLSSupport.isOn && (BackendInfo.apiVersion ?? .v0) >= .v2
     }
 

--- a/wire-ios-share-engine/WireShareEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-share-engine/WireShareEngine.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		166DCD9E2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166DCD9D2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift */; };
 		5470D3F31D76E1B000FDE440 /* WireShareEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */; };
 		63172F792902A42700DBECC9 /* SharingSession+CoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63172F782902A42700DBECC9 /* SharingSession+CoreCrypto.swift */; };
-		63172F96290AB47500DBECC9 /* MLSEncryptionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63172F95290AB47500DBECC9 /* MLSEncryptionController.swift */; };
+		63172F96290AB47500DBECC9 /* MLSEncryptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63172F95290AB47500DBECC9 /* MLSEncryptionService.swift */; };
 		637ED12E29119689001157F4 /* SharingSessionTests+CryptoStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637ED12D29119689001157F4 /* SharingSessionTests+CryptoStack.swift */; };
 		BFA18BD41D806050005C281B /* BaseSharingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */; };
 		CE7FBFC41E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */; };
@@ -97,7 +97,7 @@
 		5470D42B1D770CEE00FDE440 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		5470D42C1D770CEE00FDE440 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		63172F782902A42700DBECC9 /* SharingSession+CoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingSession+CoreCrypto.swift"; sourceTree = "<group>"; };
-		63172F95290AB47500DBECC9 /* MLSEncryptionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSEncryptionController.swift; sourceTree = "<group>"; };
+		63172F95290AB47500DBECC9 /* MLSEncryptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSEncryptionService.swift; sourceTree = "<group>"; };
 		637ED12D29119689001157F4 /* SharingSessionTests+CryptoStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingSessionTests+CryptoStack.swift"; sourceTree = "<group>"; };
 		BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseSharingSessionTests.swift; sourceTree = "<group>"; };
 		CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestGeneratorStoreTests.swift; sourceTree = "<group>"; };
@@ -242,7 +242,7 @@
 			isa = PBXGroup;
 			children = (
 				63172F782902A42700DBECC9 /* SharingSession+CoreCrypto.swift */,
-				63172F95290AB47500DBECC9 /* MLSEncryptionController.swift */,
+				63172F95290AB47500DBECC9 /* MLSEncryptionService.swift */,
 			);
 			path = CoreCrypto;
 			sourceTree = "<group>";
@@ -448,7 +448,7 @@
 				F1DABFA31E9B8B6100AD2324 /* Conversation.swift in Sources */,
 				F1DABFAB1E9B8B6100AD2324 /* ZMConversation+Conversation.swift in Sources */,
 				165C55F62551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift in Sources */,
-				63172F96290AB47500DBECC9 /* MLSEncryptionController.swift in Sources */,
+				63172F96290AB47500DBECC9 /* MLSEncryptionService.swift in Sources */,
 				F1DABFA21E9B8B6100AD2324 /* AuthenticationStatusProvider.swift in Sources */,
 				F1DABFA41E9B8B6100AD2324 /* OperationLoop.swift in Sources */,
 				F1DABFA91E9B8B6100AD2324 /* StrategyFactory.swift in Sources */,

--- a/wire-ios-share-engine/WireShareEngineTests/SharingSessionTests+CryptoStack.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/SharingSessionTests+CryptoStack.swift
@@ -65,7 +65,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -73,7 +73,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
         _ = try createSharingSession()
 
         // THEN
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNotNil(context.proteusService)
         XCTAssertNotNil(context.coreCrypto)
     }
@@ -84,7 +84,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -92,7 +92,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
         _ = try createSharingSession()
 
         // THEN
-        XCTAssertNotNil(context.mlsController)
+        XCTAssertNotNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNotNil(context.coreCrypto)
     }
@@ -104,7 +104,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -112,7 +112,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
         _ = try createSharingSession()
 
         // THEN
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
     }
@@ -124,7 +124,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -132,7 +132,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
         _ = try createSharingSession()
 
         // THEN
-        XCTAssertNotNil(context.mlsController)
+        XCTAssertNotNil(context.mlsService)
         XCTAssertNotNil(context.proteusService)
         XCTAssertNotNil(context.coreCrypto)
     }
@@ -144,7 +144,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
 
         let context = coreDataStack.syncContext
 
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
 
@@ -152,7 +152,7 @@ class SharingSessionTestsCryptoStack: BaseTest {
         _ = try createSharingSession()
 
         // THEN
-        XCTAssertNil(context.mlsController)
+        XCTAssertNil(context.mlsService)
         XCTAssertNil(context.proteusService)
         XCTAssertNil(context.coreCrypto)
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -457,7 +457,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
             didRetryUpdatingCapabilities = false
         } else if keysToParse.contains(UserClient.needsToUploadMLSPublicKeysKey), response.result == .success {
             userClient.needsToUploadMLSPublicKeys = false
-            userClient.managedObjectContext?.mlsController?.uploadKeyPackagesIfNeeded()
+            userClient.managedObjectContext?.mlsService?.uploadKeyPackagesIfNeeded()
         }
 
         return false

--- a/wire-ios-sync-engine/Source/UserSession/NSManagedObject+CryptoStack.swift
+++ b/wire-ios-sync-engine/Source/UserSession/NSManagedObject+CryptoStack.swift
@@ -29,7 +29,7 @@ extension NSManagedObjectContext {
         )
 
         proteusService = nil
-        mlsController = nil
+        mlsService = nil
         try? coreCrypto?.tearDown()
         coreCrypto = nil
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+CoreCrypto.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+CoreCrypto.swift
@@ -141,11 +141,11 @@ extension ZMUserSession {
                     throw CryptoStackSetupError.missingCoreCrypto
                 }
 
-                try createMLSControllerIfNeeded(coreCrypto: coreCrypto, clientID: clientID)
+                try createMLSServiceIfNeeded(coreCrypto: coreCrypto, clientID: clientID)
 
                 WireLogger.coreCrypto.info("success: setup crypto stack (mls)")
-            } catch let error as MLSControllerSetupFailure {
-                WireLogger.coreCrypto.error("fail: setup MLSController: \(String(describing: error))")
+            } catch let error as MLSServiceSetupFailure {
+                WireLogger.coreCrypto.error("fail: setup mlsService: \(String(describing: error))")
             } catch {
                 WireLogger.coreCrypto.error("fail: setup crypto stack (mls): \(String(describing: error))")
             }
@@ -189,26 +189,26 @@ extension ZMUserSession {
 
     // MARK: - MLS
 
-    private func createMLSControllerIfNeeded(
+    private func createMLSServiceIfNeeded(
         coreCrypto: SafeCoreCryptoProtocol,
         clientID: String
     ) throws {
         guard
             shouldSetupMLS,
-            syncContext.mlsController == nil
+            syncContext.mlsService == nil
         else {
             return
         }
 
         guard let syncStatus = syncStatus else {
-            throw MLSControllerSetupFailure.missingSyncStatus
+            throw MLSServiceSetupFailure.missingSyncStatus
         }
 
         guard let userDefaults = UserDefaults(suiteName: "com.wire.mls.\(clientID)") else {
-            throw MLSControllerSetupFailure.invalidUserDefaults
+            throw MLSServiceSetupFailure.invalidUserDefaults
         }
 
-        syncContext.mlsController = MLSController(
+        syncContext.mlsService = MLSService(
             context: syncContext,
             coreCrypto: coreCrypto,
             conversationEventProcessor: ConversationEventProcessor(context: syncContext),
@@ -221,7 +221,7 @@ extension ZMUserSession {
         return DeveloperFlag.enableMLSSupport.isOn && (BackendInfo.apiVersion ?? .v0) >= .v2
     }
 
-    private enum MLSControllerSetupFailure: Error {
+    private enum MLSServiceSetupFailure: Error {
         case missingSyncStatus
         case invalidUserDefaults
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -613,7 +613,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
         Self.logger.trace("did finish quick sync")
         processEvents()
 
-        syncContext.mlsController?.performPendingJoins()
+        syncContext.mlsService?.performPendingJoins()
 
         managedObjectContext.performGroupedBlock { [weak self] in
             self?.notifyThirdPartyServices()
@@ -651,10 +651,10 @@ extension ZMUserSession: ZMSyncStateDelegate {
     }
 
     private func commitPendingProposalsIfNeeded() {
-        let mlsController = syncContext.mlsController
+        let mlsService = syncContext.mlsService
         Task {
             do {
-                try await mlsController?.commitPendingProposals()
+                try await mlsService?.commitPendingProposals()
             } catch {
                 Logging.mls.error("Failed to commit pending proposals: \(String(describing: error))")
             }

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
@@ -19,8 +19,8 @@
 import Foundation
 import WireDataModel
 
-// Temporary Mock until we find a way to use a single mocked `MLSControllerProcotol` accross frameworks
-class MockMLSController: MLSControllerProtocol {
+// Temporary Mock until we find a way to use a single mocked `mlsServiceProcotol` accross frameworks
+class MockMLSService: MLSServiceInterface {
 
     func commitPendingProposals(in groupID: WireDataModel.MLSGroupID) async throws {
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -609,10 +609,10 @@ class CallingRequestStrategyTests: MessagingTest {
 
         syncMOC.saveOrRollback()
 
-        let mockMLSController = MockMLSController()
+        let mockMLSService = MockMLSService()
 
         syncMOC.performGroupedBlock {
-            self.syncMOC.mlsController = mockMLSController
+            self.syncMOC.mlsService = mockMLSService
         }
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -675,10 +675,10 @@ class CallingRequestStrategyTests: MessagingTest {
 
         syncMOC.saveOrRollback()
 
-        let mockMLSController = MockMLSController()
+        let mockMLSService = MockMLSService()
 
         syncMOC.performGroupedBlock {
-            self.syncMOC.mlsController = mockMLSController
+            self.syncMOC.mlsService = mockMLSService
         }
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -735,10 +735,10 @@ class CallingRequestStrategyTests: MessagingTest {
 
         syncMOC.saveOrRollback()
 
-        let mockMLSController = MockMLSController()
+        let mockMLSService = MockMLSService()
 
         syncMOC.performGroupedBlock {
-            self.syncMOC.mlsController = mockMLSController
+            self.syncMOC.mlsService = mockMLSService
         }
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+CryptoStack.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+CryptoStack.swift
@@ -65,7 +65,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         // WHEN
         createSut(with: selfUser)
@@ -73,7 +73,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNotNil(syncMOC.coreCrypto)
         XCTAssertNotNil(syncMOC.proteusService)
-        XCTAssertNotNil(syncMOC.mlsController)
+        XCTAssertNotNil(syncMOC.mlsService)
     }
 
     func test_CryptoStackSetup_OnInit_ProteusOnly() {
@@ -86,7 +86,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         // WHEN
         createSut(with: selfUser)
@@ -94,7 +94,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNotNil(syncMOC.coreCrypto)
         XCTAssertNotNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
     }
 
     func test_CryptoStackSetup_OnInit_MLSOnly() {
@@ -107,7 +107,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         // WHEN
         createSut(with: selfUser)
@@ -115,7 +115,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNotNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNotNil(syncMOC.mlsController)
+        XCTAssertNotNil(syncMOC.mlsService)
     }
 
     func test_CryptoStackSetup_DontSetupMLSIfAPIV2IsNotAvailable() throws {
@@ -129,7 +129,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         // WHEN
         createSut(with: selfUser)
@@ -137,7 +137,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
     }
 
     func test_CryptoStackSetup_OnInit_AllFlagsOff() {
@@ -151,7 +151,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         // WHEN
         createSut(with: selfUser)
@@ -159,7 +159,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
     }
 
     func test_CryptoStackSetup_WhenThereIsNoSelfClient() {
@@ -170,7 +170,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNil(syncMOC.coreCrypto)
         XCTAssertNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         // WHEN
         createSut(with: selfUser)
@@ -178,7 +178,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNotNil(syncMOC.coreCrypto)
         XCTAssertNotNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
     }
 
     func test_CryptoStackSetup_AfterRegisteringSelfClient() {
@@ -191,7 +191,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
 
         XCTAssertNotNil(syncMOC.coreCrypto)
         XCTAssertNotNil(syncMOC.proteusService)
-        XCTAssertNil(syncMOC.mlsController)
+        XCTAssertNil(syncMOC.mlsService)
 
         let client = createSelfClient()
 
@@ -201,7 +201,7 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         // THEN
         XCTAssertNotNil(syncMOC.coreCrypto)
         XCTAssertNotNil(syncMOC.proteusService)
-        XCTAssertNotNil(syncMOC.mlsController)
+        XCTAssertNotNil(syncMOC.mlsService)
     }
 
     func test_ItCommitsPendingProposals_AfterQuickSyncCompletes() {
@@ -218,8 +218,8 @@ class ZMUserSessionTests_CryptoStack: MessagingTest {
         let client = createSelfClient()
         sut.didRegisterSelfUserClient(client)
 
-        let controller = MockMLSController()
-        sut.syncContext.mlsController = controller
+        let controller = MockMLSService()
+        sut.syncContext.mlsService = controller
 
         // WHEN
         sut.didFinishQuickSync()

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -43,13 +43,13 @@ class ZMUserSessionSwiftTests: ZMUserSessionTestsBase {
 
     func test_itPerformsPendingJoins_AfterQuickSync() {
         // given
-        let mockMlsController = MockMLSController()
-        sut.syncContext.mlsController = mockMlsController
+        let mockMLSService = MockMLSService()
+        sut.syncContext.mlsService = mockMLSService
 
         // when
         sut.didFinishQuickSync()
 
         // then
-        XCTAssertTrue(mockMlsController.didCallPerformPendingJoins)
+        XCTAssertTrue(mockMLSService.didCallPerformPendingJoins)
     }
 }

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -417,7 +417,7 @@
 		63F1DF1F294B68380061565E /* APIMigrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F1DF1E294B68380061565E /* APIMigrationManager.swift */; };
 		63F1DF21294B69B20061565E /* AccessTokenMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F1DF20294B69B20061565E /* AccessTokenMigration.swift */; };
 		63F376E12835644800FE1F05 /* SessionManagerTests+APIVersionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F376DF283519CC00FE1F05 /* SessionManagerTests+APIVersionResolver.swift */; };
-		63FCE54628C7554200126D9D /* MockMLSController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FCE54528C7554200126D9D /* MockMLSController.swift */; };
+		63FCE54628C7554200126D9D /* MockMLSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FCE54528C7554200126D9D /* MockMLSService.swift */; };
 		63FE4B9E25C1D2EC002878E5 /* VideoGridPresentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FE4B9D25C1D2EC002878E5 /* VideoGridPresentationMode.swift */; };
 		70355A7327AAE62E00F02C76 /* ZMUserSession+SecurityClassification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70355A7227AAE62D00F02C76 /* ZMUserSession+SecurityClassification.swift */; };
 		707CEBB727B515B200E080A4 /* ZMUserSessionTests+SecurityClassification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707CEBB627B515B200E080A4 /* ZMUserSessionTests+SecurityClassification.swift */; };
@@ -1072,7 +1072,7 @@
 		63F65F1224729B4C00534A69 /* APNSTests+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APNSTests+Swift.swift"; sourceTree = "<group>"; };
 		63F65F212474153E00534A69 /* APNSTestsBase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APNSTestsBase.h; sourceTree = "<group>"; };
 		63F65F222474378200534A69 /* APNSTestsBase.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APNSTestsBase.m; sourceTree = "<group>"; };
-		63FCE54528C7554200126D9D /* MockMLSController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSController.swift; sourceTree = "<group>"; };
+		63FCE54528C7554200126D9D /* MockMLSService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMLSService.swift; sourceTree = "<group>"; };
 		63FE4B9D25C1D2EC002878E5 /* VideoGridPresentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoGridPresentationMode.swift; sourceTree = "<group>"; };
 		70355A7227AAE62D00F02C76 /* ZMUserSession+SecurityClassification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+SecurityClassification.swift"; sourceTree = "<group>"; };
 		707CEBB627B515B200E080A4 /* ZMUserSessionTests+SecurityClassification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+SecurityClassification.swift"; sourceTree = "<group>"; };
@@ -1538,7 +1538,7 @@
 				169BA23C25EF6E2A00374343 /* MockRegistrationStatusDelegate.swift */,
 				169BA24325EF6FFA00374343 /* MockAnalytics.swift */,
 				169BA24B25EF753100374343 /* MockReachability.swift */,
-				63FCE54528C7554200126D9D /* MockMLSController.swift */,
+				63FCE54528C7554200126D9D /* MockMLSService.swift */,
 				EECE27C5294362F100419A8B /* MockPushTokenService.swift */,
 				EEE30BB12A00EF77001A0B38 /* MockEARServiceInterface.swift */,
 			);
@@ -3210,7 +3210,7 @@
 				F170AF211E78013A0033DC33 /* UserImageAssetUpdateStrategyTests.swift in Sources */,
 				EEE30BB22A00EF77001A0B38 /* MockEARServiceInterface.swift in Sources */,
 				F95ECF511B94BD05009F91BA /* ZMHotFixTests.m in Sources */,
-				63FCE54628C7554200126D9D /* MockMLSController.swift in Sources */,
+				63FCE54628C7554200126D9D /* MockMLSService.swift in Sources */,
 				F9ABE8571EFD56BF00D83214 /* TeamDownloadRequestStrategy+EventsTests.swift in Sources */,
 				85D85EAFA1CB6E457D14E3B7 /* MockEntity2.m in Sources */,
 				166D18A6230EC418001288CD /* MockMediaManager.swift in Sources */,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
For consistency with the `ProteusService`, rename the `MLSController` (and related types) to `MLSService`. I believe the term "service" is more appropriate since it describes an object that provides a service to the caller (i.e the caller wants to perform some mls functionality), rather than an object that controls something. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
