### PR TITLE
fix: popup about users started using new device WPB-4906

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -209,6 +209,7 @@ extension ZMConversation {
             securityLevel != .secure &&
             allUsersTrusted &&
             allParticipantsHaveClients &&
+            hasMoreClientsThanSelfClient &&
             conversationType.isOne(of: .group, .oneOnOne, .invalid)
         else {
             return
@@ -674,6 +675,23 @@ extension ZMConversation {
 
     fileprivate var allParticipantsHaveClients: Bool {
         return self.localParticipants.first { $0.clients.count == 0 } == nil
+    }
+
+    fileprivate var hasMoreClientsThanSelfClient: Bool {
+        guard
+            let context = managedObjectContext,
+            let selfClient = ZMUser.selfUser(in: context).selfClient()
+        else {
+            return false
+        }
+
+        let clients = localParticipants.flatMap(\.clients)
+
+        if clients.contains(selfClient) && clients.count == 1 {
+            return false
+        }
+
+        return true
     }
 
     /// If true the conversation might still be trusted / ignored


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4906" title="WPB-4906" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4906</a>  [iOS] Pop-up about users started using new devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When sending a message to a conversation they've been added to, users see the **security degraded** ("... started using new devices") popup and must confirm they want to send a message, even though the conversation was never verified 

### Causes

When added to a conversation, the user receives a `conversation.member-join` event. Processing this events results in insert a new conversation object in the context, adding the self client, and setting the security level. The newly inserted conversation is then synced with the backend, which returns the members of the conversation. As a result, the conversation's security level is reevaluated to account for the new members.

When first setting the security level, there is only the self client in the conversation. So the conversation is considered as secure. 
When reevaluating the security level for the new members, the security level is degraded, since they're not verified.

Then when the user sends their first message in the conversation, they see the security degraded alert.

### Solutions

Only upgrade the conversation's security level to `secure` once there isn't only the self client in the conversation and the other clients are verified

