### PR TITLE
fix: remove sensitive information from the logs - WPB-1705

### DIFF
--- a/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
+++ b/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
@@ -191,7 +191,6 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
         return;
     }
 
-    ZMLogInfo(@"Requesting access token from cookie (existing token: %p).", self.accessToken);
     if(self.cookieStorage.authenticationCookieData == nil) {
         ZMLogError(@"No cookie to request access token");
         [self notifyTokenFailure:nil];
@@ -236,9 +235,6 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 
 - (void)didCompleteAccessTokenRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion
 {
-    ZMLogInfo(@"<---- Access token task completed: %@ // %@", task, task.error);
-    ZMLogInfo(@"<---- Access token URL session: %@", session.description);
-    
     NSError *transportError = [NSError transportErrorFromURLTask:task expired:NO];
     ZMTransportResponse *response = [self transportResponseFromURLResponse:task.response data:data error:transportError apiVersion:apiVersion];
     BOOL needToResend = [self processAccessTokenResponse:response];
@@ -304,7 +300,6 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
         
         if ( ! didFail) {
             self.accessToken = newToken;
-            ZMLogInfo(@"New access token <%@: %p>", self.accessToken.class, self.accessToken);
             [self notifyTokenSuccess:newToken];
         }
         

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -503,9 +503,6 @@ static NSInteger const DefaultMaximumRequests = 6;
     [self.remoteMonitoring logWithResponse:httpResponse];
 
     ZMLogDebug(@"ConnectionProxyDictionary: %@,", session.configuration.connectionProxyDictionary);
-    ZMLogPublic(@"Response to %@: %@", request.safeForLoggingDescription,  response.safeForLoggingDescription);
-    ZMLogInfo(@"<---- Response to %@ %@ (status %u): %@", [ZMTransportRequest stringForMethod:request.method], request.path, (unsigned) httpResponse.statusCode, response);
-    ZMLogInfo(@"URL Session is %@", session.description);
     if (response.result == ZMTransportResponseStatusExpired) {
         [request completeWithResponse:response];
         return;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-1705" title="WPB-1705" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-1705</a>  [wire-ios-mono] Prevent logging of sensitve data in "developer" or "internal" build
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Remove sensitive information like token informations on the logs

### Solutions

Removed logs which contain sensitive information

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
