### PR TITLE
fix: Decrease the unread count when a conversation was deleted WPB-3483

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Internal.h
@@ -79,6 +79,7 @@ extern NSString *const ZMConversationLastUnreadKnockDateKey;
 extern NSString *const ZMConversationLastUnreadMissedCallDateKey;
 extern NSString *const ZMConversationLastReadLocalTimestampKey;
 extern NSString *const ZMConversationLegalHoldStatusKey;
+extern NSString *const ZMConversationIsDeletedRemotelyKey;
 
 extern NSString *const SecurityLevelKey;
 extern NSString *const ZMConversationLabelsKey;

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -114,13 +114,14 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 {
     NSPredicate *notSelfConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeSelf];
     NSPredicate *notInvalidConversation = [NSPredicate predicateWithFormat:@"%K != %d", ZMConversationConversationTypeKey, ZMConversationTypeInvalid];
-    
+    NSPredicate *notDeletedRemotelyConversation = [NSPredicate predicateWithFormat:@"%K == NO", ZMConversationIsDeletedRemotelyKey];
+
     NSPredicate *pendingConnection = [NSPredicate predicateWithFormat:@"%K != nil AND %K.status == %d", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusPending];
     NSPredicate *acceptablePredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[pendingConnection, [self predicateForUnreadConversation]]];
     
     NSPredicate *notBlockedConnection = [NSPredicate predicateWithFormat:@"(%K == nil) OR (%K != nil AND %K.status != %d)", ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConversationConnectionKey, ZMConnectionStatusBlocked];
     
-    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, notBlockedConnection, acceptablePredicate]];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[notSelfConversation, notInvalidConversation, notDeletedRemotelyConversation, notBlockedConnection, acceptablePredicate]];
 }
 
 + (NSPredicate *)predicateForUnreadConversation

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
@@ -75,6 +75,7 @@ NSString *const ZMConversationRemoteIdentifierDataKey = @"remoteIdentifier_data"
 NSString *const SecurityLevelKey = @"securityLevel";
 NSString *const ZMConversationLabelsKey = @"labels";
 NSString *const ZMConversationDomainKey = @"domain";
+NSString *const ZMConversationIsDeletedRemotelyKey = @"isDeletedRemotely";
 
 static NSString *const ConnectedUserKey = @"connectedUser";
 static NSString *const CreatorKey = @"creator";
@@ -356,7 +357,7 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
             ZMConversation.mlsStatusKey,
             ZMConversation.commitPendingProposalDateKey,
             ZMConversation.epochKey,
-            ZMConversation.isDeletedRemotelyKey
+            ZMConversationIsDeletedRemotelyKey
         };
         
         NSSet *additionalKeys = [NSSet setWithObjects:KeysIgnoredForTrackingModifications count:(sizeof(KeysIgnoredForTrackingModifications) / sizeof(*KeysIgnoredForTrackingModifications))];

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.swift
@@ -20,9 +20,6 @@ import Foundation
 
 extension ZMConversation {
 
-    @objc
-    static let isDeletedRemotelyKey: String = #keyPath(ZMConversation.isDeletedRemotely)
-
     /// Whether the conversation was deleted on the backend.
 
     @NSManaged

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -169,6 +169,10 @@ extension ZMLocalNotification {
             WireLogger.badgeCount.info("increase internalEstimatedUnreadCount: \(conversation?.internalEstimatedUnreadCount) in \(conversation?.remoteIdentifier?.uuidString) timestamp: \(Date())")
         }
 
+        if type.shouldDecreaseUnreadCount {
+            conversation?.internalEstimatedUnreadCount -= 1
+        }
+
         if type.shouldIncreaseUnreadMentionCount {
             conversation?.internalEstimatedUnreadSelfMentionCount += 1
         }
@@ -196,6 +200,19 @@ extension LocalNotificationType {
             return false
         default:
             return true
+        }
+    }
+
+    var shouldDecreaseUnreadCount: Bool {
+        guard case LocalNotificationType.event(let contentType) = self else {
+            return false
+        }
+
+        switch contentType {
+        case .conversationDeleted:
+            return true
+        default:
+            return false
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3483" title="WPB-3483" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3483</a>  Deleting a conversation does not update the badge count
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The badge counter did not decrease the number of unread conversations if the conversation was deleted.

### Causes (Optional)

We did not decrease the value of `internalEstimatedUnreadCount` when handling the `conversationDeleted` event.

### Solutions

1. Decrease `internalEstimatedUnreadCount` after receiving `conversationDeleted` event.
2. Exclude deleted conversations (`isDeletedRemotely`) from the count of unread conversations.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
