### PR TITLE
fix: Error message for offline users WPB-4864

### DIFF
--- a/wire-ios-transport/Source/Public/NSError+ZMTransportSession.h
+++ b/wire-ios-transport/Source/Public/NSError+ZMTransportSession.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSError *)transportErrorFromURLTask:(NSURLSessionTask *)task expired:(BOOL)expired;
 
++ (nullable NSError *)transportErrorFromURLTask:(NSURLSessionTask *)task expired:(BOOL)expired payloadLabel:(nullable NSString *) payloadLabel;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/wire-ios-transport/Source/Public/ZMTransportResponse.h
+++ b/wire-ios-transport/Source/Public/ZMTransportResponse.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 @property (nonatomic, readonly, copy, nullable) NSDictionary * headers;
 
 @property (nonatomic, readonly) NSInteger HTTPStatus;
-@property (nonatomic, nullable) NSError * transportSessionError;
+@property (nonatomic, readonly, nullable) NSError * transportSessionError;
 @property (nonatomic) ZMSDispatchGroup *dispatchGroup;
 
 @property (nonatomic, readonly, nullable) NSHTTPURLResponse * rawResponse;

--- a/wire-ios-transport/Source/Public/ZMTransportResponse.h
+++ b/wire-ios-transport/Source/Public/ZMTransportResponse.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 @property (nonatomic, readonly, copy, nullable) NSDictionary * headers;
 
 @property (nonatomic, readonly) NSInteger HTTPStatus;
-@property (nonatomic, readonly, nullable) NSError * transportSessionError;
+@property (nonatomic, nullable) NSError * transportSessionError;
 @property (nonatomic) ZMSDispatchGroup *dispatchGroup;
 
 @property (nonatomic, readonly, nullable) NSHTTPURLResponse * rawResponse;

--- a/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
@@ -91,7 +91,6 @@ NSString * const FederationNotAvailableError = @"federation-not-available";
                                       (statusCode <= 599));
         BOOL const isFederationError = ([payloadLabel isEqualToString:FederationNotAvailableError]);
 
-
         if ((!isBackOff && !isInternalError) || isFederationError) {
             return nil;
         }

--- a/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
@@ -79,7 +79,7 @@ NSString * const FederationNotAvailableError = @"federation-not-available";
     return [NSError transportErrorFromURLTask:task expired:expired payloadLabel:nil];
 }
 
-+ (nullable NSError *)transportErrorFromURLTask:(NSURLSessionTask *)task expired:(BOOL)expired payloadLabel:(nullable NSString *) payloadLabel;
++ (NSError *)transportErrorFromURLTask:(NSURLSessionTask *)task expired:(BOOL)expired payloadLabel:(nullable NSString *) payloadLabel;
 {
     NSError *urlError = task.error;
     if (urlError == nil) {

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -480,7 +480,6 @@ static NSInteger const DefaultMaximumRequests = 6;
         NSError *tryAgainError = [NSError tryAgainLaterErrorWithUserInfo:userInfo];
         ZMTransportResponse *tryAgainResponse = [ZMTransportResponse responseWithTransportSessionError:tryAgainError apiVersion:request.apiVersion];
         [request completeWithResponse:tryAgainResponse];
-
     } else {
         [request completeWithResponse:response];
     }

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -459,6 +459,10 @@ static NSInteger const DefaultMaximumRequests = 6;
     ZMTransportResponse *response = [self transportResponseFromURLResponse:httpResponse data:data error:transportError apiVersion:request.apiVersion];
     [self.remoteMonitoring logWithResponse:httpResponse];
 
+    /// If the label is "federation-not-available" we should not try again this request
+    if ([[response payloadLabel] isEqualToString:@"federation-not-available"]) {
+        response.transportSessionError = nil;
+    }
     ZMLogDebug(@"ConnectionProxyDictionary: %@,", session.configuration.connectionProxyDictionary);
     if (response.result == ZMTransportResponseStatusExpired) {
         [request completeWithResponse:response];
@@ -475,6 +479,12 @@ static NSInteger const DefaultMaximumRequests = 6;
         NSError *tryAgainError = [NSError tryAgainLaterErrorWithUserInfo:userInfo];
         ZMTransportResponse *tryAgainResponse = [ZMTransportResponse responseWithTransportSessionError:tryAgainError apiVersion:request.apiVersion];
         [request completeWithResponse:tryAgainResponse];
+
+    // If the label is "federation-not-available", we shouldn't try this request again.
+//    } else if ((httpResponse.statusCode == 500) && [[response payloadLabel] isEqualToString:@"federation-not-available"]) {
+//        ZMTransportResponse *newResponse = [self transportResponseFromURLResponse:httpResponse data:data error:nil apiVersion:request.apiVersion];
+//        [request completeWithResponse:newResponse];
+
     } else {
         [request completeWithResponse:response];
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4864" title="WPB-4864" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4864</a>  [iOS] Mentioning someone from an unreachable backend "blocks" app and informs the user with an incorrect error message.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user sends a message mentioning someone from an unreachable backend, it shows the wrong error message and causes the app to send many requests. This creates the feeling of a frozen app.

### Causes (Optional)

When we open the _mension_ view, we try to get the user data for each user. If these users come from an unreachable backend, we receive a 500 error code and a "federation-not-available" label. Every time we get 500, we try to send the request again and this creates a request loop.

### Solutions

Check the `federation-not-available` label in the error response and do not retry the request.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
