### PR TITLE
fix: flaky data model tests

### DIFF
--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
@@ -49,7 +49,8 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (0...40).forEach { i in
-            try conversation.appendText(content: "\(i)")
+            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
+            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(40 - i))
         }
 
         // THEN
@@ -62,7 +63,8 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (0...40).forEach { i in
-            try conversation.appendText(content: "\(i)")
+            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
+            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(40 - i))
         }
 
         // THEN
@@ -78,7 +80,8 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (0...40).forEach { i in
-            try conversation.appendText(content: "\(i)")
+            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
+            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(41 - i))
         }
 
         // THEN
@@ -95,11 +98,13 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (1...10).forEach { i in
-            try conversation.appendText(content: "\(i)")
+            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
+            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(10 - i))
         }
 
         try (1...10).forEach { i in
-            try otherConversation.appendText(content: "Other \(i)")
+            let message = try otherConversation.appendText(content: "Other \(i)") as! ZMClientMessage
+            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(10 - i))
         }
 
         // THEN

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
@@ -50,7 +50,7 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
         // WHEN
         try (0...40).forEach { i in
             let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(40 - i))
+            message.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -64,7 +64,7 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
         // WHEN
         try (0...40).forEach { i in
             let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(40 - i))
+            message.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -81,7 +81,7 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
         // WHEN
         try (0...40).forEach { i in
             let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(41 - i))
+            message.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -99,12 +99,12 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
         // WHEN
         try (1...10).forEach { i in
             let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(10 - i))
+            message.updateTimestamp(with: Double(i))
         }
 
         try (1...10).forEach { i in
             let message = try otherConversation.appendText(content: "Other \(i)") as! ZMClientMessage
-            message.serverTimestamp = Date.init(timeIntervalSinceNow: -Double(10 - i))
+            message.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -129,6 +129,14 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // then
         XCTAssertEqual(conversation.lastEditableMessage, message)
+    }
+
+}
+
+extension ZMMessage {
+
+    func updateTimestamp(with timeInterval: TimeInterval) {
+        self.serverTimestamp = Date(timeIntervalSince1970: timeInterval)
     }
 
 }

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationLastMessagesTest.swift
@@ -49,8 +49,8 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (0...40).forEach { i in
-            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.updateTimestamp(with: Double(i))
+            let message = try conversation.appendText(content: "\(i)") as? ZMClientMessage
+            message?.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -63,8 +63,8 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (0...40).forEach { i in
-            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.updateTimestamp(with: Double(i))
+            let message = try conversation.appendText(content: "\(i)") as? ZMClientMessage
+            message?.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -80,8 +80,8 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (0...40).forEach { i in
-            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.updateTimestamp(with: Double(i))
+            let message = try conversation.appendText(content: "\(i)") as? ZMClientMessage
+            message?.updateTimestamp(with: Double(i))
         }
 
         // THEN
@@ -98,13 +98,13 @@ class ZMConversationLastMessagesTest: ZMBaseManagedObjectTest {
 
         // WHEN
         try (1...10).forEach { i in
-            let message = try conversation.appendText(content: "\(i)") as! ZMClientMessage
-            message.updateTimestamp(with: Double(i))
+            let message = try conversation.appendText(content: "\(i)") as? ZMClientMessage
+            message?.updateTimestamp(with: Double(i))
         }
 
         try (1...10).forEach { i in
-            let message = try otherConversation.appendText(content: "Other \(i)") as! ZMClientMessage
-            message.updateTimestamp(with: Double(i))
+            let message = try otherConversation.appendText(content: "Other \(i)") as? ZMClientMessage
+            message?.updateTimestamp(with: Double(i))
         }
 
         // THEN

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Confirmations.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Confirmations.swift
@@ -82,9 +82,9 @@ class ZMConversationTests_Confirmations: ZMConversationTestsBase {
         conversation.conversationType = .group
         conversation.lastReadServerTimeStamp = .distantPast
 
-        message1.serverTimestamp = Date.init(timeIntervalSinceNow: -35)
-        message2.serverTimestamp = Date.init(timeIntervalSinceNow: -30)
-        message3.serverTimestamp = Date.init(timeIntervalSinceNow: -25)
+        message1.updateTimestamp(with: 10)
+        message2.updateTimestamp(with: 20)
+        message3.updateTimestamp(with: 30)
 
         // when
         let confirmMessages = conversation.confirmUnreadMessagesAsRead(in: conversation.lastReadServerTimeStamp!...message2.serverTimestamp!)
@@ -115,10 +115,10 @@ class ZMConversationTests_Confirmations: ZMConversationTestsBase {
 
         conversation.conversationType = .group
 
-        message1.serverTimestamp = Date.init(timeIntervalSinceNow: -35)
-        message2.serverTimestamp = Date.init(timeIntervalSinceNow: -30)
-        message3.serverTimestamp = Date.init(timeIntervalSinceNow: -25)
-        message4.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
+        message1.updateTimestamp(with: 10)
+        message2.updateTimestamp(with: 20)
+        message3.updateTimestamp(with: 30)
+        message4.updateTimestamp(with: 40)
 
         // When
         // Before we confirm the unread messages, advance the last read server timestamp.

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Confirmations.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Confirmations.swift
@@ -17,7 +17,6 @@
 //
 
 import XCTest
-
 @testable import WireDataModel
 
 class ZMConversationTests_Confirmations: ZMConversationTestsBase {
@@ -83,6 +82,10 @@ class ZMConversationTests_Confirmations: ZMConversationTestsBase {
         conversation.conversationType = .group
         conversation.lastReadServerTimeStamp = .distantPast
 
+        message1.serverTimestamp = Date.init(timeIntervalSinceNow: -35)
+        message2.serverTimestamp = Date.init(timeIntervalSinceNow: -30)
+        message3.serverTimestamp = Date.init(timeIntervalSinceNow: -25)
+
         // when
         let confirmMessages = conversation.confirmUnreadMessagesAsRead(in: conversation.lastReadServerTimeStamp!...message2.serverTimestamp!)
 
@@ -111,6 +114,11 @@ class ZMConversationTests_Confirmations: ZMConversationTestsBase {
         message4.sender = user1
 
         conversation.conversationType = .group
+
+        message1.serverTimestamp = Date.init(timeIntervalSinceNow: -35)
+        message2.serverTimestamp = Date.init(timeIntervalSinceNow: -30)
+        message3.serverTimestamp = Date.init(timeIntervalSinceNow: -25)
+        message4.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
 
         // When
         // Before we confirm the unread messages, advance the last read server timestamp.

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
@@ -384,7 +384,8 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
         let systemMessage1 = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage1.systemMessageType = .missedCall
         systemMessage1.visibleInConversation = conversation
-        systemMessage1.serverTimestamp = Date.init(timeIntervalSinceNow: -30)
+        systemMessage1.updateTimestamp(with: 10)
+
         conversation.lastReadServerTimeStamp = systemMessage1.serverTimestamp
 
         // when
@@ -392,7 +393,7 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
         systemMessage2.systemMessageType = .missedCall
         systemMessage2.hiddenInConversation = conversation
         systemMessage2.parentMessage = systemMessage1
-        systemMessage2.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
+        systemMessage2.updateTimestamp(with: 20)
 
         // then
         XCTAssertEqual(conversation.firstUnreadMessage as? ZMSystemMessage, systemMessage1)

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
@@ -384,6 +384,7 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
         let systemMessage1 = ZMSystemMessage(nonce: UUID(), managedObjectContext: uiMOC)
         systemMessage1.systemMessageType = .missedCall
         systemMessage1.visibleInConversation = conversation
+        systemMessage1.serverTimestamp = Date.init(timeIntervalSinceNow: -30)
         conversation.lastReadServerTimeStamp = systemMessage1.serverTimestamp
 
         // when
@@ -391,6 +392,7 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
         systemMessage2.systemMessageType = .missedCall
         systemMessage2.hiddenInConversation = conversation
         systemMessage2.parentMessage = systemMessage1
+        systemMessage2.serverTimestamp = Date.init(timeIntervalSinceNow: -20)
 
         // then
         XCTAssertEqual(conversation.firstUnreadMessage as? ZMSystemMessage, systemMessage1)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We have several flaky tests in the data model.

### Causes (Optional)

The text messages in this test have the same server time. When we filter the first, last, first 10, etc. messages, we get a different list of messages.

### Solutions

Set serverTimestamp for inserted messages in tests.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
