### PR TITLE
fix: Crash when scrolling through Gif results - WPB-4916

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -278,7 +278,10 @@ extension GiphySearchViewController {
 
         pendingFetchTask = searchResultsController.fetchMoreResults { [weak self] result in
             if case let .success(ziphs) = result {
-                self?.insertSearchResults(ziphs)
+                self?.collectionView.performBatchUpdates {
+                    self?.insertSearchResults(ziphs)
+                }
+
             }
 
             self?.pendingFetchTask = nil
@@ -298,7 +301,7 @@ extension GiphySearchViewController {
     @discardableResult
     func pushConfirmationViewController(ziph: Ziph?, previewImage: FLAnimatedImage?, animated: Bool = true) -> GiphyConfirmationViewController {
         let confirmationController = GiphyConfirmationViewController(withZiph: ziph, previewImage: previewImage, searchResultController: searchResultsController)
-        confirmationController.title = conversation.displayNameWithFallback.localizedUppercase
+        confirmationController.title = conversation.displayNameWithFallback
         confirmationController.delegate = self
         navigationController?.pushViewController(confirmationController, animated: animated)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4916" title="WPB-4916" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4916</a>  [iOS] Crash while browsing Gif Search Results
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Starting from iOS 16.4

Invalid batch updates detected: the number of sections and/or items returned by the data source before and/or after performing the batch updates are inconsistent with the updates.

Became a fatal exception! Which means crash, whenever we hit that exception.

We were hitting that exception as we were scrolling through the gif results. As a result, the app was crashing.

One of the two solutions proposed in this forum [post](https://developer.apple.com/forums/thread/728797) is to adopt and use UICollectionViewDiffableDataSource but we can't do that yet since we need to have iOS 15 as the minimum version.

So the solution for now is to performBatchUpdates as we insert new search results.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
