### PR TITLE
fix: message context menu on ipad layout WPB-4718

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -194,7 +194,7 @@ class ConversationMessageCellTableViewAdapter<C: ConversationMessageCellDescript
 
         if let popoverPresentationController = actionsMenuController.popoverPresentationController {
             popoverPresentationController.sourceView = cellView
-            popoverPresentationController.permittedArrowDirections = .left
+            popoverPresentationController.permittedArrowDirections = [.down, .left]
         }
 
         return actionsMenuController


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4718" title="WPB-4718" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4718</a>  [iOS] message context menu on iPad has incorrect layout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When  conversations list is displayed on iPad and user long-tap on message then most of context menu is not visible and has incorrect layout
before: 
![image](https://github.com/wireapp/wire-ios-mono/assets/1401672/cc8e9f24-ba94-4cdf-a7c8-75d10bf59a88)
after:
<img width="612" alt="image" src="https://github.com/wireapp/wire-ios-mono/assets/1401672/0aa7afad-df25-4c7a-868f-9710d2838403">
