### PR TITLE
fix: Remove force unwrapping in UserClientChangeInfo observer WPB-4922.

### DIFF
--- a/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/UserClientChangeInfo.swift
+++ b/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/UserClientChangeInfo.swift
@@ -91,11 +91,14 @@ extension UserClientChangeInfo {
     /// Adds an observer for the specified userclient
     /// You must hold on to the token and use it to unregister
     @objc(addObserver:forClient:)
-    public static func add(observer: UserClientObserver, for client: UserClient) -> NSObjectProtocol {
-        return ManagedObjectObserverToken(name: .UserClientChange, managedObjectContext: client.managedObjectContext!, object: client) { [weak observer] (note) in
+    public static func add(observer: UserClientObserver, for client: UserClient) -> NSObjectProtocol? {
+        guard let managedObjectContext = client.managedObjectContext else {
+            return nil
+        }
+        return ManagedObjectObserverToken(name: .UserClientChange, managedObjectContext: managedObjectContext, object: client) { [weak observer] (note) in
             guard let `observer` = observer,
-                let changeInfo = note.changeInfo as? UserClientChangeInfo
-                else { return }
+                  let changeInfo = note.changeInfo as? UserClientChangeInfo
+            else { return }
 
             observer.userClientDidChange(changeInfo)
         }

--- a/wire-ios/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
+++ b/wire-ios/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
- 
+
 import XCTest
 @testable import Wire_Notification_Service_Extension
 

--- a/wire-ios/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
+++ b/wire-ios/Wire-iOS Tests/Notification Service Extension/SimpleNotificationServiceExtension/JobTests.swift
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
-
+ 
 import XCTest
 @testable import Wire_Notification_Service_Extension
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/DotView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/DotView.swift
@@ -24,7 +24,7 @@ final class DotView: UIView {
     private let circleView = ShapeView()
     private let centerView = ShapeView()
     private var userObserver: NSObjectProtocol!
-    private var clientsObserverTokens: [NSObjectProtocol?] = []
+    private var clientsObserverTokens: [NSObjectProtocol] = []
     private let user: ZMUser?
     public var hasUnreadMessages: Bool = false {
         didSet { self.updateIndicator() }
@@ -88,7 +88,7 @@ final class DotView: UIView {
 
     private func createClientObservers() {
         guard let user = user else { return }
-        clientsObserverTokens = user.clients.map { UserClientChangeInfo.add(observer: self, for: $0) }
+        clientsObserverTokens = user.clients.compactMap { UserClientChangeInfo.add(observer: self, for: $0) }
     }
 
     func updateIndicator() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/DotView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/DotView.swift
@@ -24,7 +24,7 @@ final class DotView: UIView {
     private let circleView = ShapeView()
     private let centerView = ShapeView()
     private var userObserver: NSObjectProtocol!
-    private var clientsObserverTokens: [NSObjectProtocol] = []
+    private var clientsObserverTokens: [NSObjectProtocol?] = []
     private let user: ZMUser?
     public var hasUnreadMessages: Bool = false {
         didSet { self.updateIndicator() }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4922" title="WPB-4922" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4922</a>  [iOS] Decryption errors and app crash on C3 build after logging in with same account on other device
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Victor reported the crash. The crash logs is on the ticket.
The short version:

`
Thread 0 name:Thread 0 Crashed:0   WireDataModel                 0x0000000105ce63a8 Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value + 0 (<compiler-generated>:0)
1   WireDataModel                 0x0000000105ce63a8 specialized static UserClientChangeInfo.add(observer:for:) + 464 (UserClientChangeInfo.swift:95)
2   Wire                          0x00000001047b3580 closure #1 in DotView.createClientObservers() + 12 (DotView.swift:91)
`
### Solutions

Remove forced unwrap.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
