### PR TITLE
fix: incorrect time in notification for self deleting messages WPB-2933

### DIFF
--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationContentType.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationContentType.swift
@@ -50,7 +50,8 @@ public enum LocalNotificationContentType: Equatable {
         case .conversationMessageTimerUpdate:
             guard let payload = event.payload["data"] as? [String: AnyHashable] else { return nil }
             let timeoutIntegerValue = (payload["message_timer"] as? Int64) ?? 0
-            let timeoutValue = MessageDestructionTimeoutValue(rawValue: TimeInterval(timeoutIntegerValue))
+            let timeoutIntegerValueInSeconds = timeoutIntegerValue / 1000
+            let timeoutValue = MessageDestructionTimeoutValue(rawValue: TimeInterval(timeoutIntegerValueInSeconds))
             self = timeoutValue == .none ? .messageTimerUpdate(nil) : .messageTimerUpdate(timeoutValue.displayString)
 
         case .conversationOtrMessageAdd:

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests.swift
@@ -208,7 +208,7 @@ class ZMLocalNotificationTests: MessagingTestBase {
     func createMessageTimerUpdateEvent(_ nonce: UUID,
                                        conversationID: UUID,
                                        senderID: UUID = UUID.create(),
-                                       timer: Int64 = 31536000,
+                                       timer: Int64 = 31536000000,
                                        timestamp: Date = Date()) -> ZMUpdateEvent {
 
        let payload: [String: Any] = [

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -416,7 +416,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages() {
         // given
         syncMOC.performGroupedBlockAndWait {
-            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversation.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 86400, timestamp: Date())
+            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversation.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 86400000, timestamp: Date())
 
             // when
             let note = ZMLocalNotification(event: event, conversation: self.groupConversation, managedObjectContext: self.syncMOC)
@@ -431,28 +431,28 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         // given
         syncMOC.performGroupedBlockAndWait {
             self.otherUser1.name = nil
-            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversation.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 86400, timestamp: Date())
+            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversation.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 2419200000, timestamp: Date())
 
             // when
             let note = ZMLocalNotification(event: event, conversation: self.groupConversation, managedObjectContext: self.syncMOC)
 
             // then
             XCTAssertNotNil(note)
-            XCTAssertEqual(note?.body, "Someone set the message timer to 1 day")
+            XCTAssertEqual(note?.body, "Someone set the message timer to 4 weeks")
         }
     }
 
     func testThatItCreatesANotificationForMessageTimerUpdateSystemMessages_NoConversationName() {
         // given
         syncMOC.performGroupedBlockAndWait {
-            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversationWithoutName.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 86400, timestamp: Date())
+            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversationWithoutName.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 10000, timestamp: Date())
 
             // when
             let note = ZMLocalNotification(event: event, conversation: self.groupConversationWithoutName, managedObjectContext: self.syncMOC)
 
             // then
             XCTAssertNotNil(note)
-            XCTAssertEqual(note?.body, "Other User1 set the message timer to 1 day in a conversation")
+            XCTAssertEqual(note?.body, "Other User1 set the message timer to 10 seconds in a conversation")
         }
     }
 
@@ -460,14 +460,14 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         // given
         syncMOC.performGroupedBlockAndWait {
             self.otherUser1.name = nil
-            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversationWithoutName.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 86400, timestamp: Date())
+            let event = self.createMessageTimerUpdateEvent(self.otherUser1.remoteIdentifier, conversationID: self.groupConversationWithoutName.remoteIdentifier!, senderID: self.otherUser1.remoteIdentifier!, timer: 300000, timestamp: Date())
 
             // when
             let note = ZMLocalNotification(event: event, conversation: self.groupConversationWithoutName, managedObjectContext: self.syncMOC)
 
             // then
             XCTAssertNotNil(note)
-            XCTAssertEqual(note?.body, "Someone set the message timer to 1 day in a conversation")
+            XCTAssertEqual(note?.body, "Someone set the message timer to 5 minutes in a conversation")
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2933" title="WPB-2933" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2933</a>  [iOS] Incorrect time in notification after enabling Self Deleting Messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When admin changes time for self-deleting messages then all members receive notifications with incorrect time. It cause by server sending time in milliseconds and iOS app interpreting it as seconds. 