### PR TITLE
fix: request loop at /users/list-clients (take 2) WPB-4849

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -396,19 +396,17 @@ final class UserClientByQualifiedUserIDTranscoder: IdentifierObjectSyncTranscode
     }
 
     private func markAllClientsAsUpdated(identifiers: Set<QualifiedID>) {
-        for identifier in identifiers {
-            if let user = ZMUser.fetch(
-                with: identifier.uuid,
-                domain: identifier.domain,
-                in: managedObjectContext
-            ) {
-                for client in user.clients {
+        let clients = UserClient.fetchClientsNeedingUpdateFromBackend(in: managedObjectContext)
+
+        for client in clients {
+            if let qualifiedID = client.user?.qualifiedID {
+                if identifiers.contains(qualifiedID) {
                     client.needsToBeUpdatedFromBackend = false
                 }
             }
         }
 
-        managedObjectContext.enqueueDelayedSave()
+        managedObjectContext.saveOrRollback()
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4849" title="WPB-4849" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4849</a>  Missing pending icon on outgoing connection request
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Follow up from https://github.com/wireapp/wire-ios/pull/569. 

### Issues

That fix didn't work when push notifications was enabled. 

### Causes

When a message from a new client is received while the app is in the background, then the new client is created in the notification extension. I suspect that when the main app is opened, although we find the client created in the extension, it isn't yet visible in the `ZMUser.clients` relationship. However, the opposite relationship `UserClient.user` is set.


As a result, we were not always marking the clients as updated when after processing the response, and these unmarked clients would then trigger the request loop again.


### Solutions

Refactor how we fetch the user clients needing to be marked as updated, obtaining directly from a fetch request rather than via the user and `clients` relationship.

### Testing

#### How to Test

- Log in to backend A with user A, enable push notifications.
- Log in to backend B with user B, share a conversation with user A.
- User A puts app in background.
- User B logs in to a new device, sends messages to A.
- A receives push notifications for the new messages.
- Backend B goes offline.
- User A opens the app.
- Assert there is no request loop.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
