### PR TITLE
chore: enable required checks on merge_queue branches

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -6,6 +6,9 @@ on:
       - '.github/workflows/swiftlint.yml'
       - '.swiftlint.yml'
       - '**/*.swift'
+  push:
+    branches:
+      - 'gh-readonly-queue/develop/**'
 
 # This is what will cancel the workflow
 concurrency:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -6,9 +6,8 @@ on:
       - '.github/workflows/swiftlint.yml'
       - '.swiftlint.yml'
       - '**/*.swift'
-  push:
-    branches:
-      - 'gh-readonly-queue/develop/**'
+  merge_group:
+    types: [checks_requested]
 
 # This is what will cancel the workflow
 concurrency:

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'gh-readonly-queue/develop/**'
 
 # This is what will cancel the workflow
 concurrency:

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'develop'
+      - 'gh-readonly-queue/develop/**'
 
 # This is what will cancel the workflow
 concurrency:

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -1,6 +1,9 @@
 name: Test Pull Request Changes
 
-on: [pull_request]
+on: 
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 
 # This is what will cancel the workflow
 concurrency:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Checks are not run for branches created for merge_queue

### Solutions

add condition to run tests on `gh-readonly-queue/develop/**`

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
