### PR TITLE
fix: use maintained swiftlint workflow - WPB-5239

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,10 +16,9 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: GitHub Action for SwiftLint
-          uses: sinoru/actions-swiftlint@v6.0.4
+          uses: sinoru/actions-swiftlint@v6
           with:
             swiftlint-version: 0.53.0
             swiftlint-args: --strict
           env:
             DIFF_BASE: ${{ github.base_ref }}
-            DIFF_HEAD: HEAD

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -15,6 +15,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
+        - name: Fetch base ref
+          run: |
+            git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
         - name: GitHub Action for SwiftLint
           uses: sinoru/actions-swiftlint@v6
           with:
@@ -22,3 +25,4 @@ jobs:
             swiftlint-args: --strict
           env:
             DIFF_BASE: ${{ github.base_ref }}
+            DIFF_HEAD: HEAD

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -19,7 +19,7 @@ jobs:
           run: |
             git fetch --prune --no-tags --depth=1 origin +refs/heads/${{ github.base_ref }}:refs/heads/${{ github.base_ref }}
         - name: GitHub Action for SwiftLint
-          uses: sinoru/actions-swiftlint@v6
+          uses: mayk-it/action-swiftlint@3.2.2
           with:
             swiftlint-version: 0.53.0
             swiftlint-args: --strict

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -21,8 +21,7 @@ jobs:
         - name: GitHub Action for SwiftLint
           uses: mayk-it/action-swiftlint@3.2.2
           with:
-            swiftlint-version: 0.53.0
-            swiftlint-args: --strict
+            args: --strict
           env:
             DIFF_BASE: ${{ github.base_ref }}
             DIFF_HEAD: HEAD

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,8 +20,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: GitHub Action for SwiftLint
-          uses: norio-nomura/action-swiftlint@3.2.1
+          uses: sinoru/actions-swiftlint@v6
           with:
-            args: --strict
+            swiftlint-args: --strict
           env:
             DIFF_BASE: ${{ github.base_ref }}   

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -2,10 +2,6 @@ name: SwiftLint
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/swiftlint.yml'
-      - '.swiftlint.yml'
-      - '**/*.swift'
   merge_group:
     types: [checks_requested]
 
@@ -20,8 +16,9 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: GitHub Action for SwiftLint
-          uses: sinoru/actions-swiftlint@v6
+          uses: sinoru/actions-swiftlint@v6.0.4
           with:
+            swiftlint-version: 0.53.0
             swiftlint-args: --strict
           env:
             DIFF_BASE: ${{ github.base_ref }}   

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -21,4 +21,5 @@ jobs:
             swiftlint-version: 0.53.0
             swiftlint-args: --strict
           env:
-            DIFF_BASE: ${{ github.base_ref }}   
+            DIFF_BASE: ${{ github.base_ref }}
+            DIFF_HEAD: HEAD

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,3 +51,5 @@ excluded:
 line_length:
     warning: 500
     error: 500
+
+swiftlint_version: 0.53.0

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -22,6 +22,9 @@ import WireSyncEngine
 import avs
 import WireCoreCrypto
 
+
+
+
 enum ApplicationLaunchType {
     case unknown
     case direct


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5239" title="WPB-5239" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5239</a>  Swiftlint broken check
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

PR #600 revealed that we have different versions of swiftlint on the project. 

Digging more It appeared that we use an unmaintained action for swiftlint that resulted in broken runs when using the  (Only files changed in the PR) option.

### Solutions

- Switch to another maintained action
- Make sure everyone is running the same swiftlint version

### Notes (Optional)

Need to double check which version of swiftlint is checked.


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
