### PR TITLE
fix: broken test in SE after merging #411

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -114,12 +114,13 @@ extension LocalNotificationDispatcherTests {
 
     func testThatItCreatesNotificationFromSystemMessagesIfNotActive() {
         // GIVEN
+        let messageTimer = MessageDestructionTimeoutValue.fiveMinutes
         let payload: [String: Any] = [
             "id": UUID.create().transportString(),
             "from": self.user1.remoteIdentifier.transportString(),
             "conversation": self.conversation1.remoteIdentifier!.transportString(),
             "time": Date().transportString(),
-            "data": ["message_timer": MessageDestructionTimeoutValue.fiveMinutes.rawValue],
+            "data": ["message_timer": messageTimer.rawValue * 1000],
             "type": "conversation.message-timer-update"
         ]
         let event = ZMUpdateEvent(fromEventStreamPayload: payload as ZMTransportData, uuid: UUID.create())!


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix a broken test which broke after merging #411. The reason we didn't catch it was because in #411 no changes in SE made so the tests in SE didn't run. 


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
