### PR TITLE
fix: free text user search - WPB-3173

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -320,7 +320,7 @@ extension SearchTask {
     func performRemoteSearch() {
         guard
             let apiVersion = BackendInfo.apiVersion,
-            apiVersion >= .v2,
+            apiVersion >= .v1,
             case .search(let searchRequest) = task,
             !searchRequest.searchOptions.contains(.localResultsOnly),
             !searchRequest.searchOptions.isDisjoint(with: [.directory, .teamMembers, .federated])


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3173" title="WPB-3173" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3173</a>  [iOS] free text user search not working on iOS Bund builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users using search with APIVersion 1 are not able to find users with partial search term.

### Causes (Optional)

During https://github.com/wireapp/wire-ios-mono/pull/164, the search/contacts API endpoint was wrongly limited to v2 at the same time as other endpoints were rightly limited to v1

### Solutions

Put search/contacts API endpoint available for v1

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

Will double check if tests need to be updated

#### How to Test

Tested on web and iOS: the results should be the same

### Attachments (Optional)

Search on web:
![Screenshot 2023-07-20 at 12 38 21](https://github.com/wireapp/wire-ios-mono/assets/254198/f1497c8e-968f-4de8-a54b-f4ce65962747)

Search on iOS:
![IMG_4995](https://github.com/wireapp/wire-ios-mono/assets/254198/334f012b-869f-44e6-8f24-e48588aa1e41)
