### PR TITLE
fix: avoid CI to cancel builds on release branch

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,7 @@ run_setup_script_template: &RUN_SETUP_SCRIPT_TEMPLATE
 
 publishing_binary_task_template: &PUBLISHING_BINARY_TASK_TEMPLATE
   trigger_type: manual
+  auto_cancellation: $CIRRUS_BRANCH !=~ 'release/.*'
   << : *CARTHAGE_CACHE_TEMPLATE
   << : *BUNDLER_CACHE_TEMPLATE
   << : *RUN_SETUP_SCRIPT_TEMPLATE
@@ -47,6 +48,7 @@ publishing_binary_task_template: &PUBLISHING_BINARY_TASK_TEMPLATE
 task:
   name: Development
   << : *PUBLISHING_BINARY_TASK_TEMPLATE
+  only_if: $CIRRUS_BRANCH == 'develop'
   script:
     - bundle exec fastlane development
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

CI cancels jobs automatically when new commit arrive on branches (except master)

### Solutions

Don't cancel on release branches. But for example cancel on develop since it automatically triggers a new job for Development build
