### PR TITLE
fix: sending files fails after canceling first file WPB-3691

### DIFF
--- a/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSync.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSync.m
@@ -283,7 +283,7 @@ ZM_EMPTY_ASSERTING_INIT();
         }
         else if (response.result == ZMTransportResponseStatusTemporaryError ||
                  response.result == ZMTransportResponseStatusTryAgainLater) {
-            [self.updatedObjects didNotFinishToSynchronizeToken:token];
+            [self.updatedObjects didFailToSynchronizeToken:token];
         }
         else if (response.result == ZMTransportResponseStatusExpired) {
             [self.updatedObjects didFailToSynchronizeToken:token];

--- a/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSyncTests.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSyncTests.m
@@ -497,7 +497,7 @@ static NSString *foo = @"foo";
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
-- (void)testThatItCallsDidNotFinishToSynchronizeTokenWhenTheRequestFailsWithATemporaryError
+- (void)testThatItCallsDidFailToSynchronizeTokenWhenTheRequestFailsWithATemporaryError
 {
     // given
     [[[(id)self.mockTranscoder stub] andReturnValue:OCMOCK_VALUE(YES)] shouldCreateRequestToSyncObject:OCMOCK_ANY forKeys:OCMOCK_ANY withSync:OCMOCK_ANY];
@@ -515,7 +515,7 @@ static NSString *foo = @"foo";
     [(ZMLocallyModifiedObjectSet *)[[self.mockLocallyModifiedSet expect] andReturn:token] didStartSynchronizingKeys:keysToSync forObject:fakeObjectWithKeys];
     [[[(id)self.mockTranscoder expect] andReturn:fakeRequest] requestForUpdatingObject:entity forKeys:keysToSync apiVersion:APIVersionV0];
     [[(id)self.mockLocallyModifiedSet expect] keysToParseAfterSyncingToken:OCMOCK_ANY];
-    [[self.mockLocallyModifiedSet expect] didNotFinishToSynchronizeToken:token];
+    [[self.mockLocallyModifiedSet expect] didFailToSynchronizeToken:token];
     
     // when
     ZMTransportRequest *request = [self.sut nextRequestForAPIVersion:APIVersionV0];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3691" title="WPB-3691" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3691</a>  [iOS] Sending anything stops working after a file failed to send
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fix for the bug where after cancelling upload of a file (for example video) every next upload fails (without user interaction). Only after killing app and launching it again uploading file starts working again.