### PR TITLE
fix: change ZMConversationDefaultLastReadTimestampSaveDelay  WPB-2969

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
@@ -109,7 +109,7 @@ static NSString *const AccessModeStringsKey = @"accessModeStrings";
 static NSString *const AccessRoleStringKey = @"accessRoleString";
 NSString *const AccessRoleStringsKeyV2 = @"accessRoleStringsV2";
 
-//
+
 NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay = 1.0;
 
 const NSUInteger ZMConversationMaxEncodedTextMessageLength = 1500;

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
@@ -110,7 +110,7 @@ static NSString *const AccessRoleStringKey = @"accessRoleString";
 NSString *const AccessRoleStringsKeyV2 = @"accessRoleStringsV2";
 
 
-NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay = 3.0;
+NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay = 1.0;
 
 const NSUInteger ZMConversationMaxEncodedTextMessageLength = 1500;
 const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTextMessageLength - 50; // Empirically we verified that the encoding adds 44 bytes

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
@@ -109,7 +109,7 @@ static NSString *const AccessModeStringsKey = @"accessModeStrings";
 static NSString *const AccessRoleStringKey = @"accessRoleString";
 NSString *const AccessRoleStringsKeyV2 = @"accessRoleStringsV2";
 
-
+//
 NSTimeInterval ZMConversationDefaultLastReadTimestampSaveDelay = 1.0;
 
 const NSUInteger ZMConversationMaxEncodedTextMessageLength = 1500;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2969" title="WPB-2969" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2969</a>  [iOS] Unread conversation badge count requires user to navigate out of conversation before marking conversation as read
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user reads a message and moves the app to the background very quickly (less than 3 seconds), the badge icon counter does not decrease the number.

### Causes (Optional)

We have a delay of 3 seconds to change the `lastReadTimestamp` for the conversation. So if the user moves the app to the background faster than 3 seconds, we don't change the lastReadTimestamp and treat the last messages as unread.

### Solutions

The solution is to change this delay to 1 seconds. However, this can impact performance as we send read receipts every time we change `lastReadTimestamp`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
