### PR TITLE
fix: inserting gap system message after conversation repair WPB-2143

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -171,67 +171,67 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     func addMembers(_ invitees: [Invitee], to groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         do {
-            WireLogger.mls.info("adding members to group (\(groupID))...")
+            WireLogger.mls.info("adding members to group (\(groupID.safeForLoggingDescription))...")
             let bundle = try commitBundle(for: .addMembers(invitees), in: groupID)
             let result = try await sendCommitBundle(bundle, for: groupID)
-            WireLogger.mls.info("success: adding members to group (\(groupID))")
+            WireLogger.mls.info("success: adding members to group (\(groupID.safeForLoggingDescription))")
             return result
         } catch {
-            WireLogger.mls.info("failed: adding members to group (\(groupID)): \(String(describing: error))")
+            WireLogger.mls.info("failed: adding members to group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
             throw error
         }
     }
 
     func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         do {
-            WireLogger.mls.info("removing clients from group (\(groupID))...")
+            WireLogger.mls.info("removing clients from group (\(groupID.safeForLoggingDescription))...")
             let bundle = try commitBundle(for: .removeClients(clients), in: groupID)
             let result = try await sendCommitBundle(bundle, for: groupID)
-            WireLogger.mls.info("success: removing clients from group (\(groupID))")
+            WireLogger.mls.info("success: removing clients from group (\(groupID.safeForLoggingDescription))")
             return result
         } catch {
-            WireLogger.mls.info("error: removing clients from group (\(groupID)): \(String(describing: error))")
+            WireLogger.mls.info("error: removing clients from group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
             throw error
         }
     }
 
     func updateKeyMaterial(for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         do {
-            WireLogger.mls.info("updating key material for group (\(groupID))...")
+            WireLogger.mls.info("updating key material for group (\(groupID.safeForLoggingDescription))...")
             let bundle = try commitBundle(for: .updateKeyMaterial, in: groupID)
             let result = try await sendCommitBundle(bundle, for: groupID)
-            WireLogger.mls.info("success: updating key material for group (\(groupID))")
+            WireLogger.mls.info("success: updating key material for group (\(groupID.safeForLoggingDescription))")
             return result
         } catch {
-            WireLogger.mls.info("error: updating key material for group (\(groupID)): \(String(describing: error))")
+            WireLogger.mls.info("error: updating key material for group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
             throw error
         }
     }
 
     func commitPendingProposals(in groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         do {
-            WireLogger.mls.info("committing pending proposals for group (\(groupID))...")
+            WireLogger.mls.info("committing pending proposals for group (\(groupID.safeForLoggingDescription))...")
             let bundle = try commitBundle(for: .proposal, in: groupID)
             let result = try await sendCommitBundle(bundle, for: groupID)
-            WireLogger.mls.info("success: committing pending proposals for group (\(groupID))")
+            WireLogger.mls.info("success: committing pending proposals for group (\(groupID.safeForLoggingDescription))")
             return result
         } catch Error.noPendingProposals {
             throw Error.noPendingProposals
         } catch {
-            WireLogger.mls.info("error: committing pending proposals for group (\(groupID)): \(String(describing: error))")
+            WireLogger.mls.info("error: committing pending proposals for group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
             throw error
         }
     }
 
     func joinGroup(_ groupID: MLSGroupID, groupInfo: Data) async throws -> [ZMUpdateEvent] {
         do {
-            WireLogger.mls.info("joining group (\(groupID)) via external commit")
+            WireLogger.mls.info("joining group (\(groupID.safeForLoggingDescription)) via external commit")
             let bundle = try commitBundle(for: .joinGroup(groupInfo), in: groupID)
             let result = try await sendExternalCommitBundle(bundle, for: groupID)
-            WireLogger.mls.info("success: joining group (\(groupID)) via external commit")
+            WireLogger.mls.info("success: joining group (\(groupID.safeForLoggingDescription)) via external commit")
             return result
         } catch {
-            WireLogger.mls.info("error: joining group (\(groupID)) via external commit: \(String(describing: error))")
+            WireLogger.mls.info("error: joining group (\(groupID.safeForLoggingDescription)) via external commit: \(String(describing: error))")
             throw error
         }
     }
@@ -240,7 +240,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     private func commitBundle(for action: Action, in groupID: MLSGroupID) throws -> CommitBundle {
         do {
-            WireLogger.mls.info("generating commit for action (\(String(describing: action))) for group (\(groupID))...")
+            WireLogger.mls.info("generating commit for action (\(String(describing: action))) for group (\(groupID.safeForLoggingDescription))...")
             switch action {
             case .addMembers(let clients):
                 let memberAddMessages = try coreCrypto.perform { try $0.addClientsToConversation(
@@ -289,7 +289,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
         } catch Error.noPendingProposals {
             throw Error.noPendingProposals
         } catch {
-            WireLogger.mls.warn("failed: generating commit for action (\(String(describing: action))) for group (\(groupID)): \(String(describing: error))")
+            WireLogger.mls.warn("failed: generating commit for action (\(String(describing: action))) for group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
             throw Error.failedToGenerateCommit
         }
     }
@@ -298,9 +298,9 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     private func sendCommitBundle(_ bundle: CommitBundle, for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         do {
-            WireLogger.mls.info("sending commit bundle for group (\(groupID))")
+            WireLogger.mls.info("sending commit bundle for group (\(groupID.safeForLoggingDescription))")
             let events = try await sendCommitBundle(bundle)
-            WireLogger.mls.info("merging commit for group (\(groupID))")
+            WireLogger.mls.info("merging commit for group (\(groupID.safeForLoggingDescription))")
             try mergeCommit(in: groupID)
             return events
         } catch let error as SendCommitBundleAction.Failure {
@@ -348,47 +348,47 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     private func mergeCommit(in groupID: MLSGroupID) throws {
         do {
-            WireLogger.mls.info("merging commit for group (\(groupID))")
+            WireLogger.mls.info("merging commit for group (\(groupID.safeForLoggingDescription))")
             try coreCrypto.perform { try $0.commitAccepted(conversationId: groupID.bytes) }
             onEpochChangedSubject.send(groupID)
         } catch {
-            WireLogger.mls.error("failed to merge commit for group (\(groupID))")
+            WireLogger.mls.error("failed to merge commit for group (\(groupID.safeForLoggingDescription))")
             throw Error.failedToMergeCommit
         }
     }
 
     private func discardPendingCommit(in groupID: MLSGroupID) throws {
         do {
-            WireLogger.mls.info("discarding pending commit for group (\(groupID))")
+            WireLogger.mls.info("discarding pending commit for group (\(groupID.safeForLoggingDescription))")
             try coreCrypto.perform { try $0.clearPendingCommit(conversationId: groupID.bytes) }
         } catch {
-            WireLogger.mls.error("failed to discard pending commit for group (\(groupID))")
+            WireLogger.mls.error("failed to discard pending commit for group (\(groupID.safeForLoggingDescription))")
             throw Error.failedToClearCommit
         }
     }
 
     private func mergePendingGroup(in groupID: MLSGroupID) throws {
         do {
-            WireLogger.mls.info("merging pending group (\(groupID))")
+            WireLogger.mls.info("merging pending group (\(groupID.safeForLoggingDescription))")
             try coreCrypto.perform {
                 try $0.mergePendingGroupFromExternalCommit(
                     conversationId: groupID.bytes
                 )
             }
         } catch {
-            WireLogger.mls.error("failed to merge pending group (\(groupID))")
+            WireLogger.mls.error("failed to merge pending group (\(groupID.safeForLoggingDescription))")
             throw Error.failedToMergePendingGroup
         }
     }
 
     private func clearPendingGroup(in groupID: MLSGroupID) throws {
         do {
-            WireLogger.mls.info("clearing pending group (\(groupID))")
+            WireLogger.mls.info("clearing pending group (\(groupID.safeForLoggingDescription))")
             try coreCrypto.perform {
                 try $0.clearPendingGroupFromExternalCommit(conversationId: groupID.bytes)
             }
         } catch {
-            WireLogger.mls.error("failed to clear pending group (\(groupID))")
+            WireLogger.mls.error("failed to clear pending group (\(groupID.safeForLoggingDescription))")
             throw Error.failedToClearPendingGroup
         }
     }

--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -95,7 +95,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
         for groupID: MLSGroupID,
         subconversationType: SubgroupType?
     ) throws -> MLSDecryptResult? {
-        WireLogger.mls.debug("decrypting message for group (\(groupID)) and subconversation type (\(String(describing: subconversationType))")
+        WireLogger.mls.debug("decrypting message for group (\(groupID.safeForLoggingDescription)) and subconversation type (\(String(describing: subconversationType)))")
 
         guard let messageBytes = message.base64DecodedBytes else {
             throw MLSMessageDecryptionError.failedToConvertMessageToBytes
@@ -136,7 +136,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
 
             return nil
         } catch {
-            WireLogger.mls.error("failed to decrypt message for group (\(groupID)) and subconversation type (\(String(describing: subconversationType)): \(String(describing: error))")
+            WireLogger.mls.error("failed to decrypt message for group (\(groupID.safeForLoggingDescription)) and subconversation type (\(String(describing: subconversationType))): \(String(describing: error))")
 
             if case CryptoError.WrongEpoch(message: _) = error {
                 throw MLSMessageDecryptionError.wrongEpoch

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.swift
@@ -113,10 +113,10 @@ class MLSMessageSync<Message: MLSMessage>: NSObject, ZMContextChangeTrackerSourc
         }
 
         do {
-            WireLogger.mls.info("preemptively commiting pending proposals before sending message in group (\(groupID))")
+            WireLogger.mls.info("preemptively commiting pending proposals before sending message in group (\(groupID.safeForLoggingDescription))")
             try await mlsService.commitPendingProposals(in: groupID)
         } catch {
-            WireLogger.mls.info("failed: preemptively commiting pending proposals before sending message in group (\(groupID)): \(String(describing: error))")
+            WireLogger.mls.info("failed: preemptively commiting pending proposals before sending message in group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2143" title="WPB-2143" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-2143</a>  [iOS] MLS Client to recover from 404 response in Quick Sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After repairing out of sync MLS conversations after the slow sync, we're not seeing a gap system message. ("You haven't used this device for a while...")

### Solutions

Add the system message. (it was removed during a refactoring)

### Note

I've updated some logs 