### PR TITLE
feat: disable reactions for ephemeral message WPB-629

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
@@ -28,6 +28,41 @@ final class MessageActionsViewControllerTests: XCTestCase {
         SelfUser.provider = SelfProvider(selfUser: mockSelfUser)
     }
 
+    func testReactionPicker_ExistForStandardMessage() {
+        // GIVEN
+        let message = MockMessageFactory.textMessage(withText: "Test tests")
+        let actionController = ConversationMessageActionController(responder: nil, message: message, context: .content, view: UIView())
+        // WHEN
+        let messageActionsViewController = MessageActionsViewController.controller(withActions: MessageAction.allCases,
+                                                                            actionController: actionController)
+        // THEN
+        XCTAssertTrue(messageActionsViewController.view.containsBasicReactionPicker())
+    }
+
+    func testReactionPicker_DoesnExistForEphemeralMessage() {
+        // GIVEN
+        let message = MockMessageFactory.textMessage(withText: "Test tests")
+        message.isEphemeral = true
+        let actionController = ConversationMessageActionController(responder: nil, message: message, context: .content, view: UIView())
+        // WHEN
+        let messageActionsViewController = MessageActionsViewController.controller(withActions: MessageAction.allCases,
+                                                                            actionController: actionController)
+        // THEN
+        XCTAssertFalse(messageActionsViewController.view.containsBasicReactionPicker())
+    }
+
+    func testReactionPicker_DoesnExistForFailedMessage() {
+        // GIVEN
+        let message = MockMessageFactory.textMessage(withText: "Test tests")
+        message.deliveryState = .failedToSend
+        let actionController = ConversationMessageActionController(responder: nil, message: message, context: .content, view: UIView())
+        // WHEN
+        let messageActionsViewController = MessageActionsViewController.controller(withActions: MessageAction.allCases,
+                                                                            actionController: actionController)
+        // THEN
+        XCTAssertFalse(messageActionsViewController.view.containsBasicReactionPicker())
+    }
+
     func testMenuActionsForTextMessage() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "Test tests")
@@ -123,5 +158,22 @@ final class BasicReactionPickerTests: ZMSnapshotTestCase {
         picker.frame = CGRect(origin: .zero, size: CGSize(width: 375, height: 84))
 
         return picker
+    }
+}
+
+fileprivate extension UIView {
+
+    func containsBasicReactionPicker() -> Bool {
+        if self.subviews.contains(where: { $0.isKind(of: BasicReactionPicker.self) }) {
+                    return true
+                }
+
+                for subview in self.subviews {
+                    if subview.containsBasicReactionPicker() {
+                        return true
+                    }
+                }
+
+                return false
     }
 }

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
@@ -39,7 +39,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         XCTAssertTrue(messageActionsViewController.view.containsBasicReactionPicker())
     }
 
-    func testReactionPicker_DoesnExistForEphemeralMessage() {
+    func testReactionPicker_DoesNotExistForEphemeralMessage() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "Test tests")
         message.isEphemeral = true
@@ -51,7 +51,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         XCTAssertFalse(messageActionsViewController.view.containsBasicReactionPicker())
     }
 
-    func testReactionPicker_DoesnExistForFailedMessage() {
+    func testReactionPicker_DoesNotExistForFailedMessage() {
         // GIVEN
         let message = MockMessageFactory.textMessage(withText: "Test tests")
         message.deliveryState = .failedToSend

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/MessageActionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/MessageActionsViewController.swift
@@ -55,7 +55,7 @@ class MessageActionsViewController: UIAlertController {
 
     private func addReactionsView(withDelegate delegate: ReactionPickerDelegate) {
         guard let customContentPlaceholder = self.view.findLabel(withText: MessageActionsViewController.MessageLabelMarker),
-              let customContainer =  customContentPlaceholder.superview else { return }
+              let customContainer = customContentPlaceholder.superview else { return }
 
         let reactionPicker = BasicReactionPicker(selectedReaction: actionController?.selfUserReaction?.unicodeValue)
         reactionPicker.delegate = delegate

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/MessageActionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/MessageActionsViewController.swift
@@ -26,7 +26,8 @@ class MessageActionsViewController: UIAlertController {
 
     static func controller(withActions actions: [MessageAction],
                            actionController: ConversationMessageActionController) -> MessageActionsViewController {
-        let controller = MessageActionsViewController(title: MessageLabelMarker,
+        let title = actionController.canPerformAction(action: .react(.like)) ? MessageLabelMarker : nil
+        let controller = MessageActionsViewController(title: title,
                                             message: nil,
                                             preferredStyle: .actionSheet)
         controller.addMessageActions(actions, withActionController: actionController)
@@ -38,9 +39,9 @@ class MessageActionsViewController: UIAlertController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-
+    
     private func addMessageActions(_ actions: [MessageAction],
-                           withActionController actionController: ConversationMessageActionController) {
+                                   withActionController actionController: ConversationMessageActionController) {
         self.actionController = actionController
         addReactionsView(withDelegate: self)
         actions.forEach { addAction($0) }
@@ -53,12 +54,12 @@ class MessageActionsViewController: UIAlertController {
     }
 
     private func addReactionsView(withDelegate delegate: ReactionPickerDelegate) {
+        guard let customContentPlaceholder = self.view.findLabel(withText: MessageActionsViewController.MessageLabelMarker),
+              let customContainer =  customContentPlaceholder.superview else { return }
+
         let reactionPicker = BasicReactionPicker(selectedReaction: actionController?.selfUserReaction?.unicodeValue)
         reactionPicker.delegate = delegate
         reactionPicker.translatesAutoresizingMaskIntoConstraints = false
-
-        guard let customContentPlaceholder = self.view.findLabel(withText: MessageActionsViewController.MessageLabelMarker),
-              let customContainer =  customContentPlaceholder.superview else { return }
 
         view.addSubview(reactionPicker)
         customContentPlaceholder.text = ""


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-629" title="WPB-629" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-629</a>  Create context menu with reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
