### PR TITLE
feat: recover from "not able to decrypt a message" WPB-534

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSActionsProvider.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionsProvider.swift
@@ -81,6 +81,11 @@ protocol MLSActionsProviderProtocol {
         context: NotificationContext
     ) async throws
 
+    func syncConversation(
+        qualifiedID: QualifiedID,
+        context: NotificationContext
+    ) async throws
+
 }
 
 final class MLSActionsProvider: MLSActionsProviderProtocol {
@@ -211,6 +216,14 @@ final class MLSActionsProvider: MLSActionsProviderProtocol {
             subconversationType: subconversationType
         )
 
+        try await action.perform(in: context)
+    }
+
+    func syncConversation(
+        qualifiedID: QualifiedID,
+        context: NotificationContext
+    ) async throws {
+        var action = SyncConversationAction(qualifiedID: qualifiedID)
         try await action.perform(in: context)
     }
 

--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -19,6 +19,7 @@
 import Foundation
 import WireCoreCrypto
 import Combine
+import WireSystem
 
 // sourcery: AutoMockable
 public protocol MLSDecryptionServiceInterface {
@@ -72,6 +73,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
 
         case failedToConvertMessageToBytes
         case failedToDecryptMessage
+        case wrongEpoch
 
     }
 
@@ -135,7 +137,12 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
             return nil
         } catch {
             WireLogger.mls.error("failed to decrypt message for group (\(groupID)) and subconversation type (\(String(describing: subconversationType)): \(String(describing: error))")
-            throw MLSMessageDecryptionError.failedToDecryptMessage
+
+            if case CryptoError.WrongEpoch(message: _) = error {
+                throw MLSMessageDecryptionError.wrongEpoch
+            } else {
+                throw MLSMessageDecryptionError.failedToDecryptMessage
+            }
         }
     }
 

--- a/wire-ios-data-model/Source/MLS/MLSGroupID.swift
+++ b/wire-ios-data-model/Source/MLS/MLSGroupID.swift
@@ -66,6 +66,14 @@ extension MLSGroupID: CustomStringConvertible {
 
 }
 
+extension MLSGroupID: SafeForLoggingStringConvertible {
+
+    public var safeForLoggingDescription: String {
+        data.readableHash
+    }
+
+}
+
 public extension MLSGroupID {
 
     static func random() -> MLSGroupID {

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -840,23 +840,6 @@ public final class MLSService: MLSServiceInterface {
         }
     }
 
-    private var conversationsBeingRepaired = Set<MLSGroupID>()
-
-    private func launchConversationRepairTaskIfNotInProgress(
-        for groupID: MLSGroupID,
-        repairOperation: @escaping () async -> Void
-    ) {
-        guard !conversationsBeingRepaired.contains(groupID) else {
-            return
-        }
-
-        Task {
-            conversationsBeingRepaired.insert(groupID)
-            await repairOperation()
-            conversationsBeingRepaired.remove(groupID)
-        }
-    }
-
     func fetchAndRepairConversation(
         with groupID: MLSGroupID,
         subconversationType: SubgroupType?
@@ -964,6 +947,23 @@ public final class MLSService: MLSServiceInterface {
             logger.info("repaired out of sync subgroup! (parent: \(parentGroupID.safeForLoggingDescription), subgroup: \(subgroup.groupID.safeForLoggingDescription))")
         } catch {
             logger.warn("failed to repair subgroup (parent: \(parentGroupID.safeForLoggingDescription)). error: \(String(describing: error))")
+        }
+    }
+
+    private var conversationsBeingRepaired = Set<MLSGroupID>()
+
+    private func launchConversationRepairTaskIfNotInProgress(
+        for groupID: MLSGroupID,
+        repairOperation: @escaping () async -> Void
+    ) {
+        guard !conversationsBeingRepaired.contains(groupID) else {
+            return
+        }
+
+        Task {
+            conversationsBeingRepaired.insert(groupID)
+            await repairOperation()
+            conversationsBeingRepaired.remove(groupID)
         }
     }
 

--- a/wire-ios-data-model/Source/Model/Conversation/Actions/AddParticipantAction.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Actions/AddParticipantAction.swift
@@ -16,18 +16,21 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 
-public enum ConversationAddParticipantsError: Error {
-    case unknown,
-         invalidOperation,
-         accessDenied,
-         notConnectedToUser,
-         conversationNotFound,
-         tooManyMembers,
-         missingLegalHoldConsent,
-         failedToAddMLSMembers
+public enum ConversationAddParticipantsError: Error, Equatable {
+
+    case unknown
+    case invalidOperation
+    case accessDenied
+    case notConnectedToUser
+    case conversationNotFound
+    case tooManyMembers
+    case missingLegalHoldConsent
+    case failedToAddMLSMembers
+    case unreachableDomains(Set<String>)
+    case nonFederatingDomains(Set<String>)
+
 }
 
 public class AddParticipantAction: EntityAction {

--- a/wire-ios-data-model/Source/Model/Conversation/Actions/AddParticipantAction.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Actions/AddParticipantAction.swift
@@ -1,0 +1,46 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public enum ConversationAddParticipantsError: Error {
+    case unknown,
+         invalidOperation,
+         accessDenied,
+         notConnectedToUser,
+         conversationNotFound,
+         tooManyMembers,
+         missingLegalHoldConsent,
+         failedToAddMLSMembers
+}
+
+public class AddParticipantAction: EntityAction {
+    public var resultHandler: ResultHandler?
+
+    public typealias Result = Void
+    public typealias Failure = ConversationAddParticipantsError
+
+    public let userIDs: [NSManagedObjectID]
+    public let conversationID: NSManagedObjectID
+
+    public required init(users: [ZMUser], conversation: ZMConversation) {
+        userIDs = users.map(\.objectID)
+        conversationID = conversation.objectID
+    }
+}

--- a/wire-ios-data-model/Source/Model/Conversation/Actions/RemoveParticipantAction.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Actions/RemoveParticipantAction.swift
@@ -1,0 +1,42 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+public enum ConversationRemoveParticipantError: Error {
+    case unknown,
+         invalidOperation,
+         conversationNotFound,
+         failedToRemoveMLSMembers
+}
+
+public class RemoveParticipantAction: EntityAction {
+    public var resultHandler: ResultHandler?
+
+    public typealias Result = Void
+    public typealias Failure = ConversationRemoveParticipantError
+
+    public let userID: NSManagedObjectID
+    public let conversationID: NSManagedObjectID
+
+    public required init(user: ZMUser, conversation: ZMConversation) {
+        userID = user.objectID
+        conversationID = conversation.objectID
+    }
+}

--- a/wire-ios-data-model/Source/Model/Conversation/Actions/SyncConversationAction.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Actions/SyncConversationAction.swift
@@ -1,5 +1,6 @@
+////
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,11 +21,11 @@ import Foundation
 /// Fetches the metadata of a single conversation and stores it locally
 /// in the database.
 
-final class SyncConversationAction: EntityAction {
+public final class SyncConversationAction: EntityAction {
 
-    typealias Result = Void
+    public typealias Result = Void
 
-    enum Failure: Error, Equatable {
+    public enum Failure: Error, Equatable {
 
         case malformedRequestPayload
         case invalidBody
@@ -36,12 +37,12 @@ final class SyncConversationAction: EntityAction {
 
     // MARK: - Properties
 
-    let qualifiedID: QualifiedID
-    var resultHandler: ResultHandler?
+    public let qualifiedID: QualifiedID
+    public var resultHandler: ResultHandler?
 
     // MARK: - Life cycle
 
-    init(
+    public init(
         qualifiedID: QualifiedID,
         resultHandler: ResultHandler? = nil
     ) {

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -19,60 +19,6 @@
 import Foundation
 import WireProtos
 
-public class AddParticipantAction: EntityAction {
-    public var resultHandler: ResultHandler?
-
-    public typealias Result = Void
-    public typealias Failure = ConversationAddParticipantsError
-
-    public let userIDs: [NSManagedObjectID]
-    public let conversationID: NSManagedObjectID
-
-    public required init(users: [ZMUser], conversation: ZMConversation) {
-        userIDs = users.map(\.objectID)
-        conversationID = conversation.objectID
-    }
-}
-
-public enum ConversationAddParticipantsError: Error, Equatable {
-
-    case unknown
-    case invalidOperation
-    case accessDenied
-    case notConnectedToUser
-    case conversationNotFound
-    case tooManyMembers
-    case missingLegalHoldConsent
-    case failedToAddMLSMembers
-    case unreachableDomains(Set<String>)
-    case nonFederatingDomains(Set<String>)
-
-}
-
-public class RemoveParticipantAction: EntityAction {
-    public var resultHandler: ResultHandler?
-
-    public typealias Result = Void
-    public typealias Failure = ConversationRemoveParticipantError
-
-    public let userID: NSManagedObjectID
-    public let conversationID: NSManagedObjectID
-
-    public required init(user: ZMUser, conversation: ZMConversation) {
-        userID = user.objectID
-        conversationID = conversation.objectID
-    }
-}
-
-public enum ConversationRemoveParticipantError: Error {
-
-    case unknown
-    case invalidOperation
-    case conversationNotFound
-    case failedToRemoveMLSMembers
-
-}
-
 class MLSClientIDsProvider {
 
     func fetchUserClients(

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -2567,8 +2567,6 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     // MARK: - Guest links
 
     func test_ItJoinsNewGroupForGuestLinkWhenConversationDoesNotExist() async throws {
-        BackendInfo.domain = "example.com"
-
         // Given
         let groupID = MLSGroupID.random()
         var conversation: ZMConversation!
@@ -2578,6 +2576,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation = createConversation(in: uiMOC)
             conversation.mlsGroupID = groupID
             conversation.messageProtocol = .mls
+            conversation.domain = "example.com"
         }
 
         let expectation1 = self.expectation(description: "CreateConversation should be called")
@@ -2618,8 +2617,6 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     }
 
     func test_ItJoinsNewGroupForGuestLinkWhenConversationExists() async throws {
-        BackendInfo.domain = "example.com"
-
         // Given
         let groupID = MLSGroupID.random()
         var conversation: ZMConversation!
@@ -2629,6 +2626,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation = createConversation(in: uiMOC)
             conversation.mlsGroupID = groupID
             conversation.messageProtocol = .mls
+            conversation.domain = "example.com"
         }
 
         mockMLSActionExecutor.mockJoinGroup = { _, _ in

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -329,6 +329,9 @@
 		63B658E0243789DE00EF463F /* GenericMessage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */; };
 		63BEF5872A2636BC00F482E8 /* MLSConferenceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */; };
 		63C07015291144F70075D598 /* CoreCryptoConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */; };
+		63C2EABD2A93B174008A0AB7 /* AddParticipantAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C2EABC2A93B174008A0AB7 /* AddParticipantAction.swift */; };
+		63C2EABF2A93B1E7008A0AB7 /* RemoveParticipantAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C2EABE2A93B1E7008A0AB7 /* RemoveParticipantAction.swift */; };
+		63C2EAC12A93B244008A0AB7 /* SyncConversationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C2EAC02A93B244008A0AB7 /* SyncConversationAction.swift */; };
 		63CA8215240812620073426A /* ZMClientMessage+Composite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CA8214240812620073426A /* ZMClientMessage+Composite.swift */; };
 		63D41E4F2452EA080076826F /* ZMConversation+SelfConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D41E4E2452EA080076826F /* ZMConversation+SelfConversation.swift */; };
 		63D41E512452F0A60076826F /* ZMMessage+Removal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D41E502452F0A60076826F /* ZMMessage+Removal.swift */; };
@@ -1202,6 +1205,9 @@
 		63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Assets.swift"; sourceTree = "<group>"; };
 		63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSConferenceInfo.swift; sourceTree = "<group>"; };
 		63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoConfigProviderTests.swift; sourceTree = "<group>"; };
+		63C2EABC2A93B174008A0AB7 /* AddParticipantAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddParticipantAction.swift; sourceTree = "<group>"; };
+		63C2EABE2A93B1E7008A0AB7 /* RemoveParticipantAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveParticipantAction.swift; sourceTree = "<group>"; };
+		63C2EAC02A93B244008A0AB7 /* SyncConversationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConversationAction.swift; sourceTree = "<group>"; };
 		63CA8214240812620073426A /* ZMClientMessage+Composite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Composite.swift"; sourceTree = "<group>"; };
 		63D41E4E2452EA080076826F /* ZMConversation+SelfConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+SelfConversation.swift"; sourceTree = "<group>"; };
 		63D41E502452F0A60076826F /* ZMMessage+Removal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Removal.swift"; sourceTree = "<group>"; };
@@ -2100,6 +2106,16 @@
 			path = Actions;
 			sourceTree = "<group>";
 		};
+		63C2EABB2A93B14D008A0AB7 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				63C2EABC2A93B174008A0AB7 /* AddParticipantAction.swift */,
+				63C2EABE2A93B1E7008A0AB7 /* RemoveParticipantAction.swift */,
+				63C2EAC02A93B244008A0AB7 /* SyncConversationAction.swift */,
+			);
+			path = Actions;
+			sourceTree = "<group>";
+		};
 		A90676E5238EAE63006417AC /* ConversationRole */ = {
 			isa = PBXGroup;
 			children = (
@@ -2462,6 +2478,7 @@
 		F9A705D91CAEE01D00C2F5FE /* Conversation */ = {
 			isa = PBXGroup;
 			children = (
+				63C2EABB2A93B14D008A0AB7 /* Actions */,
 				A943BBE725B5A59D003D66BA /* ConversationLike.swift */,
 				F1103BD82135471A00EB9ED6 /* Calling */,
 				EECA82FD26EF34E20087ECB0 /* SelfDeletingMessages */,
@@ -3761,6 +3778,7 @@
 				5E771F382080BB0000575629 /* PBMessage+Validation.swift in Sources */,
 				BF10B5971E64591600E7036E /* AnalyticsType.swift in Sources */,
 				16313D621D227DC1001B2AB3 /* LinkPreview+ProtocolBuffer.swift in Sources */,
+				63C2EABF2A93B1E7008A0AB7 /* RemoveParticipantAction.swift in Sources */,
 				F1FDF2F721B152BC00E037A1 /* GenericMessage+Helper.swift in Sources */,
 				16030DC521AEE25500F8032E /* ZMOTRMessage+Confirmations.swift in Sources */,
 				D5FA30C52063DC2D00716618 /* BackupMetadata.swift in Sources */,
@@ -3899,6 +3917,7 @@
 				018964252A6FE72700BCEE0E /* EARStorage.swift in Sources */,
 				EE2BA00625CB3AA8001EB606 /* InvalidFeatureRemoval.swift in Sources */,
 				EE8B09AD25B86AB10057E85C /* AppLockError.swift in Sources */,
+				63C2EABD2A93B174008A0AB7 /* AddParticipantAction.swift in Sources */,
 				1687ABAE20ECD51E0007C240 /* ZMSearchUser.swift in Sources */,
 				163C92AA2630A80400F8DC14 /* NSManagedObjectContext+SelfUser.swift in Sources */,
 				63298D9E24374489006B6018 /* Dictionary+ObjectForKey.swift in Sources */,
@@ -4048,6 +4067,7 @@
 				F9A706B21CAEE01D00C2F5FE /* NewUnreadMessageChangeInfos.swift in Sources */,
 				EE8B09AF25B86BB20057E85C /* AppLockPasscodePreference.swift in Sources */,
 				7C8BFFDF22FC5E1600B3C8A5 /* ZMUser+Validation.swift in Sources */,
+				63C2EAC12A93B244008A0AB7 /* SyncConversationAction.swift in Sources */,
 				161541BA1E27EBD400AC2FFB /* ZMConversation+Calling.swift in Sources */,
 				BFF8AE8520E4E12A00988700 /* ZMMessage+ShouldDisplay.swift in Sources */,
 			);

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -1054,6 +1054,26 @@ class MockMLSActionsProviderProtocol: MLSActionsProviderProtocol {
         }
 
         try await mock(conversationID, domain, subconversationType, context)            
+    }
+
+    // MARK: - syncConversation
+
+    var syncConversationQualifiedIDContext_Invocations: [(qualifiedID: QualifiedID, context: NotificationContext)] = []
+    var syncConversationQualifiedIDContext_MockError: Error?
+    var syncConversationQualifiedIDContext_MockMethod: ((QualifiedID, NotificationContext) async throws -> Void)?
+
+    func syncConversation(qualifiedID: QualifiedID, context: NotificationContext) async throws {
+        syncConversationQualifiedIDContext_Invocations.append((qualifiedID: qualifiedID, context: context))
+
+        if let error = syncConversationQualifiedIDContext_MockError {
+            throw error
+        }
+
+        guard let mock = syncConversationQualifiedIDContext_MockMethod else {
+            fatalError("no mock for `syncConversationQualifiedIDContext`")
+        }
+
+        try await mock(qualifiedID, context)            
     }
 
 }

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+Conversation.swift
@@ -194,16 +194,19 @@ extension Payload.Conversation {
     }
 
     func createOrJoinSelfConversation(from conversation: ZMConversation) {
-        guard let groupId = conversation.mlsGroupID,
-              let mlsService = conversation.managedObjectContext?.mlsService else {
+        guard
+            let groupId = conversation.mlsGroupID,
+            let mlsService = conversation.managedObjectContext?.mlsService
+        else {
             WireLogger.mls.warn("no mlsService to createOrJoinSelfConversation")
             return
         }
+
         WireLogger.mls.debug("createOrJoinSelfConversation for \(groupId); conv payload: \(String(describing: self))")
 
         if conversation.epoch <= 0 {
             mlsService.createSelfGroup(for: groupId)
-        } else {
+        } else if !mlsService.conversationExists(groupID: groupId) {
             Task {
                 try await mlsService.joinGroup(with: groupId)
             }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import WireDataModel
 
 final class SyncConversationActionHandler: ActionHandler<SyncConversationAction> {
 

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -264,7 +264,6 @@
 		EEB5DE05283773C3009B4741 /* GetFeatureConfigsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB5DE04283773C3009B4741 /* GetFeatureConfigsAction.swift */; };
 		EEB5DE0728377635009B4741 /* GetFeatureConfigsActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB5DE0628377635009B4741 /* GetFeatureConfigsActionHandler.swift */; };
 		EEB5DE0F28379A19009B4741 /* GetFeatureConfigsActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB5DE0E28379A19009B4741 /* GetFeatureConfigsActionHandlerTests.swift */; };
-		EECBE8EC28E71ED7005DE5DD /* SyncConversationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECBE8EB28E71ED7005DE5DD /* SyncConversationAction.swift */; };
 		EECBE8EE28E71F19005DE5DD /* SyncConversationActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECBE8ED28E71F19005DE5DD /* SyncConversationActionHandler.swift */; };
 		EECBE8F028E71F57005DE5DD /* SyncConversationActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECBE8EF28E71F57005DE5DD /* SyncConversationActionHandlerTests.swift */; };
 		EEDE7DAD28EAE538007DC6A3 /* ConversationEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEDE7DAC28EAE538007DC6A3 /* ConversationEventProcessorTests.swift */; };
@@ -703,7 +702,6 @@
 		EEB5DE04283773C3009B4741 /* GetFeatureConfigsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFeatureConfigsAction.swift; sourceTree = "<group>"; };
 		EEB5DE0628377635009B4741 /* GetFeatureConfigsActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFeatureConfigsActionHandler.swift; sourceTree = "<group>"; };
 		EEB5DE0E28379A19009B4741 /* GetFeatureConfigsActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFeatureConfigsActionHandlerTests.swift; sourceTree = "<group>"; };
-		EECBE8EB28E71ED7005DE5DD /* SyncConversationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConversationAction.swift; sourceTree = "<group>"; };
 		EECBE8ED28E71F19005DE5DD /* SyncConversationActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConversationActionHandler.swift; sourceTree = "<group>"; };
 		EECBE8EF28E71F57005DE5DD /* SyncConversationActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncConversationActionHandlerTests.swift; sourceTree = "<group>"; };
 		EEDE7DAC28EAE538007DC6A3 /* ConversationEventProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationEventProcessorTests.swift; sourceTree = "<group>"; };
@@ -1153,7 +1151,6 @@
 				06A9FDD128B36FF500B3C730 /* UpdateAccessRolesAction.swift */,
 				06A9FDD328B3701000B3C730 /* UpdateAccessRolesActionHandler.swift */,
 				06A9FDD528B3702700B3C730 /* UpdateAccessRolesActionHandlerTests.swift */,
-				EECBE8EB28E71ED7005DE5DD /* SyncConversationAction.swift */,
 				EECBE8ED28E71F19005DE5DD /* SyncConversationActionHandler.swift */,
 				EECBE8EF28E71F57005DE5DD /* SyncConversationActionHandlerTests.swift */,
 				EE7F02262A80E5F400FE5695 /* CreateGroupConversationActionHandler.swift */,
@@ -1942,7 +1939,6 @@
 				EEE0EE0528591D3200BBEE29 /* OptionalString+NonEmptyValue.swift in Sources */,
 				168D7CB226FB0E3F00789960 /* EntityActionSync.swift in Sources */,
 				168D7CBB26FB21D900789960 /* RemoveParticipantActionHandler.swift in Sources */,
-				EECBE8EC28E71ED7005DE5DD /* SyncConversationAction.swift in Sources */,
 				F963E8E11D955D5500098AD3 /* SharedProtocols.swift in Sources */,
 				166901F21D7081C7000FE4AF /* ZMUpstreamModifiedObjectSync.m in Sources */,
 				063139DD2A56BD380083D5D2 /* PayloadProcessing+MLSMessageSendingStatus.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-534" title="WPB-534" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-534</a>  [iOS] MLS Client recover from "not able to decrypt a message"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In this PR, we handle the scenario stated below

> A client can detect that it has missed handshake messages when decrypting an incoming message.  The user needs to be informed about potentially missed messages and the broken MLS group needs to be repaired.

When message decryption fails, we check the error. If the error is `WrongEpoch`, we fetch the conversation, verify the epoch is out of sync, then rejoin the conversation and insert a gap message.

We also handle the case of subconversations being out of sync. 

### Changes

- Moved `SyncConversationAction` to DM
- Added methods to fetch and repair a conversation / a subgroup to `MLSService`
- Added handling of the `WrongEpoch` error to `MLSDecryptionService`
- Handling wrong epoch scenario by repairing conversation in `MLSService`
- Conformed `MLSGroupdID` to `SafeForLoggingStringConvertible` for safe and readable logging
- Added condition to join self group only if it doesn't already exist (as a fix for a request loop)

### Testing

- [x] I have added automated test to this contribution




