### PR TITLE
fix: connecting label shown in search ui WPB-530

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/UserCell.swift
@@ -48,8 +48,17 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
     let userTypeIconView = IconImageView()
     let verifiedIconView = UIImageView()
     let videoIconView = IconImageView()
-    let connectingLabel = DynamicFontLabel(fontSpec: .mediumRegularFont,
-                                           color: LabelColors.textErrorDefault)
+
+    lazy var connectingLabel: DynamicFontLabel = {
+        let label = DynamicFontLabel(
+            fontSpec: .mediumRegularFont,
+            color: LabelColors.textErrorDefault
+        )
+
+        label.isHidden = true
+        return label
+    }()
+
     let checkmarkIconView = UIImageView()
     let microphoneIconView = PulsingIconImageView()
     var contentStackView: UIStackView!
@@ -101,7 +110,7 @@ class UserCell: SeparatorCollectionViewCell, SectionListCellType {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        
+
         UIView.performWithoutAnimation {
             hidesSubtitle = false
             userTypeIconView.isHidden = true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-530" title="WPB-530" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-530</a>  [iOS]  “Indicate users with bad / lost connection during the call“
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The connecting label is shown when it shouldn't be.

### Causes (Optional)

By default the label is not hidden.

### Solutions

Make the label hidden by default.

### Testing

#### How to Test

Open the search ui and verify that the users don't have the connecting label.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
