### PR TITLE
fix: classification on unclassified backend WPB-94

### DIFF
--- a/wire-ios-data-model/Source/Model/User/UserType+Team.swift
+++ b/wire-ios-data-model/Source/Model/User/UserType+Team.swift
@@ -24,4 +24,8 @@ public extension UserType {
         return canAccessCompanyInformation(of: otherUser)
     }
 
+    var isTemporaryUser: Bool {
+        return expiresAfter > 0.0
+    }
+
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
@@ -39,7 +39,8 @@ extension ZMUserSession {
     private func classification(with user: UserType) -> SecurityClassification {
         guard isSelfClassified else { return .none }
 
-        guard let otherDomain = domain(for: user) else { return .notClassified }
+        guard let otherDomain = domain(for: user),
+              user.isTemporaryUser == false else { return .notClassified }
 
         return classifiedDomainsFeature.config.domains.contains(otherDomain) ? .classified : .notClassified
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
@@ -26,8 +26,13 @@ public enum SecurityClassification {
 
 extension ZMUserSession {
 
-    public func classification(with users: [UserType]) -> SecurityClassification {
+    public func classification(with users: [UserType], conversationDomain: String? = nil) -> SecurityClassification {
         guard isSelfClassified else { return .none }
+
+        if let conversationDomain = conversationDomain,
+           classifiedDomainsFeature.config.domains.contains(conversationDomain) == false {
+            return.notClassified
+        }
 
         let isClassified = users.allSatisfy {
             classification(with: $0) == .classified
@@ -41,7 +46,6 @@ extension ZMUserSession {
 
         guard let otherDomain = domain(for: user),
               user.isTemporaryUser == false else { return .notClassified }
-
         return classifiedDomainsFeature.config.domains.contains(otherDomain) ? .classified : .notClassified
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SecurityClassification.swift
@@ -31,7 +31,7 @@ extension ZMUserSession {
 
         if let conversationDomain = conversationDomain,
            classifiedDomainsFeature.config.domains.contains(conversationDomain) == false {
-            return.notClassified
+            return .notClassified
         }
 
         let isClassified = users.allSatisfy {

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockEARServiceInterface.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockEARServiceInterface.swift
@@ -150,4 +150,35 @@ public class MockEARServiceInterface: EARServiceInterface {
         }
     }
 
+    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys? {
+        fetchPrivateKeysIncludingPrimary_Invocations.append(includingPrimary)
+
+        if let error = fetchPrivateKeysIncludingPrimary_MockError {
+            throw error
+        }
+
+        if let mock = fetchPrivateKeysIncludingPrimary_MockMethod {
+            return try mock(includingPrimary)
+        } else if let mock = fetchPrivateKeysIncludingPrimary_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `fetchPrivateKeysIncludingPrimary`")
+        }
+    }
+
+    public func fetchPublicKeys() throws -> EARPublicKeys? {
+        fetchPublicKeys_Invocations.append(())
+
+        if let error = fetchPublicKeys_MockError {
+            throw error
+        }
+
+        if let mock = fetchPublicKeys_MockMethod {
+            return try mock()
+        } else if let mock = fetchPublicKeys_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `fetchPublicKeys`")
+        }
+    }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
@@ -264,7 +264,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
     func testThatItReturnsNotClassified_WhenFeatureIsEnabled_WhenConversationDomainNotClassified() {
         // given
         let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: nil)
+        let otherUser2 = createUser(moc: syncMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2]
         let localDomain = UUID().uuidString
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
@@ -261,4 +261,63 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertEqual(classification, .notClassified)
     }
 
+    func testThatItReturnsNotClassified_WhenFeatureIsEnabled_WhenConversationDomainNotClassified() {
+        // given
+        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: syncMOC, domain: nil)
+        let otherUsers = [otherUser1, otherUser2]
+        let localDomain = UUID().uuidString
+
+        let otherUsersDomains = otherUsers.compactMap { $0.domain }
+        let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
+
+        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
+        BackendInfo.isFederationEnabled = false
+        BackendInfo.domain = localDomain
+
+        syncMOC.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.domain = UUID().uuidString
+            self.syncMOC.saveOrRollback()
+        }
+
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // when
+        let classification = sut.classification(with: otherUsers, conversationDomain: "not.Classified.Domain")
+
+        // then
+        XCTAssertEqual(classification, .notClassified)
+    }
+
+    func testThatItReturnsClassified_WhenFeatureIsEnabled_WhenConversationDomainIsClassified() {
+        // given
+        let otherDomain = UUID().uuidString
+        let otherUser1 = createUser(moc: syncMOC, domain: otherDomain)
+        let otherUser2 = createUser(moc: syncMOC, domain: nil)
+        let otherUsers = [otherUser1, otherUser2]
+        let localDomain = UUID().uuidString
+
+        let otherUsersDomains = otherUsers.compactMap { $0.domain }
+        let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
+
+        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
+        BackendInfo.isFederationEnabled = false
+        BackendInfo.domain = localDomain
+
+        syncMOC.performGroupedBlock {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.domain = UUID().uuidString
+            self.syncMOC.saveOrRollback()
+        }
+
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // when
+        let classification = sut.classification(with: otherUsers, conversationDomain: otherDomain)
+
+        // then
+        XCTAssertEqual(classification, .classified)
+    }
+
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
@@ -243,7 +243,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
         storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-        BackendInfo.isFederationEnabled = false
+        BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
         syncMOC.performGroupedBlock {
@@ -272,7 +272,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
         storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-        BackendInfo.isFederationEnabled = false
+        BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
         syncMOC.performGroupedBlock {
@@ -294,7 +294,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         // given
         let otherDomain = UUID().uuidString
         let otherUser1 = createUser(moc: syncMOC, domain: otherDomain)
-        let otherUser2 = createUser(moc: syncMOC, domain: nil)
+        let otherUser2 = createUser(moc: syncMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2]
         let localDomain = UUID().uuidString
 
@@ -302,7 +302,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
         storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-        BackendInfo.isFederationEnabled = false
+        BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
         syncMOC.performGroupedBlock {

--- a/wire-ios/Wire-iOS Tests/Mocks/MockClassificationProvider.swift
+++ b/wire-ios/Wire-iOS Tests/Mocks/MockClassificationProvider.swift
@@ -23,7 +23,7 @@ import Foundation
 final class MockClassificationProvider: ClassificationProviding {
     var returnClassification: SecurityClassification = .none
 
-    func classification(with users: [UserType]) -> SecurityClassification {
+    func classification(with users: [UserType], conversationDomain: String? = nil) -> SecurityClassification {
         returnClassification
     }
 }

--- a/wire-ios/Wire-iOS Tests/Mocks/MockConversation.swift
+++ b/wire-ios/Wire-iOS Tests/Mocks/MockConversation.swift
@@ -85,6 +85,8 @@ final class MockGroupDetailsConversation: SwiftMockConversation, GroupDetailsCon
 }
 
 final class MockInputBarConversationType: SwiftMockConversation, InputBarConversation, TypingStatusProvider {
+    var domain: String?
+
 
     var typingUsers: [UserType] = []
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/IncomingConnectionView.swift
@@ -115,7 +115,9 @@ final class IncomingConnectionView: UIView {
         usernameLabel.attributedText = viewModel.title
         usernameLabel.accessibilityIdentifier = "name"
         userDetailView.configure(with: viewModel)
-        securityLevelView.configure(with: [user], provider: classificationProvider)
+        securityLevelView.configure(with: [user],
+                                    conversationDomain: nil,
+                                    provider: classificationProvider)
     }
 
     private func createConstraints() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
@@ -60,6 +60,7 @@ protocol InputBarConversation {
     var isReadOnly: Bool { get }
 
     var participants: [UserType] { get }
+    var domain: String? {get}
 }
 
 typealias InputBarConversationType = InputBarConversation & TypingStatusProvider & ConversationLike

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController.swift
@@ -561,7 +561,9 @@ final class ConversationInputBarViewController: UIViewController,
     // MARK: - Security Banner
 
     private func updateClassificationBanner() {
-        securityLevelView.configure(with: conversation.participants, provider: classificationProvider)
+        securityLevelView.configure(with: conversation.participants,
+                                    conversationDomain: conversation.domain,
+                                    provider: classificationProvider)
     }
 
     // MARK: - Save draft message

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -70,7 +70,7 @@ final class ProfileViewControllerViewModel: NSObject {
     }
 
     var classification: SecurityClassification {
-        classificationProvider?.classification(with: [user]) ?? .none
+        classificationProvider?.classification(with: [user], conversationDomain: nil) ?? .none
     }
 
     var hasLegalHoldItem: Bool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
@@ -22,7 +22,7 @@ import WireSyncEngine
 import WireCommonComponents
 
 protocol ClassificationProviding {
-    func classification(with users: [UserType]) -> SecurityClassification
+    func classification(with users: [UserType], conversationDomain: String?) -> SecurityClassification
 }
 
 extension ZMUserSession: ClassificationProviding {}
@@ -79,10 +79,11 @@ final class SecurityLevelView: UIView {
 
     func configure(
         with otherUsers: [UserType],
+        conversationDomain: String?,
         provider: ClassificationProviding? = ZMUserSession.shared()
     ) {
 
-        guard let classification = provider?.classification(with: otherUsers) else {
+        guard let classification = provider?.classification(with: otherUsers, conversationDomain: conversationDomain) else {
             isHidden = true
             return
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-94" title="WPB-94" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-94</a>  [iOS] Wrong classification when conversation is on federated, unclassified backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->


#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
