### PR TITLE
feat: Handle failedToSend users for MLS sending messages WPB-189

### DIFF
--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.Transcoder.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.Transcoder.swift
@@ -115,12 +115,27 @@ extension MLSMessageSync {
             case .v0, .v1:
                 return
 
-            case .v2, .v3, .v4:
+            case .v2, .v3:
                 v2processResponse(response, for: entity)
+
+            case .v4:
+                v4processResponse(response, for: entity)
             }
         }
 
         private func v2processResponse(
+            _ response: ZMTransportResponse,
+            for entity: Message
+        ) {
+            guard response.result == .success else {
+                Logging.mls.warn("failed to send mls message. Response: \(response)")
+                return
+            }
+
+            entity.delivered(with: response)
+        }
+
+        private func v4processResponse(
             _ response: ZMTransportResponse,
             for entity: Message
         ) {

--- a/wire-ios-request-strategy/Sources/Payloads/Payload.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload.swift
@@ -340,6 +340,25 @@ enum Payload {
         let failedToSend: ClientListByQualifiedUserID
     }
 
+    struct MLSMessageSendingStatus: Codable {
+
+        enum CodingKeys: String, CodingKey {
+            case time
+            case events
+            case failedToSend = "failed_to_send"
+        }
+
+        /// Time of sending message.
+        let time: Date
+
+        /// A list of events caused by sending the message.
+        let events: [Data]
+
+        /// List of federated users who could not be reached and did not receive the message.
+        let failedToSend: [QualifiedID]?
+
+    }
+
     struct PaginationStatus: Codable {
 
         enum CodingKeys: String, CodingKey {

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatus.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatus.swift
@@ -20,10 +20,12 @@ import Foundation
 extension Payload.MLSMessageSendingStatus {
 
     func updateFailedRecipients(for message: OTREntity) {
-
-        guard let failedToSendUsers = (failedToSend?.compactMap {
-            ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: message.context) }) else {
+        guard let failedToSendUserIds = failedToSend else {
             return
+        }
+        
+        let failedToSendUsers = failedToSendUserIDs.compactMap {
+            ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: message.context) 
         }
 
         if !failedToSendUsers.isEmpty {

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatus.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatus.swift
@@ -20,12 +20,12 @@ import Foundation
 extension Payload.MLSMessageSendingStatus {
 
     func updateFailedRecipients(for message: OTREntity) {
-        guard let failedToSendUserIds = failedToSend else {
+        guard let failedToSendUserIDs = failedToSend else {
             return
         }
-        
+
         let failedToSendUsers = failedToSendUserIDs.compactMap {
-            ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: message.context) 
+            ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: message.context)
         }
 
         if !failedToSendUsers.isEmpty {

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatus.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatus.swift
@@ -1,0 +1,35 @@
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Payload.MLSMessageSendingStatus {
+
+    func updateFailedRecipients(for message: OTREntity) {
+
+        guard let failedToSendUsers = (failedToSend?.compactMap {
+            ZMUser.fetch(with: $0.uuid, domain: $0.domain, in: message.context) }) else {
+            return
+        }
+
+        if !failedToSendUsers.isEmpty {
+            message.addFailedToSendRecipients(failedToSendUsers)
+        }
+
+    }
+
+}

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatusTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatusTests.swift
@@ -1,0 +1,59 @@
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireRequestStrategy
+
+class PayloadProcessing_MLSMessageSendingStatusTests: MessagingTestBase {
+
+    let domain = "example.com"
+
+    override func setUp() {
+        super.setUp()
+
+        syncMOC.performGroupedBlockAndWait {
+            self.otherUser.domain = self.domain
+        }
+    }
+
+    func testThatItAddsFailedToSendRecipients() throws {
+        try self.syncMOC.performGroupedAndWait { _ in
+            // given
+            guard let message = try self.groupConversation.appendText(content: "Test message") as? ZMClientMessage else {
+                XCTFail("Failed to add message")
+                return
+            }
+
+            XCTAssertEqual(message.failedToSendRecipients?.count, 0)
+
+            // When
+            var failedToSendUsers: [QualifiedID] = []
+            if let qualifiedID = self.otherUser.qualifiedID {
+                failedToSendUsers = [qualifiedID]
+            }
+            let payload = Payload.MLSMessageSendingStatus(time: Date(),
+                                                          events: [Data()],
+                                                          failedToSend: failedToSendUsers)
+            payload.updateFailedRecipients(for: message)
+
+            // Then
+            XCTAssertEqual(message.failedToSendRecipients?.count, 1)
+            XCTAssertEqual(message.failedToSendRecipients?.first, self.otherUser)
+        }
+    }
+
+}

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatusTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+MLSMessageSendingStatusTests.swift
@@ -41,10 +41,8 @@ class PayloadProcessing_MLSMessageSendingStatusTests: MessagingTestBase {
             XCTAssertEqual(message.failedToSendRecipients?.count, 0)
 
             // When
-            var failedToSendUsers: [QualifiedID] = []
-            if let qualifiedID = self.otherUser.qualifiedID {
-                failedToSendUsers = [qualifiedID]
-            }
+            let qualifiedID = try XCTUnwrap(self.otherUser.qualifiedID)
+            let failedToSendUsers = [qualifiedID]
             let payload = Payload.MLSMessageSendingStatus(time: Date(),
                                                           events: [Data()],
                                                           failedToSend: failedToSendUsers)

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		060ED6D62499F41000412C4A /* PushNotificationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060ED6D52499F41000412C4A /* PushNotificationStatus.swift */; };
 		062285C8276BB5B000B87C91 /* UpdateEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062285C7276BB5B000B87C91 /* UpdateEventProcessor.swift */; };
 		062DD2D82760CFAA00E27FD9 /* UUID+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062DD2D72760CFAA00E27FD9 /* UUID+SafeLogging.swift */; };
+		063139DD2A56BD380083D5D2 /* PayloadProcessing+MLSMessageSendingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063139DC2A56BD380083D5D2 /* PayloadProcessing+MLSMessageSendingStatus.swift */; };
+		063139DF2A56BD6A0083D5D2 /* PayloadProcessing+MLSMessageSendingStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063139DE2A56BD6A0083D5D2 /* PayloadProcessing+MLSMessageSendingStatusTests.swift */; };
 		06474D4B24AF6858002C695D /* EventDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06474D4A24AF6858002C695D /* EventDecoder.swift */; };
 		06474D4D24AF68AD002C695D /* StoreUpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06474D4C24AF68AD002C695D /* StoreUpdateEvent.swift */; };
 		06474D5E24B30C79002C695D /* PushNotificationStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06474D5C24B30C75002C695D /* PushNotificationStatusTests.swift */; };
@@ -379,6 +381,8 @@
 		060ED6D52499F41000412C4A /* PushNotificationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationStatus.swift; sourceTree = "<group>"; };
 		062285C7276BB5B000B87C91 /* UpdateEventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEventProcessor.swift; sourceTree = "<group>"; };
 		062DD2D72760CFAA00E27FD9 /* UUID+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UUID+SafeLogging.swift"; sourceTree = "<group>"; };
+		063139DC2A56BD380083D5D2 /* PayloadProcessing+MLSMessageSendingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PayloadProcessing+MLSMessageSendingStatus.swift"; sourceTree = "<group>"; };
+		063139DE2A56BD6A0083D5D2 /* PayloadProcessing+MLSMessageSendingStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PayloadProcessing+MLSMessageSendingStatusTests.swift"; sourceTree = "<group>"; };
 		06474D4A24AF6858002C695D /* EventDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDecoder.swift; sourceTree = "<group>"; };
 		06474D4C24AF68AD002C695D /* StoreUpdateEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdateEvent.swift; sourceTree = "<group>"; };
 		06474D5C24B30C75002C695D /* PushNotificationStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationStatusTests.swift; sourceTree = "<group>"; };
@@ -1147,6 +1151,8 @@
 				16E5F71B26F09E5B00F35FBA /* PayloadProcessing+ConversationTests.swift */,
 				16E70F8D270EEBB700718E5D /* PayloadProcessing+MessageSendingStatus.swift */,
 				16A4891526849258001F9127 /* PayloadProcessing+MessageSendingStatusTests.swift */,
+				063139DC2A56BD380083D5D2 /* PayloadProcessing+MLSMessageSendingStatus.swift */,
+				063139DE2A56BD6A0083D5D2 /* PayloadProcessing+MLSMessageSendingStatusTests.swift */,
 			);
 			path = Processing;
 			sourceTree = "<group>";
@@ -1876,6 +1882,7 @@
 				EECBE8EC28E71ED7005DE5DD /* SyncConversationAction.swift in Sources */,
 				F963E8E11D955D5500098AD3 /* SharedProtocols.swift in Sources */,
 				166901F21D7081C7000FE4AF /* ZMUpstreamModifiedObjectSync.m in Sources */,
+				063139DD2A56BD380083D5D2 /* PayloadProcessing+MLSMessageSendingStatus.swift in Sources */,
 				16FFDE441DF6C668003494D6 /* DependencyEntitySync.swift in Sources */,
 				166A22912577C06B00EF313D /* ResetSessionRequestStrategy.swift in Sources */,
 				166901E41D7081C7000FE4AF /* ZMSingleRequestSync.m in Sources */,
@@ -2043,6 +2050,7 @@
 				F18401FE2073C2EA00E9F4CC /* MessagingTest+Encryption.swift in Sources */,
 				7AEBB679285A16400090B524 /* CountSelfMLSKeyPackagesActionHandlerTests.swift in Sources */,
 				16A86B4622A5485E00A674F8 /* IdentifierObjectSyncTests.swift in Sources */,
+				063139DF2A56BD6A0083D5D2 /* PayloadProcessing+MLSMessageSendingStatusTests.swift in Sources */,
 				A90C56E62685C20E00F1007B /* ZMImagePreprocessingTrackerTests.swift in Sources */,
 				EEE0EE0728591E9C00BBEE29 /* AssetDownloadRequestFactoryTests.swift in Sources */,
 				16972DED2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-189" title="WPB-189" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-189</a>  [iOS] Implement MLS protocol for sending messages when a remote backend is offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The response to `POST /mls/messages` contains a new optional field `failed_to_send`. We need to parse this field and save failed users. The logic for saving users to the database is already implemented for the Proteus endpoint.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
