### PR TITLE
fix: There is no pen icon on the preview of an edited message someone is replying to - WPB-3494

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -62,6 +62,7 @@ extension UITextView {
 
 final class MessageThumbnailPreviewView: UIView {
     private let senderLabel = UILabel()
+    private var leftEditIconInset: CGFloat = 10
     private let contentTextView = UITextView.previewTextView()
     private let imagePreview = ImageResourceView()
     private var observerToken: Any?
@@ -144,7 +145,15 @@ final class MessageThumbnailPreviewView: UIView {
 
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
-            return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: iconColor, iconSize: 8))
+            return NSAttributedString(
+                attachment: NSTextAttachment.textAttachment(for: .pencil,
+                with: iconColor,
+                iconSize: 8,
+                insets: UIEdgeInsets(top: 0,
+                left: leftEditIconInset,
+                bottom: 0,
+                right: 0))
+            )
         } else {
             return NSAttributedString()
         }
@@ -204,6 +213,7 @@ extension MessageThumbnailPreviewView: ZMMessageObserver {
 final class MessagePreviewView: UIView {
 
     private let senderLabel = UILabel()
+    private var leftEditIconInset: CGFloat = 10
     private let contentTextView = UITextView.previewTextView()
     private var observerToken: Any?
     private let displaySender: Bool
@@ -268,7 +278,15 @@ final class MessagePreviewView: UIView {
 
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
-            return "  " + NSAttributedString(attachment: NSTextAttachment.textAttachment(for: .pencil, with: iconColor, iconSize: 8))
+            return NSAttributedString(
+                attachment: NSTextAttachment.textAttachment(for: .pencil,
+                with: iconColor,
+                iconSize: 8,
+                insets: UIEdgeInsets(top: 0,
+                left: leftEditIconInset,
+                bottom: 0,
+                right: 0))
+            )
         } else {
             return NSAttributedString()
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/MessagePreviewView.swift
@@ -146,13 +146,17 @@ final class MessageThumbnailPreviewView: UIView {
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
             return NSAttributedString(
-                attachment: NSTextAttachment.textAttachment(for: .pencil,
-                with: iconColor,
-                iconSize: 8,
-                insets: UIEdgeInsets(top: 0,
-                left: leftEditIconInset,
-                bottom: 0,
-                right: 0))
+                attachment: NSTextAttachment.textAttachment(
+                    for: .pencil,
+                    with: iconColor,
+                    iconSize: 8,
+                    insets: UIEdgeInsets(
+                        top: 0,
+                        left: leftEditIconInset,
+                        bottom: 0,
+                        right: 0
+                    )
+                )
             )
         } else {
             return NSAttributedString()
@@ -279,13 +283,17 @@ final class MessagePreviewView: UIView {
     private func editIcon() -> NSAttributedString {
         if message.updatedAt != nil {
             return NSAttributedString(
-                attachment: NSTextAttachment.textAttachment(for: .pencil,
-                with: iconColor,
-                iconSize: 8,
-                insets: UIEdgeInsets(top: 0,
-                left: leftEditIconInset,
-                bottom: 0,
-                right: 0))
+                attachment: NSTextAttachment.textAttachment(
+                    for: .pencil,
+                    with: iconColor,
+                    iconSize: 8,
+                    insets: UIEdgeInsets(
+                        top: 0,
+                        left: leftEditIconInset,
+                        bottom: 0,
+                        right: 0
+                    )
+                )
             )
         } else {
             return NSAttributedString()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3494" title="WPB-3494" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3494</a>  [iOS] There is no pen icon on the preview of an edited message someone is replying to
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we show a the edit icon when someone is replying to a message which has been edited. The problem was that instead of modifying the insets we're adding an empty string + our text attachment. For some reason our icon was still hidden and that solution wasn't working as expected. 

So now, instead of an empty string we add the proper left inset and the issue has been fixed. 


| BEFORE | AFTER |
|---|---|
| ![Icon-Edited](https://github.com/wireapp/wire-ios-mono/assets/10944108/9c05efcb-3f5e-44a6-8eb1-341bc487b0d9) | ![Screenshot 2023-07-25 at 17 28 46](https://github.com/wireapp/wire-ios-mono/assets/10944108/690ff890-f0db-46dc-85c6-6a9ea8fddfe9)  |

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
