### PR TITLE
fix: can't send reactions in MLS conversations WPB-2215

### DIFF
--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.swift
@@ -83,7 +83,6 @@ class MLSMessageSync<Message: MLSMessage>: NSObject, ZMContextChangeTrackerSourc
             context.performGroupedBlock { [dependencySync] in
                 dependencySync.synchronize(entity: message, completion: completion)
                 RequestAvailableNotification.notifyNewRequestsAvailable(nil)
-                completion(.success(()), .init())
             }
         }
     }

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
@@ -164,10 +164,6 @@ class MockMLSService: MLSServiceInterface {
         fatalError("not implemented")
     }
 
-    func subconversationMembers(for subconversationGroupID: WireDataModel.MLSGroupID) throws -> [WireDataModel.MLSClientID] {
-        fatalError("not implemented")
-    }
-
     // MARK: - New epoch
 
     func generateNewEpoch(groupID: MLSGroupID) async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2215" title="WPB-2215" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-2215</a>  [iOS] Can't like or unlike a message from iOS in an MLS conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
If I send a reaction in an MLS group, then I don't receive it on any other client in that group.

### Causes
When we want to send a reaction message in the group, we "sync" the message via the `MLSMessageSync`. However we erroneously call the completion handler with a success result after syncing the message, instead of when the message is actually encrypted and sent and the backend responds with a success. When the completion handler is invoked it will delete the reaction message, which is expected because they don't need to stay in the database. This premature deletion is preventing the reactions from being sent.

### Solutions
Remove the call to the completion handler (it is passed along in the right place already).

### Testing

#### How to Test

- Send a reaction in an MLS conversation
- Assert that it can be received by other users in the conversation.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
