### PR TITLE
chore: add more message flow logs WPB-3106

### DIFF
--- a/wire-ios-data-model/Source/Utilis/Protos/GenericMessage+Debug.swift
+++ b/wire-ios-data-model/Source/Utilis/Protos/GenericMessage+Debug.swift
@@ -85,8 +85,8 @@ extension GenericMessage: CustomStringConvertible {
 extension GenericMessage: SafeForLoggingStringConvertible {
 
     public var safeForLoggingDescription: String {
-        let contentDescription = content?.safeForLoggingDescription ?? "none"
-        return "GenericMessage(id: \(messageID.readableHash), content: \(contentDescription))"
+        let contentDescription = content?.safeForLoggingDescription ?? "unknown"
+        return "[\(contentDescription) \(messageID.readableHash)]"
     }
 
 }

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -14,6 +14,26 @@ import LocalAuthentication
 
 @testable import WireDataModel
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 public class MockCryptoboxMigrationManagerInterface: CryptoboxMigrationManagerInterface {
 
     // MARK: - Life cycle
@@ -80,10 +100,11 @@ public class MockCryptoboxMigrationManagerInterface: CryptoboxMigrationManagerIn
     }
 
 }
-
 class MockEARKeyEncryptorInterface: EARKeyEncryptorInterface {
 
     // MARK: - Life cycle
+
+
 
     // MARK: - encryptDatabaseKey
 
@@ -138,6 +159,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
 
     public init() {}
 
+
     // MARK: - storePublicKey
 
     public var storePublicKeyDescriptionKey_Invocations: [(description: PublicEARKeyDescription, key: SecKey)] = []
@@ -155,7 +177,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
             fatalError("no mock for `storePublicKeyDescriptionKey`")
         }
 
-        try mock(description, key)
+        try mock(description, key)            
     }
 
     // MARK: - fetchPublicKey
@@ -198,7 +220,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
             fatalError("no mock for `deletePublicKeyDescription`")
         }
 
-        try mock(description)
+        try mock(description)            
     }
 
     // MARK: - fetchPrivateKey
@@ -241,7 +263,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
             fatalError("no mock for `deletePrivateKeyDescription`")
         }
 
-        try mock(description)
+        try mock(description)            
     }
 
     // MARK: - storeDatabaseKey
@@ -261,7 +283,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
             fatalError("no mock for `storeDatabaseKeyDescriptionKey`")
         }
 
-        try mock(description, key)
+        try mock(description, key)            
     }
 
     // MARK: - fetchDatabaseKey
@@ -304,7 +326,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
             fatalError("no mock for `deleteDatabaseKeyDescription`")
         }
 
-        try mock(description)
+        try mock(description)            
     }
 
     // MARK: - clearCache
@@ -319,7 +341,7 @@ public class MockEARKeyRepositoryInterface: EARKeyRepositoryInterface {
             fatalError("no mock for `clearCache`")
         }
 
-        mock()
+        mock()            
     }
 
 }
@@ -332,6 +354,7 @@ public class MockEARServiceInterface: EARServiceInterface {
     // MARK: - delegate
 
     public var delegate: EARServiceDelegate?
+
 
     // MARK: - enableEncryptionAtRest
 
@@ -350,7 +373,7 @@ public class MockEARServiceInterface: EARServiceInterface {
             fatalError("no mock for `enableEncryptionAtRestContextSkipMigration`")
         }
 
-        try mock(context, skipMigration)
+        try mock(context, skipMigration)            
     }
 
     // MARK: - disableEncryptionAtRest
@@ -370,7 +393,7 @@ public class MockEARServiceInterface: EARServiceInterface {
             fatalError("no mock for `disableEncryptionAtRestContextSkipMigration`")
         }
 
-        try mock(context, skipMigration)
+        try mock(context, skipMigration)            
     }
 
     // MARK: - lockDatabase
@@ -385,7 +408,7 @@ public class MockEARServiceInterface: EARServiceInterface {
             fatalError("no mock for `lockDatabase`")
         }
 
-        mock()
+        mock()            
     }
 
     // MARK: - unlockDatabase
@@ -405,7 +428,7 @@ public class MockEARServiceInterface: EARServiceInterface {
             fatalError("no mock for `unlockDatabaseContext`")
         }
 
-        try mock(context)
+        try mock(context)            
     }
 
     // MARK: - fetchPublicKeys

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -53,6 +53,7 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
     }
 
     public func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
+        WireLogger.messaging.debug("next request for proteus sync")
         return dependencySync.nextRequest(for: apiVersion)
     }
 

--- a/wire-ios-request-strategy/Sources/Other Syncs/DependencyEntitySync.swift
+++ b/wire-ios-request-strategy/Sources/Other Syncs/DependencyEntitySync.swift
@@ -59,8 +59,14 @@ class DependencyEntitySync<Transcoder: EntityTranscoder>: NSObject, ZMContextCha
         completionHandlers[entity] = completion
 
         if let dependency = entity.dependentObjectNeedingUpdateBeforeProcessing {
+            if let message = entity as? (any ProteusMessage) {
+                WireLogger.messaging.debug("adding dependency for message \(message.debugInfo): \(String(describing: dependency))")
+            }
             entitiesWithDependencies.add(dependency: dependency, for: entity)
         } else {
+            if let message = entity as? (any ProteusMessage) {
+                WireLogger.messaging.debug("synchronizing without dependencies for message \(message.debugInfo)")
+            }
             entitiesWithoutDependencies.append(entity)
         }
     }
@@ -71,8 +77,14 @@ class DependencyEntitySync<Transcoder: EntityTranscoder>: NSObject, ZMContextCha
                 let newDependency = entity.dependentObjectNeedingUpdateBeforeProcessing
 
                 if let newDependency = newDependency, newDependency != object {
+                    if let message = entity as? (any ProteusMessage) {
+                        WireLogger.messaging.debug("adding new dependency for message \(message.debugInfo): \(String(describing: newDependency))")
+                    }
                     entitiesWithDependencies.add(dependency: newDependency, for: entity)
                 } else if newDependency == nil {
+                    if let message = entity as? (any ProteusMessage) {
+                        WireLogger.messaging.debug("removing dependencies for message \(message.debugInfo)")
+                    }
                     entitiesWithDependencies.removeAllDependencies(for: entity)
                     entitiesWithoutDependencies.append(entity)
                 }
@@ -83,38 +95,77 @@ class DependencyEntitySync<Transcoder: EntityTranscoder>: NSObject, ZMContextCha
     public func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
         guard let entity = entitiesWithoutDependencies.first else { return nil }
 
+        if let message = entity as? (any ProteusMessage) {
+            WireLogger.messaging.debug("generating request for message \(message.debugInfo)")
+        }
+
         entitiesWithoutDependencies.removeFirst()
 
         let completionHandler = completionHandlers.removeValue(forKey: entity)
 
-        if !entity.isExpired, let request = transcoder?.request(forEntity: entity, apiVersion: apiVersion) {
+        guard !entity.isExpired else {
+            if let message = entity as? (any ProteusMessage) {
+                WireLogger.messaging.error("dependency sync will not generate a request for message \(message.debugInfo): entity is expired")
+            }
 
-            request.add(ZMCompletionHandler(on: context, block: { [weak self] (response) in
-                guard
-                    let `self` = self,
-                    let transcoder = self.transcoder else { return }
-
-                switch response.result {
-                case .success:
-                    transcoder.request(forEntity: entity, didCompleteWithResponse: response)
-                    completionHandler?(.success(()), response)
-                case .expired:
-                    completionHandler?(.failure(EntitySyncError.expired), response)
-                default:
-                    let retry = transcoder.shouldTryToResend(entity: entity, afterFailureWithResponse: response)
-
-                    if retry {
-                        self.synchronize(entity: entity, completion: completionHandler)
-                    } else {
-                        completionHandler?(.failure(EntitySyncError.gaveUpRetrying), response)
-                    }
-                }
-            }))
-
-            return request
-        } else {
             return nil
         }
+
+        guard let request = transcoder?.request(forEntity: entity, apiVersion: apiVersion) else {
+            if let message = entity as? (any ProteusMessage) {
+                WireLogger.messaging.error("dependency sync could not generate a request for message \(message.debugInfo): transcoder returned nil")
+            }
+
+            return nil
+        }
+
+        if let message = entity as? (any ProteusMessage) {
+            WireLogger.messaging.debug("generated request for message \(message.debugInfo)")
+        }
+
+        request.add(ZMCompletionHandler(on: context, block: { [weak self] (response) in
+            guard
+                let `self` = self,
+                let transcoder = self.transcoder
+            else {
+                if let message = entity as? (any ProteusMessage) {
+                    WireLogger.messaging.debug("dependency sync can not process response for message \(message.debugInfo): missing self or transcoder")
+                }
+                return
+            }
+
+            switch response.result {
+            case .success:
+                if let message = entity as? (any ProteusMessage) {
+                    WireLogger.messaging.debug("dependency sync got a success response for message \(message.debugInfo)")
+                }
+                transcoder.request(forEntity: entity, didCompleteWithResponse: response)
+                completionHandler?(.success(()), response)
+
+            case .expired:
+                if let message = entity as? (any ProteusMessage) {
+                    WireLogger.messaging.error("dependency sync got an expired response for message \(message.debugInfo)")
+                }
+                completionHandler?(.failure(EntitySyncError.expired), response)
+
+            default:
+                let retry = transcoder.shouldTryToResend(entity: entity, afterFailureWithResponse: response)
+
+                if retry {
+                    if let message = entity as? (any ProteusMessage) {
+                        WireLogger.messaging.warn("dependency sync will retry request for message \(message.debugInfo)")
+                    }
+                    self.synchronize(entity: entity, completion: completionHandler)
+                } else {
+                    if let message = entity as? (any ProteusMessage) {
+                        WireLogger.messaging.error("dependency sync gave up retrying for message \(message.debugInfo)")
+                    }
+                    completionHandler?(.failure(EntitySyncError.gaveUpRetrying), response)
+                }
+            }
+        }))
+
+        return request
     }
 
     public func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3106" title="WPB-3106" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3106</a>  [iOS] Can't send messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
The last logs showed that while we create new messages and sync them with the `ProteusMessageSync`, for some reason we don't generate a request to post the message to the backend.

This PR adds more logs regarding the dependency sync so we can see if the message has some other dependencies that are blocking it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
