### PR TITLE
refactor(message-sending): Introduce an abstraction for making requests WPB-5150 WPB-5153 #2

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -144,14 +144,21 @@ extension ZMClientMessage: EncryptedPayloadGenerator {
 
     public func encryptForTransportQualified() -> Payload? {
         guard
-            let conversation = conversation,
             let context = managedObjectContext
         else {
             return nil
         }
 
-        updateUnderlayingMessageBeforeSending(in: context)
-        return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
+        return context.performAndWait {
+            guard
+                let conversation = conversation
+            else {
+                return nil
+            }
+
+            updateUnderlayingMessageBeforeSending(in: context)
+            return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
+        }
     }
 
     public var debugInfo: String {
@@ -176,14 +183,22 @@ extension ZMAssetClientMessage: EncryptedPayloadGenerator {
 
     public func encryptForTransportQualified() -> Payload? {
         guard
-            let conversation = conversation,
             let context = managedObjectContext
         else {
             return nil
         }
 
-        updateUnderlayingMessageBeforeSending(in: context)
-        return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
+        return context.performAndWait {
+            guard
+                let conversation = conversation
+            else {
+                return nil
+            }
+
+            updateUnderlayingMessageBeforeSending(in: context)
+            return underlyingMessage?.encryptForTransport(for: conversation, useQualifiedIdentifiers: true)
+        }
+
     }
 
     public var debugInfo: String {

--- a/wire-ios-request-strategy/Sources/APIs/APIProvider.swift
+++ b/wire-ios-request-strategy/Sources/APIs/APIProvider.swift
@@ -1,0 +1,39 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public struct APIProvider {
+
+    let httpClient: HttpClient
+
+    public init(httpClient: HttpClient) {
+        self.httpClient = httpClient
+    }
+
+    func prekeyAPI(apiVersion: APIVersion) -> PrekeyAPI {
+        return switch apiVersion {
+        case .v0: PrekeyAPIV0(httpClient: httpClient)
+        case .v1: PrekeyAPIV1(httpClient: httpClient)
+        case .v2: PrekeyAPIV2(httpClient: httpClient)
+        case .v3: PrekeyAPIV3(httpClient: httpClient)
+        case .v4: PrekeyAPIV4(httpClient: httpClient)
+        case .v5: PrekeyAPIV5(httpClient: httpClient)
+        }
+    }
+}

--- a/wire-ios-request-strategy/Sources/APIs/APIProvider.swift
+++ b/wire-ios-request-strategy/Sources/APIs/APIProvider.swift
@@ -36,4 +36,15 @@ public struct APIProvider {
         case .v5: PrekeyAPIV5(httpClient: httpClient)
         }
     }
+
+    func messageAPI(apiVersion: APIVersion) -> MessageAPI {
+        return switch apiVersion {
+        case .v0: MessageAPIV0(httpClient: httpClient)
+        case .v1: MessageAPIV1(httpClient: httpClient)
+        case .v2: MessageAPIV2(httpClient: httpClient)
+        case .v3: MessageAPIV3(httpClient: httpClient)
+        case .v4: MessageAPIV4(httpClient: httpClient)
+        case .v5: MessageAPIV5(httpClient: httpClient)
+        }
+    }
 }

--- a/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
@@ -1,0 +1,123 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol MessageAPI {
+
+    func sendProteusMessage(payload: EncryptedPayloadGenerator, conversationID: QualifiedID) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError>
+
+}
+
+class MessageAPIV0: MessageAPI {
+
+    open var apiVersion: APIVersion {
+        .v0
+    }
+
+    private let httpClient: HttpClient
+    private let protobufContentType = "application/x-protobuf"
+
+    init(httpClient: HttpClient) {
+        self.httpClient = httpClient
+    }
+
+    func sendProteusMessage(
+        payload: WireDataModel.EncryptedPayloadGenerator,
+        conversationID: QualifiedID
+    ) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError> {
+        let path = "/" + ["conversations", conversationID.domain, conversationID.uuid.transportString(), "proteus", "messages"].joined(separator: "/")
+
+        guard let encryptedPayload = payload.encryptForTransportQualified() else {
+            WireLogger.messaging.error("failed to encrypt message for transport")
+            return .failure(NetworkError.errorEncodingRequest)
+        }
+
+        let request = ZMTransportRequest(
+            path: path,
+            method: .methodPOST,
+            binaryData: encryptedPayload.data,
+            type: protobufContentType,
+            contentDisposition: nil,
+            apiVersion: apiVersion.rawValue
+        )
+
+        let response = await httpClient.send(request)
+
+        if response.httpStatus == 412 {
+            guard
+                let messageSendingStatus = Payload.MessageSendingStatus(response, decoder: .defaultDecoder)
+            else {
+                return .failure(NetworkError.errorDecodingResponse(response))
+            }
+            return .failure(.missingClients(messageSendingStatus, response))
+        } else {
+            return mapResponse(response).map { payload in
+                (payload, response)
+            }
+        }
+    }
+}
+
+func mapResponse<T: Decodable>(_ response: ZMTransportResponse) -> Swift.Result<T, NetworkError> {
+    if response.result == .success {
+        guard
+            let value = T(response, decoder: .defaultDecoder)
+        else {
+            return .failure(NetworkError.errorDecodingResponse(response))
+        }
+        return .success(value)
+    } else {
+        guard
+            let responseFailure = Payload.ResponseFailure(response, decoder: .defaultDecoder)
+        else {
+            return .failure(NetworkError.errorDecodingResponse(response))
+        }
+        return .failure(.invalidRequestError(responseFailure, response))
+    }
+}
+
+class MessageAPIV1: MessageAPIV0 {
+    override var apiVersion: APIVersion {
+        .v1
+    }
+}
+
+class MessageAPIV2: MessageAPIV1 {
+    override var apiVersion: APIVersion {
+        .v2
+    }
+}
+
+class MessageAPIV3: MessageAPIV2 {
+    override var apiVersion: APIVersion {
+        .v3
+    }
+}
+
+class MessageAPIV4: MessageAPIV3 {
+    override var apiVersion: APIVersion {
+        .v4
+    }
+}
+
+class MessageAPIV5: MessageAPIV4 {
+    override var apiVersion: APIVersion {
+        .v5
+    }
+}

--- a/wire-ios-request-strategy/Sources/APIs/NetworkError.swift
+++ b/wire-ios-request-strategy/Sources/APIs/NetworkError.swift
@@ -18,7 +18,22 @@
 
 import Foundation
 
-enum NetworkError: Error {
+public enum NetworkError: Error {
     case errorEncodingRequest
-    case errorDecodingResponse
+    case errorDecodingResponse(ZMTransportResponse)
+    case missingClients(Payload.MessageSendingStatus, ZMTransportResponse)
+    case invalidRequestError(Payload.ResponseFailure, ZMTransportResponse)
+
+    var response: ZMTransportResponse? {
+        return switch self {
+        case .errorEncodingRequest:
+            nil
+        case .errorDecodingResponse(let response):
+            response
+        case .missingClients(_, let response):
+            response
+        case .invalidRequestError(_, let response):
+            response
+        }
+    }
 }

--- a/wire-ios-request-strategy/Sources/APIs/NetworkError.swift
+++ b/wire-ios-request-strategy/Sources/APIs/NetworkError.swift
@@ -1,0 +1,24 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case errorEncodingRequest
+    case errorDecodingResponse
+}

--- a/wire-ios-request-strategy/Sources/APIs/PrekeyAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/PrekeyAPI.swift
@@ -1,0 +1,140 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+protocol PrekeyAPI {
+
+    func fetchPrekeys(for clients: Set<QualifiedClientID>) async -> Swift.Result<Payload.PrekeyByQualifiedUserID, Error>
+
+}
+
+class PrekeyAPIV0: PrekeyAPI {
+
+    init(httpClient: HttpClient) {
+        self.httpClient = httpClient
+    }
+
+    open var apiVersion: APIVersion {
+        return .v0
+    }
+
+    let httpClient: HttpClient
+    let defaultEncoder = JSONEncoder.defaultEncoder
+
+    func fetchPrekeys(for clients: Set<QualifiedClientID>) async -> Swift.Result<Payload.PrekeyByQualifiedUserID, Error> {
+        guard
+            let payloadData = clients.clientListByDomain.payloadData(encoder: defaultEncoder),
+            let payloadAsString = String(bytes: payloadData, encoding: .utf8)
+        else {
+            return .failure(NetworkError.errorEncodingRequest)
+        }
+
+        let request = ZMTransportRequest(path: "/users/list-prekeys",
+                                         method: .methodPOST,
+                                         payload: payloadAsString as ZMTransportData?,
+                                         apiVersion: apiVersion.rawValue)
+
+        let response = await httpClient.send(request)
+
+        guard
+            let rawData = response.rawData,
+            let prekeys = Payload.PrekeyByQualifiedUserID(rawData)
+        else {
+            return .failure(NetworkError.errorDecodingResponse)
+        }
+
+        return .success(prekeys)
+    }
+}
+
+class PrekeyAPIV1: PrekeyAPIV0 {
+    override var apiVersion: APIVersion {
+        return .v1
+    }
+}
+
+class PrekeyAPIV2: PrekeyAPIV1 {
+    override var apiVersion: APIVersion {
+        return .v2
+    }
+}
+
+class PrekeyAPIV3: PrekeyAPIV2 {
+    override var apiVersion: APIVersion {
+        return .v3
+    }
+}
+
+class PrekeyAPIV4: PrekeyAPIV3 {
+    override var apiVersion: APIVersion {
+        return .v4
+    }
+
+    override func fetchPrekeys(for clients: Set<QualifiedClientID>) async -> Swift.Result<Payload.PrekeyByQualifiedUserID, Error> {
+        guard
+            let payloadData = clients.clientListByDomain.payloadData(encoder: defaultEncoder),
+            let payloadAsString = String(bytes: payloadData, encoding: .utf8)
+        else {
+            return .failure(NetworkError.errorEncodingRequest)
+        }
+
+        let request = ZMTransportRequest(path: "/users/list-prekeys",
+                                         method: .methodPOST,
+                                         payload: payloadAsString as ZMTransportData?,
+                                         apiVersion: apiVersion.rawValue)
+
+        let response = await httpClient.send(request)
+
+        guard
+            let rawData = response.rawData,
+            let prekeys = Payload.PrekeyByQualifiedUserIDV4(rawData)
+        else {
+            return .failure(NetworkError.errorDecodingResponse)
+        }
+
+        return .success(prekeys.prekeyByQualifiedUserID)
+    }
+}
+
+class PrekeyAPIV5: PrekeyAPIV4 {
+    override var apiVersion: APIVersion {
+        return .v5
+    }
+}
+
+extension Collection where Element == QualifiedClientID {
+
+    var clientListByUserID: Payload.ClientListByUserID {
+
+        let initial: Payload.ClientListByUserID = [:]
+
+        return self.reduce(into: initial) { (result, client) in
+            result[client.userID.transportString(), default: []].append(client.clientID)
+        }
+    }
+
+    var clientListByDomain: Payload.ClientListByQualifiedUserID {
+        let initial: Payload.ClientListByQualifiedUserID = [:]
+
+        return self.reduce(into: initial) { (result, client) in
+            result[client.domain, default: Payload.ClientListByUserID()][client.userID.transportString(), default: []].append(client.clientID)
+        }
+    }
+
+}

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -203,7 +203,7 @@ public class MessageSender {
             }
         default:
             if case .permanentError = failure.response?.result {
-                return .success(Set()) // FIXME: [jacob] it's dangerous to retry indefinitely like this
+                return .success(Set()) // FIXME: [jacob] it's dangerous to retry indefinitely like this WPB-5454
             } else {
                 return .failure(MessageSendError.networkError(failure))
             }

--- a/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
@@ -19,9 +19,8 @@
 import Foundation
 
 public enum SessionEstablisherError: Error {
-    case failedToGenerateRequest
-    case failedToParseResponse
     case missingSelfClient
+    case networkError(NetworkError)
 }
 
 public class SessionEstablisher {
@@ -61,7 +60,7 @@ public class SessionEstablisher {
         }
 
         return await apiProvider.prekeyAPI(apiVersion: apiVersion).fetchPrekeys(for: clients)
-            .mapError({ _ in SessionEstablisherError.failedToGenerateRequest })
+            .mapError({ error in SessionEstablisherError.networkError(error) })
             .flatMap { prekeys in
             managedObjectContext.performAndWait {
                 _ = processor.establishSessions(from: prekeys, with: selfClient, context: managedObjectContext)

--- a/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
@@ -37,12 +37,12 @@ public class SessionEstablisher {
     private let managedObjectContext: NSManagedObjectContext
     private let requestFactory = MissingClientsRequestFactory()
     private let processor = PrekeyPayloadProcessor()
-    private let BATCH_SIZE = 28
+    private let batchSize = 28
 
     func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async -> Swift.Result<Void, SessionEstablisherError> {
 
         // Establish sessions in chunks and return on first error
-        for chunk in Array(clients).chunked(into: BATCH_SIZE) {
+        for chunk in Array(clients).chunked(into: batchSize) {
             let result = await internalEstablishSessions(for: Set(chunk), apiVersion: apiVersion)
             if case Swift.Result.failure = result {
                 return result

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ProteusMessageSync.swift
@@ -142,7 +142,7 @@ public class ProteusMessageSync<Message: ProteusMessage>: NSObject, EntityTransc
                     shouldRetry = processor.updateClientsChanges(
                         from: payload,
                         for: entity
-                    )
+                    ).isNonEmpty
                 }
 
                 WireLogger.messaging.debug("got 412, will retry: \(shouldRetry)")

--- a/wire-ios-request-strategy/Sources/Payloads/Payload.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload.swift
@@ -18,7 +18,7 @@
 import Foundation
 import WireDataModel
 
-enum Payload {
+public enum Payload {
 
     typealias UserClients = [Payload.UserClient]
     typealias UserClientByUserID = [String: UserClients]
@@ -267,7 +267,7 @@ enum Payload {
         }
     }
 
-    struct ResponseFailure: Codable {
+    public struct ResponseFailure: Codable {
 
         /// Endpoints involving federated calls to other domains can return some extra failure responses.
         /// The error response contains the following extra fields:
@@ -315,7 +315,7 @@ enum Payload {
 
     }
 
-    struct MessageSendingStatus: Codable {
+    public struct MessageSendingStatus: Codable {
 
         enum CodingKeys: String, CodingKey {
             case time

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/MessageSendingStatusPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/MessageSendingStatusPayloadProcessor.swift
@@ -23,7 +23,7 @@ final class MessageSendingStatusPayloadProcessor {
     /// Updates the reported client changes after an attempt to send the message
     ///
     /// - Parameter message: message for which the message sending status was created
-    /// - Returns *True* if the message was missing clients in the original payload.
+    /// - Returns reported missing clients
     ///
     /// If a message was missing clients we should attempt to send the message again
     /// after establishing sessions with the missing clients.
@@ -32,7 +32,7 @@ final class MessageSendingStatusPayloadProcessor {
     func updateClientsChanges(
         from payload: Payload.MessageSendingStatus,
         for message: any ProteusMessage
-    ) -> Bool {
+    ) -> [ZMUser: [UserClient]] {
         WireLogger.messaging.debug("update client changes for message \(message.debugInfo)")
 
         let deletedClients = payload.deleted.fetchClients(in: message.context)
@@ -78,7 +78,7 @@ final class MessageSendingStatusPayloadProcessor {
             message.addFailedToSendRecipients(failedToConfirmUsers)
         }
 
-        return !missingClients.isEmpty
+        return missingClients
     }
 
     func missingClientListByUser(

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -89,6 +89,9 @@
 		16229488221EBB8100A98679 /* ZMImagePreprocessingTracker+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 16229484221EBB8000A98679 /* ZMImagePreprocessingTracker+Testing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1623F8D32AE66F28004F0319 /* MessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D22AE66F28004F0319 /* MessageSender.swift */; };
 		1623F8D52AE6729D004F0319 /* SessionEstablisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D42AE6729D004F0319 /* SessionEstablisher.swift */; };
+		1623F8D82AE7FB7E004F0319 /* PrekeyAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D72AE7FB7E004F0319 /* PrekeyAPI.swift */; };
+		1623F8DA2AE7FBD6004F0319 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D92AE7FBD6004F0319 /* NetworkError.swift */; };
+		1623F8DC2AE7FD54004F0319 /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8DB2AE7FD54004F0319 /* APIProvider.swift */; };
 		16367F1E26FDB0740028AF8B /* Payload+Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16367F1D26FDB0740028AF8B /* Payload+Connection.swift */; };
 		16367F2626FDB4720028AF8B /* ConnectionRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16367F2526FDB4720028AF8B /* ConnectionRequestStrategy.swift */; };
 		164D00742225624E00A8F264 /* ZMImagePreprocessingTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 16229485221EBB8000A98679 /* ZMImagePreprocessingTrackerTests.m */; };
@@ -512,6 +515,9 @@
 		16229485221EBB8000A98679 /* ZMImagePreprocessingTrackerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMImagePreprocessingTrackerTests.m; sourceTree = "<group>"; };
 		1623F8D22AE66F28004F0319 /* MessageSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSender.swift; sourceTree = "<group>"; };
 		1623F8D42AE6729D004F0319 /* SessionEstablisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEstablisher.swift; sourceTree = "<group>"; };
+		1623F8D72AE7FB7E004F0319 /* PrekeyAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrekeyAPI.swift; sourceTree = "<group>"; };
+		1623F8D92AE7FBD6004F0319 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		1623F8DB2AE7FD54004F0319 /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
 		16367F1D26FDB0740028AF8B /* Payload+Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payload+Connection.swift"; sourceTree = "<group>"; };
 		16367F2526FDB4720028AF8B /* ConnectionRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRequestStrategy.swift; sourceTree = "<group>"; };
 		164D007522256C6E00A8F264 /* AssetV3UploadRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetV3UploadRequestStrategyTests.swift; sourceTree = "<group>"; };
@@ -1027,6 +1033,16 @@
 			path = "Message Sending";
 			sourceTree = "<group>";
 		};
+		1623F8D62AE7FB5F004F0319 /* APIs */ = {
+			isa = PBXGroup;
+			children = (
+				1623F8D72AE7FB7E004F0319 /* PrekeyAPI.swift */,
+				1623F8D92AE7FBD6004F0319 /* NetworkError.swift */,
+				1623F8DB2AE7FD54004F0319 /* APIProvider.swift */,
+			);
+			path = APIs;
+			sourceTree = "<group>";
+		};
 		16367F2926FDB5040028AF8B /* Connection */ = {
 			isa = PBXGroup;
 			children = (
@@ -1079,6 +1095,7 @@
 		1669016C1D707509000FE4AF /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				1623F8D62AE7FB5F004F0319 /* APIs */,
 				1623F8D12AE66F0A004F0319 /* Message Sending */,
 				060ED6D72499F42200412C4A /* Notifications */,
 				06474D4824AF6825002C695D /* Synchronization */,
@@ -1948,12 +1965,14 @@
 				EE402C0328996C2500CA0E40 /* MLSMessageSync.Transcoder.swift in Sources */,
 				16E5F6D626EF1BE100F35FBA /* PaginatedSync.swift in Sources */,
 				6397F6E228F447F800298DB1 /* SendCommitBundleActionHandler.swift in Sources */,
+				1623F8DC2AE7FD54004F0319 /* APIProvider.swift in Sources */,
 				161E055026655E4500DADC3D /* UserProfileRequestStrategy.swift in Sources */,
 				F18401D42073BE0800E9F4CC /* MessageExpirationTimer.swift in Sources */,
 				1622946B221C18BE00A98679 /* AssetV3UploadRequestStrategy.swift in Sources */,
 				1662ADB322B0E8B300D84071 /* VerifyLegalHoldRequestStrategy.swift in Sources */,
 				166901EC1D7081C7000FE4AF /* ZMTimedSingleRequestSync.m in Sources */,
 				F184019A2073BE0800E9F4CC /* ClientMessageRequestFactory.swift in Sources */,
+				1623F8DA2AE7FBD6004F0319 /* NetworkError.swift in Sources */,
 				EEE0EE0528591D3200BBEE29 /* OptionalString+NonEmptyValue.swift in Sources */,
 				168D7CB226FB0E3F00789960 /* EntityActionSync.swift in Sources */,
 				168D7CBB26FB21D900789960 /* RemoveParticipantActionHandler.swift in Sources */,
@@ -1977,6 +1996,7 @@
 				F18401C72073BE0800E9F4CC /* AssetV3PreviewDownloadStrategy.swift in Sources */,
 				F18401B52073BE0800E9F4CC /* OTREntityTranscoder.swift in Sources */,
 				16367F1E26FDB0740028AF8B /* Payload+Connection.swift in Sources */,
+				1623F8D82AE7FB7E004F0319 /* PrekeyAPI.swift in Sources */,
 				63DA339F286DF6ED00818C3C /* MLSEventProcessor.swift in Sources */,
 				06A1966E2A7BEAE300B43BA5 /* TerminateFederationRequestStrategy.swift in Sources */,
 				1682462F257A1FB7002AF17B /* KeyPathObjectSync.swift in Sources */,

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		1623F8D82AE7FB7E004F0319 /* PrekeyAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D72AE7FB7E004F0319 /* PrekeyAPI.swift */; };
 		1623F8DA2AE7FBD6004F0319 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D92AE7FBD6004F0319 /* NetworkError.swift */; };
 		1623F8DC2AE7FD54004F0319 /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8DB2AE7FD54004F0319 /* APIProvider.swift */; };
+		1623F8DE2AE945E2004F0319 /* MessageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8DD2AE945E2004F0319 /* MessageAPI.swift */; };
 		16367F1E26FDB0740028AF8B /* Payload+Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16367F1D26FDB0740028AF8B /* Payload+Connection.swift */; };
 		16367F2626FDB4720028AF8B /* ConnectionRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16367F2526FDB4720028AF8B /* ConnectionRequestStrategy.swift */; };
 		164D00742225624E00A8F264 /* ZMImagePreprocessingTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 16229485221EBB8000A98679 /* ZMImagePreprocessingTrackerTests.m */; };
@@ -518,6 +519,7 @@
 		1623F8D72AE7FB7E004F0319 /* PrekeyAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrekeyAPI.swift; sourceTree = "<group>"; };
 		1623F8D92AE7FBD6004F0319 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		1623F8DB2AE7FD54004F0319 /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
+		1623F8DD2AE945E2004F0319 /* MessageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAPI.swift; sourceTree = "<group>"; };
 		16367F1D26FDB0740028AF8B /* Payload+Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payload+Connection.swift"; sourceTree = "<group>"; };
 		16367F2526FDB4720028AF8B /* ConnectionRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRequestStrategy.swift; sourceTree = "<group>"; };
 		164D007522256C6E00A8F264 /* AssetV3UploadRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetV3UploadRequestStrategyTests.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				1623F8D72AE7FB7E004F0319 /* PrekeyAPI.swift */,
 				1623F8D92AE7FBD6004F0319 /* NetworkError.swift */,
 				1623F8DB2AE7FD54004F0319 /* APIProvider.swift */,
+				1623F8DD2AE945E2004F0319 /* MessageAPI.swift */,
 			);
 			path = APIs;
 			sourceTree = "<group>";
@@ -1992,6 +1995,7 @@
 				EEFB2DFE2ACD530F0094F877 /* PrekeyPayloadProcessor.swift in Sources */,
 				1623F8D32AE66F28004F0319 /* MessageSender.swift in Sources */,
 				F18401D82073BE0800E9F4CC /* ZMConversation+Notifications.swift in Sources */,
+				1623F8DE2AE945E2004F0319 /* MessageAPI.swift in Sources */,
 				F18401D92073BE0800E9F4CC /* EncryptionSessionDirectory+UpdateEvents.swift in Sources */,
 				F18401C72073BE0800E9F4CC /* AssetV3PreviewDownloadStrategy.swift in Sources */,
 				F18401B52073BE0800E9F4CC /* OTREntityTranscoder.swift in Sources */,

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -106,7 +106,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             apiProvider: apiProvider,
             context: syncMOC)
         let messageSender = MessageSender(
-            httpClient: httpClient,
+            apiProvider: apiProvider,
             clientRegistrationDelegate: applicationStatusDirectory.clientRegistrationStatus,
             sessionEstablisher: sessionEstablisher,
             context: syncMOC)

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -97,11 +97,13 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         transportSession: TransportSessionType
     ) -> [Any] {
         let syncMOC = contextProvider.syncContext
+
         let httpClient = HttpClientImpl(
             transportSession: transportSession,
             queue: syncMOC)
+        let apiProvider = APIProvider(httpClient: httpClient)
         let sessionEstablisher = SessionEstablisher(
-            httpClient: httpClient,
+            apiProvider: apiProvider,
             context: syncMOC)
         let messageSender = MessageSender(
             httpClient: httpClient,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5150" title="WPB-5150" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5150</a>  [iOS] Extract session handling into separate component (SessionEstablisher)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Introduce an abstraction for making requests (fetching prekeys, sending proteus messages), which hides the API differences between the different api versions.
- Don't rely on `missedClients` relationship on the self client for establishing missing sessions, instead we establish sessions only with clients which reported missing by the backend.

### Testing

I'll add tests in a another PR when the class boundaries are stable

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
