### PR TITLE
chore: Add automatic cherry pick from release branch to develop WPB-4343

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -1,0 +1,47 @@
+name: "Cherry-pick from release branch to develop"
+
+on:
+  pull_request:
+    branches:
+      - release/*
+    types:
+      - closed
+
+jobs:
+  cherry-pick:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SUBMODULE_PAT }}
+          submodules: recursive
+
+      - name: Append -cherry-pick to branch name
+        id: extract
+        run: |
+            PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+            NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
+            echo "New branch name: $NEW_BRANCH_NAME"
+            echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+      - name: Cherry-pick commits
+        run: |
+            git fetch origin develop:develop
+            git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
+            # Cherry-picking the last commit on the base branch
+            git cherry-pick -x ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true
+            git add .
+            git cherry-pick --continue || true
+            git push origin ${{ steps.extract.outputs.newBranchName }}
+      - name: Create PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+            title: ${{ github.event.pull_request.title }}
+            base: develop
+            assignees: ${{ github.event.pull_request.user.login }}
+            branch: "${{ steps.extract.outputs.newBranchName }}"
+            body: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4343" title="WPB-4343" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-4343</a>  Add automated cherry-pick workflow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Right now developers have to manually create a clone of PR for fixes applied to release branch,

### Solutions

This PR introduces a script similar to what Android devs use for automating that process
https://github.com/wireapp/wire-android-reloaded/pull/1951/files

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
