### PR TITLE
fix: classification when temporary user WPB-76

### DIFF
--- a/wire-ios-data-model/Source/Model/User/UserType+Team.swift
+++ b/wire-ios-data-model/Source/Model/User/UserType+Team.swift
@@ -24,4 +24,8 @@ public extension UserType {
         return canAccessCompanyInformation(of: otherUser)
     }
 
+    var isTemporaryUser: Bool {
+        return expiresAfter > 0.0
+    }
+
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
@@ -39,7 +39,8 @@ extension ZMUserSession {
     private func classification(with user: UserType) -> SecurityClassification {
         guard isSelfClassified else { return .none }
 
-        guard let otherDomain = domain(for: user) else { return .notClassified }
+        guard let otherDomain = domain(for: user),
+              user.isTemporaryUser == false else { return .notClassified }
 
         return classifiedDomainsFeature.config.domains.contains(otherDomain) ? .classified : .notClassified
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-76" title="WPB-76" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-76</a>  [iOS] Wrong classification when conversation includes a temporary user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
