### PR TITLE
fix: unable to process new update events WPB-2871

### DIFF
--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -63,15 +63,17 @@ public protocol EARServiceInterface: AnyObject {
 
     /// Fetch all public keys.
     ///
-    /// Public keys are used to encrypt content.
+    /// Public keys are used to encrypt content. If EAR is disabled,
+    /// `nil` is returned.
 
-    func fetchPublicKeys() throws -> EARPublicKeys
+    func fetchPublicKeys() throws -> EARPublicKeys?
 
     /// Fetch all private keys.
     ///
-    /// Private keys are used to decrypt context.
+    /// Private keys are used to decrypt context. If EAR is disabled,
+    /// `nil` is returned.
 
-    func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys
+    func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys?
 
 }
 
@@ -384,7 +386,11 @@ public class EARService: EARServiceInterface {
 
     // MARK: - Public keys
 
-    public func fetchPublicKeys() throws -> EARPublicKeys {
+    public func fetchPublicKeys() throws -> EARPublicKeys? {
+        guard isEAREnabled() else {
+            return nil
+        }
+
         do {
             return EARPublicKeys(
                 primary: try fetchPrimaryPublicKey(),
@@ -406,7 +412,11 @@ public class EARService: EARServiceInterface {
 
     // MARK: - Private keys
 
-    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys {
+    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys? {
+        guard isEAREnabled() else {
+            return nil
+        }
+
         do {
             return EARPrivateKeys(
                 primary: includingPrimary ? try? fetchPrimaryPrivateKey() : nil,

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -435,10 +435,10 @@ public class MockEARServiceInterface: EARServiceInterface {
 
     public var fetchPublicKeys_Invocations: [Void] = []
     public var fetchPublicKeys_MockError: Error?
-    public var fetchPublicKeys_MockMethod: (() throws -> EARPublicKeys)?
-    public var fetchPublicKeys_MockValue: EARPublicKeys?
+    public var fetchPublicKeys_MockMethod: (() throws -> EARPublicKeys?)?
+    public var fetchPublicKeys_MockValue: EARPublicKeys??
 
-    public func fetchPublicKeys() throws -> EARPublicKeys {
+    public func fetchPublicKeys() throws -> EARPublicKeys? {
         fetchPublicKeys_Invocations.append(())
 
         if let error = fetchPublicKeys_MockError {
@@ -458,10 +458,10 @@ public class MockEARServiceInterface: EARServiceInterface {
 
     public var fetchPrivateKeysIncludingPrimary_Invocations: [Bool] = []
     public var fetchPrivateKeysIncludingPrimary_MockError: Error?
-    public var fetchPrivateKeysIncludingPrimary_MockMethod: ((Bool) throws -> EARPrivateKeys)?
-    public var fetchPrivateKeysIncludingPrimary_MockValue: EARPrivateKeys?
+    public var fetchPrivateKeysIncludingPrimary_MockMethod: ((Bool) throws -> EARPrivateKeys?)?
+    public var fetchPrivateKeysIncludingPrimary_MockValue: EARPrivateKeys??
 
-    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys {
+    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys? {
         fetchPrivateKeysIncludingPrimary_Invocations.append(includingPrimary)
 
         if let error = fetchPrivateKeysIncludingPrimary_MockError {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2871" title="WPB-2871" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2871</a>  [iOS] Unable to process new update events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
It's been observed that sometimes after logging, the app can not process any new update events.

### Causes
Event though EAR is disabled, there were still EAR public keys still in the keychain. This could happen if EAR was enabled in a previous installation for the same user, and then the app was deleted. As a result, we were encrypting the new update events before storing them in the database, but when we fetched the events we couldn't decrypt them because we didn't have the private keys.

### Solutions
Only return the EAR keys if EAR is enabled.

### Testing

#### Test Coverage

- Added unit tests that we get no keys when EAR is disabled.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
