### PR TITLE
feat: Support plural and singular options for new strings WPB-3722

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -1957,15 +1957,13 @@ internal enum L10n {
           }
         }
         internal enum FailedParticipants {
-          /// %@ [Learn more](%@)
-          internal static func learnMore(_ p1: Any, _ p2: Any) -> String {
-            return L10n.tr("Localizable", "content.system.failed_participants.learn_more", String(describing: p1), String(describing: p2), fallback: "%@ [Learn more](%@)")
-          }
+          /// Learn more
+          internal static let learnMore = L10n.tr("Localizable", "content.system.failed_participants.learn_more", fallback: "Learn more")
         }
         internal enum FailedtoaddParticipants {
-          /// **%@** could not be added to the group. [Learn more](%@)
-          internal static func couldNotBeAdded(_ p1: Any, _ p2: Any) -> String {
-            return L10n.tr("Localizable", "content.system.failedtoadd_participants.could_not_be_added", String(describing: p1), String(describing: p2), fallback: "**%@** could not be added to the group. [Learn more](%@)")
+          /// Plural format key: "%#@number_of_users@"
+          internal static func couldNotBeAdded(_ p1: Int) -> String {
+            return L10n.tr("Localizable", "content.system.failedtoadd_participants.could_not_be_added", p1, fallback: "Plural format key: \"%#@number_of_users@\"")
           }
           /// **%@ participants** could not be added to the group.
           internal static func count(_ p1: Any) -> String {
@@ -1999,13 +1997,13 @@ internal enum L10n {
           internal static let hideDetails = L10n.tr("Localizable", "content.system.failedtosend_participants.hide_details", fallback: "Hide Details")
           /// Show Details
           internal static let showDetails = L10n.tr("Localizable", "content.system.failedtosend_participants.show_details", fallback: "Show Details")
-          /// **%@** will get your message later.
-          internal static func willGetMessageLater(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "content.system.failedtosend_participants.will_get_message_later", String(describing: p1), fallback: "**%@** will get your message later.")
+          /// Plural format key: "%#@number_of_users@"
+          internal static func willGetMessageLater(_ p1: Int) -> String {
+            return L10n.tr("Localizable", "content.system.failedtosend_participants.will_get_message_later", p1, fallback: "Plural format key: \"%#@number_of_users@\"")
           }
-          /// **%@** won’t get your message.
-          internal static func willNeverGetMessage(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "content.system.failedtosend_participants.will_never_get_message", String(describing: p1), fallback: "**%@** won’t get your message.")
+          /// Plural format key: "%#@number_of_users@"
+          internal static func willNeverGetMessage(_ p1: Int) -> String {
+            return L10n.tr("Localizable", "content.system.failedtosend_participants.will_never_get_message", p1, fallback: "Plural format key: \"%#@number_of_users@\"")
           }
         }
         internal enum FederationTermination {

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -475,13 +475,10 @@
 "content.system.failedtosend_participants.show_details" = "Show Details";
 "content.system.failedtosend_participants.hide_details" = "Hide Details";
 "content.system.failedtosend_participants.did_not_get_message" = "**%@ participants** didn’t get your message.";
-"content.system.failedtosend_participants.will_get_message_later" = "**%@** will get your message later.";
-"content.system.failedtosend_participants.will_never_get_message" = "**%@** won’t get your message.";
 "content.system.failedtosend_participants.from" = "**%@ from %@**";
-"content.system.failed_participants.learn_more" = "%@ [Learn more](%@)";
+"content.system.failed_participants.learn_more" = "Learn more";
 
 "content.system.failedtoadd_participants.count" = "**%@ participants** could not be added to the group.";
-"content.system.failedtoadd_participants.could_not_be_added" = "**%@** could not be added to the group. [Learn more](%@)";
 
 "content.system.like_tooltip" = "Tap to like";
 "content.system.deleted_message_prefix_timestamp" = "Deleted: %@";

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict
@@ -2,6 +2,54 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>content.system.failedtoadd_participants.could_not_be_added</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@number_of_users@</string>
+		<key>number_of_users</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$@ could not be added to the group.</string>
+			<key>other</key>
+			<string>%2$@ could not be added to the group.</string>
+		</dict>
+	</dict>
+	<key>content.system.failedtosend_participants.will_never_get_message</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@number_of_users@</string>
+		<key>number_of_users</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$@ won’t get your message.</string>
+			<key>other</key>
+			<string>%2$@ won’t get your message.</string>
+		</dict>
+	</dict>
+	<key>content.system.failedtosend_participants.will_get_message_later</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@number_of_users@</string>
+		<key>number_of_users</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$@ will get your message later.</string>
+			<key>other</key>
+			<string>%2$@ will get your message later.</string>
+		</dict>
+	</dict>
 	<key>self.new_device_alert.title_prefix.devices</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/wire-ios/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -216,7 +216,7 @@ extension URL {
         return wr_support.appendingPathComponent("hc/articles/360000574069-Share-a-link-with-a-person-without-a-Wire-account-to-join-a-guest-room-conversation-in-my-team")
     }
 
-    static var wr_backendOfflineLearnMore: URL {
+    static var wr_unreachableBackendLearnMore: URL {
         return wr_support.appendingPathComponent("hc/articles/9357718008093-Backend")
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageFailedRecipientsCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageFailedRecipientsCellDescription.swift
@@ -50,29 +50,51 @@ final class ConversationMessageFailedRecipientsCellDescription: ConversationMess
                                            buttonAction: buttonAction)
     }
 
-    private static func configureTitle(for failedUsers: [UserType]) -> String? {
-        return (failedUsers.count > 1) ? SystemContent.FailedtosendParticipants.didNotGetMessage(failedUsers.count)
-                                       : nil
+    private static func configureTitle(for failedUsers: [UserType]) -> NSAttributedString? {
+        if failedUsers.count > 1 {
+            let title = SystemContent.FailedtosendParticipants.didNotGetMessage(failedUsers.count)
+            return .markdown(from: title, style: .errorLabelStyle)
+        } else {
+            return nil
+        }
     }
 
-    private static func configureContent(for failedUsers: [UserType]) -> String {
-        var content: [String] = []
+    private static func configureContent(for failedUsers: [UserType]) -> NSAttributedString {
+        var content: [NSAttributedString] = []
         /// The list of participants with complete metadata.
         let usersWithName = failedUsers.filter { !$0.hasEmptyName }.compactMap(\.name)
         if !usersWithName.isEmpty {
-            content.append(SystemContent.FailedtosendParticipants.willGetMessageLater(usersWithName.joined(separator: ", ")))
+            let keyString = "content.system.failedtosend_participants.will_get_message_later"
+
+            let userNamesJoined = usersWithName.joined(separator: ", ")
+            let text = keyString.localized(args: usersWithName.count, userNamesJoined)
+
+            let attributedText: NSAttributedString = .markdown(from: text, style: .errorLabelStyle)
+                                                     .adding(font: .mediumSemiboldFont, to: userNamesJoined)
+
+            content.append(attributedText)
         }
 
         /// The list of participants with incomplete metadata.
         let usersWithoutName = failedUsers.filter { $0.hasEmptyName }
         if !usersWithoutName.isEmpty {
+            let keyString = "content.system.failedtosend_participants.will_never_get_message"
+
             let groupedByDomainUsers = groupByDomain(usersWithoutName)
-            content.append(SystemContent.FailedtosendParticipants.willNeverGetMessage(groupedByDomainUsers.joined(separator: ", ")))
+            let domainsJoined = groupedByDomainUsers.joined(separator: ", ")
+            let text = keyString.localized(args: groupedByDomainUsers.count, domainsJoined)
+
+            let attributedText: NSAttributedString = .markdown(from: text, style: .errorLabelStyle)
+                                 .adding(font: .mediumSemiboldFont, to: domainsJoined)
+
+            content.append(attributedText)
         }
 
-        let contentString = content.joined(separator: "\n")
+        let learnMore = NSAttributedString(string: SystemContent.FailedParticipants.learnMore,
+                                           attributes: [.font: UIFont.mediumSemiboldFont,
+                                                        .link: URL.wr_backendOfflineLearnMore])
 
-        return SystemContent.FailedParticipants.learnMore(contentString, URL.wr_backendOfflineLearnMore.absoluteString)
+        return content.joined(separator: "\n".attributedString) + " " + learnMore
     }
 
     private static func groupByDomain(_ users: [UserType]) -> [String] {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageFailedRecipientsCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageFailedRecipientsCellDescription.swift
@@ -51,12 +51,12 @@ final class ConversationMessageFailedRecipientsCellDescription: ConversationMess
     }
 
     private static func configureTitle(for failedUsers: [UserType]) -> NSAttributedString? {
-        if failedUsers.count > 1 {
-            let title = SystemContent.FailedtosendParticipants.didNotGetMessage(failedUsers.count)
-            return .markdown(from: title, style: .errorLabelStyle)
-        } else {
+        guard failedUsers.count > 1 else {
             return nil
         }
+
+        let title = SystemContent.FailedtosendParticipants.didNotGetMessage(failedUsers.count)
+        return .markdown(from: title, style: .errorLabelStyle)
     }
 
     private static func configureContent(for failedUsers: [UserType]) -> NSAttributedString {
@@ -69,9 +69,7 @@ final class ConversationMessageFailedRecipientsCellDescription: ConversationMess
             let userNamesJoined = usersWithName.joined(separator: ", ")
             let text = keyString.localized(args: usersWithName.count, userNamesJoined)
 
-            let attributedText: NSAttributedString = .markdown(from: text, style: .errorLabelStyle)
-                                                     .adding(font: .mediumSemiboldFont, to: userNamesJoined)
-
+            let attributedText = NSAttributedString.errorSystemMessage(withText: text, andHighlighted: userNamesJoined)
             content.append(attributedText)
         }
 
@@ -84,15 +82,10 @@ final class ConversationMessageFailedRecipientsCellDescription: ConversationMess
             let domainsJoined = groupedByDomainUsers.joined(separator: ", ")
             let text = keyString.localized(args: groupedByDomainUsers.count, domainsJoined)
 
-            let attributedText: NSAttributedString = .markdown(from: text, style: .errorLabelStyle)
-                                 .adding(font: .mediumSemiboldFont, to: domainsJoined)
-
+            let attributedText = NSAttributedString.errorSystemMessage(withText: text, andHighlighted: domainsJoined)
             content.append(attributedText)
         }
-
-        let learnMore = NSAttributedString(string: SystemContent.FailedParticipants.learnMore,
-                                           attributes: [.font: UIFont.mediumSemiboldFont,
-                                                        .link: URL.wr_backendOfflineLearnMore])
+        let learnMore = NSAttributedString.unreachableBackendLearnMoreLink
 
         return content.joined(separator: "\n".attributedString) + " " + learnMore
     }
@@ -105,6 +98,23 @@ final class ConversationMessageFailedRecipientsCellDescription: ConversationMess
             usersPerDomain.append(SystemContent.FailedtosendParticipants.from(usersCountString, domain ?? ""))
         }
         return usersPerDomain
+    }
+
+}
+
+extension NSAttributedString {
+
+    static var unreachableBackendLearnMoreLink: NSAttributedString {
+        typealias SystemContent = L10n.Localizable.Content.System
+
+        return NSAttributedString(string: SystemContent.FailedParticipants.learnMore,
+                                  attributes: [.font: UIFont.mediumSemiboldFont,
+                                               .link: URL.wr_unreachableBackendLearnMore])
+    }
+
+    static func errorSystemMessage(withText text: String, andHighlighted highlighted: String) -> NSAttributedString {
+        return .markdown(from: text, style: .errorLabelStyle)
+               .adding(font: .mediumSemiboldFont, to: highlighted)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -1122,14 +1122,29 @@ final class ConversationFailedToAddParticipantsCellDescription: ConversationMess
             buttonAction: buttonAction)
     }
 
-    private static func configureTitle(for failedUsers: [UserType]) -> String? {
-        return (failedUsers.count > 1) ? SystemContent.FailedtoaddParticipants.count(failedUsers.count)
-                                       : nil
+    private static func configureTitle(for failedUsers: [UserType]) -> NSAttributedString? {
+        if failedUsers.count > 1 {
+            let title = SystemContent.FailedtoaddParticipants.count(failedUsers.count)
+            return .markdown(from: title, style: .errorLabelStyle)
+        } else {
+            return nil
+        }
     }
 
-    private static func configureContent(for failedUsers: [UserType]) -> String {
-        let userNames = failedUsers.compactMap { $0.name }.joined(separator: ", ")
-        return SystemContent.FailedtoaddParticipants.couldNotBeAdded(userNames, URL.wr_backendOfflineLearnMore.absoluteString)
+    private static func configureContent(for failedUsers: [UserType]) -> NSAttributedString {
+        let keyString = "content.system.failedtoadd_participants.could_not_be_added"
+
+        let userNames = failedUsers.compactMap { $0.name }
+        let userNamesJoined = userNames.joined(separator: ", ")
+        let text = keyString.localized(args: userNames.count, userNamesJoined)
+
+        let attributedText: NSAttributedString = .markdown(from: text, style: .errorLabelStyle)
+                                                 .adding(font: .mediumSemiboldFont, to: userNamesJoined)
+        let learnMore = NSAttributedString(string: SystemContent.FailedParticipants.learnMore,
+                                           attributes: [.font: UIFont.mediumSemiboldFont,
+                                                        .link: URL.wr_backendOfflineLearnMore])
+
+        return [attributedText, learnMore].joined(separator: " ".attributedString)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCell.swift
@@ -1123,12 +1123,12 @@ final class ConversationFailedToAddParticipantsCellDescription: ConversationMess
     }
 
     private static func configureTitle(for failedUsers: [UserType]) -> NSAttributedString? {
-        if failedUsers.count > 1 {
-            let title = SystemContent.FailedtoaddParticipants.count(failedUsers.count)
-            return .markdown(from: title, style: .errorLabelStyle)
-        } else {
+        guard failedUsers.count > 1 else {
             return nil
         }
+
+        let title = SystemContent.FailedtoaddParticipants.count(failedUsers.count)
+        return .markdown(from: title, style: .errorLabelStyle)
     }
 
     private static func configureContent(for failedUsers: [UserType]) -> NSAttributedString {
@@ -1138,11 +1138,8 @@ final class ConversationFailedToAddParticipantsCellDescription: ConversationMess
         let userNamesJoined = userNames.joined(separator: ", ")
         let text = keyString.localized(args: userNames.count, userNamesJoined)
 
-        let attributedText: NSAttributedString = .markdown(from: text, style: .errorLabelStyle)
-                                                 .adding(font: .mediumSemiboldFont, to: userNamesJoined)
-        let learnMore = NSAttributedString(string: SystemContent.FailedParticipants.learnMore,
-                                           attributes: [.font: UIFont.mediumSemiboldFont,
-                                                        .link: URL.wr_backendOfflineLearnMore])
+        let attributedText = NSAttributedString.errorSystemMessage(withText: text, andHighlighted: userNamesJoined)
+        let learnMore = NSAttributedString.unreachableBackendLearnMoreLink
 
         return [attributedText, learnMore].joined(separator: " ".attributedString)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/FailedUsersSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/FailedUsersSystemMessageCell.swift
@@ -25,8 +25,8 @@ final class FailedUsersSystemMessageCell: UIView, ConversationMessageCell {
     typealias FailedtosendParticipants = L10n.Localizable.Content.System.FailedtosendParticipants
 
     struct Configuration {
-        let title: String?
-        let content: String
+        let title: NSAttributedString?
+        let content: NSAttributedString
         let isCollapsed: Bool
         let icon: UIImage?
         let buttonAction: Completion
@@ -85,15 +85,15 @@ final class FailedUsersSystemMessageCell: UIView, ConversationMessageCell {
         imageView.image = config.icon?.withTintColor(SemanticColors.Label.textErrorDefault)
 
         guard let title = config.title else {
-            usersView.attributedText = .markdown(from: config.content, style: .errorLabelStyle)
+            usersView.attributedText = config.content
             [totalCountView, button].forEach { $0.isHidden = true }
             return
         }
 
         [totalCountView, button].forEach { $0.isHidden = false }
         usersView.isHidden = isCollapsed
-        totalCountView.attributedText = .markdown(from: title, style: .errorLabelStyle)
-        usersView.attributedText = .markdown(from: config.content, style: .errorLabelStyle)
+        totalCountView.attributedText = title
+        usersView.attributedText = config.content
         setupButtonTitle()
 
         layoutIfNeeded()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -125,7 +125,7 @@ class MessageToolboxDataSource {
                 detailsString = FailedToSendMessage.generalReason
             case .federationRemoteError:
                 detailsString = FailedToSendMessage.federationRemoteErrorReason(message.conversationLike?.domain ?? "",
-                                                                                URL.wr_backendOfflineLearnMore.absoluteString)
+                                                                                URL.wr_unreachableBackendLearnMore.absoluteString)
             }
 
             content = .sendFailure(detailsString && attributes)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3722" title="WPB-3722" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-3722</a>  [iOS] Create Mandarin release branch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…ral and singular options

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some of the new strings are the same for plural and singular in English, but not in German. We should ensure that they can be translated separately into German and other languages.

### Solutions

- move these strings to `stringsdict`,
- provide custom formatting for them (user names should be bold)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
