### PR TITLE
fix: crash when context data is unavailable WPB-4920

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMGenericMessageData.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMGenericMessageData.swift
@@ -113,6 +113,7 @@ import WireCryptobox
         do {
             return try moc.encryptData(data: data)
         } catch let error as NSManagedObjectContext.EncryptionError {
+            WireLogger.ear.error("failed to encrypt message: \(String(describing: error))")
             throw ProcessingError.failedToEncrypt(reason: error)
         }
     }
@@ -123,6 +124,7 @@ import WireCryptobox
         do {
             return try moc.decryptData(data: data, nonce: nonce)
         } catch let error as NSManagedObjectContext.EncryptionError {
+            WireLogger.ear.error("failed to decrypt message: \(String(describing: error))")
             throw ProcessingError.failedToDecrypt(reason: error)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4920" title="WPB-4920" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4920</a>  [iOS] Crash when sending message in C1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
If we are unable to get context data to encrypt / decrypt a message in an EAR protected database then we will crash the app.

### Causes
The context data we use is derived from the self user and self client ids. This data is always expected to exist, so there was a fatal error when it didn't.

### Solutions
While unlikely, it is possible that some code may be executed after the assumptions that certain objects exist are no longer valid. For example, when a notification is fired and then the user session is expired or torn down. Therefore we shouldn't fatal error, but rather make an assertion failure and fail softly. In this particular case, the worst thing the user will see is an error message in the conversation that the messages are not available. 

### Testing
#### How to Test
There isn't really a way to test this.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
