### PR TITLE
fix: handling missing clients for API v5

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategy.swift
@@ -133,7 +133,7 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
 
                 return prekeys.establishSessions(with: selfClient, context: managedObjectContext)
 
-            case .v1, .v2, .v3, .v5:
+            case .v1, .v2, .v3:
                 guard let rawData = response.rawData,
                       let prekeys = Payload.PrekeyByQualifiedUserID(rawData),
                       let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient()
@@ -143,7 +143,7 @@ public final class MissingClientsRequestStrategy: AbstractRequestStrategy, ZMUps
 
                 return prekeys.establishSessions(with: selfClient, context: managedObjectContext)
 
-            case .v4:
+            case .v4, .v5:
                 guard let rawData = response.rawData,
                       let payload = Payload.PrekeyByQualifiedUserIDV4(rawData),
                       let selfClient = ZMUser.selfUser(in: managedObjectContext).selfClient()

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
@@ -507,6 +507,14 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
     }
 
     func testThatItRemovesMessagesMissingClientWhenEstablishedSessionWithClient_V4() {
+        internalTestThatItRemovesMessagesMissingClientWhenEstablishedSessionWithClient(apiVersion: .v4)
+    }
+
+    func testThatItRemovesMessagesMissingClientWhenEstablishedSessionWithClient_V5() {
+        internalTestThatItRemovesMessagesMissingClientWhenEstablishedSessionWithClient(apiVersion: .v5)
+    }
+
+    func internalTestThatItRemovesMessagesMissingClientWhenEstablishedSessionWithClient(apiVersion: APIVersion) {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let message = self.message(missingRecipient: self.otherClient)
@@ -514,7 +522,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
 
             // WHEN
             XCTAssertEqual(message.missingRecipients.count, 1)
-            guard let response = self.response(forMissing: [self.otherClient], apiVersion: .v4) else {
+            guard let response = self.response(forMissing: [self.otherClient], apiVersion: apiVersion) else {
                 return XCTFail("Response is invalid")
             }
             _ = self.sut.updateUpdatedObject(self.selfClient,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

MissingClientsRequestStrategy has a wrong implementation for API v5. This was introduced with version 5 and should not affect public clients.

### Solutions

Fix missing clients handling for API v5 and add tests.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
