### PR TITLE
chore: Extract integration tests hitting real API as E2E tests and not run them on PRs WPB-3987

### DIFF
--- a/wire-ios-link-preview/WireLinkPreview.xcodeproj/project.pbxproj
+++ b/wire-ios-link-preview/WireLinkPreview.xcodeproj/project.pbxproj
@@ -57,7 +57,7 @@
 		BF4F2B4A1E925AE8000B22D1 /* OpenGraphMockDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B471E925AE8000B22D1 /* OpenGraphMockDataProvider.swift */; };
 		BF4F2B4B1E925AE8000B22D1 /* URLMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B481E925AE8000B22D1 /* URLMocks.swift */; };
 		BF4F2B561E925AFE000B22D1 /* ImageDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B4C1E925AFE000B22D1 /* ImageDownloaderTests.swift */; };
-		BF4F2B571E925AFE000B22D1 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B4D1E925AFE000B22D1 /* IntegrationTests.swift */; };
+		BF4F2B571E925AFE000B22D1 /* E2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B4D1E925AFE000B22D1 /* E2ETests.swift */; };
 		BF4F2B581E925AFE000B22D1 /* LinkPreviewDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B4E1E925AFE000B22D1 /* LinkPreviewDetectorTests.swift */; };
 		BF4F2B591E925AFE000B22D1 /* MetaStreamContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B4F1E925AFE000B22D1 /* MetaStreamContainerTests.swift */; };
 		BF4F2B5A1E925AFE000B22D1 /* OpenGraphDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4F2B501E925AFE000B22D1 /* OpenGraphDataTests.swift */; };
@@ -164,7 +164,7 @@
 		BF4F2B471E925AE8000B22D1 /* OpenGraphMockDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OpenGraphMockDataProvider.swift; path = WireLinkPreviewTests/OpenGraphMockDataProvider.swift; sourceTree = SOURCE_ROOT; };
 		BF4F2B481E925AE8000B22D1 /* URLMocks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLMocks.swift; path = WireLinkPreviewTests/URLMocks.swift; sourceTree = SOURCE_ROOT; };
 		BF4F2B4C1E925AFE000B22D1 /* ImageDownloaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageDownloaderTests.swift; path = WireLinkPreviewTests/ImageDownloaderTests.swift; sourceTree = SOURCE_ROOT; };
-		BF4F2B4D1E925AFE000B22D1 /* IntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IntegrationTests.swift; path = WireLinkPreviewTests/IntegrationTests.swift; sourceTree = SOURCE_ROOT; };
+		BF4F2B4D1E925AFE000B22D1 /* E2ETests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = E2ETests.swift; path = WireLinkPreviewTests/E2ETests.swift; sourceTree = SOURCE_ROOT; };
 		BF4F2B4E1E925AFE000B22D1 /* LinkPreviewDetectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinkPreviewDetectorTests.swift; path = WireLinkPreviewTests/LinkPreviewDetectorTests.swift; sourceTree = SOURCE_ROOT; };
 		BF4F2B4F1E925AFE000B22D1 /* MetaStreamContainerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MetaStreamContainerTests.swift; path = WireLinkPreviewTests/MetaStreamContainerTests.swift; sourceTree = SOURCE_ROOT; };
 		BF4F2B501E925AFE000B22D1 /* OpenGraphDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OpenGraphDataTests.swift; path = WireLinkPreviewTests/OpenGraphDataTests.swift; sourceTree = SOURCE_ROOT; };
@@ -356,7 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				BF4F2B4C1E925AFE000B22D1 /* ImageDownloaderTests.swift */,
-				BF4F2B4D1E925AFE000B22D1 /* IntegrationTests.swift */,
+				BF4F2B4D1E925AFE000B22D1 /* E2ETests.swift */,
 				BF4F2B4E1E925AFE000B22D1 /* LinkPreviewDetectorTests.swift */,
 				5E9EA4C7224257C100D401B2 /* NSDataDetectorLinksTests.swift */,
 				5E9EA4C922425C4E00D401B2 /* NSDataDetectorAttachmentTests.swift */,
@@ -596,7 +596,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5E9EA4CE2242785900D401B2 /* LinkAttachmentDetectorTests.swift in Sources */,
-				BF4F2B571E925AFE000B22D1 /* IntegrationTests.swift in Sources */,
+				BF4F2B571E925AFE000B22D1 /* E2ETests.swift in Sources */,
 				BF4F2B5B1E925AFE000B22D1 /* OpenGraphScannerTests.swift in Sources */,
 				5E9EA4CC2242732F00D401B2 /* LinkAttachmentTypesTests.swift in Sources */,
 				BF4F2B5E1E925AFE000B22D1 /* StringXMLEntityParserTests.swift in Sources */,

--- a/wire-ios-link-preview/WireLinkPreview.xcodeproj/xcshareddata/xcschemes/WireLinkPreview-E2E.xcscheme
+++ b/wire-ios-link-preview/WireLinkPreview.xcodeproj/xcshareddata/xcschemes/WireLinkPreview-E2E.xcscheme
@@ -59,7 +59,40 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "E2ETests">
+                  Identifier = "ImageDownloaderTests">
+               </Test>
+               <Test
+                  Identifier = "LinkAttachmentDetectorTests">
+               </Test>
+               <Test
+                  Identifier = "LinkAttachmentTypesTests">
+               </Test>
+               <Test
+                  Identifier = "LinkPreviewDetectorTests">
+               </Test>
+               <Test
+                  Identifier = "MetaStreamContainerTests">
+               </Test>
+               <Test
+                  Identifier = "NSDataDetectorAttachmentTests">
+               </Test>
+               <Test
+                  Identifier = "NSDataDetectorLinksTests">
+               </Test>
+               <Test
+                  Identifier = "OpenGraphDataTests">
+               </Test>
+               <Test
+                  Identifier = "OpenGraphScannerTests">
+               </Test>
+               <Test
+                  Identifier = "PreviewBlackListTests">
+               </Test>
+               <Test
+                  Identifier = "PreviewDownloaderTests">
+               </Test>
+               <Test
+                  Identifier = "StringXMLEntityParserTests">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/wire-ios-link-preview/WireLinkPreviewTests/E2ETests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/E2ETests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import WireLinkPreview
 
-final class IntegrationTests: XCTestCase {
+final class E2ETests: XCTestCase {
 
     func testThatItParsesSampleDataTwitter() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "Twitter", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3987" title="WPB-3987" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3987</a>  Extract integration tests hitting real API as E2E tests and not run them on PRs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Integration tests in Link Preview were running on the real backend which cased flakiness

### Solutions

I've moved them to a separate scheme that wouldn't be run on PR changes

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
