### PR TITLE
fix: user should not be able to select picture from gallery WPB-90

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/MediaShareRestrictionManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/MediaShareRestrictionManager.swift
@@ -55,6 +55,10 @@ class MediaShareRestrictionManager {
         return SecurityFlags.fileSharing.isEnabled
     }
 
+    var isPhotoLibraryEnabled: Bool {
+        return SecurityFlags.cameraRoll.isEnabled
+    }
+
     // MARK: - Public Properties
 
     var level: MediaShareRestrictionLevel {

--- a/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
@@ -58,6 +58,15 @@ class ImagePickerManager: NSObject {
         }
         actionSheet.addAction(cameraAction)
 
+        guard !SecurityFlags.fileSharing.isEnabled else {
+            let galleryAction = UIAlertAction(title: Alert.choosePicture, style: .default) { [weak self] _ -> Void in
+                self?.sourceType = .photoLibrary
+                self?.getImage(fromSourceType: .photoLibrary)
+            }
+            actionSheet.addAction(galleryAction)
+            return actionSheet
+        }
+
         // Cancel
         actionSheet.addAction(.cancel())
 

--- a/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
@@ -35,6 +35,7 @@ class ImagePickerManager: NSObject {
     private weak var viewController: UIViewController?
     private var sourceType: UIImagePickerController.SourceType?
     private var completion: ((UIImage) -> Void)?
+    private let mediaShareRestrictionManager = MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared())
 
     // MARK: - Methods
     func showActionSheet(on viewController: UIViewController? = UIApplication.shared.topmostViewController(onlyFullScreen: false),
@@ -52,21 +53,21 @@ class ImagePickerManager: NSObject {
                                             message: nil,
                                             preferredStyle: .actionSheet)
 
+        // Choose from gallery option, if security flag enabled
+        if mediaShareRestrictionManager.isPhotoLibraryEnabled {
+            let galleryAction = UIAlertAction(title: Alert.choosePicture, style: .default) { [weak self] _ -> Void in
+                self?.sourceType = .photoLibrary
+                self?.getImage(fromSourceType: .photoLibrary)
+            }
+            actionSheet.addAction(galleryAction)
+        }
+
         // Take photo
         let cameraAction = UIAlertAction(title: Alert.takePicture, style: .default) { [weak self] _ -> Void in
             self?.sourceType = .camera
             self?.getImage(fromSourceType: .camera)
         }
         actionSheet.addAction(cameraAction)
-
-        guard !MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).isPhotoLibraryEnabled else {
-            let galleryAction = UIAlertAction(title: Alert.choosePicture, style: .default) { [weak self] _ -> Void in
-                self?.sourceType = .photoLibrary
-                self?.getImage(fromSourceType: .photoLibrary)
-            }
-            actionSheet.addAction(galleryAction)
-            return actionSheet
-        }
 
         // Cancel
         actionSheet.addAction(.cancel())

--- a/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
@@ -51,13 +51,6 @@ class ImagePickerManager: NSObject {
                                             message: nil,
                                             preferredStyle: .actionSheet)
 
-        // Choose from gallery
-        let galleryAction = UIAlertAction(title: Alert.choosePicture, style: .default) { [weak self] _ -> Void in
-            self?.sourceType = .photoLibrary
-            self?.getImage(fromSourceType: .photoLibrary)
-        }
-        actionSheet.addAction(galleryAction)
-
         // Take photo
         let cameraAction = UIAlertAction(title: Alert.takePicture, style: .default) { [weak self] _ -> Void in
             self?.sourceType = .camera

--- a/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import MobileCoreServices
+import WireSyncEngine
 
 extension UIImage {
     var jpegData: Data? {
@@ -58,7 +59,7 @@ class ImagePickerManager: NSObject {
         }
         actionSheet.addAction(cameraAction)
 
-        guard !SecurityFlags.fileSharing.isEnabled else {
+        guard !MediaShareRestrictionManager(sessionRestriction: ZMUserSession.shared()).isPhotoLibraryEnabled else {
             let galleryAction = UIAlertAction(title: Alert.choosePicture, style: .default) { [weak self] _ -> Void in
                 self?.sourceType = .photoLibrary
                 self?.getImage(fromSourceType: .photoLibrary)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-90" title="WPB-90" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-90</a>  [iOS]-Col1: Possible to select picture from library for profile picture
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users should not be able to select picture from library for profile picture

### Solutions

Removed the option to select photos from library.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
