### PR TITLE
fix: app stuck on login ear enabled -  WPB-3380

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/TextSearchQuery.swift
+++ b/wire-ios-data-model/Source/Model/Message/TextSearchQuery.swift
@@ -34,7 +34,7 @@ extension ZMClientMessage {
     /// Reccomputes the message's `normalizedText` property if the message
     /// has a message text, otherwise sets it to an empty String.
     override func updateNormalizedText() {
-        // We we don't to set or update the normalized text if the message is obfuscated
+        // We don't set or update the normalized text if the message is obfuscated
         // or if messages are encrypted at rest since that would leak a plain text version
         // of the message.
         guard !isObfuscated,

--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -23,58 +23,58 @@ import LocalAuthentication
 ///
 /// sourcery: AutoMockable
 public protocol EARServiceInterface: AnyObject {
-    
+
     var delegate: EARServiceDelegate? { get set }
-    
+
     /// Enable encryption at rest.
     ///
     /// - Parameters:
     ///   - context: a database context in which to perform migrations.
     ///   - skipMigration: whether migration of existing database should be performed.
-    
+
     func enableEncryptionAtRest(
         context: NSManagedObjectContext,
         skipMigration: Bool
     ) throws
-    
+
     /// Disable encryption at rest.
     ///
     /// - Parameters:
     ///   - context: a database context in which to perform migrations.
     ///   - skipMigration: whether migration of existing database should be performed.
-    
+
     func disableEncryptionAtRest(
         context: NSManagedObjectContext,
         skipMigration: Bool
     ) throws
-    
+
     /// Lock the database.
     ///
     /// Database content can not be decrypted until the database is unlocked.
-    
+
     func lockDatabase()
-    
+
     /// Unlock the database.
     ///
     /// - Parameters:
     ///   - context: a user authenticated context.
-    
+
     func unlockDatabase(context: LAContext) throws
-    
+
     /// Fetch all public keys.
     ///
     /// Public keys are used to encrypt content. If EAR is disabled,
     /// `nil` is returned.
-    
+
     func fetchPublicKeys() throws -> EARPublicKeys?
-    
+
     /// Fetch all private keys.
     ///
     /// Private keys are used to decrypt context. If EAR is disabled,
     /// `nil` is returned.
-    
+
     func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys?
-  
+
     func setInitialEARFlagValue(_ enabled: Bool)
 }
 
@@ -113,7 +113,7 @@ public class EARService: EARServiceInterface {
     private let secondaryPrivateKeyDescription: PrivateEARKeyDescription
     private let databaseKeyDescription: DatabaseEARKeyDescription
     private let earStorage: EARStorage
-    
+
     // MARK: - Life cycle
 
     public convenience init(
@@ -151,14 +151,13 @@ public class EARService: EARServiceInterface {
         secondaryPrivateKeyDescription = .secondaryKeyDescription(accountID: accountID)
         databaseKeyDescription = .keyDescription(accountID: accountID)
 
-        
         if canPerformKeyMigration {
             migrateKeysIfNeeded()
         }
     }
 
     // MARK: - Feature Flag
-    
+
     public var isEAREnabled: Bool {
         earStorage.earEnabled()
     }
@@ -168,7 +167,7 @@ public class EARService: EARServiceInterface {
     }
 
     // MARK: - Migrate keys
-    
+
     private func migrateKeysIfNeeded() {
         WireLogger.ear.info("migrating ear keys if needed...")
 
@@ -211,7 +210,7 @@ public class EARService: EARServiceInterface {
                 if !skipMigration {
                     try context.migrateTowardEncryptionAtRest(databaseKey: databaseKey)
                 }
-                
+
                 self.setDatabaseKeyInAllContexts(databaseKey)
                 self.earStorage.enableEAR(true)
                 context.encryptMessagesAtRest = true

--- a/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARService.swift
@@ -74,8 +74,8 @@ public protocol EARServiceInterface: AnyObject {
     /// `nil` is returned.
     
     func fetchPrivateKeys(includingPrimary: Bool) throws -> EARPrivateKeys?
-    
-    
+  
+    func setInitialEARFlagValue(_ enabled: Bool)
 }
 
 public protocol EARServiceDelegate: AnyObject {
@@ -186,13 +186,14 @@ public class EARService: EARServiceInterface {
         self.keyRepository = keyRepository
         self.keyEncryptor = keyEncryptor
         self.earStorage = earStorage
+        self.databaseContexts = databaseContexts
         primaryPublicKeyDescription = .primaryKeyDescription(accountID: accountID)
         primaryPrivateKeyDescription = .primaryKeyDescription(accountID: accountID)
         secondaryPublicKeyDescription = .secondaryKeyDescription(accountID: accountID)
         secondaryPrivateKeyDescription = .secondaryKeyDescription(accountID: accountID)
         databaseKeyDescription = .keyDescription(accountID: accountID)
-        self.databaseContexts = databaseContexts
 
+        
         if canPerformKeyMigration {
             migrateKeysIfNeeded()
         }
@@ -200,6 +201,11 @@ public class EARService: EARServiceInterface {
 
     // MARK: - Migrate keys
 
+    
+    public func setInitialEARFlagValue(_ enabled: Bool) {
+        earStorage.enableEAR(enabled)
+    }
+    
     private func migrateKeysIfNeeded() {
         WireLogger.ear.info("migrating ear keys if needed...")
 

--- a/wire-ios-data-model/Source/Utilis/EAR/EARStorage.swift
+++ b/wire-ios-data-model/Source/Utilis/EAR/EARStorage.swift
@@ -1,0 +1,58 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@objc
+public final class EARStorage: NSObject {
+
+    // MARK: - Properties
+
+    private let storage: PrivateUserDefaults<Key>
+
+    // MARK: - Types
+
+    private enum Key: String, DefaultsKey {
+        case enabledEAR = "com.wire.ear.enabled"
+    }
+
+    // MARK: - Life cycle
+
+    @objc
+    public init(
+        userID: UUID,
+        sharedUserDefaults: UserDefaults
+    ) {
+        storage = PrivateUserDefaults(
+            userID: userID,
+            storage: sharedUserDefaults
+        )
+
+        super.init()
+    }
+
+    // MARK: - Methods
+
+    public func earEnabled() -> Bool {
+        return storage.bool(forKey: .enabledEAR)
+    }
+
+    public func enableEAR(_ enabled: Bool) {
+        storage.set(enabled, forKey: .enabledEAR)
+    }
+}

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -57,7 +57,8 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
             keyRepository: keyRepository,
             keyEncryptor: keyEncryptor,
             databaseContexts: [uiMOC, syncMOC],
-            canPerformKeyMigration: canPerformMigration
+            canPerformKeyMigration: canPerformMigration,
+            earStorage: .init(userID: userIdentifier, sharedUserDefaults: .random()!)
         )
 
         sut.delegate = self

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -27,7 +27,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
     var keyRepository: MockEARKeyRepositoryInterface!
     var keyEncryptor: MockEARKeyEncryptorInterface!
     var earStorage: EARStorage!
-    
+
     var prepareForMigrationCalls = 0
 
     // MARK: - Life cycle
@@ -56,7 +56,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
     }
 
     func createSUT(canPerformMigration: Bool = false) -> EARService {
-        
+
         let sut = EARService(
             accountID: userIdentifier,
             keyRepository: keyRepository,
@@ -874,7 +874,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         let oldSecondaryPublicKey = oldPublicKeys.secondary
         let oldSecondaryPrivateKey = oldPrivateKeys.secondary
         uiMOC.encryptMessagesAtRest = false
-        
+
         // When
         try sut.enableEncryptionAtRest(context: uiMOC, skipMigration: true)
 

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -26,7 +26,8 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
     var sut: EARService!
     var keyRepository: MockEARKeyRepositoryInterface!
     var keyEncryptor: MockEARKeyEncryptorInterface!
-
+    var earStorage: EARStorage!
+    
     var prepareForMigrationCalls = 0
 
     // MARK: - Life cycle
@@ -36,6 +37,8 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
 
         keyRepository = MockEARKeyRepositoryInterface()
         keyEncryptor = MockEARKeyEncryptorInterface()
+        earStorage = .init(userID: userIdentifier, sharedUserDefaults: .random()!)
+        earStorage.enableEAR(true)
         sut = createSUT()
         prepareForMigrationCalls = 0
 
@@ -44,6 +47,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
 
     override func tearDown() {
         sut = nil
+        earStorage = nil
         keyRepository = nil
         keyEncryptor = nil
         uiMOC.encryptMessagesAtRest = false
@@ -52,13 +56,14 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
     }
 
     func createSUT(canPerformMigration: Bool = false) -> EARService {
+        
         let sut = EARService(
             accountID: userIdentifier,
             keyRepository: keyRepository,
             keyEncryptor: keyEncryptor,
             databaseContexts: [uiMOC, syncMOC],
             canPerformKeyMigration: canPerformMigration,
-            earStorage: .init(userID: userIdentifier, sharedUserDefaults: .random()!)
+            earStorage: earStorage
         )
 
         sut.delegate = self
@@ -146,6 +151,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
 
     func test_ItDoesNotMigrateKeys_IfEARIsDisabled() throws {
         // Given
+        earStorage.enableEAR(false)
         uiMOC.encryptMessagesAtRest = false
 
         // When
@@ -641,6 +647,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
 
     func test_FetchPublicKeys_EARDisabled() throws {
         // Given
+        earStorage.enableEAR(false)
         uiMOC.encryptMessagesAtRest = false
 
         // When
@@ -708,6 +715,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
 
     func test_FetchPrivateKeys_EARDisabled() throws {
         // Given
+        earStorage.enableEAR(false)
         uiMOC.encryptMessagesAtRest = false
 
         // When
@@ -851,9 +859,13 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func test_OldEncryptionKeysAreReplaced_AfterActivatingEncryptionAtRest() throws {
         // Given
-        let sut = EARService(accountID: userIdentifier, databaseContexts: [uiMOC],                 earEnabledStorage: UserDefaults.random())
+        let sut = EARService(accountID: userIdentifier,
+                         databaseContexts: [uiMOC],
+                         sharedUserDefaults: .random()!)
+
         let oldDatabaseKey = try sut.generateKeys()
 
+        sut.setInitialEARFlagValue(true)
         uiMOC.encryptMessagesAtRest = true
         let oldPublicKeys = try XCTUnwrap(sut.fetchPublicKeys())
         let oldPrivateKeys = try XCTUnwrap(sut.fetchPrivateKeys(includingPrimary: true))
@@ -862,7 +874,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         let oldSecondaryPublicKey = oldPublicKeys.secondary
         let oldSecondaryPrivateKey = oldPrivateKeys.secondary
         uiMOC.encryptMessagesAtRest = false
-
+        
         // When
         try sut.enableEncryptionAtRest(context: uiMOC, skipMigration: true)
 
@@ -882,6 +894,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         XCTAssertNotEqual(oldSecondaryPublicKey, newSecondaryPublicKey)
         XCTAssertNotEqual(oldSecondaryPrivateKey, newSecondaryPrivateKey)
         XCTAssertNotEqual(oldDatabaseKey, newDatabaseKey)
+        XCTAssertTrue(earStorage.earEnabled())
     }
 
     // @SF.Storage @TSFI.ClientRNG @S0.1 @S0.2
@@ -914,6 +927,14 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         XCTAssertEqual(decryptedData as Data, data)
     }
 
+    
+    func test_setInitialEARFlagValue_ChangesEARStorageValue() {
+        // when
+        let currentValue = earStorage.earEnabled()
+        sut.setInitialEARFlagValue(!currentValue)
+        // THEN
+        XCTAssertEqual(earStorage.earEnabled(), !currentValue)
+    }
 }
 
 private extension ZMGenericMessageData {

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -850,7 +850,7 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func test_OldEncryptionKeysAreReplaced_AfterActivatingEncryptionAtRest() throws {
         // Given
-        let sut = EARService(accountID: userIdentifier, databaseContexts: [uiMOC])
+        let sut = EARService(accountID: userIdentifier, databaseContexts: [uiMOC],                 earEnabledStorage: UserDefaults.random())
         let oldDatabaseKey = try sut.generateKeys()
 
         uiMOC.encryptMessagesAtRest = true

--- a/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Source/EAR/EARServiceTests.swift
@@ -927,7 +927,6 @@ final class EARServiceTests: ZMBaseManagedObjectTest, EARServiceDelegate {
         XCTAssertEqual(decryptedData as Data, data)
     }
 
-    
     func test_setInitialEARFlagValue_ChangesEARStorageValue() {
         // when
         let currentValue = earStorage.earEnabled()

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0129E7F929A520870065E6DB /* SafeCoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0129E7F829A520870065E6DB /* SafeCoreCrypto.swift */; };
 		0129E7FB29A520EB0065E6DB /* SafeFileContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0129E7FA29A520EB0065E6DB /* SafeFileContext.swift */; };
 		017CA4442A2742B800E8E778 /* WireCoreCrypto.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 017CA4432A2742B800E8E778 /* WireCoreCrypto.xcframework */; };
+		018964252A6FE72700BCEE0E /* EARStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018964242A6FE72700BCEE0E /* EARStorage.swift */; };
 		0189815529A66B0800B52510 /* SafeCoreCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0189815429A66B0800B52510 /* SafeCoreCryptoTests.swift */; };
 		0191513A29ACB3CA00920D04 /* SpyUserClientKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0191513929ACB3CA00920D04 /* SpyUserClientKeyStore.swift */; };
 		0191513C29ACB46000920D04 /* MockProteusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0191513B29ACB46000920D04 /* MockProteusProvider.swift */; };
@@ -826,6 +827,7 @@
 		0129E7F829A520870065E6DB /* SafeCoreCrypto.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SafeCoreCrypto.swift; sourceTree = "<group>"; };
 		0129E7FA29A520EB0065E6DB /* SafeFileContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeFileContext.swift; sourceTree = "<group>"; };
 		017CA4432A2742B800E8E778 /* WireCoreCrypto.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WireCoreCrypto.xcframework; path = ../Carthage/Build/WireCoreCrypto.xcframework; sourceTree = "<group>"; };
+		018964242A6FE72700BCEE0E /* EARStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARStorage.swift; sourceTree = "<group>"; };
 		0189815429A66B0800B52510 /* SafeCoreCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeCoreCryptoTests.swift; sourceTree = "<group>"; };
 		0191513929ACB3CA00920D04 /* SpyUserClientKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SpyUserClientKeyStore.swift; path = Tests/Source/Helper/SpyUserClientKeyStore.swift; sourceTree = SOURCE_ROOT; };
 		0191513B29ACB46000920D04 /* MockProteusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProteusProvider.swift; sourceTree = "<group>"; };
@@ -2172,6 +2174,7 @@
 				EE22F81129DD84ED0053E1C6 /* EARKeyRepository.swift */,
 				EE428C4F29F1247400ECB715 /* EARKeyGenerator.swift */,
 				EE428C5129F1533000ECB715 /* EARKeyEncryptor.swift */,
+				018964242A6FE72700BCEE0E /* EARStorage.swift */,
 				EE22F80829DD818B0053E1C6 /* BaseEARKeyDescription.swift */,
 				EE22F80A29DD81C50053E1C6 /* PublicEARKeyDescription.swift */,
 				EE22F80C29DD81FC0053E1C6 /* PrivateEARKeyDescription.swift */,
@@ -3840,6 +3843,7 @@
 				165DC52121491D8700090B7B /* ZMClientMessage+TextMessageData.swift in Sources */,
 				EE9B9F572993E57900A257BC /* NSManagedObjectContext+ProteusService.swift in Sources */,
 				BF491CCF1F02A6CF0055EE44 /* Member+Patches.swift in Sources */,
+				018964252A6FE72700BCEE0E /* EARStorage.swift in Sources */,
 				EE2BA00625CB3AA8001EB606 /* InvalidFeatureRemoval.swift in Sources */,
 				EE8B09AD25B86AB10057E85C /* AppLockError.swift in Sources */,
 				1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */,

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -477,6 +477,21 @@ public class MockEARServiceInterface: EARServiceInterface {
         }
     }
 
+    // MARK: - setInitialEARFlagValue
+
+    public var setInitialEARFlagValue_Invocations: [Bool] = []
+    public var setInitialEARFlagValue_MockMethod: ((Bool) -> Void)?
+
+    public func setInitialEARFlagValue(_ enabled: Bool) {
+        setInitialEARFlagValue_Invocations.append(enabled)
+
+        guard let mock = setInitialEARFlagValue_MockMethod else {
+            fatalError("no mock for `setInitialEARFlagValue`")
+        }
+
+        mock(enabled)            
+    }
+
 }
 class MockFileManagerInterface: FileManagerInterface {
 

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -212,7 +212,7 @@ public class NotificationSession {
         )
 
         let saveNotificationPersistence = ContextDidSaveNotificationPersistence(accountContainer: accountContainer)
-        
+
         try self.init(
             coreDataStack: coreDataStack,
             transportSession: transportSession,

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -136,8 +136,10 @@ public class NotificationSession {
             applicationContainer: sharedContainerURL
         )
 
-        coreDataStack.loadStores { _ in
-            // TODO jacob error handling
+        coreDataStack.loadStores { error in
+            if let error = error {
+                WireLogger.notifications.error("Loading coreDataStack with error: \(error.localizedDescription)")
+            }
         }
 
         let cookieStorage = ZMPersistentCookieStorage(forServerName: environment.backendURL.host!, userIdentifier: accountIdentifier)
@@ -210,7 +212,7 @@ public class NotificationSession {
         )
 
         let saveNotificationPersistence = ContextDidSaveNotificationPersistence(accountContainer: accountContainer)
-
+        
         try self.init(
             coreDataStack: coreDataStack,
             transportSession: transportSession,
@@ -219,7 +221,8 @@ public class NotificationSession {
             applicationStatusDirectory: applicationStatusDirectory,
             operationLoop: operationLoop,
             accountIdentifier: accountIdentifier,
-            pushNotificationStrategy: pushNotificationStrategy
+            pushNotificationStrategy: pushNotificationStrategy,
+            earService: EARService(accountID: accountIdentifier, sharedUserDefaults: sharedUserDefaults)
         )
     }
 
@@ -233,7 +236,7 @@ public class NotificationSession {
         accountIdentifier: UUID,
         pushNotificationStrategy: PushNotificationStrategy,
         cryptoboxMigrationManager: CryptoboxMigrationManagerInterface = CryptoboxMigrationManager(),
-        earService: EARServiceInterface? = nil
+        earService: EARServiceInterface
     ) throws {
         self.coreDataStack = coreDataStack
         self.transportSession = transportSession
@@ -241,7 +244,7 @@ public class NotificationSession {
         self.applicationStatusDirectory = applicationStatusDirectory
         self.operationLoop = operationLoop
         self.accountIdentifier = accountIdentifier
-        self.earService = earService ?? EARService(accountID: accountIdentifier)
+        self.earService = earService
 
         eventDecoder = EventDecoder(
             eventMOC: coreDataStack.eventContext,

--- a/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		015C22DD2A1566EB009119CA /* MockSafeCoreCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015C22DC2A1566EB009119CA /* MockSafeCoreCrypto.swift */; };
+		018964272A6FEA8600BCEE0E /* MockEARServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018964262A6FEA8600BCEE0E /* MockEARServiceInterface.swift */; };
 		067ECB3E2487A93D00701956 /* WireNotificationEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 067ECB3C2487A93D00701956 /* WireNotificationEngine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		067ECB602487ABF700701956 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06604297247FE76A00A5F161 /* AppDelegate.swift */; };
 		069712912497B96E00C32169 /* OperationLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06394AA12497B24600380494 /* OperationLoop.swift */; };
@@ -70,6 +71,7 @@
 
 /* Begin PBXFileReference section */
 		015C22DC2A1566EB009119CA /* MockSafeCoreCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSafeCoreCrypto.swift; sourceTree = "<group>"; };
+		018964262A6FEA8600BCEE0E /* MockEARServiceInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEARServiceInterface.swift; sourceTree = "<group>"; };
 		06394AA12497B24600380494 /* OperationLoop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationLoop.swift; sourceTree = "<group>"; };
 		06604297247FE76A00A5F161 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		066042A0247FE76C00A5F161 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 				630A584929B1182C00E26C4D /* MockCoreCrypto.swift */,
 				015C22DC2A1566EB009119CA /* MockSafeCoreCrypto.swift */,
 				EE0BA28B29D5B975004E93B5 /* MockCryptoboxMigrationManagerInterface.swift */,
+				018964262A6FEA8600BCEE0E /* MockEARServiceInterface.swift */,
 			);
 			path = WireNotificationEngineTests;
 			sourceTree = "<group>";
@@ -457,6 +460,7 @@
 			files = (
 				EE0BA28A29D59B1D004E93B5 /* NotificationSessionTests.swift in Sources */,
 				630A582D29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift in Sources */,
+				018964272A6FEA8600BCEE0E /* MockEARServiceInterface.swift in Sources */,
 				630A582B29AF9CB800E26C4D /* NotificationSessionTests+CryptoStack.swift in Sources */,
 				015C22DD2A1566EB009119CA /* MockSafeCoreCrypto.swift in Sources */,
 				630A584829B10E3800E26C4D /* MLSDecryptionServiceTests.swift in Sources */,

--- a/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
@@ -166,7 +166,8 @@ class BaseTest: ZMTBaseTest {
             operationLoop: operationLoop,
             accountIdentifier: accountIdentifier,
             pushNotificationStrategy: pushNotificationStrategy,
-            cryptoboxMigrationManager: mockCryptoboxMigrationManager
+            cryptoboxMigrationManager: mockCryptoboxMigrationManager,
+            earService: MockEARServiceInterface()
         )
     }
 }

--- a/wire-ios-notification-engine/WireNotificationEngineTests/MockEARServiceInterface.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/MockEARServiceInterface.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import WireDataModel
 import LocalAuthentication
 
 public class MockEARServiceInterface: EARServiceInterface {

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -811,8 +811,9 @@ extension ZMLocalNotificationTests_Message {
             let earService = EARService(
                 accountID: self.accountIdentifier,
                 databaseContexts: [self.syncMOC],
-                earEnabledStorage: UserDefaults.random()
+                sharedUserDefaults: UserDefaults.random()!
             )
+            earService.setInitialEARFlagValue(true)
 
             try earService.enableEncryptionAtRest(
                 context: self.syncMOC,
@@ -833,8 +834,9 @@ extension ZMLocalNotificationTests_Message {
             let earService = EARService(
                 accountID: self.accountIdentifier,
                 databaseContexts: [self.syncMOC],
-                earEnabledStorage: UserDefaults.random()
+                sharedUserDefaults: UserDefaults.random()!
             )
+            earService.setInitialEARFlagValue(true)
 
             try earService.enableEncryptionAtRest(
                 context: self.syncMOC,

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -810,7 +810,8 @@ extension ZMLocalNotificationTests_Message {
         try syncMOC.performGroupedAndWait { _ in
             let earService = EARService(
                 accountID: self.accountIdentifier,
-                databaseContexts: [self.syncMOC]
+                databaseContexts: [self.syncMOC],
+                earEnabledStorage: UserDefaults.random()
             )
 
             try earService.enableEncryptionAtRest(
@@ -831,7 +832,8 @@ extension ZMLocalNotificationTests_Message {
         try syncMOC.performGroupedAndWait { _ in
             let earService = EARService(
                 accountID: self.accountIdentifier,
-                databaseContexts: [self.syncMOC]
+                databaseContexts: [self.syncMOC],
+                earEnabledStorage: UserDefaults.random()
             )
 
             try earService.enableEncryptionAtRest(

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -217,7 +217,8 @@ public class SharingSession {
         accountIdentifier: UUID,
         hostBundleIdentifier: String,
         environment: BackendEnvironmentProvider,
-        appLockConfig: AppLockController.LegacyConfig?
+        appLockConfig: AppLockController.LegacyConfig?,
+        sharedUserDefaults: UserDefaults
     ) throws {
 
         let sharedContainerURL = FileManager.sharedContainerDirectory(for: applicationGroupIdentifier)
@@ -264,7 +265,8 @@ public class SharingSession {
             transportSession: transportSession,
             cachesDirectory: FileManager.default.cachesURLForAccount(with: accountIdentifier, in: sharedContainerURL),
             accountContainer: CoreDataStack.accountDataFolder(accountIdentifier: accountIdentifier, applicationContainer: sharedContainerURL),
-            appLockConfig: appLockConfig
+            appLockConfig: appLockConfig,
+            sharedUserDefaults: sharedUserDefaults
         )
     }
 
@@ -280,7 +282,8 @@ public class SharingSession {
         strategyFactory: StrategyFactory,
         appLockConfig: AppLockController.LegacyConfig?,
         cryptoboxMigrationManager: CryptoboxMigrationManagerInterface = CryptoboxMigrationManager(),
-        earService: EARServiceInterface? = nil
+        earService: EARServiceInterface? = nil,
+        sharedUserDefaults: UserDefaults
     ) throws {
 
         self.coreDataStack = coreDataStack
@@ -296,7 +299,8 @@ public class SharingSession {
             databaseContexts: [
                 coreDataStack.viewContext,
                 coreDataStack.syncContext
-            ]
+            ],
+            sharedUserDefaults: sharedUserDefaults
         )
 
         let selfUser = ZMUser.selfUser(in: coreDataStack.viewContext)
@@ -328,7 +332,8 @@ public class SharingSession {
         transportSession: ZMTransportSession,
         cachesDirectory: URL,
         accountContainer: URL,
-        appLockConfig: AppLockController.LegacyConfig?
+        appLockConfig: AppLockController.LegacyConfig?,
+        sharedUserDefaults: UserDefaults
     ) throws {
 
         let applicationStatusDirectory = ApplicationStatusDirectory(syncContext: coreDataStack.syncContext, transportSession: transportSession)
@@ -363,7 +368,8 @@ public class SharingSession {
             applicationStatusDirectory: applicationStatusDirectory,
             operationLoop: operationLoop,
             strategyFactory: strategyFactory,
-            appLockConfig: appLockConfig
+            appLockConfig: appLockConfig,
+            sharedUserDefaults: sharedUserDefaults
         )
     }
 

--- a/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
@@ -165,7 +165,8 @@ class BaseTest: ZMTBaseTest {
             operationLoop: operationLoop,
             strategyFactory: strategyFactory,
             appLockConfig: AppLockController.LegacyConfig(),
-            cryptoboxMigrationManager: mockCryptoboxMigrationManager
+            cryptoboxMigrationManager: mockCryptoboxMigrationManager,
+            sharedUserDefaults: .random()!
         )
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -279,7 +279,8 @@ public class ZMUserSession: NSObject {
                 coreDataStack.syncContext,
                 coreDataStack.searchContext
             ],
-            canPerformKeyMigration: true
+            canPerformKeyMigration: true,
+            sharedUserDefaults: sharedUserDefaults
         )
 
         self.lastEventIDRepository = LastEventIDRepository(

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -282,10 +282,7 @@ public class ZMUserSession: NSObject {
             canPerformKeyMigration: true,
             sharedUserDefaults: sharedUserDefaults
         )
-        
-        // As we move the flag value from CoreData to UserDefaults, we set an initial value
-        self.earService.setInitialEARFlagValue(viewContext.encryptMessagesAtRest)
-        
+                
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,
             sharedUserDefaults: sharedUserDefaults
@@ -293,6 +290,8 @@ public class ZMUserSession: NSObject {
 
         super.init()
 
+        // As we move the flag value from CoreData to UserDefaults, we set an initial value
+        self.earService.setInitialEARFlagValue(viewContext.encryptMessagesAtRest)
         self.earService.delegate = self
         appLockController.delegate = self
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -282,7 +282,10 @@ public class ZMUserSession: NSObject {
             canPerformKeyMigration: true,
             sharedUserDefaults: sharedUserDefaults
         )
-
+        
+        // As we move the flag value from CoreData to UserDefaults, we set an initial value
+        self.earService.setInitialEARFlagValue(viewContext.encryptMessagesAtRest)
+        
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,
             sharedUserDefaults: sharedUserDefaults

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -216,6 +216,7 @@ class EventProcessorTests: MessagingTest {
             let earService = EARService(
                 accountID: userIdentifier,
                 databaseContexts: [uiMOC, syncMOC]
+                earEnabledStorage: UserDefaults.random()
             )
 
             try earService.enableEncryptionAtRest(

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -215,10 +215,11 @@ class EventProcessorTests: MessagingTest {
         if isDatabaseLocked {
             let earService = EARService(
                 accountID: userIdentifier,
-                databaseContexts: [uiMOC, syncMOC]
-                earEnabledStorage: UserDefaults.random()
+                databaseContexts: [uiMOC, syncMOC],
+                sharedUserDefaults: UserDefaults.random()!
             )
-
+            earService.setInitialEARFlagValue(true)
+            
             try earService.enableEncryptionAtRest(
                 context: syncMOC,
                 skipMigration: true

--- a/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
+++ b/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
@@ -40,7 +40,10 @@ public final class PrivateUserDefaults<Key: DefaultsKey> {
     private func scopeKey(_ key: Key) -> String {
         return "\(userID.uuidString)_\(key.rawValue)"
     }
+}
 
+extension PrivateUserDefaults {
+    
     public func setUUID(_ uuid: UUID?, forKey key: Key) {
         storage.set(uuid?.uuidString, forKey: scopeKey(key))
     }
@@ -48,6 +51,15 @@ public final class PrivateUserDefaults<Key: DefaultsKey> {
     public func getUUID(forKey key: Key) -> UUID? {
         guard let uuidString = storage.string(forKey: scopeKey(key)) else { return nil }
         return UUID(uuidString: uuidString)
+    }
+    
+
+    public func set(_ value: Bool, forKey key: Key) {
+        storage.set(value, forKey: scopeKey(key))
+    }
+
+    public func bool(forKey key: Key) -> Bool {
+        return storage.bool(forKey: scopeKey(key))
     }
 
 }

--- a/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
+++ b/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
@@ -53,7 +53,6 @@ extension PrivateUserDefaults {
         return UUID(uuidString: uuidString)
     }
     
-
     public func set(_ value: Bool, forKey key: Key) {
         storage.set(value, forKey: scopeKey(key))
     }

--- a/wire-ios/Wire-iOS Share Extension/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/ShareExtensionViewController.swift
@@ -175,7 +175,8 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
             accountIdentifier: accountIdentifier,
             hostBundleIdentifier: hostBundleIdentifier,
             environment: BackendEnvironment.shared,
-            appLockConfig: legacyConfig
+            appLockConfig: legacyConfig,
+            sharedUserDefaults: .applicationGroup
         )
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationRootViewController.swift
@@ -94,7 +94,7 @@ final class ConversationRootViewController: UIViewController {
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+        super.viewDidDisappear(animated)
 
         navBarContainer.navigationBar.accessibilityElementsHidden = true
         conversationViewController?.view.accessibilityElementsHidden = true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3380" title="WPB-3380" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3380</a>  [iOS] App gets stuck on first time overlay screen on login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App becomes unresponsive while logging in with EAR enabled. We try to access the enabledEAR while we're setting the database key, both operations happen on different threads and each time we access the value on three different queues ending up on deadlock.

In addition, the encryptMessagesAtRest property has two roles: representing the fact that the feature EAR is enabled and indicating if we should do particular process on the CoreData models.

### Solutions

Refactor the earEnabled method to represent only the feature flag. We use UserDefaults to store it within User scope.
This breaks the deadlock observed since we don't access some particular context on different Threads at the same time.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

* Fixed also warning about `UIViewControllerAlertForAppearanceCallbackMisuse`

### Attachments (Optional)

![Screenshot 2023-07-21 at 12 55 21](https://github.com/wireapp/wire-ios-mono/assets/254198/f7b12831-dee4-4eee-9df3-986e9bd329df)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
