### PR TITLE
fix: Get rid of remaining tests regarding reaction notifications

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/LocalNotificationDispatcherTests.swift
@@ -326,7 +326,7 @@ extension LocalNotificationDispatcherTests {
         XCTAssertTrue(self.scheduledRequests.first!.content.body.contains(text))
     }
 
-    func testThatItDoesNotCreateNotificationForOtherGroupParticipation() { //
+    func testThatItDoesNotCreateNotificationForOtherGroupParticipation() {
         // GIVEN
         let payload: [String: Any] = [
             "from": self.user1.remoteIdentifier.transportString(),
@@ -348,31 +348,6 @@ extension LocalNotificationDispatcherTests {
 
         // THEN
         XCTAssertEqual(self.scheduledRequests.count, 0)
-    }
-
-    func testThatItCancelsNotificationWhenUserDeletesLike() {
-        let conversation = ZMConversation.insertNewObject(in: self.syncMOC)
-        conversation.remoteIdentifier = UUID.create()
-        let sender = ZMUser.insertNewObject(in: self.syncMOC)
-        sender.remoteIdentifier = UUID.create()
-
-        let message = try! conversation.appendText(content: "text") as! ZMClientMessage
-
-        let reaction1 = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: ["❤️"], messageID: message.nonce!) as! MessageCapable)
-        let reaction2 = GenericMessage(content: ProtosReactionFactory.createReaction(emojis: [], messageID: message.nonce!) as! MessageCapable)
-
-        let event1 = createUpdateEvent(UUID.create(), conversationID: conversation.remoteIdentifier!, genericMessage: reaction1, senderID: sender.remoteIdentifier!)
-        let event2 = createUpdateEvent(UUID.create(), conversationID: conversation.remoteIdentifier!, genericMessage: reaction2, senderID: sender.remoteIdentifier!)
-
-        sut.didReceive(events: [event1], conversationMap: [:])
-        XCTAssertEqual(self.scheduledRequests.count, 1)
-        let id = self.scheduledRequests.first!.identifier
-
-        // WHEN
-        sut.didReceive(events: [event2], conversationMap: [:])
-
-        // THEN
-        XCTAssertTrue(self.notificationCenter.removedNotifications.contains(id))
     }
 
     func testThatNotifyAvailabilityBehaviourChangedIfNeededSchedulesNotification_WhenNeedsToNotifyAvailabilityBehaviourChangeIsSet() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

After merging #438 some tests in Sync Engine didn't get removed and failed when running all tests in develop. With this PR I get rid of the remaining tests regarding reaction notifications.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
