### PR TITLE
fix: slow sync stuck on `fetchingUsers` phase WPB-5096

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -80,9 +80,8 @@ public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObje
             syncProgress.finishCurrentSyncPhase(phase: .fetchingUsers)
         } else {
             fetch(users: allConnectedUsers, for: apiVersion)
+            isFetchingAllConnectedUsers = true
         }
-
-        isFetchingAllConnectedUsers = true
     }
 
     func allConnectedUsers() -> Set<ZMUser> {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -198,6 +198,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
         syncMOC.performGroupedBlockAndWait {
             // then
             XCTAssertEqual(self.mockSyncProgress.didFinishCurrentSyncPhase, .fetchingUsers)
+            XCTAssertFalse(self.sut.isFetchingAllConnectedUsers)
         }
     }
 
@@ -214,6 +215,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(self.mockSyncProgress.didFinishCurrentSyncPhase, .fetchingUsers)
+            XCTAssertFalse(self.sut.isFetchingAllConnectedUsers)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5096" title="WPB-5096" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5096</a>  [iOS] Slow sync getting stuck on `fetchingUsers` phase
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes the slow sync gets stuck on the `fetchingUsers` phase

### Causes 

The flag `isFetchingAllConnectedUsers` was set to **true** even when we weren't fetching users. And it never gets set back to **false**, thus returning early each time we enter the `fetchingUsers` phase. This prevents the phase from finishing and the slow sync stays stuck in that state.

### Solutions

Only set `isFetchingAllConnectedUsers` to **true** when we're fetching users and we're sure that it'll be set back to **false** when fetching concludes 

### Testing

- [x] I have added a test to verify `isFetchingAllConnectedUsers` is set back to false after fetching

