### PR TITLE
fix: decryptMLS crash if not apiV5

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -12,5 +12,5 @@ github "wireapp/libPhoneNumber-iOS" "1.1"
 github "wireapp/ocmock" "v3.4.3_Xcode14.3.1"
 github "wireapp/Starscream" "4.0.4_min_tls_version"
 github "wireapp/dd-sdk-ios" ~> 1.22.0
-github "wireapp/core-crypto" "v0.9.2-xcode-14.3.1"
+github "wireapp/core-crypto" "v1.0.0-pre.5"
 binary "wire-avs.json" ~> 9.3.12

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -27,8 +27,8 @@ extension EventDecoder {
         Logging.mls.info("decrypting mls message")
 
         guard let decryptionService = context.mlsDecryptionService else {
-            WireLogger.mls.critical("failed to decrypt mls message: mlsDecyptionService is missing")
-            fatalError("failed to decrypt mls message: mlsService is missing")
+            WireLogger.mls.warn("failed to decrypt mls message: mlsDecyptionService is missing, maybe apiV5 not available")
+            return nil
         }
 
         guard let payload = updateEvent.eventPayload(type: Payload.UpdateConversationMLSMessageAdd.self) else {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

If somehow the user did not select apiV5 on a MLS build it will crash when receiving MLS messages.

Lower it to just ignore the event.

Notes:

Corrected the cartfile to show same version as Cartfile.resolved

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
