### PR TITLE
chore: add missing secret variable for CirrusCI API WPB-2276

### DIFF
--- a/.github/workflows/beta_app_release.yml
+++ b/.github/workflows/beta_app_release.yml
@@ -7,6 +7,8 @@ permissions:
 jobs:
   testflight_beta:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/bund_app_release_production.yml
+++ b/.github/workflows/bund_app_release_production.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   column_1_production:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -23,6 +25,8 @@ jobs:
 
   column_3_production:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/bund_app_release_restricted.yml
+++ b/.github/workflows/bund_app_release_restricted.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   column_1_restricted:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -23,6 +25,8 @@ jobs:
 
   column_3_restricted:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   playground:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/public_app_release.yml
+++ b/.github/workflows/public_app_release.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   appstore_public:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2276" title="WPB-2276" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-2276</a>  PoC experiment with implementing GithubActions that would trigger CirrusCI builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Previous configuration missed passing secret variable to env on Github Actions


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
