### PR TITLE
fix: Set the background for the separatorView in SeparatorCollectionViewCell

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorCollectionViewCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/SeparatorCollectionViewCell.swift
@@ -56,6 +56,7 @@ class SeparatorCollectionViewCell: UICollectionViewCell, SeparatorViewProtocol {
 
     private func configureSubviews() {
         backgroundColor = SemanticColors.View.backgroundUserCell
+        separator.backgroundColor = SemanticColors.View.backgroundSeparatorCell
 
         setUp()
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

While I was working on #343, I mistakenly deleted this line:

`separator.backgroundColor = SemanticColors.View.backgroundSeparatorCell` 

As a result, now the cells don't have a separator between each other. 

So with this PR I fix the issue by setting the color of the separator properly. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
