### PR TITLE
fix: developer flag compilation error

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -60,10 +60,8 @@ public enum DeveloperFlag: String, CaseIterable {
     private var defaultValue: Bool {
         guard let bundleKey = bundleKey else {
             return false
-
-        case .deprecatedCallingUI:
-            return false
         }
+
         return DeveloperFlagsDefault.isEnabled(for: bundleKey)
     }
 
@@ -81,7 +79,7 @@ public enum DeveloperFlag: String, CaseIterable {
             return "CreateMLSGroupEnabled"
         case .proteusViaCoreCrypto:
             return "ProteusByCoreCryptoEnabled"
-        case .nseV2:
+        case .nseV2, .deprecatedCallingUI:
             return nil
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The project does not compile.

### Causes

On develop branch, the developer flag for deprecated calling ui was removed, then some refactoring of the develop flags was made, and this latter change was cherry picked to the release branch. The release branch doesn't include the removal for the deprecated calling ui, so things got messed up even though there was no merge conflict.

### Solutions

Include the deprecated calling ui flag into the refactored changes.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
