### PR TITLE
fix: showing logs in console as DataDog OFF

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -188,6 +188,10 @@ public class DatadogWrapper {
     public static let shared: DatadogWrapper? = nil
 #endif
 
+    public init() {
+        WireLogger.provider = self
+    }
+
     public func log(
         level: LogLevel,
         message: String,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logs from WireLogger don't show up since no provider is set without Datadog settings.

### Solutions

Add provider self when debug configuration is used to show logs [DATADOG OFF]

### Attachments (Optional)

![Screenshot 2023-10-27 at 12 02 07](https://github.com/wireapp/wire-ios/assets/254198/c2a0cee8-2826-47f9-af1b-cc55d498b40c)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
