### PR TITLE
feat(message-sending): wait for message dependencies to resolve before sending message WBP-5154 #3

### DIFF
--- a/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolver.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolver.swift
@@ -1,0 +1,59 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+class MessageDependencyResolver {
+
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    let context: NSManagedObjectContext
+
+    func waitForDependenciesToResolve(for message: any Message) async {
+
+        let hasDependencies = context.performAndWait {
+            message.dependentObjectNeedingUpdateBeforeProcessing != nil
+        }
+
+        if !hasDependencies {
+            return
+        }
+
+        Logging.messageProcessing.debug("Message has dependency, waiting")
+
+        await withCheckedContinuation { continuation in
+            Task {
+                for await _  in NotificationCenter.default.notifications(named: .requestAvailableNotification) {
+                    let hasDependencies = self.context.performAndWait {
+                        message.dependentObjectNeedingUpdateBeforeProcessing != nil
+                    }
+
+                    if !hasDependencies {
+                        Logging.messageProcessing.debug("Message dependency resolved")
+                        continuation.resume()
+                        break
+                    } else {
+                        Logging.messageProcessing.debug("Message has dependency, waiting")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		1623F8DA2AE7FBD6004F0319 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8D92AE7FBD6004F0319 /* NetworkError.swift */; };
 		1623F8DC2AE7FD54004F0319 /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8DB2AE7FD54004F0319 /* APIProvider.swift */; };
 		1623F8DE2AE945E2004F0319 /* MessageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8DD2AE945E2004F0319 /* MessageAPI.swift */; };
+		1623F8E02AEAAF0E004F0319 /* MessageDependencyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1623F8DF2AEAAF0E004F0319 /* MessageDependencyResolver.swift */; };
 		16367F1E26FDB0740028AF8B /* Payload+Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16367F1D26FDB0740028AF8B /* Payload+Connection.swift */; };
 		16367F2626FDB4720028AF8B /* ConnectionRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16367F2526FDB4720028AF8B /* ConnectionRequestStrategy.swift */; };
 		164D00742225624E00A8F264 /* ZMImagePreprocessingTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 16229485221EBB8000A98679 /* ZMImagePreprocessingTrackerTests.m */; };
@@ -520,6 +521,7 @@
 		1623F8D92AE7FBD6004F0319 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		1623F8DB2AE7FD54004F0319 /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
 		1623F8DD2AE945E2004F0319 /* MessageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAPI.swift; sourceTree = "<group>"; };
+		1623F8DF2AEAAF0E004F0319 /* MessageDependencyResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDependencyResolver.swift; sourceTree = "<group>"; };
 		16367F1D26FDB0740028AF8B /* Payload+Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payload+Connection.swift"; sourceTree = "<group>"; };
 		16367F2526FDB4720028AF8B /* ConnectionRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRequestStrategy.swift; sourceTree = "<group>"; };
 		164D007522256C6E00A8F264 /* AssetV3UploadRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetV3UploadRequestStrategyTests.swift; sourceTree = "<group>"; };
@@ -1031,6 +1033,7 @@
 			children = (
 				1623F8D22AE66F28004F0319 /* MessageSender.swift */,
 				1623F8D42AE6729D004F0319 /* SessionEstablisher.swift */,
+				1623F8DF2AEAAF0E004F0319 /* MessageDependencyResolver.swift */,
 			);
 			path = "Message Sending";
 			sourceTree = "<group>";
@@ -2043,6 +2046,7 @@
 				EEDE7DB128EAEEC3007DC6A3 /* ConversationService.swift in Sources */,
 				F18401D12073BE0800E9F4CC /* ApplicationStatus.swift in Sources */,
 				0649D14D24F63D3E001DDC78 /* LocalNotificationType+Localization.swift in Sources */,
+				1623F8E02AEAAF0E004F0319 /* MessageDependencyResolver.swift in Sources */,
 				EEB5DE0728377635009B4741 /* GetFeatureConfigsActionHandler.swift in Sources */,
 				16E5F6DD26EF1E3200F35FBA /* Payload+Conversation.swift in Sources */,
 				16A4891A2685CECD001F9127 /* ProteusMessageSync.swift in Sources */,

--- a/wire-ios-transport/Source/Requests/RequestAvailableNotification.swift
+++ b/wire-ios-transport/Source/Requests/RequestAvailableNotification.swift
@@ -18,7 +18,9 @@
 
 import Foundation
 
-private let RequestsAvailableNotificationName = "RequestAvailableNotification"
+public extension NSNotification.Name {
+    static let requestAvailableNotification = NSNotification.Name(rawValue: "RequestAvailableNotification")
+}
 
 @objc(ZMRequestAvailableObserver) public protocol RequestAvailableObserver: NSObjectProtocol {
 
@@ -31,15 +33,15 @@ private let RequestsAvailableNotificationName = "RequestAvailableNotification"
 @objc(ZMRequestAvailableNotification) public class RequestAvailableNotification: NSObject {
 
     @objc public static func notifyNewRequestsAvailable(_ sender: NSObjectProtocol?) {
-        NotificationCenter.default.post(name: Notification.Name(rawValue: RequestsAvailableNotificationName), object: nil)
+        NotificationCenter.default.post(name: .requestAvailableNotification, object: nil)
     }
 
     @objc public static func addObserver(_ observer: RequestAvailableObserver) {
-        NotificationCenter.default.addObserver(observer, selector: #selector(RequestAvailableObserver.newRequestsAvailable), name: NSNotification.Name(rawValue: RequestsAvailableNotificationName), object: nil)
+        NotificationCenter.default.addObserver(observer, selector: #selector(RequestAvailableObserver.newRequestsAvailable), name: .requestAvailableNotification, object: nil)
     }
 
     @objc public static func removeObserver(_ observer: RequestAvailableObserver) {
-        NotificationCenter.default.removeObserver(observer, name: NSNotification.Name(rawValue: RequestsAvailableNotificationName), object: nil)
+        NotificationCenter.default.removeObserver(observer, name: .requestAvailableNotification, object: nil)
     }
 
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Wait for message dependencies to resolve before sending message. This wraps the existing dependency system in async/wait function. In a future re-factoring we could re-work the dependency resolver to actively resolve the dependencies.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
