### PR TITLE
fix: Typo in Federated users are present in German language - WPB-2200

### DIFF
--- a/wire-ios/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -335,7 +335,7 @@
 "conversation.banner.guests" = "Gäste";
 "conversation.banner.services" = "Dienste";
 "conversation.banner.externals" = "Externe";
-"conversation.banner.remotes" = "]Föderierte Benutzer";
+"conversation.banner.remotes" = "Föderierte Benutzer";
 "conversation.banner.are_present" = "%@ sind anwesend";
 "conversation.banner.are_active" = "%@ sind aktiv";
 "conversation.banner.separator" = "  und ";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2200" title="WPB-2200" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2200</a>  [iOS] Bund: Typo in Federated users are present in german language
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix a small typo in the German translation for `conversation.banner.remotes`. The` ]` needs to be removed because it's not needed. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
