### PR TITLE
fix: Failed test after last read initializer changes

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
@@ -634,7 +634,12 @@ extension IntegrationTest {
 
     @objc(remotelyAppendSelfConversationWithZMLastReadForMockConversation:atTime:)
     func remotelyAppendSelfConversationWithZMLastRead(for mockConversation: MockConversation, at time: Date) {
-        let genericMessage = GenericMessage(content: LastRead(conversationID: UUID(uuidString: mockConversation.identifier)!, lastReadTimestamp: time))
+        guard let uuid = UUID(uuidString: mockConversation.identifier) else {
+            XCTFail("There's no uuid")
+            return
+        }
+        let conversationID = QualifiedID(uuid: uuid, domain: "")
+        let genericMessage = GenericMessage(content: LastRead(conversationID: conversationID, lastReadTimestamp: time))
         mockTransportSession.performRemoteChanges { _ in
             do {
                 self.selfConversation.insertClientMessage(from: self.selfUser, data: try genericMessage.serializedData())


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is broken test in SE.

### Causes (Optional)

In the previous PR, changes have been made to the last read initializer implemented in DM.

### Solutions

Implement the changes from the DM

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
