### PR TITLE
fix: Make 533 as a permanent error - WPB-4889

### DIFF
--- a/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
+++ b/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
@@ -305,7 +305,8 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
         
     } else if (response.result == ZMTransportResponseStatusPermanentError &&
                response.HTTPStatus != EnhanceYourCalmStatusCode &&
-               response.HTTPStatus != TooManyRequestsStatusCode)
+               response.HTTPStatus != TooManyRequestsStatusCode &&
+               response.HTTPStatus != FederationRemoteError)
     {
         didFail = YES;
         needsToReRun = NO;

--- a/wire-ios-transport/Source/Public/ZMTransportRequestScheduler.h
+++ b/wire-ios-transport/Source/Public/ZMTransportRequestScheduler.h
@@ -34,7 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 enum {
     TooManyRequestsStatusCode = 429,
     EnhanceYourCalmStatusCode = 420,
-    UnauthorizedStatusCode = 401
+    UnauthorizedStatusCode = 401,
+    FederationRemoteError = 533
 };
 
 

--- a/wire-ios-transport/Source/Requests/ZMTransportResponse.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportResponse.m
@@ -120,6 +120,13 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 - (ZMTransportResponseStatus)result
 {
+    // This is a quick fix to handle remote federation errors. Without it, we would
+    // return a "try again" error, which would cause infinite failures if the
+    // remote federated backend is down.
+    if (self.HTTPStatus == 533) {
+        return ZMTransportResponseStatusPermanentError;
+    }
+
     if (self.transportSessionError) {
         if ([self.transportSessionError.domain isEqualToString:ZMTransportSessionErrorDomain]) {
             switch ((ZMTransportSessionErrorCode) self.transportSessionError.code) {

--- a/wire-ios-transport/Source/Requests/ZMTransportResponse.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportResponse.m
@@ -123,7 +123,7 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
     // This is a quick fix to handle remote federation errors. Without it, we would
     // return a "try again" error, which would cause infinite failures if the
     // remote federated backend is down.
-    if (self.HTTPStatus == 533) {
+    if (self.HTTPStatus == FederationRemoteError) {
         return ZMTransportResponseStatusPermanentError;
     }
 

--- a/wire-ios-transport/Tests/Source/Requests/ZMTransportResponseTests.m
+++ b/wire-ios-transport/Tests/Source/Requests/ZMTransportResponseTests.m
@@ -167,6 +167,11 @@
             continue;
         }
 
+        // Federation errors
+        if (i == 533) {
+            continue;
+        }
+
         ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         XCTAssertNotEqual(imageResponse.result, ZMTransportResponseStatusPermanentError);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4889" title="WPB-4889" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4889</a>  [iOS] Unable to send messages in group conversation when logging in to account with group conversation with unreachable backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We have a requests loop with `/conversations/\(domain)/\(conversationID)` endpoints because we don't handle 533 error code and try send these requests again. As a result, some other endpoints timed out and as a result we are not displaying the correct error message.
These changes have been removed in [this PR](https://github.com/wireapp/wire-ios/pull/474) as a fix for another issue with access token removal. That's why I added one exception to the access token handling.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
