### PR TITLE
chore: Add cherry-pick automatic label and display conflicts WPB-4788

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -27,23 +27,25 @@ jobs:
             PR_BRANCH="${{ github.event.pull_request.head.ref }}"
             NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
             echo "New branch name: $NEW_BRANCH_NAME"
-            echo "::set-output name=newBranchName::$NEW_BRANCH_NAME"
+            echo "newBranchName=$NEW_BRANCH_NAME" >> $GITHUB_ENV
+
       - name: Cherry-pick commits
         run: |
             git fetch origin develop:develop
-            git checkout -b ${{ steps.extract.outputs.newBranchName }} develop
+            git checkout -b ${{ env.newBranchName }} develop
             git submodule update --init --recursive || true
-            # Cherry-picking the last commit on the base branch
-            git cherry-pick -x ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true
-            git add .
-            git cherry-pick --continue || true
-            git push origin ${{ steps.extract.outputs.newBranchName }}
+            OUTPUT=$(git cherry-pick ${{ github.event.pull_request.merge_commit_sha }} --strategy-option theirs || true)
+            CONFLICTS=$(echo "$OUTPUT" | grep 'CONFLICT' || echo "")
+            if [ -n "$CONFLICTS" ]; then
+                git add .
+                git cherry-pick --continue || true
+            fi
+            git push origin ${{ env.newBranchName }} || (echo "Failed to push to origin" && exit 1)
+            echo "conflicts=$CONFLICTS" >> $GITHUB_ENV
       - name: Create PR
-        id: cpr
-        uses: peter-evans/create-pull-request@v5
-        with:
-            title: ${{ github.event.pull_request.title }}
-            base: develop
-            assignees: ${{ github.event.pull_request.user.login }}
-            branch: "${{ steps.extract.outputs.newBranchName }}"
-            body: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n ---- \n{1}', github.event.pull_request.number, github.event.pull_request.body) }}"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ env.newBranchName }}
+          PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
+          PR_BODY: "${{ format('Cherry pick from the original PR: \n- #{0}\n\n---- \n\n ⚠️ Conflicts during cherry-pick:\n{1}\n\n{2}', github.event.pull_request.number, env.conflicts, github.event.pull_request.body) }}"
+        run: gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base develop --head "$PR_BRANCH" --label "cherry-pick" --assignee "$PR_ASSIGNEE"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4788" title="WPB-4788" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-4788</a>  Add auto labeling and display conflicts  to cherry pick automation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Automate adding labels to github PRs that come from cherry-pick automation 
- Display conflicts in the PR description

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
