### PR TITLE
feat: create context menu with reactions WPB-629

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
@@ -31,16 +31,71 @@ final class MessageActionsViewControllerTests: XCTestCase {
     func testMenuActionsForTextMessage() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "Test tests")
-        message.senderUser = MockUserType.createUser(name: "Bob")
-
         // WHEN
+        let actionsTitles = actionsTitlesForMessage(message: message)
+        // THEN
+        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+    }
+
+    func testMenuActionsForImageMessage() {
+        // GIVEN
+        let message = MockMessageFactory.imageMessage()
+        // WHEN
+        let actionsTitles = actionsTitlesForMessage(message: message)
+        // THEN
+        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Save", "Share", "Delete", "Cancel"])
+    }
+
+    func testMenuActionsForAudioMessage() {
+        // GIVEN
+        guard let message = MockMessageFactory.audioMessage() else {
+            XCTFail("audio message shouldn't be nil")
+            return
+        }
+        // WHEN
+        let actionsTitles = actionsTitlesForMessage(message: message)
+        // THEN
+        XCTAssertArrayEqual(actionsTitles, ["Reply", "Details", "Download", "Delete", "Cancel"])
+    }
+
+    func testMenuActionsForLocationMessage() {
+        // GIVEN
+        let message = MockMessageFactory.locationMessage()
+        // WHEN
+        let actionsTitles = actionsTitlesForMessage(message: message)
+        // THEN
+        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+    }
+
+    func testMenuActionsForLinkMessage() {
+        // GIVEN
+        guard let message = MockMessageFactory.linkMessage() else {
+            XCTFail("link message shouldn't be nil")
+            return
+        }
+        // WHEN
+        let actionsTitles = actionsTitlesForMessage(message: message)
+        // THEN
+        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+    }
+
+    func testMenuActionsForPingMessage() {
+        // GIVEN
+        let message = MockMessageFactory.pingMessage()
+        // WHEN
+        let actionsTitles = actionsTitlesForMessage(message: message)
+        // THEN
+        XCTAssertArrayEqual(actionsTitles, ["Delete", "Cancel"])
+    }
+
+    func actionsTitlesForMessage(message: MockMessage) -> [String] {
+        message.senderUser = MockUserType.createUser(name: "Bob")
         let actionController = ConversationMessageActionController(responder: nil, message: message, context: .content, view: UIView())
         let sut = MessageActionsViewController.controller(withActions: MessageAction.allCases, actionController: actionController)
 
-        // THEN
-        let actionsTitles = sut.actions.map { $0.title ?? "" }
-        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+        return sut.actions.map { $0.title ?? "" }
     }
+
 }
 
 final class BasicReactionPickerTests: ZMSnapshotTestCase {

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -2099,8 +2099,8 @@ internal enum L10n {
           internal static let cancel = L10n.tr("Localizable", "conversation.create.mls.cancel", fallback: "Cancel")
           /// Select Protocol
           internal static let pickerTitle = L10n.tr("Localizable", "conversation.create.mls.picker_title", fallback: "Select Protocol")
-          /// Select MLS to create a MLS conversation (Beta functionality, use at your own risk).
-          internal static let subtitle = L10n.tr("Localizable", "conversation.create.mls.subtitle", fallback: "Select MLS to create a MLS conversation (Beta functionality, use at your own risk).")
+          /// Select MLS to create a group using Messaging Layer Security protocol (beta version).
+          internal static let subtitle = L10n.tr("Localizable", "conversation.create.mls.subtitle", fallback: "Select MLS to create a group using Messaging Layer Security protocol (beta version).")
           /// Protocol
           internal static let title = L10n.tr("Localizable", "conversation.create.mls.title", fallback: "Protocol")
         }

--- a/wire-ios/Wire-iOS/Sources/Components/ImageResourceView.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/ImageResourceView.swift
@@ -97,50 +97,10 @@ final class ImageResourceView: FLAnimatedImageView {
         NSLayoutConstraint.activate([
             centerXAnchor.constraint(equalTo: loadingView.centerXAnchor),
             centerYAnchor.constraint(equalTo: loadingView.centerYAnchor)])
-
-            let interaction = UIContextMenuInteraction(delegate: self)
-            addInteraction(interaction)
     }
 
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-}
-
-// MARK: - UIContextMenuInteractionDelegate
-
-extension ImageResourceView: UIContextMenuInteractionDelegate {
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-
-        let previewProvider: UIContextMenuContentPreviewProvider = {
-            guard let message = self.delegate?.message,
-                  let actionResponder = self.delegate?.delegate else {
-                    return nil
-            }
-
-            return self.messagePresenter.viewController(forImageMessagePreview: message, actionResponder: actionResponder)
-        }
-
-        return UIContextMenuConfiguration(identifier: nil,
-                                          previewProvider: previewProvider,
-                                          actionProvider: { _ in
-                                            return self.delegate?.makeContextMenu(title: "conversation.input_bar.message_preview.image".localized, view: self)
-        })
-    }
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
-                                animator: UIContextMenuInteractionCommitAnimating) {
-        guard let message = delegate?.message,
-            let actionResponder = delegate?.delegate else {
-                return
-        }
-
-        animator.addCompletion {
-            self.messagePresenter.open(message, targetView: self, actionResponder: actionResponder)
-        }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/MediaPreviewView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/MediaPreviewView.swift
@@ -35,9 +35,6 @@ final class MediaPreviewView: RoundedView {
         super.init(frame: .zero)
         setupSubviews()
         setupLayout()
-
-        addInteraction(UIContextMenuInteraction(delegate: self))
-
     }
 
     @available(*, unavailable)
@@ -103,23 +100,5 @@ final class MediaPreviewView: RoundedView {
             playButton.centerXAnchor.constraint(equalTo: centerXAnchor),
             playButton.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
-    }
-
-}
-
-// MARK: - UIContextMenuInteractionDelegate
-
-extension MediaPreviewView: UIContextMenuInteractionDelegate {
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        return delegate?.linkPreviewContextMenu(view: self)
-    }
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
-                                animator: UIContextMenuInteractionCommitAnimating) {
-        animator.addCompletion {
-            self.delegate?.linkViewWantsToOpenURL(self)
-        }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -58,9 +58,6 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
         super.init(frame: frame)
         configureViews()
         createConstraints()
-
-        let interaction = UIContextMenuInteraction(delegate: self)
-        addInteraction(interaction)
     }
 
     @available(*, unavailable)
@@ -178,37 +175,6 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
     @objc
     private func openInMaps() {
         lastConfiguration?.location.openInMaps(with: mapView.region.span)
-    }
-
-}
-
-// MARK: - context menu
-extension ConversationLocationMessageCell: UIContextMenuInteractionDelegate {
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
-        guard let message = message,
-            let actionResponder = delegate else {
-                return nil
-        }
-
-        let previewProvider: UIContextMenuContentPreviewProvider = {
-            return LocationPreviewController(message: message, actionResponder: actionResponder)
-        }
-
-        return UIContextMenuConfiguration(identifier: message.objectIdentifier as NSCopying,
-                                          previewProvider: previewProvider,
-                                          actionProvider: { _ in
-                                            return self.makeContextMenu(title: "", view: self)
-        })
-    }
-
-    func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
-                                willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
-                                animator: UIContextMenuInteractionCommitAnimating) {
-        animator.addCompletion {
-            self.openInMaps()
-        }
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -59,9 +59,6 @@ final class ArticleView: UIView {
 
         setupViews()
         setupConstraints(imagePlaceholder)
-
-        let interaction = UIContextMenuInteraction(delegate: self)
-        addInteraction(interaction)
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-629" title="WPB-629" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-629</a>  Create context menu with reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Enabling new context menu (with reactions) for other message types than just text message

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
