### PR TITLE
fix: Failing to build and run Test Suite in Request Strategy because of reaction changes

### DIFF
--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -55,7 +55,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
 
     func reactionEventInOneOnOneConversation() -> ZMUpdateEvent {
         let message = try! oneOnOneConversation.appendText(content: "text") as! ZMClientMessage
-        let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "❤️", messageID: message.nonce!) as! MessageCapable)
+        let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as! MessageCapable)
         let event = createUpdateEvent(UUID.create(), conversationID: oneOnOneConversation.remoteIdentifier!, genericMessage: reaction, senderID: sender.remoteIdentifier!)
         return event
     }
@@ -64,7 +64,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
 
         // given
         let message = try! conversation.appendText(content: "text") as! ZMClientMessage
-        let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "❤️", messageID: message.nonce!) as! MessageCapable)
+        let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as! MessageCapable)
         let event = createUpdateEvent(UUID.create(), conversationID: conversation.remoteIdentifier!, genericMessage: reaction, senderID: aSender.remoteIdentifier!)
 
         // when
@@ -79,7 +79,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
 
         // given
         let message = try! conversation.appendText(content: "text") as! ZMClientMessage
-        let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "❤️", messageID: message.nonce!) as! MessageCapable)
+        let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as! MessageCapable)
         let event = createUpdateEvent(UUID.create(), conversationID: conversation.remoteIdentifier!, genericMessage: reaction, senderID: aSender.remoteIdentifier!)
 
         // when
@@ -300,7 +300,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         // given
         syncMOC.performGroupedBlockAndWait {
             let message = try! self.oneOnOneConversation.appendText(content: "text") as! ZMClientMessage
-            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "liked", messageID: message.nonce!) as! MessageCapable)
+            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as! MessageCapable)
             let eventNonce = UUID.create()
             let event = self.createUpdateEvent(eventNonce, conversationID: self.oneOnOneConversation.remoteIdentifier!, genericMessage: reaction, senderID: self.sender.remoteIdentifier!)
 
@@ -366,7 +366,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         // given
         syncMOC.performGroupedBlockAndWait {
             let message = try! self.oneOnOneConversation.appendText(content: "text") as! ZMClientMessage
-            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "", messageID: message.nonce!) as! MessageCapable)
+            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: [], messageID: message.nonce!) as MessageCapable)
             let event = self.createUpdateEvent(UUID.create(), conversationID: self.oneOnOneConversation.remoteIdentifier!, genericMessage: reaction, senderID: self.sender.remoteIdentifier!)
 
             // when
@@ -382,7 +382,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         // given
         syncMOC.performGroupedBlockAndWait {
             let message = try! self.oneOnOneConversation.appendText(content: "text") as! ZMClientMessage
-            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "❤️", messageID: message.nonce!) as! MessageCapable)
+            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as MessageCapable)
             let event = self.createUpdateEvent(UUID.create(), conversationID: self.oneOnOneConversation.remoteIdentifier!, genericMessage: reaction, senderID: self.selfUser.remoteIdentifier!)
 
             // when
@@ -400,7 +400,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
             let message = try! self.oneOnOneConversation.appendText(content: "text") as! ZMClientMessage
             message.sender = self.otherUser1
 
-            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emoji: "❤️", messageID: message.nonce!) as! MessageCapable)
+            let reaction = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as MessageCapable)
             let event = self.createUpdateEvent(UUID.create(), conversationID: self.oneOnOneConversation.remoteIdentifier!, genericMessage: reaction, senderID: self.sender.remoteIdentifier!)
 
             // when


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

While working on Reactions we made changes in Data Model, Sync Engine but not to Request Strategy. Because of that, RS tests never ran on CI and I didn't run them individually. When we merged to develop I saw some errors in Request Strategy. With this PR we fix those errors. 





















----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
