### PR TITLE
fix: partial search for local users - WPB-3510

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
@@ -57,7 +57,7 @@ extension ZMUser {
         }
 
         if !query.isEmpty {
-            let namePredicate = NSPredicate(formatDictionary: [#keyPath(ZMUser.normalizedName): "%K MATCHES %@"], matchingSearch: query)
+            let namePredicate =  NSPredicate(format: "%K CONTAINS[c] %@", #keyPath(ZMUser.normalizedName), query)
             let handlePredicate = NSPredicate(format: "%K BEGINSWITH %@", #keyPath(ZMUser.handle), query.strippingLeadingAtSign())
             allPredicates.append([namePredicate, handlePredicate].compactMap {$0})
         }

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
@@ -57,7 +57,7 @@ extension ZMUser {
         }
 
         if !query.isEmpty {
-            let namePredicate = NSPredicate(format: "%K CONTAINS[c] %@", #keyPath(ZMUser.normalizedName), query)
+            let namePredicate = NSPredicate(formatDictionary: [#keyPath(ZMUser.normalizedName): "%K MATCHES %@"], matchingSearch: query)
             let handlePredicate = NSPredicate(format: "%K BEGINSWITH %@", #keyPath(ZMUser.handle), query.strippingLeadingAtSign())
             allPredicates.append([namePredicate, handlePredicate].compactMap {$0})
         }

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
@@ -57,7 +57,7 @@ extension ZMUser {
         }
 
         if !query.isEmpty {
-            let namePredicate =  NSPredicate(format: "%K CONTAINS[c] %@", #keyPath(ZMUser.normalizedName), query)
+            let namePredicate = NSPredicate(format: "%K CONTAINS[c] %@", #keyPath(ZMUser.normalizedName), query)
             let handlePredicate = NSPredicate(format: "%K BEGINSWITH %@", #keyPath(ZMUser.handle), query.strippingLeadingAtSign())
             allPredicates.append([namePredicate, handlePredicate].compactMap {$0})
         }

--- a/wire-ios-data-model/Source/Utilis/NSPredicate+ZMSearch.m
+++ b/wire-ios-data-model/Source/Utilis/NSPredicate+ZMSearch.m
@@ -31,7 +31,7 @@
     [searchString enumerateSubstringsInRange:NSMakeRange(0, searchString.length) options:NSStringEnumerationByWords usingBlock:^(NSString *substring, NSRange __unused substringRange, NSRange __unused enclosingRange, BOOL * __unused stop) {
         
         NSString *normalizedString = substring.normalizedString;
-        NSString *regExp = [NSString stringWithFormat:@".*\\b%@.*", normalizedString];
+        NSString *regExp = [NSString stringWithFormat:@".*%@.*", normalizedString];
         
         NSMutableArray *subPredicates = [NSMutableArray array];
         [formatDictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *formatString, BOOL * __unused s) {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -2783,7 +2783,7 @@
 }
 
 
-- (void)testThatItDoesNotFindAConversationThatDoesNotStartWithButContainsTheSearchString
+- (void)testThatItDoesFindAConversationThatDoesNotStartWithButContainsTheSearchString
 {
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -2799,7 +2799,7 @@
     NSArray *result = [self.uiMOC executeFetchRequestOrAssert:request];
     
     // then
-    XCTAssertEqual(result.count, 0u);
+    XCTAssertEqual(result.count, 1u);
 }
 
 - (void)testThatItDoesNotFindAConversationBelongingToTeamWhenSearchingForPersonalConversations

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -160,10 +160,11 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
 
-    func testThatItDoesNotFindUsersContainingButNotBeginningWithSearchString() {
+    func testThatItDoesFindUsersContainingButNotBeginningWithSearchString() {
         // given
         let resultArrived = expectation(description: "received result")
-        _ = createConnectedUser(withName: "userA")
+        let user = createConnectedUser(withName: "userA")
+        let normaliedName = user.normalizedName
 
         let request = SearchRequest(query: "serA", searchOptions: [.contacts])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
@@ -171,7 +172,7 @@ class SearchTaskTests: DatabaseTest {
         // expect
         task.onResult { (result, _) in
             resultArrived.fulfill()
-            XCTAssertEqual(result.contacts.count, 0)
+            XCTAssertEqual(result.contacts.count, 1)
         }
 
         // when
@@ -555,10 +556,10 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
     }
 
-    func testThatItDoesNotFindConversationsUsingPartialNames() {
+    func testThatItDoesFindConversationsUsingPartialNames() {
         // given
         let resultArrived = expectation(description: "received result")
-        _ = createGroupConversation(withName: "Somebody")
+        let conversation = createGroupConversation(withName: "Somebody")
 
         let request = SearchRequest(query: "mebo", searchOptions: [.conversations])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
@@ -566,7 +567,7 @@ class SearchTaskTests: DatabaseTest {
         // expect
         task.onResult { (result, _) in
             resultArrived.fulfill()
-            XCTAssertEqual(result.conversations, [])
+            XCTAssertEqual(result.conversations, [conversation])
         }
 
         // when


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3510" title="WPB-3510" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3510</a>  [iOS]: Partial search doesn't work. eg: user "abc123" is found if I type "abc" but is not found if I type "123"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix an issue where it wouldn't allow for a partial search in terms of names. The problem was how we defined the regular expression within the method. By removing `\b`.

`\b = Word boundary. Matches a word boundary position between a word character and non-word character or position (start / end of string).`

So by removing that we allow partial search. I've updated some of the tests to reflect those changes. 


The new definition allows for the partial search to work as expected. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
