### PR TITLE
feat: adding users when one of the backend is offline WPB-1200

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Payload+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload+Conversation.swift
@@ -465,6 +465,7 @@ extension Payload {
             case timestamp = "time"
             case type
             case data
+            case failedToAddUsers = "failed_to_add"
         }
 
         let id: UUID?
@@ -474,6 +475,7 @@ extension Payload {
         let timestamp: Date?
         let type: String?
         let data: T
+        let failedToAddUsers: [QualifiedID]?
     }
 
     struct UpdateConverationMemberLeave: CodableEventData {

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
@@ -613,7 +613,9 @@ extension Payload.ConversationEvent where T == Payload.UpdateConversationDeleted
                 let failedUsers = failedQualifiedIDs.compactMap {
                     ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: context)
                 }
-                conversation.appendFailedToAddUsersSystemMessage(users: Set(failedUsers), sender: conversation.creator, at: serverTimestamp)
+                conversation.appendFailedToAddUsersSystemMessage(users: Set(failedUsers),
+                                                                 sender: conversation.creator,
+                                                                 at: serverTimestamp)
             }
         }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
@@ -606,6 +606,15 @@ extension Payload.ConversationEvent where T == Payload.UpdateConversationDeleted
                 conversation.addParticipantsAndUpdateConversationState(users: users, role: nil)
             }
 
+            if let serverTimestamp = timestamp,
+               let failedQualifiedIDs = failedToAddUsers,
+               !failedQualifiedIDs.isEmpty {
+
+                let failedUsers = failedQualifiedIDs.compactMap {
+                    ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: context)
+                }
+                conversation.appendFailedToAddUsersSystemMessage(users: Set(failedUsers), sender: conversation.creator, at: serverTimestamp)
+            }
         }
 
     }

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+ConversationTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+ConversationTests.swift
@@ -123,6 +123,7 @@ class PayloadProcessing_ConversationTests: MessagingTestBase {
         }
     }
 
+    ///
     func testUpdateOrCreateConversation_Group_AddSystemMessageWhenFailedToAddUsers() throws {
         syncMOC.performGroupedBlockAndWait {
             // given
@@ -936,7 +937,8 @@ class PayloadProcessing_ConversationTests: MessagingTestBase {
             qualifiedFrom: otherUser.qualifiedID,
             timestamp: nil,
             type: nil,
-            data: payload
+            data: payload,
+            failedToAddUsers: nil
         )
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -46,7 +46,8 @@ class ConversationEventProcessorTests: MessagingTestBase {
                 data: Payload.UpdateConverationMemberJoin(
                     userIDs: [],
                     users: [selfMember]
-                )
+                ),
+                failedToAddUsers: nil
             )
 
             guard let transportPayload = try? payload.toTransportDictionary() else {

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Payloads.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTest+Payloads.swift
@@ -105,7 +105,8 @@ extension MessagingTestBase {
             qualifiedFrom: senderID,
             timestamp: timestamp,
             type: ZMUpdateEvent.eventTypeString(for: Event.eventType),
-            data: data
+            data: data,
+            failedToAddUsers: nil
         )
 
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1200" title="WPB-1200" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-1200</a>  [iOS] Implement Proteus client protocol for adding users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?


**Tech specification:**
- the client makes a request to add some users (using Proteus) to the conversation,
- the backend returns success, and a list of users that were not added to the conversation due to an unreachable remote backend is returned in the **failed_to_add** field of the response.

This PR handles this new field and inserts a system message with a list of users that cannot be added to the conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
