### PR TITLE
chore: add backup and logout DD logs

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Backup.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Backup.swift
@@ -68,6 +68,7 @@ extension CoreDataStack {
                 try fileManager.removeItem(at: url)
             } catch {
                 log.debug("error removing directory: \(error)")
+                WireLogger.localStorage.debug("backup: clearBackupDirectory got error removing directory: \(error)")
             }
         }
 
@@ -120,6 +121,7 @@ extension CoreDataStack {
                 let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: false)
 
                 // Recreate the persistent store inside a new location
+                WireLogger.localStorage.debug("backup: Recreate the persistent store inside a new location")
                 try coordinator.replacePersistentStore(
                     at: backupLocation,
                     destinationOptions: options,
@@ -128,6 +130,7 @@ extension CoreDataStack {
                     ofType: NSSQLiteStoreType
                 )
 
+                WireLogger.localStorage.debug("backup: prepareStoreForBackupExport")
                 try prepareStoreForBackupExport(
                     coordinator: coordinator,
                     location: backupLocation,
@@ -136,6 +139,7 @@ extension CoreDataStack {
                 )
 
                 // Create & write metadata
+                WireLogger.localStorage.debug("backup: Create & write metadata")
                 let metadata = BackupMetadata(userIdentifier: accountIdentifier, clientIdentifier: clientIdentifier)
                 try metadata.write(to: metadataURL)
                 log.info("successfully created backup at: \(backupDirectory.path), metadata: \(metadata)")
@@ -166,6 +170,7 @@ extension CoreDataStack {
         ) {
 
         func fail(_ error: BackupImportError) {
+            WireLogger.localStorage.debug("backup: error backing up local store: \(error)")
             log.debug("error backing up local store: \(error)")
             DispatchQueue.main.async(group: dispatchGroup) {
                 completion(.failure(error))
@@ -192,9 +197,11 @@ extension CoreDataStack {
                 try fileManager.createDirectory(at: accountStoreFile.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
                 let options = NSPersistentStoreCoordinator.persistentStoreOptions(supportsMigration: true)
 
+                WireLogger.localStorage.debug("backup: import prepare")
                 try prepareStoreForBackupImport(coordinator: coordinator, location: backupStoreFile, options: options)
 
                 // Import the persistent store to the account data directory
+                WireLogger.localStorage.debug("backup: import the persistent store to the account data directory")
                 try coordinator.replacePersistentStore(
                     at: accountStoreFile,
                     destinationOptions: options,

--- a/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+FetchRequest.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+FetchRequest.swift
@@ -26,6 +26,7 @@ public extension NSManagedObjectContext {
             let result = try fetch(request)
             return result
         } catch let error {
+            WireLogger.localStorage.error("CoreData: Error in fetching request : \(request),  \(error.localizedDescription)")
             fatal("Error in fetching \(error.localizedDescription)")
         }
     }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -712,6 +712,7 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     fileprivate func logout(account: Account, error: Error? = nil) {
+        WireLogger.session.debug("Logging out account \(account.userIdentifier)...")
         log.debug("Logging out account \(account.userIdentifier)...")
 
         if let session = backgroundUserSessions[account.userIdentifier] {
@@ -1040,6 +1041,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     internal func tearDownBackgroundSession(for accountId: UUID) {
         guard let userSession = self.backgroundUserSessions[accountId] else {
+            WireLogger.session.error("No session to tear down for \(accountId), known sessions: \(self.backgroundUserSessions)")
             log.error("No session to tear down for \(accountId), known sessions: \(self.backgroundUserSessions)")
             return
         }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -936,7 +936,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     fileprivate func deleteAccountData(for account: Account) {
         log.debug("Deleting the data for \(account.userName) -- \(account.userIdentifier)")
-
+        WireLogger.session.debug("Deleting the data for \(account.userName) -- \(account.userIdentifier)")
         environment.cookieStorage(for: account).deleteKeychainItems()
         account.deleteKeychainItems()
 
@@ -947,6 +947,7 @@ public final class SessionManager: NSObject, SessionManagerType {
             try FileManager.default.removeItem(at: CoreDataStack.accountDataFolder(accountIdentifier: accountID, applicationContainer: sharedContainerURL))
         } catch let error {
             log.error("Impossible to delete the acccount \(account): \(error)")
+            WireLogger.session.error("Impossible to delete the acccount \(account): \(error)")
         }
     }
 

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -936,7 +936,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     fileprivate func deleteAccountData(for account: Account) {
         log.debug("Deleting the data for \(account.userName) -- \(account.userIdentifier)")
-        WireLogger.session.debug("Deleting the data for \(account.userName) -- \(account.userIdentifier)")
+        WireLogger.session.debug("Deleting the data for account \(account)")
         environment.cookieStorage(for: account).deleteKeychainItems()
         account.deleteKeychainItems()
 

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -173,5 +173,6 @@ public extension WireLogger {
     static let userClient = WireLogger(tag: "user-client")
     static let localStorage = WireLogger(tag: "local-storage")
     static let conversation = WireLogger(tag: "conversation")
+    static let session = WireLogger(tag: "session")
 
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
@@ -82,12 +82,14 @@ final class BackupRestoreController: NSObject {
             guard let `self` = self else { return }
             switch result {
             case .failure(SessionManager.BackupError.decryptionError):
+                WireLogger.localStorage.error("Failed restoring backup: \(SessionManager.BackupError.decryptionError)")
                 self.target.isLoadingViewVisible = false
                 self.showWrongPasswordAlert { _ in
                     self.restore(with: url)
                 }
 
             case .failure(let error):
+                WireLogger.localStorage.error("Failed restoring backup: \(error)")
                 BackupEvent.importFailed.track()
                 self.showRestoreError(error)
                 self.target.isLoadingViewVisible = false


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adding logs about backup and logout for DataDog
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
