### PR TITLE
fix: swiftlint not found when committing via xcode

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -59,6 +59,12 @@ def swiftlint_exists
 	$?.success?
 end
 
+# Add Homebrew bin directory to PATH if it exists
+if File.directory?("/opt/homebrew/bin/")
+  ENV['PATH'] = "/opt/homebrew/bin:" + ENV['PATH']
+end
+
+
 # Checking if current commit is not a merge commit. For merge commits we don't want to perform linting
 # since we would be linting changes not related to our work.
 commit_hash = `git rev-parse -q --verify MERGE_HEAD`


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When attempting to create a commit from within Xcode I get a: `swiftlint not installed` error from the precommit hook.

### Causes

I've installed SwiftLint via homebrew which installs it in the non default path `/opt/homebrew/bin/`

### Solutions

Add `/opt/homebrew/bin/` to `PATH` if it exists.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
