### PR TITLE
fix: personal user can't log in on API v4 WPB-4665

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
@@ -221,8 +221,10 @@ public final class TeamDownloadRequestStrategy: AbstractRequestStrategy, ZMConte
             return TeamDownloadRequestFactory.getTeamsRequest(apiVersion: apiVersion)
         case .v4, .v5:
             guard let teamID = ZMUser.selfUser(in: managedObjectContext).teamIdentifier else {
+                syncStatus.finishCurrentSyncPhase(phase: expectedSyncPhase)
                 return nil
             }
+
             return TeamDownloadRequestFactory.getRequest(for: [teamID], apiVersion: apiVersion)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4665" title="WPB-4665" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4665</a>  [iOS] API V4 makes personal users unable to log in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Personal users (who don't have a team) are not able to log in when the resolved API version is v4.

### Causes

The teams download endpoint changed in API v4, it now accepts a team id in the path. If there is no team id, then a nil request is returned. However, this request is part of the slow sync, and since we don't inform the sync status that the sync phase isn't complete, the app gets stuck idling.

### Solutions

Inform the sync status that the current sync phase is completed.

### Testing

#### Test Coverage

- Unit tests to assert a nil request and completed sync phase.

#### How to Test

- Make sure you're connected to a backend with API v4 supported.
- Install a client that supports API v4.
- Login with credentials of a personal users.
- Assert that you can reach the conversation list.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
