### PR TITLE
fix: cherry pick reactions layout fix

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Components/GridLayoutView.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/GridLayoutView.swift
@@ -27,7 +27,7 @@ public final class GridLayoutView: UIView {
 
     // MARK: - Properties
 
-    var verticalSpacing: CGFloat = 0
+    var verticalSpacing: CGFloat = 4
     var horizontalSpacing: CGFloat = 4
 
     private(set) var views = [UIView]()
@@ -40,21 +40,6 @@ public final class GridLayoutView: UIView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
-
-    private lazy var heightConstraint: NSLayoutConstraint = {
-        let constraint = heightAnchor.constraint(equalToConstant: 0)
-        constraint.isActive = true
-        return constraint
-    }()
-
-    private var calculatedHeight: CGFloat = 0 {
-        didSet {
-            guard calculatedHeight != oldValue else { return }
-            setNeedsUpdateConstraints()
-            setNeedsLayout()
-            layoutIfNeeded()
-        }
-    }
 
     // MARK: - Life cycle
 
@@ -73,14 +58,7 @@ public final class GridLayoutView: UIView {
     }
 
     // MARK: - Layout
-
-    public override func updateConstraints() {
-        super.updateConstraints()
-        heightConstraint.constant = calculatedHeight
-    }
-
     public func prepareForReuse() {
-        calculatedHeight = 0
         stackView.removeArrangedSubviews()
         views.removeAll(keepingCapacity: true)
     }
@@ -91,39 +69,33 @@ public final class GridLayoutView: UIView {
         setNeedsLayout()
         layoutIfNeeded()
     }
-
+    
+    public var widthForCalculations: CGFloat = 0
+    
     public override func layoutSubviews() {
         super.layoutSubviews()
-        stackView.removeArrangedSubviews()
 
         guard !views.isEmpty else { return }
 
+        stackView.removeArrangedSubviews()
+
         var lineWidth: CGFloat = 0
-        var maxHeight: CGFloat = 0
-        var totalHeight: CGFloat = 0
 
         var currentLineStackView = createNewRow()
         stackView.addArrangedSubview(currentLineStackView)
 
         for view in views {
-            view.setNeedsLayout()
-            view.layoutIfNeeded()
+            let viewSize = view.systemLayoutSizeFitting(currentLineStackView.bounds.size)
 
-            if lineWidth + view.frame.width > frame.width {
+            if lineWidth + viewSize.width > widthForCalculations {
                 currentLineStackView = createNewRow()
                 stackView.addArrangedSubview(currentLineStackView)
-                totalHeight += maxHeight + verticalSpacing
                 lineWidth = 0
-                maxHeight = 0
             }
 
             currentLineStackView.addArrangedSubview(view)
-            lineWidth += view.frame.width + horizontalSpacing
-            maxHeight = max(view.frame.height, maxHeight)
+            lineWidth += viewSize.width + horizontalSpacing
         }
-
-        totalHeight += maxHeight
-        calculatedHeight = totalHeight
     }
 
     private func createNewRow() -> UIStackView {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
@@ -102,5 +102,24 @@ final class MessageReactionsCell: UIView, ConversationMessageCell {
 
         reactionsView.configure(views: reactionToggles)
     }
-
+    
+    func prepareForReuse() {
+        reactionsView.prepareForReuse()
+    }
+    
+    override func systemLayoutSizeFitting(
+        _ targetSize: CGSize,
+        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
+        verticalFittingPriority: UILayoutPriority
+    ) -> CGSize {
+        let insetsWidth = insets.left + insets.right
+        reactionsView.widthForCalculations = targetSize.width - insetsWidth
+        reactionsView.setNeedsLayout()
+        reactionsView.layoutIfNeeded()
+        return super.systemLayoutSizeFitting(
+            CGSize(width: targetSize.width - insetsWidth, height: UIView.noIntrinsicMetric),
+            withHorizontalFittingPriority: horizontalFittingPriority,
+            verticalFittingPriority: verticalFittingPriority
+        )
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -70,6 +70,8 @@ protocol ConversationMessageCell: AnyObject {
 
     /// Called after the cell as been moved off screen.
     func didEndDisplaying()
+    
+    func prepareForReuse()
 }
 
 extension ConversationMessageCell {
@@ -92,6 +94,10 @@ extension ConversationMessageCell {
 
     func didEndDisplaying() {
         // to be overriden
+    }
+    
+    func prepareForReuse() {
+        
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -253,7 +253,16 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
         // other gesture recognizers the opportunity to fire.
         return cellDescription?.actionController?.singleTapAction != nil
     }
-
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        cellView.prepareForReuse()
+    }
+    
+    override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
+        _ = cellView.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+        return super.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
+    }
 }
 
 extension UITableView {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Cherry picking fix already added to develop in https://github.com/wireapp/wire-ios-mono/pull/437 
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
