### PR TITLE
fix: crash - WPB-4895

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -58,7 +58,12 @@ public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObje
 
     public override func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
         fetchAllConnectedUsers(for: apiVersion)
-        return userProfileByQualifiedID.nextRequest(for: apiVersion) ?? userProfileByID.nextRequest(for: apiVersion)
+        switch apiVersion {
+        case .v0:
+            return userProfileByID.nextRequest(for: apiVersion)
+        case .v1, .v2, .v3, .v4, .v5:
+            return userProfileByQualifiedID.nextRequest(for: apiVersion)
+        }
     }
 
     func fetchAllConnectedUsers(for apiVersion: APIVersion) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -82,6 +82,25 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
         }
     }
 
+    func testThatRequestInV4_DoesNotUseLegacyEndpointWhenNoRequestFromCurrentEndpoint() {
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.apiVersion = .v0
+            self.otherUser.domain = "example.com"
+            self.otherUser.needsToBeUpdatedFromBackend = true
+            // set object to sync to legacy endpoint transcoder
+            self.sut.objectsDidChange(Set([self.otherUser]))
+
+            // when
+            // use v4 endpoint
+            self.apiVersion = .v4
+            let request = self.sut.nextRequest(for: self.apiVersion)
+
+            // then
+            // .v0 endpoint should not be used
+            XCTAssertNil(request)
+        }
+    }
     // MARK: - Slow Sync
 
     func testThatRequestToFetchConnectedUsersIsGenerated_DuringFetchingUsersSyncPhase() {
@@ -201,6 +220,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
     // MARK: - Response processing
 
     func testThatUsesLegacyEndpoint_WhenFederatedEndpointIsDisabled() {
+        // TODO: check if this test is right?
         syncMOC.performGroupedBlockAndWait {
             // given
             self.otherUser.domain = "example.com"

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -88,16 +88,16 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
             self.apiVersion = .v0
             self.otherUser.domain = "example.com"
             self.otherUser.needsToBeUpdatedFromBackend = true
-            // set object to sync to legacy endpoint transcoder
+            // By reporting the otherUser did change while on v0, sut will case the legacy transcoder to get in a state where it would produce a next request
             self.sut.objectsDidChange(Set([self.otherUser]))
 
             // when
-            // use v4 endpoint
+            // By switching to v4 and asking for a next request, we get nil because we would only ask the non legacy transcoder for a request, but it's not in a state to do that
             self.apiVersion = .v4
             let request = self.sut.nextRequest(for: self.apiVersion)
 
             // then
-            // .v0 endpoint should not be used
+            // non legacy transcoder's endpoint should not be used
             XCTAssertNil(request)
         }
     }
@@ -219,8 +219,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
 
     // MARK: - Response processing
 
-    func testThatUsesLegacyEndpoint_WhenFederatedEndpointIsDisabled() {
-        // TODO: check if this test is right?
+    func testThatUsesLegacyEndpointOnV0_WhenFederatedEndpointIsDisabled() {
         syncMOC.performGroupedBlockAndWait {
             // given
             self.otherUser.domain = "example.com"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4895" title="WPB-4895" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4895</a>  crash fetching multiple Users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On a federated environment, we got the following crash (see attachment)

### Causes (Optional)

It crashes because we end up fetching ZMUser with same remoteIdentifier without specifying the domain (and we assert only one occurrence should exist).

The call is made by `UserProfileByIDTranscoder` which should not be used on api version 4 as we deal with QualifiedId only.  

The `UserProfileRequestStrategy`'s `nextRequest(for:)` method will call `UserProfileByIDTranscoder` if the `UserProfileByQualifiedIDTranscoder` does not return a request, which will perform the mentioned fetch causing the crash.

### Solutions

Use `UserProfileByIDTranscoder` only on api version 0.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Attachments (Optional)

![Screenshot 2023-09-27 at 21 27 06](https://github.com/wireapp/wire-ios/assets/254198/57fe6b52-f88f-46b2-8bbf-390a8d6fbafa)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
