### PR TITLE
chore: Tweak github actions for cirrus CI WPB-2276

### DIFF
--- a/.github/workflows/beta_app_release.yml
+++ b/.github/workflows/beta_app_release.yml
@@ -1,4 +1,4 @@
-name: Trigger Beta Release tasks from CirrusCI
+name: (CirrusCI) Beta
 
 on: workflow_dispatch
 permissions: 
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: 'Testflight Beta'

--- a/.github/workflows/bund_app_release_production.yml
+++ b/.github/workflows/bund_app_release_production.yml
@@ -1,4 +1,4 @@
-name: Trigger Bund Production Release tasks from CirrusCI
+name: (CirrusCI) Bund Production
 
 on: 
   workflow_dispatch:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: '-e SKIP_SECURITY_TESTS="${{ inputs.skip_security_tests }}" AppStore C1 Production'
 
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: '-e SKIP_SECURITY_TESTS="${{ inputs.skip_security_tests }}" AppStore C3 Production'

--- a/.github/workflows/bund_app_release_restricted.yml
+++ b/.github/workflows/bund_app_release_restricted.yml
@@ -1,4 +1,4 @@
-name: Trigger Bund Restricted Release tasks from CirrusCI
+name: (CirrusCI) Bund Restricted
 
 on: 
   workflow_dispatch:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: '-e SKIP_SECURITY_TESTS="${{ inputs.skip_security_tests }}" AppStore C1 Restricted'
 
@@ -29,6 +29,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: '-e SKIP_SECURITY_TESTS="${{ inputs.skip_security_tests }}" AppStore C3 Restricted'

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,4 +1,4 @@
-name: Trigger Playground Release tasks from CirrusCI
+name: (CirrusCI) Playground
 
 on:  workflow_dispatch
 
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: 'Playground'

--- a/.github/workflows/public_app_release.yml
+++ b/.github/workflows/public_app_release.yml
@@ -1,4 +1,4 @@
-name: Trigger Public Release tasks from CirrusCI
+name: (CirrusCI) Public AppStore
 
 on: workflow_dispatch
 permissions: 
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@latest
+      - uses: cirruslabs/cirrus-action@v2
         with:
           args: 'AppStore Public Production'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2276" title="WPB-2276" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-2276</a>  PoC experiment with implementing GithubActions that would trigger CirrusCI builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes configuration of github actions for CirrusCI

### Testing

#### How to Test

Trigger github actions related to CirrusCI 

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
