### PR TITLE
fix: reaction title is truncated WPB-3940

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/BasicReactionPicker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/BasicReactionPicker.swift
@@ -59,6 +59,7 @@ private extension BasicReactionPicker {
     func setupViews() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.text = L10n.Localizable.Content.Message.reactions
+        titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         addSubview(titleLabel)
 
         horizontalStackView.alignment = .center


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3940" title="WPB-3940" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3940</a>  [iOS] Reactions title in new message menu is truncated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
This PR contains fix for bug where after long press on message action sheet appear with truncated title
![image](https://github.com/wireapp/wire-ios-mono/assets/1401672/31ef243a-29b0-45b2-9075-1e8d4f58bb3a)
<img width="383" alt="image" src="https://github.com/wireapp/wire-ios-mono/assets/1401672/1e480175-a424-4442-babb-2b6d38393963">
