### PR TITLE
fix: auto-deleting pictures sent from other device of current user WPB-1238

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -66,11 +66,11 @@ extension ZMAssetClientMessage {
 
     @discardableResult @objc public override func startDestructionIfNeeded() -> Bool {
         let imageNotDownloaded = imageMessageData != nil && !hasDownloadedFile
-        let fileNotUploadedNorUploaded = fileMessageData != nil
+        let fileHasNoUploadState = fileMessageData != nil
             && underlyingMessage?.assetData?.hasUploaded == false
             && underlyingMessage?.assetData?.hasNotUploaded == false
-        let otherSenderCheck = sender == nil || (sender?.isSelfUser == false && managedObjectContext?.zm_isUserInterfaceContext == true)
-        let destructionStartCondition = !(fileNotUploadedNorUploaded || (otherSenderCheck && imageNotDownloaded))
+        let hasOtherUserSender = sender == nil || (sender?.isSelfUser == false && managedObjectContext?.zm_isUserInterfaceContext == true)
+        let destructionStartCondition = !(fileHasNoUploadState || (hasOtherUserSender && imageNotDownloaded))
         if destructionStartCondition {
             return super.startDestructionIfNeeded()
         }

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -67,11 +67,11 @@ extension ZMAssetClientMessage {
     @discardableResult @objc public override func startDestructionIfNeeded() -> Bool {
         if let isSelfUser = sender?.isSelfUser {
             // check for download state only for images that were sent by another user
-            if !isSelfUser && managedObjectContext?.zm_userInterface != nil
+            if !isSelfUser && managedObjectContext?.zm_isUserInterfaceContext == true
                 && imageMessageData != nil
                 && !hasDownloadedFile {
                 return false
-            } else if isSelfUser && managedObjectContext?.zm_isSyncContext != nil
+            } else if isSelfUser && managedObjectContext?.zm_isSyncContext == true
                         && fileMessageData != nil
                         && underlyingMessage?.assetData?.hasUploaded == false
                         && underlyingMessage?.assetData?.hasNotUploaded == false {

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -65,15 +65,27 @@ extension ZMAssetClientMessage {
     }
 
     @discardableResult @objc public override func startDestructionIfNeeded() -> Bool {
-
-        if imageMessageData != nil && !hasDownloadedFile {
-            return false
-        } else if fileMessageData != nil
-            && underlyingMessage?.assetData?.hasUploaded == false
-            && underlyingMessage?.assetData?.hasNotUploaded == false {
-            return false
+        if let isSelfUser = sender?.isSelfUser {
+            // check for download state only for images that were sent by another user
+            if !isSelfUser && managedObjectContext?.zm_userInterface != nil
+                && imageMessageData != nil
+                && !hasDownloadedFile {
+                return false
+            } else if isSelfUser && managedObjectContext?.zm_isSyncContext != nil
+                        && fileMessageData != nil
+                        && underlyingMessage?.assetData?.hasUploaded == false
+                        && underlyingMessage?.assetData?.hasNotUploaded == false {
+                    return false
+            }
+        } else {
+            if imageMessageData != nil && !hasDownloadedFile {
+                return false
+            } else if fileMessageData != nil
+                && underlyingMessage?.assetData?.hasUploaded == false
+                && underlyingMessage?.assetData?.hasNotUploaded == false {
+                return false
+            }
         }
-
         return super.startDestructionIfNeeded()
     }
 

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -71,8 +71,7 @@ extension ZMAssetClientMessage {
                 && imageMessageData != nil
                 && !hasDownloadedFile {
                 return false
-            } else if isSelfUser && managedObjectContext?.zm_isSyncContext == true
-                        && fileMessageData != nil
+            } else if fileMessageData != nil
                         && underlyingMessage?.assetData?.hasUploaded == false
                         && underlyingMessage?.assetData?.hasNotUploaded == false {
                     return false

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+Ephemeral.swift
@@ -65,27 +65,18 @@ extension ZMAssetClientMessage {
     }
 
     @discardableResult @objc public override func startDestructionIfNeeded() -> Bool {
-        if let isSelfUser = sender?.isSelfUser {
-            // check for download state only for images that were sent by another user
-            if !isSelfUser && managedObjectContext?.zm_isUserInterfaceContext == true
-                && imageMessageData != nil
-                && !hasDownloadedFile {
-                return false
-            } else if fileMessageData != nil
-                        && underlyingMessage?.assetData?.hasUploaded == false
-                        && underlyingMessage?.assetData?.hasNotUploaded == false {
-                    return false
-            }
-        } else {
-            if imageMessageData != nil && !hasDownloadedFile {
-                return false
-            } else if fileMessageData != nil
-                && underlyingMessage?.assetData?.hasUploaded == false
-                && underlyingMessage?.assetData?.hasNotUploaded == false {
-                return false
-            }
+        let imageNotDownloaded = imageMessageData != nil && !hasDownloadedFile
+        let fileNotUploadedNorUploaded = fileMessageData != nil
+            && underlyingMessage?.assetData?.hasUploaded == false
+            && underlyingMessage?.assetData?.hasNotUploaded == false
+        let otherSenderCheck = sender == nil || (sender?.isSelfUser == false && managedObjectContext?.zm_isUserInterfaceContext == true)
+        let destructionStartCondition = !(fileNotUploadedNorUploaded || (otherSenderCheck && imageNotDownloaded))
+        if destructionStartCondition {
+            return super.startDestructionIfNeeded()
         }
-        return super.startDestructionIfNeeded()
+        else {
+            return false
+        }
     }
 
     /// Extends the destruction timer to the given date, which must be later

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/EphemeralCountdownView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/EphemeralCountdownView.swift
@@ -25,7 +25,7 @@ class EphemeralCountdownView: UIView {
     fileprivate let destructionCountdownView: DestructionCountdownView = DestructionCountdownView()
     fileprivate let containerView =  UIView()
     fileprivate var timer: Timer?
-    fileprivate var everAnimated = false
+    fileprivate var wasEverAnimated = false
 
     var message: ZMConversationMessage?
 
@@ -65,7 +65,7 @@ class EphemeralCountdownView: UIView {
             return
         }
 
-        guard !everAnimated else {
+        guard !wasEverAnimated else {
             return
         }
 
@@ -79,19 +79,19 @@ class EphemeralCountdownView: UIView {
         }
     }
 
-    func stopCountDown(everAnimated: Bool = false) {
+    func stopCountDown(wasEverAnimated: Bool = false) {
         destructionCountdownView.stopAnimating()
         timer?.invalidate()
         timer = nil
-        self.everAnimated = everAnimated
+        self.wasEverAnimated = wasEverAnimated
     }
 
     @objc
     fileprivate func updateCountdown() {
         guard let destructionDate = message?.destructionDate else {
-            if everAnimated || message?.isObfuscated == true {
+            if wasEverAnimated || message?.isObfuscated == true {
                 isHidden = true
-                stopCountDown(everAnimated: everAnimated)
+                stopCountDown(wasEverAnimated: wasEverAnimated)
             }
             return
         }
@@ -102,10 +102,10 @@ class EphemeralCountdownView: UIView {
             if progress < 1 {
                 destructionCountdownView.startAnimating(duration: duration, currentProgress: CGFloat(progress))
                 isHidden = false
-                everAnimated = true
+                wasEverAnimated = true
             } else {
                 isHidden = true
-                stopCountDown(everAnimated: true)
+                stopCountDown(wasEverAnimated: true)
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1238" title="WPB-1238" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1238</a>  [iOS] Self-deleting pictures sent from another device are not deleted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Counter for self-deleting pictures does not start for pictures sent from current user's another device (web/android).
The timer on the pictures was flickering on the UI as well when the cells were repainted.

### Causes

There is a split of logic implemented. Pictures sent by other users undergo other behaviour than pictures sent by current user. When the V3 asset is downloaded, the AssetClientMessage is updated on uiContext which goes the route of deleting the picture. For the current user it should go the route of obfuscation instead of deletion. This behaviour can be triggered only on sync context which for that case is never fired as the `hasDownloadedFile` variable is not synced via CoreData. So since the update is being done on uiContext, all pictures are treated as sent by another user, which is not the case therefore deletion nor obfuscation is never triggered.

### Solutions

The provided fix verifies if the AssetClientMessage was sent by current user or another sender while preparing for firing auto-deletion. This additional check allows for checking `hasDownloadedFile` only for another users and skipping this requirement for current user and triggering auto-obfuscation immediately after receiving a message.
The UI timer flickering was fixed by providing another flag for animation & visibility control.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Send self-deleting picture from web and iOS app. Images sent from current user should obfuscate. Images from other users should auto-delete. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
