### PR TITLE
feat: generate new epoch when requested WPB-635

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -63,6 +63,8 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
         subConversationGroupID: MLSGroupID
     ) -> AnyPublisher<MLSConferenceInfo, Never>
 
+    func generateNewEpoch(groupID: MLSGroupID) async throws
+
 }
 
 public protocol MLSServiceDelegate: AnyObject {
@@ -1261,6 +1263,13 @@ public final class MLSService: MLSServiceInterface {
         return decryptionService.onEpochChanged()
             .merge(with: mlsActionExecutor.onEpochChanged())
             .eraseToAnyPublisher()
+    }
+
+    // MARK: - Generate new epoch
+
+    public func generateNewEpoch(groupID: MLSGroupID) async throws {
+        logger.info("generating new epoch in subconveration (\(groupID))")
+        try await updateKeyMaterial(for: groupID)
     }
 
 }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -2061,4 +2061,28 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 2.0))
     }
 
+    func test_GenerateNewEpoch() async throws {
+        // Given
+        let groupID = MLSGroupID.random()
+
+        var commitPendingProposalsInvocations = [MLSGroupID]()
+        mockMLSActionExecutor.mockCommitPendingProposals = {
+            commitPendingProposalsInvocations.append($0)
+            return []
+        }
+
+        var updateKeyMaterialInvocations = [MLSGroupID]()
+        mockMLSActionExecutor.mockUpdateKeyMaterial = {
+            updateKeyMaterialInvocations.append($0)
+            return []
+        }
+
+        // When
+        try await sut.generateNewEpoch(groupID: groupID)
+
+        // Then
+        XCTAssertEqual(commitPendingProposalsInvocations, [groupID])
+        XCTAssertEqual(updateKeyMaterialInvocations, [groupID])
+    }
+
 }

--- a/wire-ios-data-model/Tests/MLS/MockMLSService.swift
+++ b/wire-ios-data-model/Tests/MLS/MockMLSService.swift
@@ -200,4 +200,10 @@ class MockMLSService: MLSServiceInterface {
         fatalError("not implemented")
     }
 
+    // MARK: - New epoch
+
+    func generateNewEpoch(groupID: MLSGroupID) async throws {
+        fatalError("not implemented")
+    }
+
 }

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
@@ -138,4 +138,10 @@ class MockMLSService: MLSServiceInterface {
         calls.joinSelfGroup.append(groupID)
     }
 
+    // MARK: - New epoch
+
+    func generateNewEpoch(groupID: MLSGroupID) async throws {
+        fatalError("not implemented")
+    }
+
 }

--- a/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper+Handlers.swift
+++ b/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper+Handlers.swift
@@ -205,5 +205,12 @@ extension AVSWrapper {
         /// typedef void (wcall_active_speaker_h)(WUSER_HANDLE wuser, const char *convid, const char *json_levels, void *arg);
 
         typealias ActiveSpeakersChange = @convention(c) (UInt32, StringPtr, StringPtr, ContextRef) -> Void
+
+        /// Callback used to request a new epoch to be generated for an mls conference.
+        ///
+        /// typedef void (wcall_req_new_epoch_h)(WUSER_HANDLE wuser, const char *convid, void *arg);
+
+        typealias RequestNewEpoch = @convention(c) (UInt32, StringPtr, ContextRef) -> Void
+
     }
 }

--- a/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper.swift
+++ b/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper.swift
@@ -103,6 +103,7 @@ public class AVSWrapper: AVSWrapperType {
         wcall_set_participant_changed_handler(handle, callParticipantHandler, observer)
         wcall_set_req_clients_handler(handle, requestClientsHandler)
         wcall_set_active_speaker_handler(handle, activeSpeakersHandler)
+        wcall_set_req_new_epoch_handler(handle, requestNewEpochHandler)
         Self.logger.info("init finished")
     }
 
@@ -393,6 +394,12 @@ public class AVSWrapper: AVSWrapperType {
     private let activeSpeakersHandler: Handler.ActiveSpeakersChange = { _, conversationIdRef, json, contextRef in
         AVSWrapper.withCallCenter(contextRef, conversationIdRef, json) {
             $0.handleActiveSpeakersChange(conversationId: AVSIdentifier.from(string: $1), data: $2)
+        }
+    }
+
+    private let requestNewEpochHandler: Handler.RequestNewEpoch = { handle, conversationIdRef, contextRef in
+        AVSWrapper.withCallCenter(contextRef, conversationIdRef) { (callCenter, conversationID: String) in
+            callCenter.handleNewEpochRequest(conversationID: .from(string: conversationID))
         }
     }
 

--- a/wire-ios-sync-engine/Source/Calling/CallSnapshot.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallSnapshot.swift
@@ -24,6 +24,10 @@ import Combine
  */
 
 struct CallSnapshot {
+
+    var qualifiedID: QualifiedID?
+    var groupIDs: (parent: MLSGroupID, subconversation: MLSGroupID)?
+
     let callParticipants: CallParticipantsSnapshot
     let callState: CallState
     let callStarter: AVSIdentifier
@@ -50,6 +54,8 @@ struct CallSnapshot {
 
     func update(with callState: CallState) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,
@@ -74,6 +80,8 @@ struct CallSnapshot {
 
     func updateConstantBitrate(_ enabled: Bool) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,
@@ -98,6 +106,8 @@ struct CallSnapshot {
 
     func updateVideoState(_ videoState: VideoState) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,
@@ -122,6 +132,8 @@ struct CallSnapshot {
 
     func updateNetworkQuality(_ networkQuality: NetworkQuality) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,
@@ -150,6 +162,8 @@ struct CallSnapshot {
 
     func updateDegradedUser(_ degradedUser: ZMUser) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,
@@ -174,6 +188,8 @@ struct CallSnapshot {
 
     func updateActiveSpeakers(_ activeSpeakers: [AVSActiveSpeakersChange.ActiveSpeaker]) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,
@@ -198,6 +214,8 @@ struct CallSnapshot {
 
     func updateVideoGridPresentationMode(_ presentationMode: VideoGridPresentationMode) -> CallSnapshot {
         return CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: groupIDs,
             callParticipants: callParticipants,
             callState: callState,
             callStarter: callStarter,

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -363,6 +363,29 @@ extension WireCallCenterV3 {
             }
         }
     }
+
+    func handleNewEpochRequest(conversationID: AVSIdentifier) {
+        handleEvent("new-epoch-request") {
+            guard
+                let viewContext = self.uiMOC,
+                let syncContext = viewContext.zm_sync,
+                let snapshot = self.callSnapshots[conversationID],
+                let groupIDs = snapshot.groupIDs
+            else {
+                return
+            }
+
+            syncContext.perform {
+                guard let mlsService = syncContext.mlsService else {
+                    return
+                }
+
+                Task {
+                    try await mlsService.generateNewEpoch(groupID: groupIDs.subconversation)
+                }
+            }
+        }
+    }
 }
 
 private extension Set where Element == ZMUser {

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -578,7 +578,6 @@ extension WireCallCenterV3 {
 
         case .mls:
             try setUpMLSConference(in: conversation)
-            
         }
     }
 
@@ -635,6 +634,8 @@ extension WireCallCenterV3 {
                     }
 
                     if var snapshot = self.callSnapshots[conversationID] {
+                        snapshot.qualifiedID = parentQualifiedID
+                        snapshot.groupIDs = (parentGroupID, subgroupID)
                         snapshot.onConferenceInfoChangedToken = token
                         self.callSnapshots[conversationID] = snapshot
                     }

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -1697,6 +1697,69 @@ extension WireCallCenterV3Tests {
     }
 }
 
+// MARK: - Request new epoch
+
+extension WireCallCenterV3Tests {
+
+    func testHandleNewEpochRequest() throws {
+        // Given
+        let conversationID = try XCTUnwrap(groupConversationID)
+        let qualifiedID = try XCTUnwrap(groupConversation.qualifiedID)
+        let parentGroupID = MLSGroupID.random()
+        let subconversationGroupID = MLSGroupID.random()
+
+        createsMLSConferenceSnapshot(
+            conversationID: conversationID,
+            qualifiedID: qualifiedID,
+            parentGroupID: parentGroupID,
+            subconversationGroupID: subconversationGroupID
+        )
+
+        let mlsService = MockMLSService()
+        uiMOC.zm_sync.mlsService = mlsService
+
+        let didGenereateNewEpoch = expectation(description: "didGenerateNewEpoch")
+        mlsService.mockGenerateNewEpoch = {
+            XCTAssertEqual($0, subconversationGroupID)
+            didGenereateNewEpoch.fulfill()
+        }
+
+        // When
+        sut.handleNewEpochRequest(conversationID: conversationID)
+
+        // Then
+        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
+    }
+
+    private func createsMLSConferenceSnapshot(
+        conversationID: AVSIdentifier,
+        qualifiedID: QualifiedID,
+        parentGroupID: MLSGroupID,
+        subconversationGroupID: MLSGroupID
+    ) {
+        sut.callSnapshots[conversationID] = CallSnapshot(
+            qualifiedID: qualifiedID,
+            groupIDs: (parentGroupID, subconversationGroupID),
+            callParticipants: CallParticipantsSnapshot(
+                conversationId: conversationID,
+                members: [],
+                callCenter: sut
+            ),
+            callState: .established,
+            callStarter: selfUserID,
+            isVideo: false,
+            isGroup: true,
+            isConstantBitRate: false,
+            videoState: .stopped,
+            networkQuality: .normal,
+            isConferenceCall: true,
+            degradedUser: nil,
+            activeSpeakers: [],
+            videoGridPresentationMode: .allVideoStreams
+        )
+    }
+}
+
 private extension AVSClient {
     static var mockClient: AVSClient {
         return AVSClient(userId: AVSIdentifier(identifier: UUID(), domain: "wire.com"),

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
@@ -133,4 +133,14 @@ class MockMLSService: MLSServiceInterface {
         return mock()
     }
 
+    var mockGenerateNewEpoch: ((MLSGroupID) -> Void)?
+
+    func generateNewEpoch(groupID: MLSGroupID) async throws {
+        guard let mock = mockGenerateNewEpoch else {
+            fatalError("not implemented")
+        }
+
+        return mock(groupID)
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-635" title="WPB-635" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-635</a>  [iOS] Implement the callback `wcall_req_new_epoch_h` for AVS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Sometimes AVS will ask the client to generate a new epoch for an MLS conference. It will do this by invoking a callback handler, which should then trigger the generation of the new epoch. The new epoch will be passed back to AVS in the normal flow.

In this PR, we:
- define the callback handler for requesting a new epoch
- registering the callback handler with AVS
- handling the new epoch request by delegating to the mls service

In this PR I've also added some ids to the call snapshot which makes it much easier to get the group ids. I think this can also be used for to simply other MLS conference code, something I'll look into in another PR.

### Testing

#### Test Coverage

- Unit test asserting a new epoch is generated when requested
- Unit test asserting new epoch generation

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
