### PR TITLE
feat: fetch and store other users supported protocols WPB-2170

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+SupportedProtocols.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+SupportedProtocols.swift
@@ -48,7 +48,10 @@ extension ZMUser {
             willChangeValue(forKey: Self.supportedProtocolsKey)
             primitiveSupportedProtocols = newValue.map(\.rawValue)
             didChangeValue(forKey: Self.supportedProtocolsKey)
-            setLocallyModifiedKeys([Self.supportedProtocolsKey])
+
+            if isSelfUser {
+                setLocallyModifiedKeys([Self.supportedProtocolsKey])
+            }
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Payload.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload.swift
@@ -168,6 +168,13 @@ enum Payload {
 
     struct UserProfile: Codable {
 
+        enum MessageProtocol: String, Codable {
+
+            case proteus
+            case mls
+
+        }
+
         enum CodingKeys: String, CodingKey, CaseIterable {
             case id
             case qualifiedID = "qualified_id"
@@ -184,6 +191,7 @@ enum Payload {
             case isDeleted = "deleted"
             case expiresAt = "expires_at"
             case legalholdStatus = "legalhold_status"
+            case supportedProtocols = "supported_protocols"
         }
 
         let id: UUID?
@@ -201,6 +209,7 @@ enum Payload {
         let isDeleted: Bool?
         let expiresAt: Date?
         let legalholdStatus: LegalholdStatus?
+        let supportedProtocols: Set<MessageProtocol>?
 
         /// All keys which were present in the original payload even if they
         /// contained a null value.
@@ -224,6 +233,7 @@ enum Payload {
              isDeleted: Bool? = nil,
              expiresAt: Date? = nil,
              legalholdStatus: LegalholdStatus? = nil,
+             supportedProtocols: Set<MessageProtocol>? = nil,
              updatedKeys: Set<CodingKeys>? = nil) {
 
             self.id = id
@@ -241,6 +251,7 @@ enum Payload {
             self.isDeleted = isDeleted
             self.expiresAt = expiresAt
             self.legalholdStatus = legalholdStatus
+            self.supportedProtocols = supportedProtocols
             self.updatedKeys = updatedKeys ?? Set(CodingKeys.allCases)
         }
 
@@ -261,6 +272,7 @@ enum Payload {
             self.isDeleted = try container.decodeIfPresent(Bool.self, forKey: .isDeleted)
             self.expiresAt = try container.decodeIfPresent(Date.self, forKey: .expiresAt)
             self.legalholdStatus = try container.decodeIfPresent(LegalholdStatus.self, forKey: .legalholdStatus)
+            self.supportedProtocols = try container.decodeIfPresent(Set<MessageProtocol>.self, forKey: .supportedProtocols)
             self.updatedKeys = Set(container.allKeys)
         }
     }

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+UserProfile.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+UserProfile.swift
@@ -94,6 +94,10 @@ extension Payload.UserProfile {
 
         updateAssets(for: user, authoritative: authoritative)
 
+        if let supportedProtocols = supportedProtocols {
+            user.supportedProtocols = Set(supportedProtocols.map(\.dataModelMessageProtocol))
+        }
+
         if authoritative {
             user.needsToBeUpdatedFromBackend = false
         }
@@ -139,6 +143,20 @@ extension Payload.UserProfiles {
             }
 
             userProfile.updateUserProfile(for: user)
+        }
+    }
+
+}
+
+private extension Payload.UserProfile.MessageProtocol {
+
+    var dataModelMessageProtocol: WireDataModel.MessageProtocol {
+        switch self {
+        case .proteus:
+            return .proteus
+
+        case .mls:
+            return .mls
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+UserProfileTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/PayloadProcessing+UserProfileTests.swift
@@ -475,4 +475,18 @@ class PayloadProcessing_UserProfileTests: MessagingTestBase {
         }
     }
 
+    func testUpdateUserProfile_UpdatesSupportedProtocols() throws {
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            XCTAssertEqual(self.otherUser.supportedProtocols, [])
+            let userProfile = Payload.UserProfile(supportedProtocols: [.proteus, .mls])
+
+            // when
+            userProfile.updateUserProfile(for: self.otherUser)
+
+            // then
+            XCTAssertEqual(self.otherUser.supportedProtocols, [.proteus, .mls])
+        }
+    }
+
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSConversationGroupInfoActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSConversationGroupInfoActionHandlerTests.swift
@@ -27,20 +27,20 @@ class FetchMLSConversationGroupInfoActionHandlerTests: BaseFetchMLSGroupInfoActi
         action = FetchMLSConversationGroupInfoAction(conversationId: conversationId, domain: domain)
     }
 
-    func test_itGeneratesARequest_APIV4() throws {
+    override func test_itGeneratesARequest_APIV5() throws {
         try test_itGeneratesARequest(
             for: action,
-            expectedPath: "/v4/conversations/\(domain)/\(conversationId.transportString())/groupinfo",
+            expectedPath: "/v5/conversations/\(domain)/\(conversationId.transportString())/groupinfo",
             expectedMethod: .methodGET,
             expectedAcceptType: .messageMLS,
-            apiVersion: .v4
+            apiVersion: .v5
         )
     }
 
-    func test_itDoesntGenerateRequests_APIV3() {
+    func test_itDoesntGenerateRequests_APIV4() {
         test_itDoesntGenerateARequest(
             action: action,
-            apiVersion: .v3,
+            apiVersion: .v4,
             expectedError: .endpointUnavailable
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSSubconversationGroupInfoActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSSubconversationGroupInfoActionHandlerTests.swift
@@ -29,20 +29,20 @@ class FetchMLSSubconversationGroupInfoActionHandlerTests: BaseFetchMLSGroupInfoA
         action = FetchMLSSubconversationGroupInfoAction(conversationId: conversationId, domain: domain, subgroupType: subgroupType)
     }
 
-    func test_itGeneratesARequest_APIV4() throws {
+    override func test_itGeneratesARequest_APIV5() throws {
         try test_itGeneratesARequest(
             for: action,
-            expectedPath: "/v4/conversations/\(domain)/\(conversationId.transportString())/subconversations/\(subgroupType.rawValue)/groupinfo",
+            expectedPath: "/v5/conversations/\(domain)/\(conversationId.transportString())/subconversations/\(subgroupType.rawValue)/groupinfo",
             expectedMethod: .methodGET,
             expectedAcceptType: .messageMLS,
-            apiVersion: .v4
+            apiVersion: .v5
         )
     }
 
-    func test_itDoesntGenerateRequests_APIV3() {
+    func test_itDoesntGenerateRequests_APIV4() {
         test_itDoesntGenerateARequest(
             action: action,
-            apiVersion: .v3,
+            apiVersion: .v4,
             expectedError: .endpointUnavailable
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
@@ -35,8 +35,8 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
             expectedPath: "/v5/mls/commit-bundles",
             expectedMethod: .methodPOST,
             expectedData: commitBundle,
-            apiVersion: .v5
             expectedContentType: "message/mls",
+            apiVersion: .v5
         )
     }
 
@@ -48,7 +48,7 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
                 expectedError: .endpointUnavailable
             )
         }
-        
+
         test_itDoesntGenerateARequest(
             action: SendCommitBundleAction(commitBundle: Data()),
             apiVersion: .v5,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2170" title="WPB-2170" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-2170</a>  [iOS] [Clients] Parse supported protocols when fetching user profiles
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In order to know with who we can establish an MLS 1-1 conversation with, we need to know which message protocols they support. This PR adds support for fetching the supported protocols of other users and persists the values in the database.

### Testing

#### Test Coverage

- Unit test asserting we persist the supported protocols of another users.

#### How to Test

- Be connected with other users who have pushed their supported protocols.
- When fetching their profile metadata (via slow sync or opening their profile page), assert that we see their supported protocols in the database.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
