### PR TITLE
feat: trigger CI build from develop branch - WPB-2859

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,6 +45,12 @@ publishing_binary_task_template: &PUBLISHING_BINARY_TASK_TEMPLATE
   << : *RUN_SETUP_SCRIPT_TEMPLATE
 
 task:
+  name: Development
+  << : *PUBLISHING_BINARY_TASK_TEMPLATE
+  script:
+    - bundle exec fastlane development
+
+task:
   name: Playground
   << : *PUBLISHING_BINARY_TASK_TEMPLATE
   script:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,22 @@
+name: (CirrusCI) Development
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    
+
+permissions: 
+  checks: write
+
+jobs:
+  development:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: cirruslabs/cirrus-action@v2
+        with:
+          args: 'Development'

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -32,10 +32,10 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.WIRE_IOS_CI_WEBHOOK }}
     steps:
-      - name: Notify on Wire (Automatic Branch)
+      - name: Notify on Wire
         uses: 8398a7/action-slack@v3
         env:
-          TASK_ID: playtest/${{ jobs.development.steps.trigger.stdout }}
+          TASK_URL: ${{ jobs.development.steps.trigger.stdout }}
         with:
           status: ${{ job.status }}
-          text: "Wire Development build triggered. Job: https://cirrus-ci.com/task/${{ env.TASK_ID }}"
+          text: "Wire Development build triggered. Job: ${{ env.TASK_URL }}"

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,6 +1,10 @@
 name: (CirrusCI) Development
 
-on:  workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'develop'
 
 permissions: 
   checks: write

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,11 +1,6 @@
 name: (CirrusCI) Development
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - develop
-    
+on:  workflow_dispatch
 
 permissions: 
   checks: write
@@ -13,10 +8,30 @@ permissions:
 jobs:
   development:
     runs-on: ubuntu-latest
+    env:
+      CIRRUS_CI_API_TOKEN: ${{ secrets.CIRRUS_CI_API_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: cirruslabs/cirrus-action@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          args: 'Development'
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: bundle install
+      - name: Trigger build
+        id: trigger
+        run: bundle exec fastlane trigger_api_build_cirrus_ci task:"Development"
+  notify:
+    needs: development
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.WIRE_IOS_CI_WEBHOOK }}
+    steps:
+      - name: Notify on Wire (Automatic Branch)
+        uses: 8398a7/action-slack@v3
+        env:
+          TASK_ID: playtest/${{ jobs.development.steps.trigger.stdout }}
+        with:
+          status: ${{ job.status }}
+          text: "Wire Development build triggered. Job: https://cirrus-ci.com/task/${{ env.TASK_ID }}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,8 +214,8 @@ platform :ios do
             body: trigger_task_body,
             headers: authorization_header
         )
-        
-        puts triggered_task
+        # {"data":{"trigger":{"task":{"id":"6498826324803584"}}}}
+        puts triggered_task["data"]["trigger"]["task"]["id"]
     end
 
     def build_and_upload_app(options)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,7 +214,7 @@ platform :ios do
             body: trigger_task_body,
             headers: authorization_header
         )
-        puts triggered_task["data"]["trigger"]["task"]["id"]
+        puts "https://cirrus-ci.com/task/#{triggered_task["data"]["trigger"]["task"]["id"]}"
     end
 
     def build_and_upload_app(options)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,6 +51,15 @@ platform :ios do
         sh "cd .. && ./setup.sh"
         sh "cd .. && ./download-assets.sh --configuration_repo https://github.com/wireapp/wire-ios-build-configuration.git"
     end
+    
+    desc "Build & Upload Development build"
+    lane :development do |options|
+        options[:build_type] = "Development"
+        options[:upload_app_center] = true
+        options[:upload_dsyms_to_datadog] = true
+        options[:produce_debug_builds] = true
+        build_and_upload_app(options)
+    end
 
     desc "Build & Upload Playground build"
     lane :playground do |options|

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,7 +214,6 @@ platform :ios do
             body: trigger_task_body,
             headers: authorization_header
         )
-        # {"data":{"trigger":{"task":{"id":"6498826324803584"}}}}
         puts triggered_task["data"]["trigger"]["task"]["id"]
     end
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2859" title="WPB-2859" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-2859</a>  Trigger a 'development' build on every develop update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The job to trigger Development build from develop is not set on cirrus-ci.

### Notes (Optional)

Add notification to Wire when trigger is build with job link (experimental)
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
