### PR TITLE
fix: session expired when sending message to defederated backend WPB-4491 (#474)

### DIFF
--- a/wire-ios-transport/Source/Requests/ZMTransportResponse.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportResponse.m
@@ -120,14 +120,6 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 - (ZMTransportResponseStatus)result
 {
-    // TODO: [John] We need to properly handle all federation errors
-    // This is a quick fix to handle remote federation errors. Without it, we would
-    // return a "try again" error, which would cause infinite failures if the
-    // remote federated backend is down.
-    if (self.HTTPStatus == 533) {
-        return ZMTransportResponseStatusPermanentError;
-    }
-
     if (self.transportSessionError) {
         if ([self.transportSessionError.domain isEqualToString:ZMTransportSessionErrorDomain]) {
             switch ((ZMTransportSessionErrorCode) self.transportSessionError.code) {

--- a/wire-ios-transport/Tests/Source/Requests/ZMTransportResponseTests.m
+++ b/wire-ios-transport/Tests/Source/Requests/ZMTransportResponseTests.m
@@ -167,12 +167,6 @@
             continue;
         }
 
-        // TODO: [John] remove this exception when we properly handle
-        // federation errors.
-        if (i == 533) {
-            continue;
-        }
-
         ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         XCTAssertNotEqual(imageResponse.result, ZMTransportResponseStatusPermanentError);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4491" title="WPB-4491" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4491</a>  [iOS] Session expired when sending message while re-syncing with backend that was offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Cherry pick #474

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
