### PR TITLE
fix: can't send messages WPB-3106

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -69,10 +69,10 @@ else
 fi 
 echo ""
 
-echo "ℹ️  Installing bundler and Ruby dependencies..."
-which bundle || gem install bundler
-bundle check || bundle install
-echo ""
+#echo "ℹ️  Installing bundler and Ruby dependencies..."
+#which bundle || gem install bundler
+#bundle check || bundle install
+#echo ""
 
 echo "ℹ️  Downloading additional assets..."
 scripts/download-assets.sh "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -69,10 +69,10 @@ else
 fi 
 echo ""
 
-#echo "ℹ️  Installing bundler and Ruby dependencies..."
-#which bundle || gem install bundler
-#bundle check || bundle install
-#echo ""
+echo "ℹ️  Installing bundler and Ruby dependencies..."
+which bundle || gem install bundler
+bundle check || bundle install
+echo ""
 
 echo "ℹ️  Downloading additional assets..."
 scripts/download-assets.sh "$@"

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -411,6 +411,12 @@ public extension UserClient {
         return context.fetchOrAssert(request: fetchRequest).first
     }
 
+    static func fetchClientsNeedingUpdateFromBackend(in context: NSManagedObjectContext) -> [UserClient] {
+        let fetchRequest = NSFetchRequest<UserClient>(entityName: UserClient.entityName())
+        fetchRequest.predicate = NSPredicate(format: "%K == YES", #keyPath(UserClient.needsToBeUpdatedFromBackend))
+        return context.fetchOrAssert(request: fetchRequest)
+    }
+
     /// Use this method only for selfUser clients (selfClient + remote clients)
     @objc static func createOrUpdateSelfUserClient(
         _ payloadData: [String: AnyObject],

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -110,11 +110,20 @@ public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
     }
 
     public override func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
+        // There may exist some clients that need an update, so try to sync any before asking
+        // for requests.
+        syncClientsNeedingUpdateIfNeeded()
+
         return
             userClientsByUserClientID.nextRequest(for: apiVersion) ??
             userClientsByUserID.nextRequest(for: apiVersion) ??
             userClientsByQualifiedUserID.nextRequest(for: apiVersion) ??
             entitySync.nextRequest(for: apiVersion)
+    }
+
+    private func syncClientsNeedingUpdateIfNeeded() {
+        let clients = UserClient.fetchClientsNeedingUpdateFromBackend(in: managedObjectContext)
+        fetch(userClients: clients)
     }
 
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -98,6 +98,19 @@ extension FetchClientRequestStrategyTests {
         }
     }
 
+    func testThatItCreatesARequestForV2_WhenUserClientNeedsToBeUpdatedFromBackend_AutomaticSync() {
+        // Given
+        let apiVersion: APIVersion = .v2
+
+        createsARequest_WhenUserClientNeedsToBeUpdatedFromBackend(
+            for: apiVersion,
+            reportObjectsChanged: false
+        ) { request in
+            XCTAssertEqual(request.path, "/v2/users/list-clients")
+            XCTAssertEqual(request.method, .methodPOST)
+        }
+    }
+
     func testThatItUpdatesTheClient_WhenReceivingTheResponse() {
         apiVersion = .v1
 
@@ -634,7 +647,12 @@ extension FetchClientRequestStrategyTests {
 // MARK: - Helper Methods
 
 extension FetchClientRequestStrategyTests {
-    func createsARequest_WhenUserClientNeedsToBeUpdatedFromBackend(for apiVersion: APIVersion, clientUUID: UUID = UUID(), completion: @escaping (ZMTransportRequest) -> Void) {
+    func createsARequest_WhenUserClientNeedsToBeUpdatedFromBackend(
+        for apiVersion: APIVersion,
+        clientUUID: UUID = UUID(),
+        reportObjectsChanged: Bool = true,
+        completion: @escaping (ZMTransportRequest) -> Void
+    ) {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             self.apiVersion = apiVersion
@@ -645,7 +663,10 @@ extension FetchClientRequestStrategyTests {
 
             // WHEN
             client.needsToBeUpdatedFromBackend = true
-            self.sut.objectsDidChange(clientSet)
+
+            if reportObjectsChanged {
+                self.sut.objectsDidChange(clientSet)
+            }
 
             // THEN
             let request = self.sut.nextRequest(for: self.apiVersion)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3106" title="WPB-3106" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3106</a>  [iOS] Can't send messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Given
-  My app is in the background
- I'm in a conversation with another user "Bob"

When
- Bob logs in with a new client and sends a message in our conversation from the new client

Then
- When I open the app, I see Bob's new message, but if I try to send a message then it fails

### Causes
I think what is happening is that because the self user receives a new message from a new client while the app is in the background, the notification service extension will fetch the update event and create a new `UserClient` instance for the newly discovered client. New clients have `needsToBeUpdatedFromBackend` set to `true` by default.

When the app is woken and the self user wishes to send a message, we first detect that the message is dependent on fetching the new client from the backend. However, the request to sync the client is never generated, therefore the message is blocked by the dependent object and never gets sent.

The `FetchingClientRequestStrategy` is responsible for syncing user clients. It tracks changes to `UserClient` objects, particularly those that have `needsToBeUpdatedFromBackend` set to `true`. But this only happens when the object **changes** and those changes have been saved. Since the new client was created in the NSE (another process), the main app doesn't get notified of this (also because it's in the background) and so the `FetchingClientRequestStrategy` doesn't attempt to sync the client.

### Solutions

When `FetchingClientRequestStrategy` is asked for a request, check if there are any user clients that need to be updated from the backend, and sync those clients in order to generate a request.

### Testing

#### Test Coverage

- Unit test asserting that clients are synced (not via changed object tracking)

#### How to Test

- User A logs in with Client A1 on iOS
- User B logs in with Client B1 on any platform
- User A and B exchange messages in a conversation C
- User A locks phone (i.e puts app in BG)
- User B logs in with new Client B2
- User B sends a message from B2 into conversation C
- User A observes that they do not see a push notification.
- User A opens the app, sees the new message, tries to send a message

The message should send successfully.

### Notes

There were some failing tests which I have fixed here as well.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
