### PR TITLE
feat: add bundle identifier to developer tools WPB-4582

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -126,7 +126,8 @@ final class DeveloperToolsViewModel: ObservableObject {
             header: "App info",
             items: [
                 .text(TextItem(title: "App version", value: appVersion)),
-                .text(TextItem(title: "Build number", value: buildNumber))
+                .text(TextItem(title: "Build number", value: buildNumber)),
+                .text(TextItem(title: "Bundle Identifier", value: bundleIdentifier))
             ]
         ))
 
@@ -267,6 +268,10 @@ final class DeveloperToolsViewModel: ObservableObject {
 
     private var appVersion: String {
         return Bundle.main.shortVersionString ?? "Unknown"
+    }
+
+    private var bundleIdentifier: String {
+        return Bundle.main.bundleIdentifier ?? "Unknown"
     }
 
     private var buildNumber: String {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4582" title="WPB-4582" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4582</a>  [iOS] Add bundle id to developer tools
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a lot of apps are installed it is troublesome to know bundle identifier of the app, especially on builds installed from testflight. These bundle ids are required to create deeplinks to connect to other backends.

### Solutions

Add bundle identifier info to Developer Tools (shake gesture) for easy access to bundle id.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
