### PR TITLE
fix: Handle launch argument --preferred-api-version - WPB-5233

### DIFF
--- a/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -214,7 +214,7 @@ final class BackendInfoOperation: LaunchSequenceOperation {
     func execute() {
         BackendInfo.storage = .applicationGroup
 
-        if let preferredVersion = AutomationHelper.sharedHelper.preferredAPIversion {
+        if let preferredVersion = AutomationHelper.sharedHelper.preferredAPIVersion {
             BackendInfo.preferredAPIVersion = preferredVersion
         }
     }

--- a/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -215,6 +215,7 @@ final class BackendInfoOperation: LaunchSequenceOperation {
         BackendInfo.storage = .applicationGroup
 
         if let preferredVersion = AutomationHelper.sharedHelper.preferredAPIVersion {
+            WireLogger.environment.info("automation helper will set preferred api version to \(preferredVersion)")
             BackendInfo.preferredAPIVersion = preferredVersion
         }
     }

--- a/wire-ios/WireCommonComponents/AutomationHelper.swift
+++ b/wire-ios/WireCommonComponents/AutomationHelper.swift
@@ -126,8 +126,6 @@ public final class AutomationHelper: NSObject {
             let value = arguments.flagValueIfPresent(AutomationKey.preferredAPIVersion.rawValue),
             let apiVersion = Int32(value)
         {
-            WireLogger.environment.info("automation helper will set preferred api version to \(apiVersion)")
-            BackendInfo.preferredAPIVersion = APIVersion(rawValue: apiVersion)
             preferredAPIVersion = APIVersion(rawValue: apiVersion)
         }
 

--- a/wire-ios/WireCommonComponents/AutomationHelper.swift
+++ b/wire-ios/WireCommonComponents/AutomationHelper.swift
@@ -86,7 +86,7 @@ public final class AutomationHelper: NSObject {
     /// Whether the calling overlay should disappear automatically.
     public let keepCallingOverlayVisible: Bool
 
-    public var preferredAPIversion: APIVersion?
+    public var preferredAPIVersion: APIVersion?
     public var allowMLSGroupCreation: Bool?
     public var enableMLSSupport: Bool?
 
@@ -123,11 +123,12 @@ public final class AutomationHelper: NSObject {
         self.delayInAddressBookRemoteSearch = AutomationHelper.addressBookSearchDelay(arguments)
 
         if
-            let value = arguments.flagValueIfPresent(AutomationKey.preferredAPIversion.rawValue),
+            let value = arguments.flagValueIfPresent(AutomationKey.preferredAPIVersion.rawValue),
             let apiVersion = Int32(value)
         {
             WireLogger.environment.info("automation helper will set preferred api version to \(apiVersion)")
             BackendInfo.preferredAPIVersion = APIVersion(rawValue: apiVersion)
+            preferredAPIVersion = APIVersion(rawValue: apiVersion)
         }
 
         allowMLSGroupCreation = arguments.hasFlag(AutomationKey.allowMLSGroupCreation.rawValue)
@@ -152,7 +153,7 @@ public final class AutomationHelper: NSObject {
         case disableInteractiveKeyboardDismissal = "disable-interactive-keyboard-dismissal"
         case useAppCenter = "use-app-center"
         case keepCallingOverlayVisible = "keep-calling-overlay-visible"
-        case preferredAPIversion = "preferred-api-version"
+        case preferredAPIVersion = "preferred-api-version"
         case allowMLSGroupCreation = "allow-mls-group-creation"
         case deprecatedCallingUI = "deprecated-calling-ui"
         case enableMLSSupport = "enable-mls-support"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5233" title="WPB-5233" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5233</a>  [iOS] E2E automation does not work with --preferred-api-version=5 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

Fix capitalisation of APIversion to APIVersion + Set API version variable in AutomationHelper.swift

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ x] contains a reference JIRA issue number like `SQPIT-764`
  - [ x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The launch argument was never stored, which made End to End automation on development API's impossible. This PR sets the value, and fixes inconsistent capitalisation 

### Causes (Optional)

The apiVersion was set in BackendInfo, but once BackendInfo changed it's store and the value would be gone by the time Automation was running. 

### Solutions

Storing the value in the AutomationHelper class (the variable was there already but unused), which will be read when the app starts.

### Dependencies (Optional)

-
Needs releases with:

-

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Tested by running End to End automation with Appium and providing different arguments for --preferred-api-version=[int]

### Notes (Optional)



### Attachments (Optional)



----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
