### PR TITLE
feat: periodically check if migration can start WPB-2895

### DIFF
--- a/wire-ios-data-model/Source/MLS/Actions/FetchBackendMLSPublicKeysAction.swift
+++ b/wire-ios-data-model/Source/MLS/Actions/FetchBackendMLSPublicKeysAction.swift
@@ -26,6 +26,7 @@ public class FetchBackendMLSPublicKeysAction: EntityAction {
 
         case endpointUnavailable
         case malformedResponse
+        case mlsNotEnabled
         case unknown(status: Int, label: String, message: String)
 
         public var errorDescription: String? {
@@ -35,6 +36,9 @@ public class FetchBackendMLSPublicKeysAction: EntityAction {
 
             case .malformedResponse:
                 return "Malformed response"
+
+            case .mlsNotEnabled:
+                return "MLS not enabled"
 
             case let .unknown(status, label, message):
                 return "Unknown error response status: \(status), label: \(label), message: \(message)"

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -85,6 +85,8 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
 
     func repairOutOfSyncConversations()
 
+    func startProteusToMLSMigration()
+
 }
 
 public protocol MLSServiceDelegate: AnyObject {
@@ -1646,6 +1648,12 @@ public final class MLSService: MLSServiceInterface {
     public func generateNewEpoch(groupID: MLSGroupID) async throws {
         logger.info("generating new epoch in subconveration (\(groupID.safeForLoggingDescription))")
         try await updateKeyMaterial(for: groupID)
+    }
+
+    // MARK: - Proteus to MLS Migration
+
+    public func startProteusToMLSMigration() {
+        // Migrate proteus team group conversations to MLS
     }
 
 }

--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
@@ -21,7 +21,7 @@ import WireUtilities
 import WireTransport
 
 public protocol ProteusToMLSMigrationCoordinating {
-    func updateMigrationStatus()
+    func updateMigrationStatus() async
 }
 
 public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating {
@@ -86,12 +86,10 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
 
     // MARK: - Public Interface
 
-    public func updateMigrationStatus() {
+    public func updateMigrationStatus() async {
         switch storage.migrationStatus {
         case .notStarted:
-            Task {
-                await startMigrationIfNeeded()
-            }
+            await startMigrationIfNeeded()
         case .started:
             // check if it should be finalised
             break

--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationStorage.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationStorage.swift
@@ -1,0 +1,64 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+// sourcery: AutoMockable
+protocol ProteusToMLSMigrationStorageInterface {
+    var migrationStatus: ProteusToMLSMigrationCoordinator.MigrationStatus { get set }
+}
+
+class ProteusToMLSMigrationStorage: ProteusToMLSMigrationStorageInterface {
+
+    // MARK: - Properties
+
+    private let storage: PrivateUserDefaults<Key>
+
+    // MARK: - Types
+
+    private enum Key: String, DefaultsKey {
+        case migrationStatus = "com.wire.mls.migration.status"
+    }
+
+    typealias MigrationStatus = ProteusToMLSMigrationCoordinator.MigrationStatus
+
+    // MARK: - Life cycle
+
+    init(
+        userID: UUID,
+        userDefaults: UserDefaults
+    ) {
+        storage = PrivateUserDefaults(
+            userID: userID,
+            storage: userDefaults
+        )
+    }
+
+    // MARK: - Interface
+
+    var migrationStatus: MigrationStatus {
+        get {
+            let value = storage.integer(forKey: Key.migrationStatus)
+            return MigrationStatus(rawValue: value)!
+        }
+
+        set {
+            storage.set(newValue.rawValue, forKey: Key.migrationStatus)
+        }
+    }
+}

--- a/wire-ios-data-model/Source/MLS/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/ProteusToMLSMigrationCoordinator.swift
@@ -52,7 +52,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
     // MARK: - Properties
 
     private let context: NSManagedObjectContext
-    private let featureRepository: FeatureRepository
+    private let featureRepository: FeatureRepositoryInterface
     private let actionsProvider: MLSActionsProviderProtocol
     private let storage: ProteusToMLSMigrationStorage
     private let logger = WireLogger.mls
@@ -75,7 +75,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
         context: NSManagedObjectContext,
         userID: UUID,
         userDefaults: UserDefaults = .standard,
-        featureRepository: FeatureRepository? = nil,
+        featureRepository: FeatureRepositoryInterface? = nil,
         actionsProvider: MLSActionsProviderProtocol? = nil
     ) {
         self.context = context

--- a/wire-ios-data-model/Source/MLS/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/ProteusToMLSMigrationCoordinator.swift
@@ -1,0 +1,218 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireUtilities
+import WireTransport
+
+public protocol ProteusToMLSMigrationCoordinating {
+    func updateMigrationStatus()
+}
+
+public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating {
+
+    // MARK: - Types
+
+    enum MigrationStatus {
+        case notStarted
+        case started
+        case finalising
+        case finalised
+    }
+
+    enum MigrationStartStatus {
+        case canStart
+        case cannotStart(reason: CannotStartMigrationReason)
+
+        enum CannotStartMigrationReason {
+            case unsupportedAPIVersion
+            case mlsProtocolIsNotSupported
+            case clientDoesntSupportMLS
+            case backendDoesntSupportMLS
+            case mlsMigrationIsNotEnabled
+            case startTimeHasNotBeenReached
+        }
+    }
+
+    // MARK: - Properties
+
+    private let context: NSManagedObjectContext
+    private let featureRepository: FeatureRepository
+    private let actionsProvider: MLSActionsProviderProtocol
+    private let storage: ProteusToMLSMigrationStorage
+    private let logger = WireLogger.mls
+
+    private var migrationStatus: MigrationStatus {
+        storage.migrationStatus ?? .notStarted
+    }
+
+    // MARK: - Life cycle
+
+    public convenience init(
+        context: NSManagedObjectContext,
+        userID: UUID
+    ) {
+        self.init(
+            context: context,
+            userID: userID,
+            featureRepository: nil,
+            actionsProvider: nil
+        )
+    }
+
+    init(
+        context: NSManagedObjectContext,
+        userID: UUID,
+        userDefaults: UserDefaults = .standard,
+        featureRepository: FeatureRepository? = nil,
+        actionsProvider: MLSActionsProviderProtocol? = nil
+    ) {
+        self.context = context
+        self.storage = ProteusToMLSMigrationStorage(
+            userID: userID,
+            userDefaults: userDefaults
+        )
+        self.featureRepository = featureRepository ?? FeatureRepository(context: context)
+        self.actionsProvider = actionsProvider ?? MLSActionsProvider()
+
+        if storage.migrationStatus == nil {
+            storage.migrationStatus = .notStarted
+        }
+    }
+
+    // MARK: - Interface
+
+    public func updateMigrationStatus() {
+        switch migrationStatus {
+        case .notStarted:
+            Task {
+                await startMigrationIfNeeded()
+            }
+        case .started:
+            // check if it should be finalised
+            break
+        default:
+            break
+        }
+    }
+
+    // MARK: - Private Methods
+
+    func startMigrationIfNeeded() async {
+        logger.info("checking if proteus-to-mls migration can start")
+        let migrationStartStatus = await resolveMigrationStartStatus()
+
+        switch migrationStartStatus {
+        case .canStart:
+            guard let mlsService = context.mlsService else {
+                return logger.warn("can't start migration: missing `mlsService`")
+            }
+
+            logger.info("starting proteus-to-mls migration")
+            mlsService.startProteusToMLSMigration()
+            storage.migrationStatus = .started
+        case .cannotStart(reason: let reason):
+            logger.info("proteus-to-mls migration can't start (reason: \(reason))")
+        }
+    }
+
+    private func resolveMigrationStartStatus() async -> MigrationStartStatus {
+
+        // TODO: Might need to perform this on the context
+        let mlsFeature = featureRepository.fetchMLS()
+        let mlsMigrationFeature = featureRepository.fetchMLSMigration()
+
+        if (BackendInfo.apiVersion ?? .v0) < .v5 {
+            return .cannotStart(reason: .unsupportedAPIVersion)
+        }
+
+        if !mlsFeature.config.supportedProtocols.contains(.mls) {
+            return .cannotStart(reason: .mlsProtocolIsNotSupported)
+        }
+
+        if !DeveloperFlag.enableMLSSupport.isOn {
+            return .cannotStart(reason: .clientDoesntSupportMLS)
+        }
+
+        if await !isMLSEnabledOnBackend() {
+            return .cannotStart(reason: .backendDoesntSupportMLS)
+        }
+
+        if mlsMigrationFeature.status == .disabled {
+            return .cannotStart(reason: .mlsMigrationIsNotEnabled)
+        }
+
+        if mlsMigrationFeature.config.startTime > .now {
+            return .cannotStart(reason: .startTimeHasNotBeenReached)
+        }
+
+        return .canStart
+    }
+
+    // MARK: - Helpers
+
+    // TODO: add a catch for the `mls-not-enabled` error and log any other error
+    private func isMLSEnabledOnBackend() async -> Bool  {
+        do {
+            _ = try await actionsProvider.fetchBackendPublicKeys(in: context.notificationContext)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+}
+
+class ProteusToMLSMigrationStorage {
+
+    // MARK: - Properties
+
+    private let storage: PrivateUserDefaults<Key>
+
+    // MARK: - Types
+
+    private enum Key: String, DefaultsKey {
+        case migrationStatus = "com.wire.mls.migration.status"
+    }
+
+    typealias MigrationStatus = ProteusToMLSMigrationCoordinator.MigrationStatus
+
+    // MARK: - Life cycle
+
+    public init(
+        userID: UUID,
+        userDefaults: UserDefaults
+    ) {
+        storage = PrivateUserDefaults(
+            userID: userID,
+            storage: userDefaults
+        )
+    }
+
+    // MARK: - Interface
+
+    var migrationStatus: MigrationStatus? {
+        get {
+            storage.object(forKey: Key.migrationStatus) as? MigrationStatus
+        }
+
+        set {
+            storage.set(newValue, forKey: Key.migrationStatus)
+        }
+    }
+}

--- a/wire-ios-data-model/Source/Model/FeatureConfig/Feature.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/Feature.swift
@@ -40,6 +40,7 @@ public class Feature: ZMManagedObject {
         case classifiedDomains
         case digitalSignature
         case mls
+        case mlsMigration
 
     }
 
@@ -216,7 +217,7 @@ public class Feature: ZMManagedObject {
 
             needsToNotifyUser = oldConfig.enforcedTimeoutSeconds != newConfig.enforcedTimeoutSeconds
 
-        case .conferenceCalling, .fileSharing, .conversationGuestLinks, .classifiedDomains, .digitalSignature, .mls:
+        case .conferenceCalling, .fileSharing, .conversationGuestLinks, .classifiedDomains, .digitalSignature, .mls, .mlsMigration:
             break
         }
     }

--- a/wire-ios-data-model/Source/Model/FeatureConfig/FeatureRepository.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/FeatureRepository.swift
@@ -252,6 +252,29 @@ public class FeatureRepository: FeatureRepositoryInterface {
         }
     }
 
+    // MARK: - MLSMigration
+
+    public func fetchMLSMigration() -> Feature.MLSMigration {
+        guard
+            let feature = Feature.fetch(name: .mlsMigration, context: context),
+            let featureConfig = feature.config
+        else {
+            return .init()
+        }
+
+        let config = try! JSONDecoder().decode(Feature.MLSMigration.Config.self, from: featureConfig)
+        return .init(status: feature.status, config: config)
+    }
+
+    public func storeMLSMigration(_ mlsMigration: Feature.MLSMigration) {
+        let config = try! JSONEncoder().encode(mlsMigration.config)
+
+        Feature.updateOrCreate(havingName: .mlsMigration, in: context) {
+            $0.status = mlsMigration.status
+            $0.config = config
+        }
+    }
+
     // MARK: - Methods
 
     func createDefaultConfigsIfNeeded() {
@@ -280,6 +303,9 @@ public class FeatureRepository: FeatureRepositoryInterface {
 
             case .mls:
                 storeMLS(.init())
+
+            case .mlsMigration:
+                storeMLSMigration(.init())
             }
         }
     }

--- a/wire-ios-data-model/Source/Model/FeatureConfig/FeatureRepository.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/FeatureRepository.swift
@@ -21,24 +21,26 @@ import Foundation
 // sourcery: AutoMockable
 public protocol FeatureRepositoryInterface {
 
-     func fetchAppLock() -> Feature.AppLock
-     func storeAppLock(_ appLock: Feature.AppLock)
-     func fetchConferenceCalling() -> Feature.ConferenceCalling
-     func storeConferenceCalling(_ conferenceCalling: Feature.ConferenceCalling)
-     func fetchFileSharing() -> Feature.FileSharing
-     func storeFileSharing(_ fileSharing: Feature.FileSharing)
-     func fetchSelfDeletingMesssages() -> Feature.SelfDeletingMessages
-     func storeSelfDeletingMessages(_ selfDeletingMessages: Feature.SelfDeletingMessages)
-     func fetchConversationGuestLinks() -> Feature.ConversationGuestLinks
-     func storeConversationGuestLinks(_ conversationGuestLinks: Feature.ConversationGuestLinks)
-     func fetchClassifiedDomains() -> Feature.ClassifiedDomains
-     func storeClassifiedDomains(_ classifiedDomains: Feature.ClassifiedDomains)
-     func fetchDigitalSignature() -> Feature.DigitalSignature
-     func storeDigitalSignature(_ digitalSignature: Feature.DigitalSignature)
-     func fetchMLS() -> Feature.MLS
-     func storeMLS(_ mls: Feature.MLS)
+    func fetchAppLock() -> Feature.AppLock
+    func storeAppLock(_ appLock: Feature.AppLock)
+    func fetchConferenceCalling() -> Feature.ConferenceCalling
+    func storeConferenceCalling(_ conferenceCalling: Feature.ConferenceCalling)
+    func fetchFileSharing() -> Feature.FileSharing
+    func storeFileSharing(_ fileSharing: Feature.FileSharing)
+    func fetchSelfDeletingMesssages() -> Feature.SelfDeletingMessages
+    func storeSelfDeletingMessages(_ selfDeletingMessages: Feature.SelfDeletingMessages)
+    func fetchConversationGuestLinks() -> Feature.ConversationGuestLinks
+    func storeConversationGuestLinks(_ conversationGuestLinks: Feature.ConversationGuestLinks)
+    func fetchClassifiedDomains() -> Feature.ClassifiedDomains
+    func storeClassifiedDomains(_ classifiedDomains: Feature.ClassifiedDomains)
+    func fetchDigitalSignature() -> Feature.DigitalSignature
+    func storeDigitalSignature(_ digitalSignature: Feature.DigitalSignature)
+    func fetchMLS() -> Feature.MLS
+    func storeMLS(_ mls: Feature.MLS)
+    func fetchMLSMigration() -> Feature.MLSMigration
+    func storeMLSMigration(_ mlsMigration: Feature.MLSMigration)
 
- }
+}
 
 /// This class facilitates storage and retrieval of feature configs to and from
 /// the database.
@@ -55,6 +57,8 @@ public class FeatureRepository: FeatureRepositoryInterface {
     // MARK: - Properties
 
     private let context: NSManagedObjectContext
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
 
     // MARK: - Life cycle
 
@@ -69,12 +73,12 @@ public class FeatureRepository: FeatureRepositoryInterface {
               let featureConfig = feature.config else {
                   return .init()
               }
-        let config = try! JSONDecoder().decode(Feature.AppLock.Config.self, from: featureConfig)
+        let config = try! decoder.decode(Feature.AppLock.Config.self, from: featureConfig)
         return.init(status: feature.status, config: config)
     }
 
     public func storeAppLock(_ appLock: Feature.AppLock) {
-        let config = try! JSONEncoder().encode(appLock.config)
+        let config = try! encoder.encode(appLock.config)
 
         Feature.updateOrCreate(havingName: .appLock, in: context) {
             $0.status = appLock.status
@@ -139,12 +143,12 @@ public class FeatureRepository: FeatureRepositoryInterface {
               let featureConfig = feature.config else {
                   return .init()
               }
-        let config = try! JSONDecoder().decode(Feature.SelfDeletingMessages.Config.self, from: featureConfig)
+        let config = try! decoder.decode(Feature.SelfDeletingMessages.Config.self, from: featureConfig)
         return .init(status: feature.status, config: config)
     }
 
     public func storeSelfDeletingMessages(_ selfDeletingMessages: Feature.SelfDeletingMessages) {
-        let config = try! JSONEncoder().encode(selfDeletingMessages.config)
+        let config = try! encoder.encode(selfDeletingMessages.config)
 
         Feature.updateOrCreate(havingName: .selfDeletingMessages, in: context) {
             $0.status = selfDeletingMessages.status
@@ -200,12 +204,12 @@ public class FeatureRepository: FeatureRepositoryInterface {
             return .init()
         }
 
-        let config = try! JSONDecoder().decode(Feature.ClassifiedDomains.Config.self, from: featureConfig)
+        let config = try! decoder.decode(Feature.ClassifiedDomains.Config.self, from: featureConfig)
         return .init(status: feature.status, config: config)
     }
 
     public func storeClassifiedDomains(_ classifiedDomains: Feature.ClassifiedDomains) {
-        let config = try! JSONEncoder().encode(classifiedDomains.config)
+        let config = try! encoder.encode(classifiedDomains.config)
 
         Feature.updateOrCreate(havingName: .classifiedDomains, in: context) {
             $0.status = classifiedDomains.status
@@ -239,12 +243,12 @@ public class FeatureRepository: FeatureRepositoryInterface {
             return .init()
         }
 
-        let config = try! JSONDecoder().decode(Feature.MLS.Config.self, from: featureConfig)
+        let config = try! decoder.decode(Feature.MLS.Config.self, from: featureConfig)
         return .init(status: feature.status, config: config)
     }
 
     public func storeMLS(_ mls: Feature.MLS) {
-        let config = try! JSONEncoder().encode(mls.config)
+        let config = try! encoder.encode(mls.config)
 
         Feature.updateOrCreate(havingName: .mls, in: context) {
             $0.status = mls.status
@@ -262,12 +266,12 @@ public class FeatureRepository: FeatureRepositoryInterface {
             return .init()
         }
 
-        let config = try! JSONDecoder().decode(Feature.MLSMigration.Config.self, from: featureConfig)
+        let config = try! decoder.decode(Feature.MLSMigration.Config.self, from: featureConfig)
         return .init(status: feature.status, config: config)
     }
 
     public func storeMLSMigration(_ mlsMigration: Feature.MLSMigration) {
-        let config = try! JSONEncoder().encode(mlsMigration.config)
+        let config = try! encoder.encode(mlsMigration.config)
 
         Feature.updateOrCreate(havingName: .mlsMigration, in: context) {
             $0.status = mlsMigration.status

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
@@ -65,6 +65,7 @@ public extension Feature {
             public let defaultCipherSuite: MLSCipherSuite
 
             /// The list of supported message protocols
+
             public let supportedProtocols: [MessageProtocol]
 
             public init(

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
@@ -62,16 +62,22 @@ public extension Feature {
 
             public let defaultCipherSuite: MLSCipherSuite
 
+            /// The list of supported message protocols
+            // TODO: check if/how we need to migrate the feature config
+            public let supportedProtocols: [MessageProtocol]
+
             public init(
                 protocolToggleUsers: [UUID] = [],
                 defaultProtocol: MessageProtocol = .proteus,
                 allowedCipherSuites: [MLSCipherSuite] = [.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
-                defaultCipherSuite: MLSCipherSuite = .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+                defaultCipherSuite: MLSCipherSuite = .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+                supportedProtocols: [MessageProtocol] = [.proteus, .mls]
             ) {
                 self.protocolToggleUsers = protocolToggleUsers
                 self.defaultProtocol = defaultProtocol
                 self.allowedCipherSuites = allowedCipherSuites
                 self.defaultCipherSuite = defaultCipherSuite
+                self.supportedProtocols = supportedProtocols
             }
 
             public enum MessageProtocol: String, Codable {

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
@@ -44,8 +44,6 @@ public extension Feature {
         // WARNING: This config is encoded and stored in the database, so any changes
         // to it will require some migration code.
 
-        // TODO: check if/how we need to migrate the feature config
-
         public struct Config: Codable, Equatable {
 
             /// The ids of users who have the option to create new MLS groups.

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
@@ -44,6 +44,8 @@ public extension Feature {
         // WARNING: This config is encoded and stored in the database, so any changes
         // to it will require some migration code.
 
+        // TODO: check if/how we need to migrate the feature config
+
         public struct Config: Codable, Equatable {
 
             /// The ids of users who have the option to create new MLS groups.
@@ -63,7 +65,6 @@ public extension Feature {
             public let defaultCipherSuite: MLSCipherSuite
 
             /// The list of supported message protocols
-            // TODO: check if/how we need to migrate the feature config
             public let supportedProtocols: [MessageProtocol]
 
             public init(
@@ -84,6 +85,7 @@ public extension Feature {
 
                 case proteus
                 case mls
+                case mixed
 
             }
 

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
@@ -24,11 +24,11 @@ public extension Feature {
 
         // MARK: - Properties
 
-        /// Whether MLS is availble to the user.
+        /// Whether MLS Migration is enabled.
 
         public let status: Status
 
-        /// The configuration used to control how the MLS behaves.
+        /// The configuration used to control how the MLS Migration behaves.
 
         public let config: Config
 
@@ -46,11 +46,11 @@ public extension Feature {
 
         public struct Config: Codable, Equatable {
 
-            // The starting time of the migration
+            /// The starting time of the migration
 
             public let startTime: Date?
 
-            // The date until the migration has to finalise
+            /// The date until the migration has to finalise
 
             public let finaliseRegardlessAfter: Date?
 

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
@@ -55,8 +55,8 @@ public extension Feature {
             public let finaliseRegardlessAfter: Date?
 
             public init(
-                startTime: Date = .now,
-                finaliseRegardlessAfter: Date = .now
+                startTime: Date? = nil,
+                finaliseRegardlessAfter: Date? = nil
             ) {
                 self.startTime = startTime
                 self.finaliseRegardlessAfter = finaliseRegardlessAfter

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
-
 
 public extension Feature {
 
@@ -50,11 +48,11 @@ public extension Feature {
 
             // The starting time of the migration
 
-            public let startTime: Date
+            public let startTime: Date?
 
             // The date until the migration has to finalise
 
-            public let finaliseRegardlessAfter: Date
+            public let finaliseRegardlessAfter: Date?
 
             public init(
                 startTime: Date = .now,

--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLSMigration.swift
@@ -1,0 +1,69 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+
+
+public extension Feature {
+
+    struct MLSMigration: Codable {
+
+        // MARK: - Properties
+
+        /// Whether MLS is availble to the user.
+
+        public let status: Status
+
+        /// The configuration used to control how the MLS behaves.
+
+        public let config: Config
+
+        // MARK: - Life cycle
+
+        public init(status: Feature.Status = .disabled, config: Config = .init()) {
+            self.status = status
+            self.config = config
+        }
+
+        // MARK: - Types
+
+        // WARNING: This config is encoded and stored in the database, so any changes
+        // to it will require some migration code.
+
+        public struct Config: Codable, Equatable {
+
+            // The starting time of the migration
+
+            public let startTime: Date
+
+            // The date until the migration has to finalise
+
+            public let finaliseRegardlessAfter: Date
+
+            public init(
+                startTime: Date = .now,
+                finaliseRegardlessAfter: Date = .now
+            ) {
+                self.startTime = startTime
+                self.finaliseRegardlessAfter = finaliseRegardlessAfter
+            }
+        }
+    }
+
+}

--- a/wire-ios-data-model/Tests/MLS/MockMLSService.swift
+++ b/wire-ios-data-model/Tests/MLS/MockMLSService.swift
@@ -247,4 +247,15 @@ class MockMLSService: MLSServiceInterface {
         mock()
     }
 
+    // MARK: - Migration
+
+    typealias StartProteusToMLSMigrationMock = () -> Void
+    var startProteusToMLSMigrationMock: StartProteusToMLSMigrationMock?
+
+    func startProteusToMLSMigration() {
+        guard let mock = startProteusToMLSMigrationMock else {
+            return
+        }
+        mock()
+    }
 }

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -1,0 +1,223 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModel
+
+class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
+
+    var sut: ProteusToMLSMigrationCoordinator!
+    var mockStorage: MockProteusToMLSMigrationStorageInterface!
+    var mockFeatureRepository: MockFeatureRepositoryInterface!
+    var mockActionsProvider: MockMLSActionsProviderProtocol!
+    var mockMLSService: MockMLSService!
+
+    override func setUp() {
+        super.setUp()
+
+        mockStorage = MockProteusToMLSMigrationStorageInterface()
+        mockFeatureRepository = MockFeatureRepositoryInterface()
+        mockActionsProvider = MockMLSActionsProviderProtocol()
+        mockMLSService = MockMLSService()
+
+        sut = ProteusToMLSMigrationCoordinator(
+            context: syncMOC,
+            storage: mockStorage,
+            featureRepository: mockFeatureRepository,
+            actionsProvider: mockActionsProvider
+        )
+
+        syncMOC.mlsService = mockMLSService
+
+        BackendInfo.storage = .random()!
+        DeveloperFlag.storage = .random()!
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockStorage = nil
+        mockFeatureRepository = nil
+        mockActionsProvider = nil
+        mockMLSService = nil
+        BackendInfo.storage = .standard
+        DeveloperFlag.storage = .standard
+        super.tearDown()
+    }
+
+    // MARK: - UpdateMigrationStatus
+
+    func test_UpdateMigrationStatus_StartsMigration_IfNotStartedAndReady() {
+        // Given
+        setMigrationReadiness(to: true)
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        let expectation = XCTestExpectation(description: "started migration")
+        mockMLSService.startProteusToMLSMigrationMock = {
+            expectation.fulfill()
+        }
+
+        // When
+        sut.updateMigrationStatus()
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func test_UpdateMigrationStatus_DoesntStartMigration_IfAlreadyStarted() {
+        // Given
+        setMigrationReadiness(to: true)
+        mockStorage.underlyingMigrationStatus = .started
+
+        let expectation = XCTestExpectation(description: "started migration")
+        expectation.isInverted = true
+        mockMLSService.startProteusToMLSMigrationMock = {
+            expectation.fulfill()
+        }
+
+        // When
+        sut.updateMigrationStatus()
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func test_UpdateMigrationStatus_DoesntStartMigration_IfNotReady() {
+        // Given
+        setMigrationReadiness(to: false)
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        let expectation = XCTestExpectation(description: "started migration")
+        expectation.isInverted = true
+        mockMLSService.startProteusToMLSMigrationMock = {
+            expectation.fulfill()
+        }
+
+        // When
+        sut.updateMigrationStatus()
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    // MARK: - StartMigrationIfNeeded
+
+    func test_StartMigrationIfNeeded_SetsMigrationStatus() async {
+        // Given
+        setMigrationReadiness(to: true)
+
+        // When
+        await sut.startMigrationIfNeeded()
+
+        // Then
+        mockStorage.underlyingMigrationStatus = .started
+    }
+
+    // MARK: - ResolveMigrationStartStatus
+
+    func test_ResolveMigrationStartStatus() async {
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .canStart)
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .cannotStart(reason: .unsupportedAPIVersion))
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .cannotStart(reason: .clientDoesntSupportMLS))
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .cannotStart(reason: .backendDoesntSupportMLS))
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .cannotStart(reason: .mlsProtocolIsNotSupported))
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .cannotStart(reason: .mlsMigrationIsNotEnabled))
+        await test_ResolveMigrationStartStatus_ResolvesTo(status: .cannotStart(reason: .startTimeHasNotBeenReached))
+    }
+
+    private func test_ResolveMigrationStartStatus_ResolvesTo(status: MigrationStartStatus) async {
+        // Given
+        setMigrationReadiness(for: status)
+
+        // When / Then
+        let resolvedStatus = await sut.resolveMigrationStartStatus()
+
+        // Then
+        XCTAssertEqual(resolvedStatus, status)
+    }
+
+    // MARK: - Helpers
+
+    private typealias MigrationStartStatus = ProteusToMLSMigrationCoordinator.MigrationStartStatus
+
+    private func setMigrationReadiness(to ready: Bool) {
+        setMockValues(
+            isAPIV5Supported: ready,
+            isClientSupportingMLS: ready,
+            isBackendSupportingMLS: ready,
+            isMLSProtocolSupported: ready,
+            isMLSMigrationFeatureEnabled: ready,
+            hasStartTimeBeenReached: ready
+        )
+    }
+
+    private func setMigrationReadiness(for status: ProteusToMLSMigrationCoordinator.MigrationStartStatus) {
+        switch status {
+        case .canStart:
+            setMigrationReadiness(to: true)
+        case .cannotStart(reason: let reason):
+            setMockValues(
+                isAPIV5Supported: reason != .unsupportedAPIVersion,
+                isClientSupportingMLS: reason != .clientDoesntSupportMLS,
+                isBackendSupportingMLS: reason != .backendDoesntSupportMLS,
+                isMLSProtocolSupported: reason != .mlsProtocolIsNotSupported,
+                isMLSMigrationFeatureEnabled: reason != .mlsMigrationIsNotEnabled,
+                hasStartTimeBeenReached: reason != .startTimeHasNotBeenReached
+            )
+        }
+    }
+
+    private func setMockValues(
+        isAPIV5Supported: Bool,
+        isClientSupportingMLS: Bool,
+        isBackendSupportingMLS: Bool,
+        isMLSProtocolSupported: Bool,
+        isMLSMigrationFeatureEnabled: Bool,
+        hasStartTimeBeenReached: Bool
+    ) {
+        // Set APIVersion
+        BackendInfo.apiVersion = isAPIV5Supported ? .v5 : .v0
+
+        // Set MLS flag
+        var flag = DeveloperFlag.enableMLSSupport
+        flag.isOn = isClientSupportingMLS
+
+        // Set backend support for MLS
+        if isBackendSupportingMLS {
+            mockActionsProvider.fetchBackendPublicKeysIn_MockValue = BackendMLSPublicKeys()
+            mockActionsProvider.fetchBackendPublicKeysIn_MockError = nil
+        } else {
+            mockActionsProvider.fetchBackendPublicKeysIn_MockValue = nil
+            mockActionsProvider.fetchBackendPublicKeysIn_MockError = FetchBackendMLSPublicKeysAction.Failure.mlsNotEnabled
+        }
+
+        // Set MLS feature
+        mockFeatureRepository.fetchMLS_MockValue = Feature.MLS(
+            status: .enabled,
+            config: .init(supportedProtocols: isMLSProtocolSupported ? [.mls] : [])
+        )
+
+        // Set MLS Migration feature
+        let startTime: Date = hasStartTimeBeenReached ? .distantPast : .distantFuture
+        mockFeatureRepository.fetchMLSMigration_MockValue = Feature.MLSMigration(
+            status: isMLSMigrationFeatureEnabled ? .enabled : .disabled,
+            config: .init(startTime: startTime)
+        )
+    }
+
+}

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -62,70 +62,58 @@ class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
 
     // MARK: - UpdateMigrationStatus
 
-    func test_UpdateMigrationStatus_StartsMigration_IfNotStartedAndReady() {
+    func test_UpdateMigrationStatus_StartsMigration_IfNotStartedAndReady() async {
         // Given
         setMigrationReadiness(to: true)
         mockStorage.underlyingMigrationStatus = .notStarted
 
-        let expectation = XCTestExpectation(description: "started migration")
+        var startedMigration = false
         mockMLSService.startProteusToMLSMigrationMock = {
-            expectation.fulfill()
+            startedMigration = true
         }
 
         // When
-        sut.updateMigrationStatus()
+        await sut.updateMigrationStatus()
 
         // Then
-        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStorage.underlyingMigrationStatus, .started)
+        XCTAssertTrue(startedMigration)
     }
 
-    func test_UpdateMigrationStatus_DoesntStartMigration_IfAlreadyStarted() {
+    func test_UpdateMigrationStatus_DoesntStartMigration_IfAlreadyStarted() async {
         // Given
         setMigrationReadiness(to: true)
         mockStorage.underlyingMigrationStatus = .started
 
-        let expectation = XCTestExpectation(description: "started migration")
-        expectation.isInverted = true
+        var startedMigration = false
         mockMLSService.startProteusToMLSMigrationMock = {
-            expectation.fulfill()
+            startedMigration = true
         }
 
         // When
-        sut.updateMigrationStatus()
+        await sut.updateMigrationStatus()
 
         // Then
-        wait(for: [expectation], timeout: 0.5)
+        XCTAssertEqual(mockStorage.underlyingMigrationStatus, .started)
+        XCTAssertFalse(startedMigration)
     }
 
-    func test_UpdateMigrationStatus_DoesntStartMigration_IfNotReady() {
+    func test_UpdateMigrationStatus_DoesntStartMigration_IfNotReady() async {
         // Given
         setMigrationReadiness(to: false)
         mockStorage.underlyingMigrationStatus = .notStarted
 
-        let expectation = XCTestExpectation(description: "started migration")
-        expectation.isInverted = true
+        var startedMigration = false
         mockMLSService.startProteusToMLSMigrationMock = {
-            expectation.fulfill()
+            startedMigration = true
         }
 
         // When
-        sut.updateMigrationStatus()
+        await sut.updateMigrationStatus()
 
         // Then
-        wait(for: [expectation], timeout: 0.5)
-    }
-
-    // MARK: - StartMigrationIfNeeded
-
-    func test_StartMigrationIfNeeded_SetsMigrationStatus() async {
-        // Given
-        setMigrationReadiness(to: true)
-
-        // When
-        await sut.startMigrationIfNeeded()
-
-        // Then
-        mockStorage.underlyingMigrationStatus = .started
+        XCTAssertEqual(mockStorage.underlyingMigrationStatus, .notStarted)
+        XCTAssertFalse(startedMigration)
     }
 
     // MARK: - ResolveMigrationStartStatus

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		6308F8A62A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6308F8A52A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift */; };
 		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
 		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
+		6326E4722AEBB2E4006EEA28 /* ProteusToMLSMigrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6326E4712AEBB2E4006EEA28 /* ProteusToMLSMigrationCoordinatorTests.swift */; };
 		6326E4762AEBB946006EEA28 /* ProteusToMLSMigrationStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6326E4732AEBB92D006EEA28 /* ProteusToMLSMigrationStorage.swift */; };
 		63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D992434D04D006B6018 /* GenericMessage+External.swift */; };
 		63298D9C24374094006B6018 /* GenericMessageTests+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D9B24374094006B6018 /* GenericMessageTests+External.swift */; };
@@ -1163,6 +1164,7 @@
 		6308F8A52A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMLSConversationGroupInfoAction.swift; sourceTree = "<group>"; };
 		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
 		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
+		6326E4712AEBB2E4006EEA28 /* ProteusToMLSMigrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusToMLSMigrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		6326E4732AEBB92D006EEA28 /* ProteusToMLSMigrationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusToMLSMigrationStorage.swift; sourceTree = "<group>"; };
 		63298D992434D04D006B6018 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
 		63298D9B24374094006B6018 /* GenericMessageTests+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessageTests+External.swift"; sourceTree = "<group>"; };
@@ -2313,6 +2315,7 @@
 				63FACD55291BC598003AB25D /* MLSClientIDTests.swift */,
 				EED6C7152A31AD1200CB8B60 /* MLSUserIDTests.swift */,
 				EE74E4DF2A37B3BF00B63E6E /* SubconversationGroupIDRepositoryTests.swift */,
+				6326E4712AEBB2E4006EEA28 /* ProteusToMLSMigrationCoordinatorTests.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -4250,6 +4253,7 @@
 				F92C992D1DAFC5AC0034AFDD /* ZMConversationTests+Ephemeral.swift in Sources */,
 				EEBF69ED28A2724800195771 /* ZMConversationTests+MLS.swift in Sources */,
 				7A2778C8285329210044A73F /* KeychainManagerTests.swift in Sources */,
+				6326E4722AEBB2E4006EEA28 /* ProteusToMLSMigrationCoordinatorTests.swift in Sources */,
 				0617001323E2FC14005C262D /* GenericMessageTests+LinkMetaData.swift in Sources */,
 				068D610324629AB900A110A2 /* ZMBaseManagedObjectTest.swift in Sources */,
 				54563B7B1E0189780089B1D7 /* ZMMessageCategorizationTests.swift in Sources */,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		63B1337329A798C800009D84 /* ProteusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1337229A798C800009D84 /* ProteusProvider.swift */; };
 		63B658DE243754E100EF463F /* GenericMessage+UpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DD243754E100EF463F /* GenericMessage+UpdateEvent.swift */; };
 		63B658E0243789DE00EF463F /* GenericMessage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */; };
+		63B74CBD2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B74CBC2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift */; };
 		63B74CBF2AE17D6600A73006 /* Feature.MLSMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B74CBE2AE17D6600A73006 /* Feature.MLSMigration.swift */; };
 		63BEF5872A2636BC00F482E8 /* MLSConferenceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */; };
 		63C07015291144F70075D598 /* CoreCryptoConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */; };
@@ -1211,6 +1212,7 @@
 		63B1337229A798C800009D84 /* ProteusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusProvider.swift; sourceTree = "<group>"; };
 		63B658DD243754E100EF463F /* GenericMessage+UpdateEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GenericMessage+UpdateEvent.swift"; sourceTree = "<group>"; };
 		63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Assets.swift"; sourceTree = "<group>"; };
+		63B74CBC2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusToMLSMigrationCoordinator.swift; sourceTree = "<group>"; };
 		63B74CBE2AE17D6600A73006 /* Feature.MLSMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.MLSMigration.swift; sourceTree = "<group>"; };
 		63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSConferenceInfo.swift; sourceTree = "<group>"; };
 		63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoConfigProviderTests.swift; sourceTree = "<group>"; };
@@ -2091,6 +2093,7 @@
 				63B1335329A503D000009D84 /* StaleMLSKeyMaterialDetector.swift */,
 				63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */,
 				63F0781129F6C59D0031E19D /* MLSSubgroup.swift */,
+				63B74CBC2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift */,
 			);
 			name = MLS;
 			path = Source/MLS;
@@ -3695,6 +3698,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */,
+				63B74CBD2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift in Sources */,
 				BF1B98041EC313C600DE033B /* Team.swift in Sources */,
 				A90676E7238EAE8B006417AC /* ParticipantRole.swift in Sources */,
 				165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		6308F8A62A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6308F8A52A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift */; };
 		631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0577240420380062B387 /* UserClient+SafeLogging.swift */; };
 		631A0586240439470062B387 /* UserClientTests+SafeLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */; };
+		6326E4762AEBB946006EEA28 /* ProteusToMLSMigrationStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6326E4732AEBB92D006EEA28 /* ProteusToMLSMigrationStorage.swift */; };
 		63298D9A2434D04D006B6018 /* GenericMessage+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D992434D04D006B6018 /* GenericMessage+External.swift */; };
 		63298D9C24374094006B6018 /* GenericMessageTests+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D9B24374094006B6018 /* GenericMessageTests+External.swift */; };
 		63298D9E24374489006B6018 /* Dictionary+ObjectForKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63298D9D24374489006B6018 /* Dictionary+ObjectForKey.swift */; };
@@ -1162,6 +1163,7 @@
 		6308F8A52A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMLSConversationGroupInfoAction.swift; sourceTree = "<group>"; };
 		631A0577240420380062B387 /* UserClient+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClient+SafeLogging.swift"; sourceTree = "<group>"; };
 		631A0585240439470062B387 /* UserClientTests+SafeLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserClientTests+SafeLogging.swift"; sourceTree = "<group>"; };
+		6326E4732AEBB92D006EEA28 /* ProteusToMLSMigrationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusToMLSMigrationStorage.swift; sourceTree = "<group>"; };
 		63298D992434D04D006B6018 /* GenericMessage+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+External.swift"; sourceTree = "<group>"; };
 		63298D9B24374094006B6018 /* GenericMessageTests+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessageTests+External.swift"; sourceTree = "<group>"; };
 		63298D9D24374489006B6018 /* Dictionary+ObjectForKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+ObjectForKey.swift"; sourceTree = "<group>"; };
@@ -2018,6 +2020,15 @@
 			path = Validation;
 			sourceTree = "<group>";
 		};
+		6326E4752AEBB936006EEA28 /* Migration */ = {
+			isa = PBXGroup;
+			children = (
+				63B74CBC2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift */,
+				6326E4732AEBB92D006EEA28 /* ProteusToMLSMigrationStorage.swift */,
+			);
+			path = Migration;
+			sourceTree = "<group>";
+		};
 		63370CB9242CB8310072C37F /* Composite */ = {
 			isa = PBXGroup;
 			children = (
@@ -2093,7 +2104,7 @@
 				63B1335329A503D000009D84 /* StaleMLSKeyMaterialDetector.swift */,
 				63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */,
 				63F0781129F6C59D0031E19D /* MLSSubgroup.swift */,
-				63B74CBC2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift */,
+				6326E4752AEBB936006EEA28 /* Migration */,
 			);
 			name = MLS;
 			path = Source/MLS;
@@ -3901,6 +3912,7 @@
 				F963E9811D9C09E700098AD3 /* ZMMessageTimer.m in Sources */,
 				EE79699629D4684C00075E38 /* CryptoboxMigrationManager.swift in Sources */,
 				4058AAA22AA76BFA0013DE71 /* ReactionData.swift in Sources */,
+				6326E4762AEBB946006EEA28 /* ProteusToMLSMigrationStorage.swift in Sources */,
 				0129E7FB29A520EB0065E6DB /* SafeFileContext.swift in Sources */,
 				63370CC4242CFA860072C37F /* ZMAssetClientMessage+UpdateEvent.swift in Sources */,
 				F9A706C61CAEE01D00C2F5FE /* ZMFetchRequestBatch.m in Sources */,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		63B1337329A798C800009D84 /* ProteusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1337229A798C800009D84 /* ProteusProvider.swift */; };
 		63B658DE243754E100EF463F /* GenericMessage+UpdateEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DD243754E100EF463F /* GenericMessage+UpdateEvent.swift */; };
 		63B658E0243789DE00EF463F /* GenericMessage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */; };
+		63B74CBF2AE17D6600A73006 /* Feature.MLSMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B74CBE2AE17D6600A73006 /* Feature.MLSMigration.swift */; };
 		63BEF5872A2636BC00F482E8 /* MLSConferenceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */; };
 		63C07015291144F70075D598 /* CoreCryptoConfigProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */; };
 		63C2EABD2A93B174008A0AB7 /* AddParticipantAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C2EABC2A93B174008A0AB7 /* AddParticipantAction.swift */; };
@@ -1210,6 +1211,7 @@
 		63B1337229A798C800009D84 /* ProteusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusProvider.swift; sourceTree = "<group>"; };
 		63B658DD243754E100EF463F /* GenericMessage+UpdateEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GenericMessage+UpdateEvent.swift"; sourceTree = "<group>"; };
 		63B658DF243789DE00EF463F /* GenericMessage+Assets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Assets.swift"; sourceTree = "<group>"; };
+		63B74CBE2AE17D6600A73006 /* Feature.MLSMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.MLSMigration.swift; sourceTree = "<group>"; };
 		63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSConferenceInfo.swift; sourceTree = "<group>"; };
 		63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoConfigProviderTests.swift; sourceTree = "<group>"; };
 		63C2EABC2A93B174008A0AB7 /* AddParticipantAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddParticipantAction.swift; sourceTree = "<group>"; };
@@ -2313,6 +2315,7 @@
 			isa = PBXGroup;
 			children = (
 				EEB803AA283F61E600412F62 /* Feature.MLS.swift */,
+				63B74CBE2AE17D6600A73006 /* Feature.MLSMigration.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -4067,6 +4070,7 @@
 				06D33FCB2524E402004B9BC1 /* ZMConversation+UnreadCount.swift in Sources */,
 				EE22F80929DD818B0053E1C6 /* BaseEARKeyDescription.swift in Sources */,
 				F9A706901CAEE01D00C2F5FE /* ZMUser.m in Sources */,
+				63B74CBF2AE17D6600A73006 /* Feature.MLSMigration.swift in Sources */,
 				F14B7AFF2220302B00458624 /* ZMUser+Predicates.swift in Sources */,
 				066A96FF25A88E510083E317 /* BiometricsState.swift in Sources */,
 				EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */,

--- a/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/sourcery/generated/AutoMockable.generated.swift
@@ -1,5 +1,7 @@
-// Generated using Sourcery 2.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
+// swiftlint:disable line_length
+// swiftlint:disable variable_name
 
 import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS)
@@ -763,6 +765,39 @@ public class MockFeatureRepositoryInterface: FeatureRepositoryInterface {
         mock(mls)            
     }
 
+    // MARK: - fetchMLSMigration
+
+    public var fetchMLSMigration_Invocations: [Void] = []
+    public var fetchMLSMigration_MockMethod: (() -> Feature.MLSMigration)?
+    public var fetchMLSMigration_MockValue: Feature.MLSMigration?
+
+    public func fetchMLSMigration() -> Feature.MLSMigration {
+        fetchMLSMigration_Invocations.append(())
+
+        if let mock = fetchMLSMigration_MockMethod {
+            return mock()
+        } else if let mock = fetchMLSMigration_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `fetchMLSMigration`")
+        }
+    }
+
+    // MARK: - storeMLSMigration
+
+    public var storeMLSMigration_Invocations: [Feature.MLSMigration] = []
+    public var storeMLSMigration_MockMethod: ((Feature.MLSMigration) -> Void)?
+
+    public func storeMLSMigration(_ mlsMigration: Feature.MLSMigration) {
+        storeMLSMigration_Invocations.append(mlsMigration)
+
+        guard let mock = storeMLSMigration_MockMethod else {
+            fatalError("no mock for `storeMLSMigration`")
+        }
+
+        mock(mlsMigration)            
+    }
+
 }
 class MockFileManagerInterface: FileManagerInterface {
 
@@ -1475,6 +1510,22 @@ public class MockProteusServiceInterface: ProteusServiceInterface {
 
         try mock(url)            
     }
+
+}
+class MockProteusToMLSMigrationStorageInterface: ProteusToMLSMigrationStorageInterface {
+
+    // MARK: - Life cycle
+
+
+    // MARK: - migrationStatus
+
+    var migrationStatus: ProteusToMLSMigrationCoordinator.MigrationStatus {
+        get { return underlyingMigrationStatus }
+        set(value) { underlyingMigrationStatus = value }
+    }
+
+    var underlyingMigrationStatus: ProteusToMLSMigrationCoordinator.MigrationStatus!
+
 
 }
 public class MockSubconversationGroupIDRepositoryInterface: SubconversationGroupIDRepositoryInterface {

--- a/wire-ios-mocktransport/Source/Feature Configs/MockTransportSession+FeatureConfigs.swift
+++ b/wire-ios-mocktransport/Source/Feature Configs/MockTransportSession+FeatureConfigs.swift
@@ -54,13 +54,21 @@ extension MockTransportSession {
                     "protocolToggleUsers": [],
                     "defaultProtocol": "proteus",
                     "allowedCipherSuites": [1],
-                    "defaultCipherSuite": 1
+                    "defaultCipherSuite": 1,
+                    "supportedProtocols": []
                 ]
             ],
             "selfDeletingMessages": [
                 "status": "enabled",
                 "config": [
                     "enforcedTimeoutSeconds": 0
+                ]
+            ],
+            "mlsMigration": [
+                "status": "disabled",
+                "config": [
+                    "startTime": nil,
+                    "finaliseRegardlessAfter": nil
                 ]
             ]
         ]

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
@@ -111,6 +111,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
         expectedRequestPayload = nil
         successResponsePayloadProteus = nil
         successResponsePayloadMLS = nil
+        BackendInfo.storage = .standard
         super.tearDown()
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
@@ -124,6 +124,10 @@ extension FeatureConfigRequestStrategy: ZMEventConsumer {
         case .mls:
             let response = try decoder.decode(FeatureStatusWithConfig<Feature.MLS.Config>.self, from: data)
             featureRepository.storeMLS(.init(status: response.status, config: response.config))
+
+        case .mlsMigration:
+            let response = try decoder.decode(FeatureStatusWithConfig<Feature.MLSMigration.Config>.self, from: data)
+            featureRepository.storeMLSMigration(.init(status: response.status, config: response.config))
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
@@ -90,7 +90,7 @@ extension FeatureConfigRequestStrategy: ZMEventConsumer {
 
     private func processResponse(featureName: Feature.Name, data: Data) throws {
         let featureRepository = FeatureRepository(context: managedObjectContext)
-        let decoder = JSONDecoder()
+        let decoder = JSONDecoder.defaultDecoder
 
         switch featureName {
         case .conferenceCalling:

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
@@ -295,4 +295,101 @@ class FeatureConfigRequestStrategyTests: MessagingTestBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
 
+    func test_ItProcessesEvent_MLS() {
+        // Given
+
+        let userID = UUID()
+
+        syncMOC.performAndWait {
+            let mls = Feature.MLS(status: .disabled, config: .init())
+            self.featureRepository.storeMLS(mls)
+
+            let config: NSDictionary = [
+                "allowedCipherSuites": [1],
+                "defaultCipherSuite": 1,
+                "defaultProtocol": "proteus",
+                "protocolToggleUsers": [
+                    userID.transportString()
+                ],
+                "supportedProtocols": [
+                    "proteus", "mls", "mixed"
+                ]
+            ]
+
+            let data: NSDictionary = [
+                "status": "enabled",
+                "config": config
+            ]
+
+            let payload: NSDictionary = [
+                "type": "feature-config.update",
+                "data": data,
+                "name": "mls"
+            ]
+
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
+
+            // When
+            self.sut.processEvents([event], liveEvents: false, prefetchResult: nil)
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // Then
+        syncMOC.performGroupedAndWait { _ in
+            let mls = self.featureRepository.fetchMLS()
+            XCTAssertEqual(mls.status, .enabled)
+            XCTAssertEqual(mls.config.allowedCipherSuites, [.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519])
+            XCTAssertEqual(mls.config.defaultCipherSuite, .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+            XCTAssertEqual(mls.config.defaultProtocol, .proteus)
+            XCTAssertEqual(mls.config.protocolToggleUsers, [userID])
+            XCTAssertEqual(mls.config.supportedProtocols, [.proteus, .mls, .mixed])
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+
+    func test_ItProcessesEvent_MLSMigration() {
+        // Given
+        let startTime = "2023-10-27T12:43:48.000Z"
+        let finaliseTime = "2023-11-02T12:43:48.000Z"
+
+        syncMOC.performAndWait {
+            let mlsMigration = Feature.MLSMigration(status: .disabled, config: .init())
+            self.featureRepository.storeMLSMigration(mlsMigration)
+
+            let config: NSDictionary = [
+                "startTime": startTime,
+                "finaliseRegardlessAfter": finaliseTime
+            ]
+
+            let data: NSDictionary = [
+                "status": "enabled",
+                "config": config
+            ]
+
+            let payload: NSDictionary = [
+                "type": "feature-config.update",
+                "data": data,
+                "name": "mlsMigration"
+            ]
+
+            let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil)!
+
+            // When
+            self.sut.processEvents([event], liveEvents: false, prefetchResult: nil)
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // Then
+        syncMOC.performGroupedAndWait { _ in
+            let mlsMigration = self.featureRepository.fetchMLSMigration()
+            XCTAssertEqual(mlsMigration.status, .enabled)
+            XCTAssertEqual(mlsMigration.config.startTime, Date(transportString: startTime))
+            XCTAssertEqual(mlsMigration.config.finaliseRegardlessAfter, Date(transportString: finaliseTime))
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandler.swift
@@ -49,7 +49,7 @@ final class GetFeatureConfigsActionHandler: ActionHandler<GetFeatureConfigsActio
             }
 
             do {
-                let payload = try JSONDecoder().decode(ResponsePayload.self, from: data)
+                let payload = try JSONDecoder.defaultDecoder.decode(ResponsePayload.self, from: data)
                 processPayload(payload)
                 action.succeed()
             } catch {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandler.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireDataModel
 
 final class GetFeatureConfigsActionHandler: ActionHandler<GetFeatureConfigsAction> {
 
@@ -139,6 +140,15 @@ final class GetFeatureConfigsActionHandler: ActionHandler<GetFeatureConfigsActio
                 )
             )
         }
+
+        if let mlsMigration = payload.mlsMigration {
+            featureRepository.storeMLSMigration(
+                Feature.MLSMigration(
+                    status: mlsMigration.status,
+                    config: mlsMigration.config
+                )
+            )
+        }
     }
 
 }
@@ -157,6 +167,7 @@ extension GetFeatureConfigsActionHandler {
         let fileSharing: FeatureStatus?
         let mls: FeatureStatusWithConfig<Feature.MLS.Config>?
         let selfDeletingMessages: FeatureStatusWithConfig<Feature.SelfDeletingMessages.Config>?
+        let mlsMigration: FeatureStatusWithConfig<Feature.MLSMigration.Config>?
 
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
@@ -64,6 +64,9 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
             let sut = GetFeatureConfigsActionHandler(context: self.syncMOC)
             var action = GetFeatureConfigsAction()
 
+            let mlsMigrationStartDate = Date()
+            let mlsMigrationFinaliseDate = Date.distantFuture
+
             // Expectation
             let gotResult = self.expectation(description: "gotResult")
 
@@ -87,7 +90,14 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
                 digitalSignatures: .init(status: .enabled),
                 fileSharing: .init(status: .enabled),
                 mls: .init(status: .enabled, config: .init(defaultProtocol: .mls)),
-                selfDeletingMessages: .init(status: .enabled, config: .init(enforcedTimeoutSeconds: 22))
+                selfDeletingMessages: .init(status: .enabled, config: .init(enforcedTimeoutSeconds: 22)),
+                mlsMigration: .init(
+                    status: .enabled,
+                    config: .init(
+                        startTime: mlsMigrationStartDate,
+                        finaliseRegardlessAfter: mlsMigrationFinaliseDate
+                    )
+                )
             )
 
             guard let payloadData = try? JSONEncoder().encode(payload),
@@ -131,6 +141,11 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
             let selfDeletingMessage = featureRepository.fetchSelfDeletingMesssages()
             XCTAssertEqual(selfDeletingMessage.status, .enabled)
             XCTAssertEqual(selfDeletingMessage.config.enforcedTimeoutSeconds, 22)
+
+            let mlsMigration = featureRepository.fetchMLSMigration()
+            XCTAssertEqual(mlsMigration.status, .enabled)
+            XCTAssertEqual(mlsMigration.config, .init(startTime: mlsMigrationStartDate, finaliseRegardlessAfter: mlsMigrationFinaliseDate))
+
         }
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -165,7 +180,8 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
                 digitalSignatures: nil,
                 fileSharing: nil,
                 mls: nil,
-                selfDeletingMessages: nil
+                selfDeletingMessages: nil,
+                mlsMigration: nil
             )
 
             guard let payloadData = try? JSONEncoder().encode(payload),
@@ -208,6 +224,10 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
             let selfDeletingMessage = featureRepository.fetchSelfDeletingMesssages()
             XCTAssertEqual(selfDeletingMessage.status, .enabled)
             XCTAssertEqual(selfDeletingMessage.config, .init())
+
+            let mlsMigration = featureRepository.fetchMLSMigration()
+            XCTAssertEqual(mlsMigration.status, .disabled)
+            XCTAssertEqual(mlsMigration.config, .init())
         }
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
@@ -144,16 +144,14 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
 
             let mlsMigration = featureRepository.fetchMLSMigration()
             XCTAssertEqual(mlsMigration.status, .enabled)
-            XCTAssertTrue(Calendar.current.isDate(
-                try XCTUnwrap(mlsMigration.config.startTime),
-                equalTo: mlsMigrationStartDate,
-                toGranularity: .nanosecond
-            ))
-            XCTAssertTrue(Calendar.current.isDate(
-                try XCTUnwrap(mlsMigration.config.finaliseRegardlessAfter),
-                equalTo: mlsMigrationFinaliseDate,
-                toGranularity: .nanosecond
-            ))
+            XCTAssertEqual(
+                String(describing: try XCTUnwrap(mlsMigration.config.startTime)),
+                String(describing: mlsMigrationStartDate)
+            )
+            XCTAssertEqual(
+                String(describing: try XCTUnwrap(mlsMigration.config.finaliseRegardlessAfter)),
+                String(describing: mlsMigrationFinaliseDate)
+            )
         }
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandler.swift
@@ -59,8 +59,8 @@ class FetchBackendMLSPublicKeysActionHandler: ActionHandler<FetchBackendMLSPubli
     override func handleResponse(_ response: ZMTransportResponse, action: FetchBackendMLSPublicKeysAction) {
         var action = action
 
-        switch response.httpStatus {
-        case 200:
+        switch (response.httpStatus, response.payloadLabel()) {
+        case (200, _):
             guard
                 let data = response.rawData,
                 let payload = try? JSONDecoder().decode(ResponsePayload.self, from: data)
@@ -73,6 +73,9 @@ class FetchBackendMLSPublicKeysActionHandler: ActionHandler<FetchBackendMLSPubli
                 .map(\.data)
 
             action.succeed(with: Action.Result(removal: .init(ed25519: ed25519RemovalKey)))
+
+        case (400, "mls-not-enabled"):
+            action.fail(with: .mlsNotEnabled)
 
         default:
             let error = response.errorInfo

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -53,6 +53,7 @@ class FetchClientRequestStrategyTests: MessagingTestBase {
         sut = nil
         NotificationCenter.default.removeObserver(self)
         apiVersion = nil
+        BackendInfo.storage = .standard
         super.tearDown()
     }
 

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
@@ -188,4 +188,9 @@ class MockMLSService: MLSServiceInterface {
         fatalError("not implemented")
     }
 
+    // MARK: Proteus to MLS migration
+
+    func startProteusToMLSMigration() {
+        fatalError("not implemented")
+    }
 }

--- a/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Mocks/MockMLSService.swift
@@ -188,9 +188,15 @@ class MockMLSService: MLSServiceInterface {
         fatalError("not implemented")
     }
 
-    // MARK: Proteus to MLS migration
+    // MARK: - Migration
+
+    typealias StartProteusToMLSMigrationMock = () -> Void
+    var startProteusToMLSMigrationMock: StartProteusToMLSMigrationMock?
 
     func startProteusToMLSMigration() {
-        fatalError("not implemented")
+        guard let mock = startProteusToMLSMigrationMock else {
+            return
+        }
+        mock()
     }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+LifeCycle.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+LifeCycle.swift
@@ -22,6 +22,7 @@ extension ZMUserSession {
 
     public func application(_ application: ZMApplication, didFinishLaunching launchOptions: [UIApplication.LaunchOptionsKey: Any?]) {
         startEphemeralTimers()
+        mlsMigrationCoordinator.startPeriodicMigrationStatusCheck()
     }
 
     public func application(_ application: ZMApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void ) {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+LifeCycle.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+LifeCycle.swift
@@ -22,7 +22,6 @@ extension ZMUserSession {
 
     public func application(_ application: ZMApplication, didFinishLaunching launchOptions: [UIApplication.LaunchOptionsKey: Any?]) {
         startEphemeralTimers()
-        mlsMigrationCoordinator.startPeriodicMigrationStatusCheck()
     }
 
     public func application(_ application: ZMApplication, performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void ) {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
@@ -20,6 +20,12 @@ import Foundation
 
 extension ZMUserSession {
 
+    func updateProteusToMLSMigrationStatus(interval: TimeInterval = .oneDay) -> RecurringAction {
+        return RecurringAction(id: "updateProteusToMLSMigrationStatus", interval: interval) { [weak self] in
+            self?.proteusToMLSMigrationCoordinator.updateMigrationStatus()
+        }
+    }
+
     func refreshUsersMissingMetadata(interval: TimeInterval = 3 * .oneHour) -> RecurringAction {
 
         return RecurringAction(id: "refreshUserMetadata", interval: interval) { [weak self] in

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
@@ -22,7 +22,9 @@ extension ZMUserSession {
 
     func updateProteusToMLSMigrationStatus(interval: TimeInterval = .oneDay) -> RecurringAction {
         return RecurringAction(id: "updateProteusToMLSMigrationStatus", interval: interval) { [weak self] in
-            self?.proteusToMLSMigrationCoordinator.updateMigrationStatus()
+            Task { [weak self] in
+                await self?.proteusToMLSMigrationCoordinator.updateMigrationStatus()
+            }
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -122,6 +122,7 @@ class WireCallCenterV3Tests: MessagingTest {
         mockTransport = nil
         mockAVSWrapper = nil
         conferenceCalling = nil
+        BackendInfo.storage = .standard
 
         super.tearDown()
     }

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
@@ -211,8 +211,8 @@ class MockMLSService: MLSServiceInterface {
     func fetchAndRepairGroup(with groupID: MLSGroupID) async {
         guard let mock = fetchAndRepairGroupMock else {
             return
-        mock(groupID)
         }
+        mock(groupID)
     }
 
     // MARK: - Migration
@@ -220,10 +220,9 @@ class MockMLSService: MLSServiceInterface {
 
     var startProteusToMLSMigrationMock: StartProteusToMLSMigrationMock?
     func startProteusToMLSMigration() {
-
         guard let mock = startProteusToMLSMigrationMock else {
             return
-        mock()
         }
+        mock()
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockMLSService.swift
@@ -205,4 +205,15 @@ class MockMLSService: MLSServiceInterface {
         mock()
     }
 
+    // MARK: - Migration
+
+    typealias StartProteusToMLSMigrationMock = () -> Void
+    var startProteusToMLSMigrationMock: StartProteusToMLSMigrationMock?
+
+    func startProteusToMLSMigration() {
+        guard let mock = startProteusToMLSMigrationMock else {
+            return
+        }
+        mock()
+    }
 }

--- a/wire-ios-transport/Source/Public/SwiftStructs+TransportEncoding.swift
+++ b/wire-ios-transport/Source/Public/SwiftStructs+TransportEncoding.swift
@@ -30,4 +30,11 @@ extension Date {
     public func transportString() -> String {
         return (self as NSDate).transportString()
     }
+
+    public init?(transportString: String) {
+        guard let date = NSDate(transport: transportString) as? Date else {
+            return nil
+        }
+        self = date
+    }
 }

--- a/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
+++ b/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
@@ -69,6 +69,14 @@ extension PrivateUserDefaults {
         return storage.object(forKey: scopeKey(key))
     }
 
+    public func set(_ value: Int, forKey key: Key) {
+        storage.set(value, forKey: scopeKey(key))
+    }
+
+    public func integer(forKey key: Key) -> Int {
+        return storage.integer(forKey: scopeKey(key))
+    }
+
 }
 
 public protocol DefaultsKey {

--- a/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
+++ b/wire-ios-utilities/Source/Public/PrivateUserDefaults.swift
@@ -61,6 +61,14 @@ extension PrivateUserDefaults {
         return storage.bool(forKey: scopeKey(key))
     }
 
+    public func set(_ value: Any?, forKey key: Key) {
+        storage.set(value, forKey: scopeKey(key))
+    }
+
+    public func object(forKey key: Key) -> Any? {
+        return storage.object(forKey: scopeKey(key))
+    }
+
 }
 
 public protocol DefaultsKey {

--- a/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -55,6 +55,7 @@ final class SettingsTableViewControllerSnapshotTests: ZMSnapshotTestCase {
         selfUser = nil
         SelfUser.provider = nil
         Settings.shared.reset()
+        BackendInfo.storage = .standard
         BackendInfo.isFederationEnabled = false
         super.tearDown()
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2895" title="WPB-2895" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-2895</a>  [iOS] Periodically check if migration can be initialised
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

To ensure the MLS migration starts and ends at specific times, we need to periodically check (every 24h) if the migration can start. Once it's started, we also need to periodically check if it should be finalised.

For this purpose I've introduced the `ProteusToMLSMigrationCoordinator`. Its responsibility is to keep track of the migration status and to initiate migration steps when necessary. In the scope of this PR, we're only implementing the coordinator's logic for starting the migration. Finalising the migration will come at a later time.

To satisfy the periodic check requirement, the coordinator is asked to update the migration status every 24h through a recurring action.

### Changes

- Introduced `ProteusToMLSMigrationCoordinator`
- Introduced `ProteusToMLSMigrationStorage` to handle storing the migration status per account
- Added the `Feature.MLSMigration` feature
- Updated `Feature.MLS`
- Added interface to start migration to `MLSService`
- Registered new `RecurringAction` to periodically update the migration status
- Handled `mls-not-enabled` error for `GET /mls/public-keys`
- Updated some utilities

### Testing

- Added tests for `ProteusToMLSMigrationCoordinator`
- Updated tests related to Feature management
