### PR TITLE
chore: bump minor version for next release cycle

### DIFF
--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,4 +16,4 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.110
+WIRE_SHORT_VERSION = 3.111


### PR DESCRIPTION
# What's new in this PR?

Bumping to 3.111 for next release cycle. 

This helps to distinguish 3.110 cycle builds (develop | Beta...)
