### PR TITLE
feat: Add progress bar to the AddParticipantsViewController WPB-4451

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -87,7 +87,7 @@ extension AddParticipantsViewController.Context {
     }
 }
 
-final class AddParticipantsViewController: UIViewController {
+final class AddParticipantsViewController: UIViewController, SpinnerCapable {
 
     enum CreateAction {
         case updatedUsers(UserSet)
@@ -120,6 +120,8 @@ final class AddParticipantsViewController: UIViewController {
             updateValues()
         }
     }
+
+    var dismissSpinner: SpinnerCompletion?
 
     deinit {
         userSelection.remove(observer: self)
@@ -345,8 +347,16 @@ final class AddParticipantsViewController: UIViewController {
     @objc private func rightNavigationItemTapped(_ sender: Any!) {
         switch viewModel.context {
         case .add: navigationController?.dismiss(animated: true, completion: nil)
-        case .create: conversationCreationDelegate?.addParticipantsViewController(self, didPerform: .create)
+
+        case .create:
+            setLoadingView(isVisible: true)
+            conversationCreationDelegate?.addParticipantsViewController(self, didPerform: .create)
         }
+    }
+
+    func setLoadingView(isVisible: Bool) {
+        isLoadingViewVisible = isVisible
+        navigationItem.rightBarButtonItem?.isEnabled = !isVisible
     }
 
     @objc func keyboardFrameWillChange(notification: Notification) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -347,10 +347,7 @@ final class AddParticipantsViewController: UIViewController, SpinnerCapable {
     @objc private func rightNavigationItemTapped(_ sender: Any!) {
         switch viewModel.context {
         case .add: navigationController?.dismiss(animated: true, completion: nil)
-
-        case .create:
-            setLoadingView(isVisible: true)
-            conversationCreationDelegate?.addParticipantsViewController(self, didPerform: .create)
+        case .create: conversationCreationDelegate?.addParticipantsViewController(self, didPerform: .create)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -295,6 +295,8 @@ extension ConversationCreationController: AddParticipantsConversationCreationDel
             ) { [weak self] in
                 guard let self = self else { return }
 
+                addParticipantsViewController.setLoadingView(isVisible: false)
+
                 switch $0 {
                 case .success(let conversation):
                     delegate?.conversationCreationController(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -279,6 +279,8 @@ extension ConversationCreationController: AddParticipantsConversationCreationDel
 
         case .create:
             guard let userSession = ZMUserSession.shared() else { return }
+
+            addParticipantsViewController.setLoadingView(isVisible: true)
             let service = ConversationService(context: userSession.viewContext)
 
             let users = values.participants


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4451" title="WPB-4451" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4451</a>  [iOS] Group creation does nothing when backend offline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Creating a conversation sometimes takes a few seconds if there are users from different domains or one of the domains is offline. From the user's point of view, it looks like the "Done" button does not work and can be clicked many times. As a result, several conversations are created in a few seconds.

### Solutions

The solution is to add a loading view and prevent users from creating many conversations while the backend is responding.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
