### PR TITLE
feat: Remove connected users owned by backend that stopped federation with own backend WPB-184

### DIFF
--- a/wire-ios-request-strategy/Sources/Helpers/FederationTerminationManager.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/FederationTerminationManager.swift
@@ -84,8 +84,8 @@ private extension FederationTerminationManager {
     func removeConnectedUsers(with domain: String) {
         let connectedUsersPredicate = ZMUser.predicateForConnectedUsers(hostedOnDomain: domain)
         let fetchRequest = ZMUser.sortedFetchRequest(with: connectedUsersPredicate)
-        if let pendingUsers = context.fetchOrAssert(request: fetchRequest) as? [ZMUser] {
-            pendingUsers.forEach { user in
+        if let connectedUsers = context.fetchOrAssert(request: fetchRequest) as? [ZMUser] {
+            connectedUsers.forEach { user in
                 user.connection = nil
             }
         }

--- a/wire-ios-request-strategy/Sources/Helpers/FederationTerminationManagerTest.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/FederationTerminationManagerTest.swift
@@ -84,6 +84,20 @@ class FederationTerminationManagerTests: MessagingTestBase {
         }
     }
 
+    func testThatItRemovesConnectionForConnectedUsers() throws {
+        syncMOC.performGroupedAndWait { [self] _ in
+            // GIVEN
+            otherUser.domain = defederatedDomain
+            otherUser.connection?.status = .accepted
+
+            // WHEN
+            sut.handleFederationTerminationWith(defederatedDomain)
+
+            // THEN
+            XCTAssertEqual(otherUser.connection, nil)
+        }
+    }
+
     func testItRemovesSelfUserFromConversationHostedByDefederatedDomain_AndAddsSystemMessages() throws {
         syncMOC.performGroupedAndWait { [self] syncMOC in
             // GIVEN


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-184" title="WPB-184" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-184</a>  [iOS] Clean local state when receiving `federation.delete` event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When two backends ( **backend A** and **own backend**) stop federating, we should consider that we are no longer connected with any of the users from that **backend A**. So after we process the `federation.delete` event that tells that we don't federate anymore, we should remove connection with all connected users from the **backend A**. 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
