### PR TITLE
feat: send messages over MLS self conversation WPB-2063

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -159,18 +159,32 @@ public extension ZMConversation {
         return context.executeFetchRequestOrAssert(request) as? [ZMConversation] ?? []
     }
 
-    
     static func fetchSelfMLSConversation(
         in context: NSManagedObjectContext
     ) -> ZMConversation? {
         let request = Self.fetchRequest()
         request.fetchLimit = 2
 
-        request.predicate = NSPredicate(
-            format: "%K == %i && %K != nil",
-            argumentArray: [Self.messageProtocolKey, MessageProtocol.mls.rawValue,
-                            Self.mlsGroupIdKey]
+        let isSelfConversation = NSPredicate(
+            format: "%K == %i",
+            argumentArray: [
+                ZMConversationConversationTypeKey,
+                ZMConversationType.`self`.rawValue
+            ]
         )
+
+        let isMLSConveration = NSPredicate(
+            format: "%K == %i && %K != nil",
+            argumentArray: [
+                Self.messageProtocolKey,
+                MessageProtocol.mls.rawValue,
+                Self.mlsGroupIdKey
+            ]
+        )
+
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            isSelfConversation, isMLSConveration
+        ])
 
         let result = context.executeFetchRequestOrAssert(request)
         require(result.count <= 1, "More than one conversation found for a single group id")

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
@@ -133,23 +133,39 @@ extension ZMConversation {
 
     // MARK: - Sync downstream
 
-    static func updateConversation(withLastReadFromSelfConversation lastRead: LastRead, inContext moc: NSManagedObjectContext) {
-        let newTimeStamp = Double(integerLiteral: lastRead.lastReadTimestamp)
-        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
+    static func updateConversation(
+        withLastReadFromSelfConversation lastRead: LastRead,
+        in context: NSManagedObjectContext
+    ) {
         guard let conversationID = UUID(uuidString: lastRead.conversationID) else {
             return
         }
-        let conversation = ZMConversation.fetchOrCreate(with: conversationID, domain: lastRead.qualifiedConversationID.domain, in: moc)
+
+        let newTimeStamp = Double(integerLiteral: lastRead.lastReadTimestamp)
+        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
+        let conversation = ZMConversation.fetchOrCreate(
+            with: conversationID,
+            domain: lastRead.qualifiedConversationID.domain,
+            in: context
+        )
         conversation.updateLastRead(timestamp, synchronize: false)
     }
 
-    static func updateConversation(withClearedFromSelfConversation cleared: Cleared, inContext moc: NSManagedObjectContext) {
-        let newTimeStamp = Double(integerLiteral: cleared.clearedTimestamp)
-        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
+    static func updateConversation(
+        withClearedFromSelfConversation cleared: Cleared,
+        in context: NSManagedObjectContext
+    ) {
         guard let conversationID = UUID(uuidString: cleared.conversationID) else {
             return
         }
-        let conversation = ZMConversation.fetchOrCreate(with: conversationID, domain: cleared.qualifiedConversationID.domain, in: moc)
+
+        let newTimeStamp = Double(integerLiteral: cleared.clearedTimestamp)
+        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
+        let conversation = ZMConversation.fetchOrCreate(
+            with: conversationID,
+            domain: cleared.qualifiedConversationID.domain,
+            in: context
+        )
         conversation.updateCleared(timestamp, synchronize: false)
     }
 

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
@@ -141,14 +141,16 @@ extension ZMConversation {
             return
         }
 
-        let newTimeStamp = Double(integerLiteral: lastRead.lastReadTimestamp)
-        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
         let conversation = ZMConversation.fetchOrCreate(
             with: conversationID,
             domain: lastRead.qualifiedConversationID.domain,
             in: context
         )
-        conversation.updateLastRead(timestamp, synchronize: false)
+
+        conversation.updateLastRead(
+            dateFromTimestamp(lastRead.lastReadTimestamp),
+            synchronize: false
+        )
     }
 
     static func updateConversation(
@@ -159,14 +161,21 @@ extension ZMConversation {
             return
         }
 
-        let newTimeStamp = Double(integerLiteral: cleared.clearedTimestamp)
-        let timestamp = Date(timeIntervalSince1970: newTimeStamp/1000)
         let conversation = ZMConversation.fetchOrCreate(
             with: conversationID,
             domain: cleared.qualifiedConversationID.domain,
             in: context
         )
-        conversation.updateCleared(timestamp, synchronize: false)
+
+        conversation.updateCleared(
+            dateFromTimestamp(cleared.clearedTimestamp),
+            synchronize: false
+        )
+    }
+
+    private static func dateFromTimestamp(_ timestamp: Int64) -> Date {
+        let interval = Double(integerLiteral: timestamp) / 1000
+        return Date(timeIntervalSince1970: interval)
     }
 
 }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
@@ -97,7 +97,7 @@ extension ZMConversation {
         _ content: MessageCapable,
         in context: NSManagedObjectContext
     ) throws -> (proteus: ZMClientMessage, mls: ZMClientMessage?) {
-        let proteusMessage = try sendMessageOverProtuesSelfConversation(
+        let proteusMessage = try sendMessageOverProteusSelfConversation(
             content,
             in: context
         )
@@ -110,7 +110,7 @@ extension ZMConversation {
         return (proteusMessage, mlsMessage)
     }
 
-    private static func sendMessageOverProtuesSelfConversation(
+    private static func sendMessageOverProteusSelfConversation(
         _ content: MessageCapable,
         in context: NSManagedObjectContext
     ) throws -> ZMClientMessage {

--- a/wire-ios-data-model/Source/Model/Message/ConversationMessage+Deletion.swift
+++ b/wire-ios-data-model/Source/Model/Message/ConversationMessage+Deletion.swift
@@ -24,13 +24,14 @@ extension ZMConversation {
         guard
             let messageId = message.nonce,
             let conversation = message.conversation,
-            let conversationId = conversation.remoteIdentifier
+            let conversationId = conversation.remoteIdentifier,
+            let context = message.managedObjectContext
         else {
             return
         }
 
-        let genericMessage = GenericMessage(content: MessageHide(conversationId: conversationId, messageId: messageId))
-        _ = try ZMConversation.appendMessageToSelfConversation(genericMessage, in: message.managedObjectContext!)
+        let message = MessageHide(conversationId: conversationId, messageId: messageId)
+        try ZMConversation.sendMessageToSelfClients(message, in: context)
     }
 }
 

--- a/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -61,10 +61,16 @@ extension ZMOTRMessage {
         // Insert the message
         switch content {
         case .lastRead where conversation.isSelfConversation:
-            ZMConversation.updateConversation(withLastReadFromSelfConversation: message.lastRead, inContext: moc)
+            ZMConversation.updateConversation(
+                withLastReadFromSelfConversation: message.lastRead,
+                in: moc
+            )
 
         case .cleared where conversation.isSelfConversation:
-            ZMConversation.updateConversation(withClearedFromSelfConversation: message.cleared, inContext: moc)
+            ZMConversation.updateConversation(
+                withClearedFromSelfConversation: message.cleared,
+                in: moc
+            )
 
         case .hidden where conversation.isSelfConversation:
             ZMMessage.remove(remotelyHiddenMessage: message.hidden, inContext: moc)

--- a/wire-ios-data-model/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+AnalyticsIdentifier.swift
@@ -57,9 +57,9 @@ extension ZMUser {
     }
 
     private func broadcast(identifier: UUID) {
-        guard let moc = managedObjectContext else { return }
-        let message = GenericMessage(content: DataTransfer(trackingIdentifier: identifier))
-        _ = try? ZMConversation.appendMessageToSelfConversation(message, in: moc)
+        guard let context = managedObjectContext else { return }
+        let message = DataTransfer(trackingIdentifier: identifier)
+        _ = try? ZMConversation.sendMessageToSelfClients(message, in: context)
     }
 
 }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -49,6 +49,8 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCrypto.mockClientValidKeypackagesCount = { _ in
             return 100
         }
+
+        createSut()
     }
 
     private func createSut() {
@@ -1735,7 +1737,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
             return [ZMUpdateEvent()]
         }
-        
+
         mockMLSActionExecutor.mockAddMembers = { _, _ in
             expectation2.fulfill()
             return [ZMUpdateEvent()]

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
@@ -20,6 +20,113 @@ import Foundation
 @testable import WireDataModel
 
 class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
+
+    private func createMLSSelfConversation(in context: NSManagedObjectContext) -> ZMConversation {
+        let conversation = ZMConversation.insertNewObject(in: uiMOC)
+        conversation.remoteIdentifier = UUID.create()
+        conversation.mlsGroupID = .random()
+        conversation.messageProtocol = .mls
+        conversation.mlsStatus = .ready
+        conversation.conversationType = .`self`
+        return conversation
+    }
+
+    // MARK: - Post last read
+
+    func test_UpdateSelfConversationWithLastRead() throws {
+        // Given self conversations
+        let proteusSelfConversation = try XCTUnwrap(ZMConversation.selfConversation(in: uiMOC))
+        let mlsSelfConversation = createMLSSelfConversation(in: uiMOC)
+
+        // A conversation with a last read time stamp
+        let conversationID = UUID.create()
+        let lastReadTimestamp = Date(timeIntervalSince1970: 0)
+
+        let conversation = createConversation(in: uiMOC)
+        conversation.remoteIdentifier = conversationID
+        conversation.lastReadServerTimeStamp = lastReadTimestamp
+
+        // When
+        try  ZMConversation.updateSelfConversation(withLastReadOf: conversation)
+
+        // Then a last read message is posted in the proteus self conversation
+        guard
+            let lastProteusMessage = proteusSelfConversation.lastMessage as? ZMClientMessage,
+            let proteusGenericMessage = lastProteusMessage.underlyingMessage,
+            proteusGenericMessage.hasLastRead
+        else {
+            XCTFail("expected a last read generic message")
+            return
+        }
+
+        let proteusLastRead = proteusGenericMessage.lastRead
+        XCTAssertEqual(proteusLastRead.conversationID, conversationID.transportString())
+        XCTAssertEqual(proteusLastRead.lastReadTimestamp, Int64(lastReadTimestamp.timeIntervalSince1970 * 1000))
+
+        // Then a last read message is posted in the mls self conversation
+        guard
+            let lastMLSMessage = mlsSelfConversation.lastMessage as? ZMClientMessage,
+            let mlsGenericMessage = lastMLSMessage.underlyingMessage,
+            mlsGenericMessage.hasLastRead
+        else {
+            XCTFail("expected a last read generic message")
+            return
+        }
+
+        let mlsLastRead = mlsGenericMessage.lastRead
+        XCTAssertEqual(mlsLastRead.conversationID, conversationID.transportString())
+        XCTAssertEqual(mlsLastRead.lastReadTimestamp, Int64(lastReadTimestamp.timeIntervalSince1970 * 1000))
+    }
+
+    // MARK: - Post cleared
+
+    func test_UpdateSelfConversationWithCleared() throws {
+        // Given self conversations
+        let proteusSelfConversation = try XCTUnwrap(ZMConversation.selfConversation(in: uiMOC))
+        let mlsSelfConversation = createMLSSelfConversation(in: uiMOC)
+
+        // A conversation with a cleared time stamp
+        let conversationID = UUID.create()
+        let clearedTimestamp = Date(timeIntervalSince1970: 0)
+
+        let conversation = createConversation(in: uiMOC)
+        conversation.remoteIdentifier = conversationID
+        conversation.clearedTimeStamp = clearedTimestamp
+
+        // When
+        try  ZMConversation.updateSelfConversation(withClearedOf: conversation)
+
+        // Then a cleared message is posted in the proteus self conversation
+        guard
+            let lastProteusMessage = proteusSelfConversation.lastMessage as? ZMClientMessage,
+            let proteusGenericMessage = lastProteusMessage.underlyingMessage,
+            proteusGenericMessage.hasCleared
+        else {
+            XCTFail("expected a cleared generic message")
+            return
+        }
+
+        let proteusCleared = proteusGenericMessage.cleared
+        XCTAssertEqual(proteusCleared.conversationID, conversationID.transportString())
+        XCTAssertEqual(proteusCleared.clearedTimestamp, Int64(clearedTimestamp.timeIntervalSince1970 * 1000))
+
+        // Then a cleared message is posted in the mls self conversation
+        guard
+            let lastMLSMessage = mlsSelfConversation.lastMessage as? ZMClientMessage,
+            let mlsGenericMessage = lastMLSMessage.underlyingMessage,
+            mlsGenericMessage.hasCleared
+        else {
+            XCTFail("expected a cleared generic message")
+            return
+        }
+
+        let mlsCleared = mlsGenericMessage.cleared
+        XCTAssertEqual(mlsCleared.conversationID, conversationID.transportString())
+        XCTAssertEqual(mlsCleared.clearedTimestamp, Int64(clearedTimestamp.timeIntervalSince1970 * 1000))
+    }
+
+    // MARK: - Process last read
+
     func testThatItUpdatesTheLastReadTimestamp() {
         // GIVEN
         let nonce = UUID.create()
@@ -45,6 +152,8 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
         // THEN
         XCTAssertEqual(conversation.lastReadServerTimeStamp, Date(timeIntervalSince1970: Double(integerLiteral: timeinterval) / 1000))
     }
+
+    // MARK: - Process cleared
 
     func testThatItUpdatesClearedTimestamp() {
         // GIVEN

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
@@ -35,7 +35,10 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
 
         // WHEN
         performPretendingUiMocIsSyncMoc {
-            ZMConversation.updateConversation(withLastReadFromSelfConversation: lastRead, inContext: self.uiMOC)
+            ZMConversation.updateConversation(
+                withLastReadFromSelfConversation: lastRead,
+                in: self.uiMOC
+            )
         }
         uiMOC.saveOrRollback()
 
@@ -58,7 +61,10 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
 
         // WHEN
         performPretendingUiMocIsSyncMoc {
-            ZMConversation.updateConversation(withClearedFromSelfConversation: cleared, inContext: self.uiMOC)
+            ZMConversation.updateConversation(
+                withClearedFromSelfConversation: cleared,
+                in: self.uiMOC
+            )
         }
         uiMOC.saveOrRollback()
 

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockEARServiceInterface.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockEARServiceInterface.swift
@@ -108,10 +108,10 @@ public class MockEARServiceInterface: EARServiceInterface {
 
     public var fetchPublicKeys_Invocations: [Void] = []
     public var fetchPublicKeys_MockError: Error?
-    public var fetchPublicKeys_MockMethod: (() throws -> EARPublicKeys)?
-    public var fetchPublicKeys_MockValue: EARPublicKeys?
+    public var fetchPublicKeys_MockMethod: (() throws -> EARPublicKeys?)?
+    public var fetchPublicKeys_MockValue: EARPublicKeys??
 
-    public func fetchPublicKeys() throws -> EARPublicKeys {
+    public func fetchPublicKeys() throws -> EARPublicKeys? {
         fetchPublicKeys_Invocations.append(())
 
         if let error = fetchPublicKeys_MockError {
@@ -131,10 +131,10 @@ public class MockEARServiceInterface: EARServiceInterface {
 
     public var fetchPrivateKeysIncludingPrimary_Invocations: [Bool] = []
     public var fetchPrivateKeysIncludingPrimary_MockError: Error?
-    public var fetchPrivateKeysIncludingPrimary_MockMethod: ((Bool) throws -> EARPrivateKeys)?
-    public var fetchPrivateKeysIncludingPrimary_MockValue: EARPrivateKeys?
+    public var fetchPrivateKeysIncludingPrimary_MockMethod: ((Bool) throws -> EARPrivateKeys?)?
+    public var fetchPrivateKeysIncludingPrimary_MockValue: EARPrivateKeys??
 
-    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys {
+    public func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys? {
         fetchPrivateKeysIncludingPrimary_Invocations.append(includingPrimary)
 
         if let error = fetchPrivateKeysIncludingPrimary_MockError {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2063" title="WPB-2063" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-2063</a>  [iOS] Send sync messages through the self MLS conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When we need to send messages to all the clients of the self user, we send them over the self conversation. So far we have only done this over the existing self conversation which uses proteus. With this PR, we also send the messages over the MLS self conversation if it exists.

This works for all kinds of messages, whether "delete for me", "cleared", or last read.

### Testing

#### Test Coverage

- Unit test asserting sending last read messages over the self conversations
- Unit test asserting sending cleared messages over the self conversations

#### How to Test
- Log in with multiple mls clients.
- Send a message in an MLS conversation.
- Delete the message "for me"
- Verify that the message is deleted only for the self user and not for other users.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
