### PR TITLE
fix: upload stuck after lost connection WPB-3691

### DIFF
--- a/wire-ios-request-strategy/Sources/Object Syncs/Downstream/ZMDownstreamObjectSync.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Downstream/ZMDownstreamObjectSync.m
@@ -166,7 +166,7 @@
 - (void)processResponse:(ZMTransportResponse *)response forObject:(ZMManagedObject *)object token:(ZMSyncToken *)token transcoder:(id<ZMDownstreamTranscoder>)transcoder
 {
     NSSet *keys = [self.objectsToDownload keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:object result:response.result];
-    switch (response.result) {
+    switch (response.result) { //~!@#$%^&*
         case ZMTransportResponseStatusTryAgainLater: {
             break;
         }
@@ -180,7 +180,8 @@
         }
         case ZMTransportResponseStatusTemporaryError:
         case ZMTransportResponseStatusPermanentError:
-        case ZMTransportResponseStatusExpired: {
+        case ZMTransportResponseStatusExpired:
+        case ZMTransportResponseStatusCancelled:{
             [self.objectsToDownload removeObject:object];
             [transcoder deleteObject:object withResponse:response downstreamSync:self];
             break;

--- a/wire-ios-request-strategy/Sources/Object Syncs/Downstream/ZMDownstreamObjectSync.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Downstream/ZMDownstreamObjectSync.m
@@ -166,7 +166,7 @@
 - (void)processResponse:(ZMTransportResponse *)response forObject:(ZMManagedObject *)object token:(ZMSyncToken *)token transcoder:(id<ZMDownstreamTranscoder>)transcoder
 {
     NSSet *keys = [self.objectsToDownload keysForWhichToApplyResultsAfterFinishedSynchronizingSyncWithToken:token forObject:object result:response.result];
-    switch (response.result) { //~!@#$%^&*
+    switch (response.result) {
         case ZMTransportResponseStatusTryAgainLater: {
             break;
         }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMRemoteIdentifierObjectSync.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMRemoteIdentifierObjectSync.m
@@ -79,7 +79,7 @@
                 break;
             }
             case ZMTransportResponseStatusExpired:
-            case ZMTransportResponseStatusCancelled:  //~!@#$%^&*
+            case ZMTransportResponseStatusCancelled:
                 break;
             case ZMTransportResponseStatusTemporaryError:
             case ZMTransportResponseStatusTryAgainLater: {

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMRemoteIdentifierObjectSync.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMRemoteIdentifierObjectSync.m
@@ -79,6 +79,7 @@
                 break;
             }
             case ZMTransportResponseStatusExpired:
+            case ZMTransportResponseStatusCancelled:  //~!@#$%^&*
                 break;
             case ZMTransportResponseStatusTemporaryError:
             case ZMTransportResponseStatusTryAgainLater: {

--- a/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSync.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSync.m
@@ -271,31 +271,26 @@ ZM_EMPTY_ASSERTING_INIT();
         ZM_STRONG(request);
         id <ZMUpstreamTranscoder> localTranscoder = self.transcoder;
         NSSet *keysToParse = [self.updatedObjects keysToParseAfterSyncingToken:token];
-        //  self.remoteMonitoring = [[RemoteMonitoring alloc] initWithLevel: LevelInfo];
         if(response.result == ZMTransportResponseStatusSuccess) {
             BOOL transcoderNeedsMoreRequests = [localTranscoder updateUpdatedObject:objectWithKeys.object requestUserInfo:userInfo response:response keysToParse:keysToParse];
             BOOL needsMoreRequests = (keysToParse.count > 0) && transcoderNeedsMoreRequests;
             if (needsMoreRequests) {
                 [self.updatedObjects didNotFinishToSynchronizeToken:token];
-                NSLog(@"qqq didNotFinishToSynchronizeToken");
             } else {
                 [self.updatedObjects didSynchronizeToken:token];
-                NSLog(@"qqq didSynchronizeToken");
             }
         }
         else if (response.result ==  ZMTransportResponseStatusCancelled) {
-//            NSLog(@"qqq result = CANCELLED");
-            NSLog(@"qqq CANCELLED token: %@", token);
             [self.updatedObjects didFailToSynchronizeToken:token];
+            if ([localTranscoder respondsToSelector:@selector(requestExpiredForObject:forKeys:)]) {
+                [localTranscoder requestExpiredForObject:objectWithKeys.object forKeys:objectWithKeys.keysToSync];
+            }
         }
         else if (response.result == ZMTransportResponseStatusTemporaryError ||
                  response.result == ZMTransportResponseStatusTryAgainLater) {
-//            NSLog(@"qqq result = TRY AGAIN LATER");
-            NSLog(@"qqq TRY AGAIN LATER token: %@", token);
             [self.updatedObjects didNotFinishToSynchronizeToken:token];
         }
         else if (response.result == ZMTransportResponseStatusExpired) {
-            NSLog(@"qqq result = expired");
             [self.updatedObjects didFailToSynchronizeToken:token];
             if ([localTranscoder respondsToSelector:@selector(requestExpiredForObject:forKeys:)]) {
                 [localTranscoder requestExpiredForObject:objectWithKeys.object forKeys:objectWithKeys.keysToSync];

--- a/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSyncTests.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamModifiedObjectSyncTests.m
@@ -497,7 +497,7 @@ static NSString *foo = @"foo";
     WaitForAllGroupsToBeEmpty(0.5);
 }
 
-- (void)testThatItCallsDidFailToSynchronizeTokenWhenTheRequestFailsWithATemporaryError
+- (void)testThatItCallsDidNotFinishToSynchronizeTokenWhenTheRequestFailsWithATemporaryError
 {
     // given
     [[[(id)self.mockTranscoder stub] andReturnValue:OCMOCK_VALUE(YES)] shouldCreateRequestToSyncObject:OCMOCK_ANY forKeys:OCMOCK_ANY withSync:OCMOCK_ANY];
@@ -515,7 +515,7 @@ static NSString *foo = @"foo";
     [(ZMLocallyModifiedObjectSet *)[[self.mockLocallyModifiedSet expect] andReturn:token] didStartSynchronizingKeys:keysToSync forObject:fakeObjectWithKeys];
     [[[(id)self.mockTranscoder expect] andReturn:fakeRequest] requestForUpdatingObject:entity forKeys:keysToSync apiVersion:APIVersionV0];
     [[(id)self.mockLocallyModifiedSet expect] keysToParseAfterSyncingToken:OCMOCK_ANY];
-    [[self.mockLocallyModifiedSet expect] didFailToSynchronizeToken:token];
+    [[self.mockLocallyModifiedSet expect] didNotFinishToSynchronizeToken:token];
     
     // when
     ZMTransportRequest *request = [self.sut nextRequestForAPIVersion:APIVersionV0];

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
@@ -179,15 +179,10 @@ extension AssetV3UploadRequestStrategy: ZMUpstreamTranscoder {
         }
     }
 
-    public func shouldRetryToSyncAfterFailed(toUpdate managedObject: ZMManagedObject,
-                                             request upstreamRequest: ZMUpstreamRequest,
-                                             response: ZMTransportResponse,
-                                             keysToParse keys: Set<String>) -> Bool {
-        guard let message = managedObject as? ZMAssetClientMessage else { return false }
-
+    public func requestExpired(for managedObject: ZMManagedObject, forKeys keys: Set<String>) {
+        guard let message = managedObject as? ZMAssetClientMessage else { return  }
         message.expire()
-
-        return false
+        return
     }
 
     public func objectToRefetchForFailedUpdate(of managedObject: ZMManagedObject) -> ZMManagedObject? {

--- a/wire-ios-request-strategy/Sources/Request Syncs/ZMSingleRequestSync.m
+++ b/wire-ios-request-strategy/Sources/Request Syncs/ZMSingleRequestSync.m
@@ -107,6 +107,7 @@
         case ZMTransportResponseStatusSuccess:
         case ZMTransportResponseStatusPermanentError:
         case ZMTransportResponseStatusExpired: // TODO Offline
+        case ZMTransportResponseStatusCancelled:
         {
             self.status = ZMSingleRequestCompleted;
             [self.transcoder didReceiveResponse:response forSingleRequest:self];

--- a/wire-ios-transport/Source/Public/ZMTransportResponse.h
+++ b/wire-ios-transport/Source/Public/ZMTransportResponse.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
     ZMTransportResponseStatusPermanentError,
     ZMTransportResponseStatusExpired,
     ZMTransportResponseStatusTryAgainLater,
+    ZMTransportResponseStatusCancelled,
 };
 
 

--- a/wire-ios-transport/Source/Public/ZMTransportSession.h
+++ b/wire-ios-transport/Source/Public/ZMTransportSession.h
@@ -52,6 +52,7 @@ typedef NS_ENUM(NSInteger, ZMTransportSessionErrorCode) {
     ZMTransportSessionErrorCodeAuthenticationFailed, ///< Unable to get access token / cookie
     ZMTransportSessionErrorCodeRequestExpired, ///< Request went over its expiration date
     ZMTransportSessionErrorCodeTryAgainLater, ///< c.f. @code -[NSError isTryAgainLaterError] @endcode
+    ZMTransportSessionErrorCodeCancelled,
 };
 
 extern NSString * const ZMTransportSessionNewRequestAvailableNotification;

--- a/wire-ios-transport/Source/Requests/ZMTransportResponse.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportResponse.m
@@ -121,6 +121,7 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 - (ZMTransportResponseStatus)result
 {
     if (self.transportSessionError) {
+        NSLog(@"qqq error domain: %@", self.transportSessionError);
         if ([self.transportSessionError.domain isEqualToString:ZMTransportSessionErrorDomain]) {
             switch ((ZMTransportSessionErrorCode) self.transportSessionError.code) {
                 case ZMTransportSessionErrorCodeRequestExpired:
@@ -129,6 +130,8 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
                     return ZMTransportResponseStatusTryAgainLater;
                 case ZMTransportSessionErrorCodeAuthenticationFailed:
                     return ZMTransportResponseStatusPermanentError;
+                case ZMTransportSessionErrorCodeCancelled:
+                    return ZMTransportResponseStatusCancelled;
                 default:
                     ZMLogWarn(@"Invalid ZMTransportSessionErrorCode %d", (int) self.transportSessionError.code);
                     break;

--- a/wire-ios-transport/Source/Requests/ZMTransportResponse.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportResponse.m
@@ -121,7 +121,6 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 - (ZMTransportResponseStatus)result
 {
     if (self.transportSessionError) {
-        NSLog(@"qqq error domain: %@", self.transportSessionError);
         if ([self.transportSessionError.domain isEqualToString:ZMTransportSessionErrorDomain]) {
             switch ((ZMTransportSessionErrorCode) self.transportSessionError.code) {
                 case ZMTransportSessionErrorCodeRequestExpired:

--- a/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
@@ -94,14 +94,11 @@ NSString * const ZMTransportSessionErrorDomain = @"ZMTransportSession";
             return nil;
         }
     } else if (urlError.isCancelledURLTaskError && expired) {
-        NSLog(@"qqq transportERROR expired task: %@", task);
         return [NSError requestExpiredError];
     }
     else if (urlError.isCancelledURLTaskError && !expired) {
-        NSLog(@"qqq transportERROR notExpired task: %@", task);
         return [NSError requestCancelledError];
     }
-    NSLog(@"qqq transportERROR otherCase task: %@", task);
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Request finished with task error %@.", task.error.localizedDescription]};
     return [NSError tryAgainLaterErrorWithUserInfo:userInfo];
 }

--- a/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/NSError+ZMTransportSession.m
@@ -48,6 +48,11 @@ NSString * const ZMTransportSessionErrorDomain = @"ZMTransportSession";
     return [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeRequestExpired userInfo:nil];
 }
 
++ (NSError *)requestCancelledError;
+{
+    return [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeCancelled userInfo:nil];
+}
+
 + (NSError *)tryAgainLaterError;
 {
     return [self.class tryAgainLaterErrorWithUserInfo:nil];
@@ -89,8 +94,14 @@ NSString * const ZMTransportSessionErrorDomain = @"ZMTransportSession";
             return nil;
         }
     } else if (urlError.isCancelledURLTaskError && expired) {
+        NSLog(@"qqq transportERROR expired task: %@", task);
         return [NSError requestExpiredError];
     }
+    else if (urlError.isCancelledURLTaskError && !expired) {
+        NSLog(@"qqq transportERROR notExpired task: %@", task);
+        return [NSError requestCancelledError];
+    }
+    NSLog(@"qqq transportERROR otherCase task: %@", task);
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Request finished with task error %@.", task.error.localizedDescription]};
     return [NSError tryAgainLaterErrorWithUserInfo:userInfo];
 }

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSessionErrorCode.h
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSessionErrorCode.h
@@ -23,4 +23,5 @@ typedef NS_ENUM(NSInteger, ZMTransportSessionErrorCode) {
     ZMTransportSessionErrorCodeAuthenticationFailed, ///< Unable to get access token / cookie
     ZMTransportSessionErrorCodeRequestExpired, ///< Request went over its expiration date
     ZMTransportSessionErrorCodeTryAgainLater, ///< c.f. @code -[NSError isTryAgainLaterError] @endcode
+    ZMTransportSessionErrorCodeCancelled,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3691" title="WPB-3691" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3691</a>  [iOS] Sending anything stops working after a file failed to send
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
There are two connected issues. First:
Path to reproduce: user is uploading big file and turn on airplane mode. Then leave it for two minutest or lock and unlock device. After that disable airplane mode.
Expecting behaviour: upload task resumes
Current behaviour: task is cancelled and new task with the same request is made. Because previous task was cancelled and `didFailToSynchronizeToken` was called token for that message was deleted from ZMLocallyModifiedObjectSet.objectIDsToStatus dictionary. Which prevent second task from ending. UI is displaying progress wheel and "sending..." status under video cell and no new message can be sent.
Solution: we expire request after first failure without trying to sending it again.

Second issue: when user cancel upload it stuck in sending and no other messages can be sent.  It was caused by calling `didNotFinishToSynchronizeToken` which keeps token undeleted. 
Solution here is to detect that situation and call `didFailToSynchronizeToken` instead.