### PR TITLE
docs: add README prerequisites for ruby and SSH key

### DIFF
--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -34,6 +34,7 @@ jobs:
       wire-ios-link-preview : ${{ steps.filter.outputs.wire-ios-link-preview }}
       wire-ios-utilities: ${{ steps.filter.outputs.wire-ios-utilities }}
       wire-ios-testing: ${{ steps.filter.outputs.wire-ios-testing }}
+      any: ${{ steps.filter.outputs.carthage == 'true' || steps.filter.outputs.wire-ios == 'true' || steps.filter.outputs.wire-ios-sync-engine == 'true' || steps.filter.outputs.wire-ios-data-model == 'true' || steps.filter.outputs.wire-ios-system == 'true' || steps.filter.outputs.wire-ios-request-strategy == 'true' || steps.filter.outputs.wire-ios-transport == 'true' || steps.filter.outputs.wire-ios-share-engine == 'true' || steps.filter.outputs.wire-ios-cryptobox == 'true' || steps.filter.outputs.wire-ios-mocktransport == 'true' || steps.filter.outputs.wire-ios-notification-engine == 'true' || steps.filter.outputs.wire-ios-protos == 'true' || steps.filter.outputs.wire-ios-images == 'true' || steps.filter.outputs.wire-ios-link-preview == 'true' || steps.filter.outputs.wire-ios-utilities == 'true' || steps.filter.outputs.wire-ios-testing == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +77,7 @@ jobs:
 
   trigger_tests:
     needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.any == 'true' }}
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:
       wire-ios: ${{ needs.detect-changes.outputs.wire-ios == 'true' }}

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -34,7 +34,6 @@ jobs:
       wire-ios-link-preview : ${{ steps.filter.outputs.wire-ios-link-preview }}
       wire-ios-utilities: ${{ steps.filter.outputs.wire-ios-utilities }}
       wire-ios-testing: ${{ steps.filter.outputs.wire-ios-testing }}
-      any: ${{ steps.filter.outputs.carthage == 'true' || steps.filter.outputs.wire-ios == 'true' || steps.filter.outputs.wire-ios-sync-engine == 'true' || steps.filter.outputs.wire-ios-data-model == 'true' || steps.filter.outputs.wire-ios-system == 'true' || steps.filter.outputs.wire-ios-request-strategy == 'true' || steps.filter.outputs.wire-ios-transport == 'true' || steps.filter.outputs.wire-ios-share-engine == 'true' || steps.filter.outputs.wire-ios-cryptobox == 'true' || steps.filter.outputs.wire-ios-mocktransport == 'true' || steps.filter.outputs.wire-ios-notification-engine == 'true' || steps.filter.outputs.wire-ios-protos == 'true' || steps.filter.outputs.wire-ios-images == 'true' || steps.filter.outputs.wire-ios-link-preview == 'true' || steps.filter.outputs.wire-ios-utilities == 'true' || steps.filter.outputs.wire-ios-testing == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +76,6 @@ jobs:
 
   trigger_tests:
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.any == 'true' }}
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:
       wire-ios: ${{ needs.detect-changes.outputs.wire-ios == 'true' }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In order to build Wire for iOS locally, it is necessary to install and setup the
 - macOS 13.5 (Ventura) or newer
 - [Xcode 15.0.0](https://xcodereleases.com)
 - Carthage 0.38 or newer (https://github.com/Carthage/Carthage)
-- `gem` must be setup to use ruby without admin permissions. One way to archive this is to use [rbenv](https://github.com/rbenv/rbenv), install the latest ruby version and set it as global version.
+- `gem` must be setup to use ruby without admin permissions. One way to achieve this is to use [rbenv](https://github.com/rbenv/rbenv), install the latest ruby version and set it as global version.
 - SSH key for git. [Generate a new key, add it locally](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and [add it to GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
 The setup script will automatically check for you that you satisfy these requirements.

--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ These differences are:
 - the open source project links against the open source Wire audio-video-signaling (AVS) library. The binary App Store client links against an AVS version that contains proprietary improvements for the call quality.
 
 ### Prerequisites
-In order to build Wire for iOS locally, it is necessary to install the following tools on the local machine:
+In order to build Wire for iOS locally, it is necessary to install and setup the following tools on the local machine:
 
 - macOS 13.5 (Ventura) or newer
 - [Xcode 15.0.0](https://xcodereleases.com)
 - Carthage 0.38 or newer (https://github.com/Carthage/Carthage)
 - `gem` must be setup to use ruby without admin permissions. One way to archive this is to use [rbenv](https://github.com/rbenv/rbenv), install the latest ruby version and set it as global version.
+- SSH key for git. [Generate a new key, add it locally](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) and [add it to GitHub](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
-The setup script will automatically check for you that you satisfy these requirements
+The setup script will automatically check for you that you satisfy these requirements.
 
 ### How to build locally
 1. Check out the wire-ios-mono repository.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ In order to build Wire for iOS locally, it is necessary to install the following
 - macOS 13.5 (Ventura) or newer
 - [Xcode 15.0.0](https://xcodereleases.com)
 - Carthage 0.38 or newer (https://github.com/Carthage/Carthage)
+- `gem` must be setup to use ruby without admin permissions. One way to archive this is to use [rbenv](https://github.com/rbenv/rbenv), install the latest ruby version and set it as global version.
 
 The setup script will automatically check for you that you satisfy these requirements
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On a new machine running `./setup.sh` will produce errors for `gem install bundler`, that you need admin permissions to write to the Apple macOS standard path of ruby.

### Solutions

Therefore to setup the project you need to have `gem` working without admin permissions. This can be archived in multiple ways, so I just added my suggestion to install another ruby version via `rbenv` (can be discussed!).

### Testing

#### Test Coverage (Optional)

- [ ] ~~I have added automated test to this contribution~~

#### How to Test

- install `rbenv` as described in the README

### Notes (Optional)

- Are there other simple ways to get rid of the admin permissions issue?

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
