### PR TITLE
fix: overflowing settings cell - WPB-2545

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -58,10 +58,12 @@ class SettingsTableCell: SettingsTableCellProtocol {
 
     let valueLabel: UILabel = {
         let valueLabel = UILabel()
-
         valueLabel.textColor = SemanticColors.Label.textDefault
         valueLabel.font = UIFont.systemFont(ofSize: 17)
         valueLabel.textAlignment = .right
+        valueLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        valueLabel.setContentHuggingPriority(.required, for: .horizontal)
+        valueLabel.adjustsFontSizeToFitWidth = true
 
         return valueLabel
     }()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -61,9 +61,9 @@ class SettingsTableCell: SettingsTableCellProtocol {
         valueLabel.textColor = SemanticColors.Label.textDefault
         valueLabel.font = UIFont.systemFont(ofSize: 17)
         valueLabel.textAlignment = .right
+        valueLabel.lineBreakMode = .byTruncatingTail
         valueLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         valueLabel.setContentHuggingPriority(.required, for: .horizontal)
-        valueLabel.adjustsFontSizeToFitWidth = true
 
         return valueLabel
     }()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2545" title="WPB-2545" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2545</a>  [iOS] text overflows settings cell
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Setting's cell value field is overflowing causing the cell to break and hide title if the texts are long.

### Causes (Optional)

There is incorrect hugging and compression priority set for the cell. Other part of the issue is that long texts are not supported in that field.

### Solutions

Setting hugging & compression priorities in relation to title field. Setting line break mode for value field to truncate tail.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### How to Test

Set language to French. Open Settings -> Options, scroll down to "Mode Synchroniser avec les..." cell.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
