### PR TITLE
fix: flaky tests in MLS service WPB-2910

### DIFF
--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -49,7 +49,9 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCrypto.mockClientValidKeypackagesCount = { _ in
             return 100
         }
+    }
 
+    private func createSut() {
         sut = MLSService(
             context: uiMOC,
             coreCrypto: mockSafeCoreCrypto,
@@ -159,6 +161,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     func test_Encrypt_IsSuccessful() {
         do {
             // Given
+            createSut()
             let groupID = MLSGroupID([1, 1, 1])
             let unencryptedMessage: Bytes = [2, 2, 2]
             let encryptedMessage: Bytes = [3, 3, 3]
@@ -186,6 +189,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_Encrypt_Fails() {
         // Given
+        createSut()
         let groupID = MLSGroupID([1, 1, 1])
         let unencryptedMessage: Bytes = [2, 2, 2]
 
@@ -207,6 +211,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     func test_Decrypt_ThrowsFailedToConvertMessageToBytes() {
         syncMOC.performAndWait {
             // Given
+            createSut()
             let invalidBase64String = "%"
 
             // When / Then
@@ -219,6 +224,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     func test_Decrypt_ThrowsFailedToDecryptMessage() {
         syncMOC.performAndWait {
             // Given
+            createSut()
             let message = Data([1, 2, 3]).base64EncodedString()
             self.mockCoreCrypto.mockDecryptMessage = { _, _ in
                 throw CryptoError.ConversationNotFound(message: "conversation not found")
@@ -234,6 +240,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     func test_Decrypt_ReturnsNil_WhenCoreCryptoReturnsNil() {
         syncMOC.performAndWait {
             // Given
+            createSut()
             let messageBytes: Bytes = [1, 2, 3]
             self.mockCoreCrypto.mockDecryptMessage = { _, _ in
                 DecryptedMessage(
@@ -263,6 +270,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     func test_Decrypt_IsSuccessful() {
         syncMOC.performAndWait {
             // Given
+            createSut()
             let messageBytes: Bytes = [1, 2, 3]
             let sender = MLSClientID(
                 userID: UUID.create().transportString(),
@@ -306,6 +314,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CreateGroup_IsSuccessful() throws {
         // Given
+        createSut()
         let groupID = MLSGroupID(Data([1, 2, 3]))
         let removalKey = Data([1, 2, 3])
 
@@ -335,6 +344,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CreateGroup_ThrowsError() throws {
         // Given
+        createSut()
         let groupID = MLSGroupID(Data([1, 2, 3]))
         let config = ConversationConfiguration(
             ciphersuite: .mls128Dhkemx25519Aes128gcmSha256Ed25519,
@@ -365,6 +375,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_AddingMembersToConversation_Successfully() async {
         // Given
+        createSut()
         let id = UUID.create()
         let domain = "example.com"
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
@@ -411,6 +422,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CommitPendingProposals_BeforeAddingMembersToConversation_Successfully() async {
         // Given
+        createSut()
         let groupID = MLSGroupID(.random())
         var conversation: ZMConversation!
         let futureCommitDate = Date().addingTimeInterval(2)
@@ -478,6 +490,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_AddingMembersToConversation_ThrowsNoParticipantsToAdd() async {
         // Given
+        createSut()
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
 
         // Mock no pending proposals.
@@ -493,6 +506,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_AddingMembersToConversation_ClaimKeyPackagesFails() async {
         // Given
+        createSut()
         let domain = "example.com"
         let id = UUID.create()
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
@@ -514,6 +528,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_AddingMembersToConversation_ExecutorFails() async {
         // Given
+        createSut()
         let domain = "example.com"
         let id = UUID.create()
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
@@ -546,6 +561,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RemoveMembersFromConversation_IsSuccessful() async throws {
         // Given
+        createSut()
         let id = UUID.create().uuidString
         let domain = "example.com"
         let clientID = UUID.create().uuidString
@@ -587,6 +603,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CommitPendingProposals_BeforeRemoveMembersFromConversation_IsSuccessful() async throws {
         // Given
+        createSut()
         let groupID = MLSGroupID(.random())
         var conversation: ZMConversation!
         let futureCommitDate = Date().addingTimeInterval(2)
@@ -649,6 +666,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RemovingMembersToConversation_ThrowsNoClientsToRemove() async {
         // Given
+        createSut()
         let mlsGroupID = MLSGroupID(Data([1, 2, 3]))
 
         // Mock no pending proposals.
@@ -664,6 +682,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RemovingMembersToConversation_ExecutorFails() async {
         // Given
+        createSut()
         let id = UUID.create().uuidString
         let domain = "example.com"
         let clientID = UUID.create().uuidString
@@ -690,6 +709,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_SchedulePendingProposalCommit() throws {
         // Given
+        createSut()
         let conversationID = UUID.create()
         let groupID = MLSGroupID([1, 2, 3])
 
@@ -708,6 +728,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CommitPendingProposals_NoProposalsExist() async throws {
         // Given
+        createSut()
         let overdueCommitDate = Date().addingTimeInterval(-5)
         let groupID = MLSGroupID(.random())
         var conversation: ZMConversation!
@@ -735,6 +756,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CommitPendingProposals_OneOverdueCommit() async throws {
         // Given
+        createSut()
         let overdueCommitDate = Date().addingTimeInterval(-5)
         let groupID = MLSGroupID(.random())
         var conversation: ZMConversation!
@@ -774,6 +796,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CommitPendingProposals_OneFutureCommit() async throws {
         // Given
+        createSut()
         let futureCommitDate = Date().addingTimeInterval(2)
         let groupID = MLSGroupID([1, 2, 3])
         var conversation: ZMConversation!
@@ -813,6 +836,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_CommitPendingProposals_MultipleCommits() async throws {
         // Given
+        createSut()
         let overdueCommitDate = Date().addingTimeInterval(-5)
         let futureCommitDate1 = Date().addingTimeInterval(2)
         let futureCommitDate2 = Date().addingTimeInterval(5)
@@ -910,6 +934,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_PerformPendingJoins_IsSuccessful() {
         // Given
+        createSut()
         let groupID = MLSGroupID(.random())
         let conversationID = UUID.create()
         let domain = "example.domain.com"
@@ -984,6 +1009,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     private func test_PerformPendingJoinsRecovery(_ recovery: MLSActionExecutor.ExternalCommitErrorRecovery) {
         // Given
+        createSut()
         let shouldRetry = recovery == .retry
         let groupID = MLSGroupID(.random())
         let conversationID = UUID.create()
@@ -1051,6 +1077,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_PerformPendingJoins_DoesntJoinGroupNotPending() {
         // Given
+        createSut()
         let groupID = MLSGroupID(.random())
 
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
@@ -1091,6 +1118,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_WipeGroup_IsSuccessfull() {
         // Given
+        createSut()
         let groupID = MLSGroupID(.random())
 
         var count = 0
@@ -1110,6 +1138,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_UploadKeyPackages_IsSuccessfull() {
         // Given
+        createSut()
         let clientID = self.createSelfClient(onMOC: uiMOC).remoteIdentifier
         let keyPackages: [Bytes] = [
             [1, 2, 3],
@@ -1166,6 +1195,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_UploadKeyPackages_DoesntCountUnclaimedKeyPackages_WhenNotNeeded() {
         // Given
+        createSut()
         createSelfClient(onMOC: uiMOC)
 
         // expectation
@@ -1194,6 +1224,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_UploadKeyPackages_DoesntUploadKeyPackages_WhenNotNeeded() {
         // Given
+        createSut()
         createSelfClient(onMOC: uiMOC)
 
         // we need more than half the target number to have a sufficient amount
@@ -1238,6 +1269,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_ProcessWelcomeMessage_Sucess() throws {
         // Given
+        createSut()
         let groupID = MLSGroupID(.random())
         let message = Bytes.random().base64EncodedString
 
@@ -1442,6 +1474,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RetryOnCommitFailure_SingleRetry() async throws {
         // Given a group.
+        createSut()
         let groupID = MLSGroupID.random()
 
         // Mock no pending proposals.
@@ -1482,6 +1515,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RetryOnCommitFailure_MultipleRetries() async throws {
         // Given a group.
+        createSut()
         let groupID = MLSGroupID.random()
 
         // Mock no pending proposals.
@@ -1522,6 +1556,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RetryOnCommitFailure_ChainMultipleRecoverableOperations() async throws {
         // Given a group.
+        createSut()
         let groupID = MLSGroupID.random()
 
         // Mock two failures to commit pending proposals, then a success.
@@ -1572,6 +1607,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RetryOnCommitFailure_CommitPendingProposalsAfterRetry() async throws {
         // Given a group.
+        createSut()
         let groupID = MLSGroupID.random()
 
         // Mock no pending proposals when first trying to update key material, but
@@ -1620,6 +1656,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_RetryOnCommitFailure_ItGivesUp() async throws {
         // Given a group.
+        createSut()
         let groupID = MLSGroupID.random()
 
         // Mock no pending proposals.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2910" title="WPB-2910" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-2910</a>  Fix flaky tests in MLSService
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There were flaky tests inside MLSServiceTests

### Causes (Optional)

Flakiness was related to tests that were testing the initialization behavior. All 3 of them created 'system under test' twice, but mock mechanism consumed mock for the first instance (sometimes) 

### Solutions

The solution is to make sure we create sut only once per test, so I've extracted that into separate method and called at the beginning of every test, except three tests that create sut separately 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
