### PR TITLE
fix: can not create new mls conversation

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+ConversationTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+ConversationTests.swift
@@ -904,6 +904,11 @@ class PayloadProcessing_ConversationTests: MessagingTestBase {
     func testUpdateOrCreate_withMLSSelfGroupEpoch1_callsMLSServiceJoinGroup() {
         let mockMLS = internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 1)
 
+        let didJoinGroup = XCTestExpectation(description: "didJoinGroup")
+        mockMLS.mockJoinGroup = { _ in didJoinGroup.fulfill() }
+
+        wait(for: [didJoinGroup], timeout: 0.5)
+
         // then
         XCTAssertFalse(mockMLS.calls.joinGroup.isEmpty)
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
@@ -207,7 +207,7 @@ final class CreateGroupConversationActionHandler: ActionHandler<CreateGroupConve
             // Self user is creator, so we don't need to process a welcome message
             newConversation.mlsStatus = .ready
 
-            guard let mlsService = context.mlsService else {
+            guard let mlsService = context.zm_sync.mlsService else {
                 Logging.mls.warn("failed to create mls group: mlsService doesn't exist")
                 action.fail(with: .proccessingError)
                 return

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
@@ -139,8 +139,10 @@ class MockMLSService: MLSServiceInterface {
         calls.joinNewGroup.append(groupID)
     }
 
+    var mockJoinGroup: ((MLSGroupID) throws -> Void)?
     func joinGroup(with groupID: MLSGroupID) async throws {
         calls.joinGroup.append(groupID)
+        try mockJoinGroup?(groupID)
     }
 
     func leaveSubconversation(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Can't create new mls conversation.

### Causes

The mls service isn't available because we try to get it from the view context, but it's only available on the sync context.

### Solutions

Get it from the sync context.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
