### PR TITLE
fix: multithreading violation when inserting a message on degraded conversation

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMMessage+Insert.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMMessage+Insert.swift
@@ -35,7 +35,7 @@ extension ZMMessage {
             syncMoc.performGroupedBlock {
                 guard let message = (try? syncMoc.existingObject(with: self.objectID)) as? ZMOTRMessage else { return }
                 message.causedSecurityLevelDegradation = true
-                WireLogger.messaging.warn("expiring message because inserting into degraded conversation \(self.nonce?.transportString().readableHash)")
+                WireLogger.messaging.warn("expiring message because inserting into degraded conversation \(message.nonce?.transportString().readableHash)")
                 message.expire()
                 syncMoc.saveOrRollback()
                 NotificationDispatcher.notifyNonCoreDataChanges(objectID: conversation.objectID, changedKeys: [#keyPath(ZMConversation.securityLevel)], uiContext: uiMoc)


### PR DESCRIPTION
…nversation

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When inserting a message on a degraded MLS conversation, the app crashes.

### Causes

A log statement uses `self.nonce` which belongs to another context (view) than the one it's currently on (sync).

### Solutions

Use the `nonce` property from the object from the sync context.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
