### PR TITLE
refactor(message-sending): replace MessageSync with MessageSender in all remaining strategies #6

### DIFF
--- a/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
@@ -62,7 +62,7 @@ class MessageAPIV0: MessageAPI {
     ) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError> {
         let path = "/" + ["conversations", conversationID.uuid.transportString(), "otr", "messages"].joined(separator: "/")
 
-        guard let encryptedPayload = message.context.performAndWait({
+        guard let encryptedPayload = await message.context.perform({
             message.encryptForTransportQualified()
         }) else {
             WireLogger.messaging.error("failed to encrypt message for transport")
@@ -78,7 +78,7 @@ class MessageAPIV0: MessageAPI {
             apiVersion: apiVersion.rawValue
         )
 
-        if let expirationDate = (message.context.performAndWait {
+        if let expirationDate = (await message.context.perform {
             message.expirationDate
         }) {
             request.expire(at: expirationDate)
@@ -135,7 +135,7 @@ class MessageAPIV1: MessageAPIV0 {
     ) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError> {
         let path = "/" + ["conversations", conversationID.domain, conversationID.uuid.transportString(), "proteus", "messages"].joined(separator: "/")
 
-        guard let encryptedPayload = message.context.performAndWait({
+        guard let encryptedPayload = await message.context.perform({
             message.encryptForTransportQualified()
         }) else {
             WireLogger.messaging.error("failed to encrypt message for transport")
@@ -151,7 +151,7 @@ class MessageAPIV1: MessageAPIV0 {
             apiVersion: apiVersion.rawValue
         )
 
-        if let expirationDate = (message.context.performAndWait {
+        if let expirationDate = (await message.context.perform {
             message.expirationDate
         }) {
             request.expire(at: expirationDate)

--- a/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
@@ -62,7 +62,9 @@ class MessageAPIV0: MessageAPI {
     ) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError> {
         let path = "/" + ["conversations", conversationID.uuid.transportString(), "otr", "messages"].joined(separator: "/")
 
-        guard let encryptedPayload = message.encryptForTransportQualified() else {
+        guard let encryptedPayload = message.context.performAndWait({
+            message.encryptForTransportQualified()
+        }) else {
             WireLogger.messaging.error("failed to encrypt message for transport")
             return .failure(NetworkError.errorEncodingRequest)
         }
@@ -76,7 +78,9 @@ class MessageAPIV0: MessageAPI {
             apiVersion: apiVersion.rawValue
         )
 
-        if let expirationDate = message.expirationDate {
+        if let expirationDate = (message.context.performAndWait {
+            message.expirationDate
+        }) {
             request.expire(at: expirationDate)
         }
 
@@ -131,7 +135,9 @@ class MessageAPIV1: MessageAPIV0 {
     ) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError> {
         let path = "/" + ["conversations", conversationID.domain, conversationID.uuid.transportString(), "proteus", "messages"].joined(separator: "/")
 
-        guard let encryptedPayload = message.encryptForTransportQualified() else {
+        guard let encryptedPayload = message.context.performAndWait({
+            message.encryptForTransportQualified()
+        }) else {
             WireLogger.messaging.error("failed to encrypt message for transport")
             return .failure(NetworkError.errorEncodingRequest)
         }
@@ -145,7 +151,9 @@ class MessageAPIV1: MessageAPIV0 {
             apiVersion: apiVersion.rawValue
         )
 
-        if let expirationDate = message.expirationDate {
+        if let expirationDate = (message.context.performAndWait {
+            message.expirationDate
+        }) {
             request.expire(at: expirationDate)
         }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -101,21 +101,22 @@ public class MessageSender: MessageSenderInterface {
     public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
         WireLogger.messaging.debug("send message")
 
-        if (managedObjectContext.performAndWait {
-            message.conversation?.securityLevel == .secureWithIgnored
-        }) {
-            return .failure(MessageSendError.securityLevelDegraded)
-        }
-
-        await messageDependencyResolver.waitForDependenciesToResolve(for: message)
-
-        return await attemptToSend(message: message)
-            .map({ success in
-                // Triggering request loop to re-evalute dependencies, other messages
-                // might have been waiting for this message to be sent.
-                RequestAvailableNotification.notifyNewRequestsAvailable(nil)
-                return success
-            })
+        return await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+            .mapError { dependencyError in
+                switch dependencyError {
+                case .securityLevelDegraded:
+                    MessageSendError.securityLevelDegraded
+                }
+            }
+            .flatMapAsync { _ in
+                await attemptToSend(message: message)
+                    .map({ success in
+                        // Triggering request loop to re-evalute dependencies, other messages
+                        // might have been waiting for this message to be sent.
+                        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
+                        return success
+                    })
+            }
             .mapError { error in
                 WireLogger.messaging.debug("send message failed: \(error)")
                 return error
@@ -139,7 +140,7 @@ public class MessageSender: MessageSenderInterface {
         }
     }
 
-    private func attemptToSendWithProteus(message: any ProteusMessage, apiVersion: APIVersion) async -> Swift.Result<Void, MessageSendError> {
+    private func attemptToSendWithProteus(message: any SendableMessage, apiVersion: APIVersion) async -> Swift.Result<Void, MessageSendError> {
         guard let conversationID = managedObjectContext.performAndWait({
             message.conversation?.qualifiedID
         }) else {
@@ -171,7 +172,7 @@ public class MessageSender: MessageSenderInterface {
                         }
                     })
                     .flatMapAsync { _ in
-                        await attemptToSendWithProteus(message: message, apiVersion: apiVersion)
+                        await sendMessage(message: message)
                     }
             }
         }

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -198,6 +198,7 @@ public class MessageSender: MessageSenderInterface {
                 from: messageSendingStatus,
                 for: message
             )
+            managedObjectContext.enqueueDelayedSave()
 
             if message.isExpired {
                 return .failure(MessageSendError.messageExpired)

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -113,7 +113,7 @@ public class MessageSender: MessageSenderInterface {
             .flatMapAsync { _ in
                 await attemptToSend(message: message)
                     .map({ success in
-                        // Triggering request loop to re-evalute dependencies, other messages
+                        // Triggering request polling to re-evalute dependencies, other messages
                         // might have been waiting for this message to be sent.
                         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
                         return success

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -101,6 +101,8 @@ public class MessageSender: MessageSenderInterface {
     public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
         WireLogger.messaging.debug("send message")
 
+        // TODO: [jacob] we need to wait until we are "online"
+
         return await messageDependencyResolver.waitForDependenciesToResolve(for: message)
             .mapError { dependencyError in
                 switch dependencyError {

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -34,6 +34,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withMessageDependencyResolverReturning(result: .failure(.securityLevelDegraded))
             .arrange()
 
         // when
@@ -51,7 +52,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: nil)
             .arrange()
 
@@ -70,7 +71,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: nil)
             .arrange()
 
@@ -99,7 +100,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessage(returning: .success((messageSendingStatus, response)))
             .arrange()
@@ -120,7 +121,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: NetworkError.missingClients(
                 Arrangement.Scaffolding.messageSendingStatusMissingClients,
@@ -147,7 +148,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: NetworkError.errorDecodingResponse(response))
             .withEstablishSessions(returning: .success(Void()))
@@ -171,7 +172,7 @@ final class MessageSenderTests: MessagingTestBase {
         message.isExpired = true
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: NetworkError.errorDecodingResponse(response))
             .arrange()
@@ -193,7 +194,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: networkError)
             .arrange()
@@ -226,7 +227,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: networkError)
             .arrange()
@@ -260,7 +261,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
-            .withMessageDependencyResolverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: networkError)
             .arrange()
@@ -316,8 +317,8 @@ final class MessageSenderTests: MessagingTestBase {
             return self
         }
 
-        func withMessageDependencyResolverCompleting() -> Arrangement {
-            messageDependencyResolver.waitForDependenciesToResolveFor_MockMethod = { _ in }
+        func withMessageDependencyResolverReturning(result: Swift.Result<Void, MessageDependencyResolverError>) -> Arrangement {
+            messageDependencyResolver.waitForDependenciesToResolveFor_MockMethod = { _ in result }
             return self
         }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/MessageSendingStatusPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/MessageSendingStatusPayloadProcessor.swift
@@ -70,7 +70,7 @@ final class MessageSendingStatusPayloadProcessor {
         for (_, userClients) in missingClients {
             userClients.forEach({ $0.discoveredByMessage = message as? ZMOTRMessage })
             message.registersNewMissingClients(Set(userClients))
-            message.conversation?.decreaseSecurityLevelIfNeededAfterDiscovering(clients: Set(userClients), causedBy: nil)
+            message.conversation?.decreaseSecurityLevelIfNeededAfterDiscovering(clients: Set(userClients), causedBy: message as? ZMOTRMessage)
         }
 
         let failedToConfirmUsers = payload.failedToConfirm.fetchUsers(in: message.context)

--- a/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
@@ -84,6 +84,7 @@ extension OTREntity {
             return conversation.connection
         }
 
+        // FIXME: [jacob] we can remove this check since we fail the message sending in MessageDependencyResolver
         // If the conversation is degraded we shouldn't send the message until the conversation
         // is marked as not secure or it's verified again
         if conversation.securityLevel == .secureWithIgnored {

--- a/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
@@ -367,7 +367,6 @@ extension OTREntity {
         let selfClient = ZMUser.selfUser(in: self.context).selfClient()!
         selfClient.missesClients(missingClients)
         self.missesRecipients(missingClients)
-        self.conversation?.decreaseSecurityLevelIfNeededAfterDiscovering(clients: missingClients, causedBy: nil)
 
         selfClient.addNewClientsToIgnored(missingClients)
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -23,33 +23,25 @@ import Foundation
 /// upload the asset, receive the asset ID in the response, manually add it to the genericMessage and
 /// send it using the `/messages` endpoint like any other message. This is an additional step required
 /// as the fan-out was previously done by the backend when uploading a v2 asset.
-public final class AssetClientMessageRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource {
+public final class AssetClientMessageRequestStrategy: NSObject, ZMContextChangeTrackerSource {
 
+    let managedObjectContext: NSManagedObjectContext
     let insertedObjectSync: InsertedObjectSync<AssetClientMessageRequestStrategy>
-    let messageSync: MessageSync<ZMAssetClientMessage>
+    let messageSender: MessageSenderInterface
 
-    public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext, applicationStatus: ApplicationStatus) {
+    public init(managedObjectContext: NSManagedObjectContext, messageSender: MessageSenderInterface) {
 
+        self.managedObjectContext = managedObjectContext
         self.insertedObjectSync = InsertedObjectSync(insertPredicate: Self.shouldBeSentPredicate(context: managedObjectContext))
+        self.messageSender = messageSender
 
-        self.messageSync = MessageSync(
-            context: managedObjectContext,
-            appStatus: applicationStatus
-        )
-
-        super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
+        super.init()
 
         insertedObjectSync.transcoder = self
-        configuration = [.allowsRequestsWhileOnline,
-                         .allowsRequestsWhileInBackground]
-    }
-
-    public override func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
-        return messageSync.nextRequest(for: apiVersion)
     }
 
     public var contextChangeTrackers: [ZMContextChangeTracker] {
-        return [insertedObjectSync] + messageSync.contextChangeTrackers
+        return [insertedObjectSync]
     }
 
     static func shouldBeSentPredicate(context: NSManagedObjectContext) -> NSPredicate {
@@ -68,27 +60,33 @@ extension AssetClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
     typealias Object = ZMAssetClientMessage
 
     func insert(object: ZMAssetClientMessage, completion: @escaping () -> Void) {
-        messageSync.sync(object) { [weak self] (result, response) in
-            switch result {
-            case .success:
-                object.markAsSent()
-            case .failure(let error):
-                switch error {
-                case .messageProtocolMissing:
+        // Enter groups to enable waiting for message sending to complete in tests
+        let groups = managedObjectContext.enterAllGroupsExceptSecondary()
+        Task {
+            let result = await messageSender.sendMessage(message: object)
+
+            managedObjectContext.performAndWait {
+                switch result {
+                case .success:
+                    object.markAsSent()
+                case .failure(let error):
                     object.expire()
 
-                case .expired, .gaveUpRetrying:
-                    object.expire()
-
-                    let payload = Payload.ResponseFailure(response, decoder: .defaultDecoder)
-                    if response.httpStatus == 403 && payload?.label == .missingLegalholdConsent {
-                        self?.managedObjectContext.zm_userInterface.performGroupedBlock {
-                            guard let context = self?.managedObjectContext.notificationContext else { return }
-                            NotificationInContext(name: ZMConversation.failedToSendMessageNotificationName, context: context).post()
+                    if case .networkError(let networkError) = error,
+                       case .invalidRequestError(let responseFailure, _) = networkError,
+                       responseFailure.label == .missingLegalholdConsent {
+                        managedObjectContext.zm_userInterface.performGroupedBlock {
+                            NotificationInContext(
+                                name: ZMConversation.failedToSendMessageNotificationName,
+                                context: self.managedObjectContext.notificationContext
+                            ).post()
                         }
                     }
                 }
             }
+
+            completion()
+            managedObjectContext.leaveAllGroups(groups)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -83,6 +83,7 @@ extension AssetClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
                         }
                     }
                 }
+                managedObjectContext.enqueueDelayedSave()
             }
 
             completion()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -21,45 +21,28 @@ import WireRequestStrategy
 import XCTest
 import WireDataModel
 
-fileprivate extension ZMTransportRequest {
-
-    func complete(withHttpStatus status: Int, apiVersion: APIVersion) {
-        let payload = ["time": Date().transportString()] as ZMTransportData
-        let response = ZMTransportResponse(payload: payload, httpStatus: status, transportSessionError: nil, apiVersion: apiVersion.rawValue)
-        complete(with: response)
-    }
-
-}
-
 final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
 
-    fileprivate var mockApplicationStatus: MockApplicationStatus!
+    fileprivate var mockMessageSender: MockMessageSenderInterface!
     fileprivate var sut: AssetClientMessageRequestStrategy!
     fileprivate var imageData = mediumJPEGData()
-
-    var apiVersion: APIVersion! {
-        didSet {
-            setCurrentAPIVersion(apiVersion)
-        }
-    }
 
     override func setUp() {
         super.setUp()
 
-        mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .online
+        mockMessageSender = MockMessageSenderInterface()
 
-        self.syncMOC.performGroupedBlockAndWait {
-            self.sut = AssetClientMessageRequestStrategy(withManagedObjectContext: self.syncMOC, applicationStatus: self.mockApplicationStatus)
-        }
-
-        apiVersion = .v0
+        self.sut = syncMOC.performAndWait({
+            AssetClientMessageRequestStrategy(
+                managedObjectContext: self.syncMOC,
+                messageSender: mockMessageSender
+            )
+        })
     }
 
     override func tearDown() {
-        mockApplicationStatus = nil
+        mockMessageSender = nil
         sut = nil
-        apiVersion = nil
         super.tearDown()
     }
 
@@ -70,6 +53,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         uploaded: Bool = false,
         preview: Bool = false,
         assetId: Bool = false,
+        expired: Bool = false,
         previewAssetId: Bool = false,
         transferState: AssetTransferState = .uploading,
         conversation: ZMConversation? = nil,
@@ -143,6 +127,10 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             message.sender = sender
         }
 
+        if expired {
+            message.expire()
+        }
+
         syncMOC.saveOrRollback()
         prepareUpload(of: message)
 
@@ -160,286 +148,89 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         ZMChangeTrackerBootstrap.bootStrapChangeTrackers(sut.contextChangeTrackers, on: syncMOC)
     }
 
-    @discardableResult
-    private func assertCreatesValidRequestForAsset(in conversation: ZMConversation, line: UInt = #line) -> ZMTransportRequest! {
-        switch apiVersion! {
-        case .v0:
-            guard let request = sut.nextRequest(for: self.apiVersion) else {
-                XCTFail("No request generated", line: line)
-                return nil
-            }
-
-            let converationID = conversation.remoteIdentifier!.transportString()
-
-            XCTAssertEqual(request.path, "/conversations/\(converationID)/otr/messages", line: line)
-            XCTAssertEqual(request.method, .methodPOST, line: line)
-            return request
-
-        case .v1, .v2, .v3, .v4, .v5:
-            guard let request = sut.nextRequest(for: self.apiVersion) else {
-                XCTFail("No request generated", line: line)
-                return nil
-            }
-
-            let domain = conversation.domain!
-            let conversationID = conversation.remoteIdentifier!.transportString()
-
-            XCTAssertEqual(request.path, "/v\(apiVersion.rawValue)/conversations/\(domain)/\(conversationID)/proteus/messages", line: line)
-            XCTAssertEqual(request.method, .methodPOST, line: line)
-            return request
-        }
-    }
-
-    // MARK: Request Generation
-
-    func testThatItDoesNotCreateARequestIfThereIsNoMatchingMessage() {
-        XCTAssertNil(sut.nextRequest(for: apiVersion))
-    }
-
-    func testThatItDoesNotCreateARequestForAnImageMessageUploadedByOtherUser() {
+    func testThatItDoesNotScheduleAMessageForAnImageMessageUploadedByOtherUser() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.createMessage(uploaded: true, sender: self.otherUser)
-
-            // THEN
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            let message = self.createMessage(uploaded: true, sender: self.otherUser)
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(0, mockMessageSender.sendMessageMessage_Invocations.count)
+
     }
 
     func testThatItDoesNotCreateARequestForAnImageMessageWhichIsExpired() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            let message = self.createMessage(uploaded: true)
-            message.expire()
-
-            // THEN
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            let message = self.createMessage(uploaded: true, expired: true)
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(0, mockMessageSender.sendMessageMessage_Invocations.count)
     }
 
     func testThatItDoesNotCreateARequestForAnImageMessageWithoutUploaded() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
             self.createMessage(uploaded: false)
-
-            // THEN
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(0, mockMessageSender.sendMessageMessage_Invocations.count)
     }
 
     func testThatItDoesNotCreateARequestForAnImageMessageWithUploadedAndAssetIdInTheWrongTransferState() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
             let message = self.createMessage()
             message.updateTransferState(.uploaded, synchronize: true)
-
-            // THEN
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(0, mockMessageSender.sendMessageMessage_Invocations.count)
     }
 
     func testThatItCreatesARequestForAnUploadedImageMessage() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
             self.createMessage(uploaded: true, assetId: true)
-
-            // THEN
-            self.assertCreatesValidRequestForAsset(in: self.groupConversation)
         }
-    }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-    func testThatItCreatesARequestForAnUploadedImageMessage_WithFederationEndpointEnabled() {
-        self.syncMOC.performGroupedBlockAndWait {
-            // GIVEN
-            self.apiVersion = .v1
-            self.createMessage(uploaded: true, assetId: true)
-
-            // THEN
-            self.assertCreatesValidRequestForAsset(in: self.groupConversation)
-        }
+        // THEN
+        XCTAssertEqual(1, mockMessageSender.sendMessageMessage_Invocations.count)
     }
 
     func testThatItCreatesARequestForAnUploadedImageMessage_Ephemeral() {
+
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
             self.groupConversation.setMessageDestructionTimeoutValue(.custom(15), for: .selfUser)
             self.createMessage(uploaded: true, assetId: true)
-
-            // WHEN
-            guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
-
-            // THEN
-            let expected = "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages"
-            XCTAssertEqual(request.path, expected)
-            XCTAssertEqual(request.method, .methodPOST)
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(1, mockMessageSender.sendMessageMessage_Invocations.count)
+
     }
-
-    func testThatItUpdatesExpectsReadConfirmationFlagWhenSendingMessageInOneToOne() {
-        self.syncMOC.performGroupedBlockAndWait {
-            // GIVEN
-            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = true
-            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.oneToOneConversation)
-
-            // WHEN
-            XCTAssertNotNil(self.sut.nextRequest(for: self.apiVersion))
-
-            // THEN
-            switch message.underlyingMessage?.content {
-            case .asset(let data)?:
-                XCTAssertTrue(data.expectsReadConfirmation)
-            default:
-                XCTFail("Unexpected message content")
-            }
-        }
-    }
-
-    func testThatItDoesntUpdateExpectsReadConfirmationFlagWhenSendingMessageInGroup() {
-        self.syncMOC.performGroupedBlockAndWait {
-            // GIVEN
-            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = true
-            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.groupConversation)
-
-            // WHEN
-            XCTAssertNotNil(self.sut.nextRequest(for: self.apiVersion))
-
-            // THEN
-            switch message.underlyingMessage?.content {
-            case .asset(let data)?:
-                XCTAssertFalse(data.expectsReadConfirmation)
-            default:
-                XCTFail("Unexpected message content")
-            }
-        }
-    }
-
-    func testThatItUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreDisabled() {
-        self.syncMOC.performGroupedBlockAndWait {
-            // GIVEN
-            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = false
-            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.oneToOneConversation)
-            var genericMessage = message.underlyingMessage!
-            genericMessage.setExpectsReadConfirmation(true)
-
-            do {
-                try message.setUnderlyingMessage(genericMessage)
-            } catch {
-                XCTFail("Could not set generic message")
-            }
-
-            // WHEN
-            XCTAssertNotNil(self.sut.nextRequest(for: self.apiVersion))
-
-            // THEN
-            XCTAssertFalse(message.underlyingMessage!.asset.expectsReadConfirmation)
-        }
-    }
-
-    func testThatItUpdateExpectsReadConfirmationFlagWhenReadReceiptsAreEnabled() {
-        self.syncMOC.performGroupedBlockAndWait {
-            // GIVEN
-            ZMUser.selfUser(in: self.syncMOC).readReceiptsEnabled = true
-            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.oneToOneConversation)
-            var genericMessage = message.underlyingMessage!
-            genericMessage.setExpectsReadConfirmation(true)
-
-            do {
-                try message.setUnderlyingMessage(genericMessage)
-            } catch {
-                XCTFail("Could not set generic message")
-            }
-
-            // WHEN
-            XCTAssertNotNil(self.sut.nextRequest(for: self.apiVersion))
-
-            // THEN
-            XCTAssertTrue(message.underlyingMessage!.asset.expectsReadConfirmation)
-        }
-    }
-
-    func testThatItUpdatesLegalHoldStatusFlagWhenLegalHoldIsEnabled() {
-        self.syncMOC.performGroupedBlockAndWait {
-
-            // GIVEN
-            let legalHoldClient = UserClient.insertNewObject(in: self.syncMOC)
-            legalHoldClient.deviceClass = .legalHold
-            legalHoldClient.type = .legalHold
-            legalHoldClient.user = self.otherUser
-
-            let conversation = self.groupConversation!
-            conversation.decreaseSecurityLevelIfNeededAfterDiscovering(clients: [legalHoldClient], causedBy: [self.otherUser])
-            XCTAssertTrue(conversation.isUnderLegalHold)
-
-            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.groupConversation)
-            var genericMessage = message.underlyingMessage!
-            genericMessage.setLegalHoldStatus(.enabled)
-
-            do {
-                try message.setUnderlyingMessage(genericMessage)
-            } catch {
-                XCTFail("Could not set generic message")
-            }
-
-            self.syncMOC.saveOrRollback()
-
-            // WHEN
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
-            if self.sut.nextRequest(for: self.apiVersion) == nil {
-                XCTFail("Request is nil")
-                return
-            }
-
-            // THEN
-            XCTAssertEqual(message.underlyingMessage!.asset.legalHoldStatus, .enabled)
-        }
-    }
-
-    func testThatItUpdatesLegalHoldStatusFlagWhenLegalHoldIsDisabled() {
-        self.syncMOC.performGroupedBlockAndWait {
-
-            // GIVEN
-            let conversation = self.groupConversation!
-            XCTAssertFalse(conversation.isUnderLegalHold)
-
-            let message = self.createMessage(isImage: true, uploaded: true, assetId: true, conversation: self.groupConversation)
-            var genericMessage = message.underlyingMessage!
-            genericMessage.setLegalHoldStatus(.enabled)
-
-            do {
-                try message.setUnderlyingMessage(genericMessage)
-            } catch {
-                XCTFail("Could not set generic message")
-            }
-
-            self.syncMOC.saveOrRollback()
-
-            // WHEN
-            self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
-            if self.sut.nextRequest(for: self.apiVersion) == nil {
-                XCTFail("Request is nil")
-                return
-            }
-
-            // THEN
-            XCTAssertEqual(message.underlyingMessage!.asset.legalHoldStatus, .disabled)
-        }
-    }
-
-    // MARK: Response handling
 
     func testThatItExpiresAMessageWhenItReceivesAFailureResponse() {
         // GIVEN
+        mockMessageSender.sendMessageMessage_MockValue = .failure(MessageSendError.messageExpired)
         var message: ZMAssetClientMessage!
         self.syncMOC.performGroupedBlockAndWait {
             message = self.createMessage(uploaded: true, assetId: true)
-        }
-
-        // WHEN
-        self.syncMOC.performGroupedBlockAndWait {
-            guard let request = self.assertCreatesValidRequestForAsset(in: self.groupConversation) else {
-                return XCTFail("Failed to create request")
-            }
-            request.complete(withHttpStatus: 400, apiVersion: self.apiVersion)
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -447,16 +238,22 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         self.syncMOC.performGroupedBlockAndWait {
             XCTAssert(message.isExpired)
             XCTAssertEqual(message.deliveryState, .failedToSend)
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
     }
 
     func testThatItNotifiesWhenAnImageCannotBeSent_MissingLegalholdConsent() {
         // GIVEN
-        var message: ZMAssetClientMessage!
+        let response = ZMTransportResponse(payload: nil, httpStatus: 403, transportSessionError: nil, apiVersion: 0)
+        let missingLegalholdConsentFailure = Payload.ResponseFailure(
+            code: 403,
+            label: .missingLegalholdConsent,
+            message: "",
+            data: nil)
+        let failure = MessageSendError.networkError(NetworkError.invalidRequestError(missingLegalholdConsentFailure, response))
+        mockMessageSender.sendMessageMessage_MockValue = .failure(failure)
         var token: Any?
         self.syncMOC.performGroupedBlockAndWait {
-            message = self.createMessage(uploaded: true, assetId: true)
+            self.createMessage(uploaded: true, assetId: true)
             let expectation = self.expectation(description: "Notification fired")
             token = NotificationInContext.addObserver(name: ZMConversation.failedToSendMessageNotificationName,
                                                       context: self.uiMOC.notificationContext,
@@ -464,16 +261,6 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
                 expectation.fulfill()
             }
         }
-
-        // WHEN
-        self.syncMOC.performGroupedBlockAndWait {
-            guard let request = self.assertCreatesValidRequestForAsset(in: self.groupConversation) else {
-                return XCTFail("Failed to create request")
-            }
-            let payload = ["label": "missing-legalhold-consent", "code": 403, "message": ""] as NSDictionary
-            request.complete(with: ZMTransportResponse(payload: payload, httpStatus: 403, transportSessionError: nil, apiVersion: self.apiVersion.rawValue))
-        }
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         withExtendedLifetime(token) { () -> Void in
@@ -485,15 +272,9 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
 
         // GIVEN
         var message: ZMAssetClientMessage!
+        mockMessageSender.sendMessageMessage_MockValue = .success(Void())
         self.syncMOC.performGroupedBlockAndWait {
             message = self.createMessage(uploaded: true, assetId: true)
-        }
-
-        // WHEN
-        self.syncMOC.performGroupedBlockAndWait {
-            guard let request = self.assertCreatesValidRequestForAsset(in: self.groupConversation)
-                else { return XCTFail("No request generated") }
-            request.complete(withHttpStatus: 200, apiVersion: self.apiVersion)
         }
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -501,33 +282,6 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         self.syncMOC.performGroupedBlockAndWait {
             XCTAssert(message.delivered)
             XCTAssertEqual(message.deliveryState, .sent)
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
     }
-
-    func testThatItMarksAnImageMessageAsSentWhenItReceivesASuccesfulResponse_Ephemeral() {
-        // GIVEN
-        var message: ZMAssetClientMessage!
-        self.syncMOC.performGroupedBlockAndWait {
-            self.groupConversation.setMessageDestructionTimeoutValue(.custom(15), for: .selfUser)
-            message = self.createMessage(uploaded: true, assetId: true)
-        }
-
-        // WHEN
-        self.syncMOC.performGroupedBlockAndWait {
-            guard let request = self.sut.nextRequest(for: self.apiVersion)
-                else { return XCTFail("No request generated") }
-            request.complete(withHttpStatus: 200, apiVersion: self.apiVersion)
-        }
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        // THEN
-        self.syncMOC.performGroupedBlockAndWait {
-
-            XCTAssert(message.delivered)
-            XCTAssertEqual(message.deliveryState, .sent)
-            XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
-        }
-    }
-
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
@@ -18,10 +18,11 @@
 
 import Foundation
 
-public class LinkPreviewUpdateRequestStrategy: AbstractRequestStrategy, ZMContextChangeTrackerSource {
+public class LinkPreviewUpdateRequestStrategy: NSObject, ZMContextChangeTrackerSource {
 
+    let managedObjectContext: NSManagedObjectContext
     let modifiedKeysSync: ModifiedKeyObjectSync<LinkPreviewUpdateRequestStrategy>
-    let messageSync: MessageSync<ZMClientMessage>
+    let messageSender: MessageSenderInterface
 
     static func linkPreviewIsUploadedPredicate(context: NSManagedObjectContext) -> NSPredicate {
         return NSPredicate(format: "%K == %@ AND %K == %d",
@@ -29,33 +30,24 @@ public class LinkPreviewUpdateRequestStrategy: AbstractRequestStrategy, ZMContex
                            #keyPath(ZMClientMessage.linkPreviewState), ZMLinkPreviewState.uploaded.rawValue)
     }
 
-    public override init(withManagedObjectContext managedObjectContext: NSManagedObjectContext,
-                         applicationStatus: ApplicationStatus) {
+    public init(managedObjectContext: NSManagedObjectContext,
+                messageSender: MessageSenderInterface) {
 
         let modifiedPredicate = Self.linkPreviewIsUploadedPredicate(context: managedObjectContext)
         self.modifiedKeysSync = ModifiedKeyObjectSync(trackedKey: ZMClientMessage.linkPreviewStateKey,
                                                       modifiedPredicate: modifiedPredicate)
 
-        self.messageSync = MessageSync<ZMClientMessage>(
-            context: managedObjectContext,
-            appStatus: applicationStatus
-        )
+        self.managedObjectContext = managedObjectContext
+        self.messageSender = messageSender
 
-        super.init(withManagedObjectContext: managedObjectContext,
-                   applicationStatus: applicationStatus)
+        super.init()
 
-        self.configuration = .allowsRequestsWhileOnline
         self.modifiedKeysSync.transcoder = self
     }
 
     public var contextChangeTrackers: [ZMContextChangeTracker] {
-        return [modifiedKeysSync] + messageSync.contextChangeTrackers
+        return [modifiedKeysSync]
     }
-
-    public override func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
-        return messageSync.nextRequest(for: apiVersion)
-    }
-
 }
 
 extension LinkPreviewUpdateRequestStrategy: ModifiedKeyObjectSyncTranscoder {
@@ -63,9 +55,15 @@ extension LinkPreviewUpdateRequestStrategy: ModifiedKeyObjectSyncTranscoder {
     typealias Object = ZMClientMessage
 
     func synchronize(key: String, for object: ZMClientMessage, completion: @escaping () -> Void) {
-        messageSync.sync(object) { (_, _) in
-            object.linkPreviewState = .done
-            completion()
+        // Enter groups to enable waiting for message sending to complete in tests
+        let groups = managedObjectContext.enterAllGroupsExceptSecondary()
+        Task {
+            let result = await messageSender.sendMessage(message: object)
+            managedObjectContext.performAndWait {
+                object.linkPreviewState = .done
+                completion()
+            }
+            managedObjectContext.leaveAllGroups(groups)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -44,43 +44,19 @@ extension ZMUpdateEvent {
 }
 
 @objcMembers
-public final class DeliveryReceiptRequestStrategy: AbstractRequestStrategy {
+public final class DeliveryReceiptRequestStrategy: NSObject {
 
-    private let messageSync: MessageSync<GenericMessageEntity>
+    private let messageSender: MessageSenderInterface
+    private let managedObjectContext: NSManagedObjectContext
 
     // MARK: - Init
 
     public init(managedObjectContext: NSManagedObjectContext,
-                applicationStatus: ApplicationStatus,
-                clientRegistrationDelegate: ClientRegistrationDelegate) {
+                messageSender: MessageSenderInterface) {
 
-        self.messageSync = MessageSync(
-            context: managedObjectContext,
-            appStatus: applicationStatus
-        )
-
-        super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
-
-        self.configuration = [.allowsRequestsWhileInBackground,
-                              .allowsRequestsWhileOnline,
-                              .allowsRequestsWhileWaitingForWebsocket]
+        self.managedObjectContext = managedObjectContext
+        self.messageSender = messageSender
     }
-
-    // MARK: - Methods
-
-    public override func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
-        return messageSync.nextRequest(for: apiVersion)
-    }
-}
-
-// MARK: - Context Change Tracker
-
-extension DeliveryReceiptRequestStrategy: ZMContextChangeTrackerSource {
-
-    public var contextChangeTrackers: [ZMContextChangeTracker] {
-        return messageSync.contextChangeTrackers
-    }
-
 }
 
 // MARK: - Event Consumer
@@ -102,11 +78,15 @@ extension DeliveryReceiptRequestStrategy: ZMEventConsumer {
                                                    type: .delivered) else { return }
         let senderUserSet: Set<ZMUser> = [deliveryReceipt.sender]
 
-        messageSync.sync(GenericMessageEntity(conversation: deliveryReceipt.conversation,
-                                              message: GenericMessage(content: confirmation),
-                                              targetRecipients: .users(senderUserSet),
-                                              completionHandler: nil),
-                         completion: {_, _ in })
+        // Enter groups to enable waiting for message sending to complete in tests
+        let groups = managedObjectContext.enterAllGroupsExceptSecondary()
+        Task {
+            _ = await messageSender.sendMessage(message: GenericMessageEntity(conversation: deliveryReceipt.conversation,
+                                                                    message: GenericMessage(content: confirmation),
+                                                                    targetRecipients: .users(senderUserSet),
+                                                                    completionHandler: nil))
+            managedObjectContext.leaveAllGroups(groups)
+        }
     }
 
     func deliveryReceipts(for events: [ZMUpdateEvent]) -> [DeliveryReceipt] {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
@@ -23,6 +23,7 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
 
     var mockApplicationStatus: MockApplicationStatus!
     var mockClientRegistrationStatus: MockClientRegistrationStatus!
+    var mockMessageSender: MockMessageSenderInterface!
     var secondOneToOneConveration: ZMConversation!
     var secondUser: ZMUser!
     var sut: DeliveryReceiptRequestStrategy!
@@ -32,10 +33,10 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
         mockApplicationStatus = MockApplicationStatus()
         mockApplicationStatus.mockSynchronizationState = .online
         mockClientRegistrationStatus = MockClientRegistrationStatus()
+        mockMessageSender = MockMessageSenderInterface()
 
         sut = DeliveryReceiptRequestStrategy(managedObjectContext: syncMOC,
-                                             applicationStatus: mockApplicationStatus,
-                                             clientRegistrationDelegate: mockClientRegistrationStatus)
+                                             messageSender: mockMessageSender)
 
         syncMOC.performGroupedBlockAndWait {
             let user = ZMUser.insertNewObject(in: self.syncMOC)
@@ -57,33 +58,21 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
 
     // MARK: Request generation
 
-    func testThatRequestIsGenerated_WhenProcessingEventWhichNeedsDeliveryReceipt() throws {
-        try syncMOC.performGroupedAndWait { _ in
+    func testThatDeliveryReceiptIsScheduled_WhenProcessingEventWhichNeedsDeliveryReceipt() throws {
+        syncMOC.performGroupedAndWait { _ in
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
             let conversationID = self.oneToOneConversation.remoteIdentifier!.transportString()
             let conversationDomain = self.oneToOneConversation.domain!
             let event = self.createTextUpdateEvent(from: self.otherUser, in: self.oneToOneConversation)
 
             // when
             self.sut.processEvents([event], liveEvents: Bool.random(), prefetchResult: nil)
-
-            // then
-            let request = try XCTUnwrap(self.sut.nextRequest(for: .v1))
-            XCTAssertEqual(request.path, "/v1/conversations/\(conversationDomain)/\(conversationID)/proteus/messages")
         }
-    }
+        XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-    func testThatRequestIsGenerated_WhenProcessingEventWhichNeedsDeliveryReceipt_With_FederationEndpointDisabled() throws {
-        try syncMOC.performGroupedAndWait { _ in
-            let conversationID = self.oneToOneConversation.remoteIdentifier!.transportString()
-            let event = self.createTextUpdateEvent(from: self.otherUser, in: self.oneToOneConversation)
+        // then
+        XCTAssertEqual(1, self.mockMessageSender.sendMessageMessage_Invocations.count)
 
-            // when
-            self.sut.processEvents([event], liveEvents: Bool.random(), prefetchResult: nil)
-
-            // then
-            let request = try XCTUnwrap(self.sut.nextRequest(for: .v0))
-            XCTAssertEqual(request.path, "/conversations/\(conversationID)/otr/messages")
-        }
     }
 
     // MARK: Delivery receipt creation

--- a/wire-ios-request-strategy/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategy.swift
@@ -33,7 +33,7 @@ import Foundation
     public var expirationDate: Date?
     public var expirationReasonCode: NSNumber?
 
-    private let targetRecipients: Recipients
+    public let targetRecipients: Recipients
 
     public init(conversation: ZMConversation, message: GenericMessage, targetRecipients: Recipients = .conversationParticipants, completionHandler: ((_ response: ZMTransportResponse) -> Void)?) {
         self.conversation = conversation

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
@@ -22,7 +22,7 @@ import XCTest
 class ResetSessionRequestStrategyTests: MessagingTestBase {
 
     var sut: ResetSessionRequestStrategy!
-    var mockApplicationStatus: MockApplicationStatus!
+    var mockMessageSender: MockMessageSenderInterface!
 
     override var useInMemoryStore: Bool {
         return false
@@ -30,22 +30,21 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
 
     override func setUp() {
         super.setUp()
-        mockApplicationStatus = MockApplicationStatus()
-        mockApplicationStatus.mockSynchronizationState = .online
-        sut = ResetSessionRequestStrategy(managedObjectContext: self.syncMOC,
-                                    applicationStatus: mockApplicationStatus,
-                                    clientRegistrationDelegate: mockApplicationStatus.clientRegistrationDelegate)
+        mockMessageSender = MockMessageSenderInterface()
+        sut = ResetSessionRequestStrategy(
+            managedObjectContext: self.syncMOC,
+            messageSender: mockMessageSender
+        )
     }
 
     override func tearDown() {
-        mockApplicationStatus = nil
         sut = nil
         super.tearDown()
     }
 
     // MARK: Request generation
 
-    func testThatItCreatesARequest_WhenUserClientNeedsToNotifyOtherUserAboutSessionReset() {
+    func testThatItSendsSessionResetMessage_WhenUserClientNeedsToNotifyOtherUserAboutSessionReset() {
         syncMOC.performGroupedBlockAndWait {
             // GIVEN
             let otherUser = self.createUser()
@@ -54,16 +53,18 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
             let conversationID = conversation.remoteIdentifier!.transportString()
             let conversationDomain = conversation.domain!
             otherClient.needsToNotifyOtherUserAboutSessionReset = true
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
 
             // WHEN
             self.sut.contextChangeTrackers.forEach {
                 let otherClientSet: Set<NSManagedObject> = [otherClient]
                 $0.objectsDidChange(otherClientSet)
             }
-
-            // THEN
-            XCTAssertEqual(self.sut.nextRequest(for: .v1)?.path, "/v1/conversations/\(conversationDomain)/\(conversationID)/proteus/messages")
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        XCTAssertEqual(1, self.mockMessageSender.sendMessageMessage_Invocations.count)
     }
 
     // MARK: Response handling
@@ -76,17 +77,15 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
             _ = self.setupOneToOneConversation(with: otherUser)
             otherClient = self.createClient(user: otherUser)
             otherClient.needsToNotifyOtherUserAboutSessionReset = true
+            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
 
+            // WHEN
             self.sut.contextChangeTrackers.forEach {
                 let otherClientSet: Set<NSManagedObject> = [otherClient]
                 $0.objectsDidChange(otherClientSet)
             }
-            let request = self.sut.nextRequest(for: .v0)
-
-            // WHEN
-            request?.complete(with: ZMTransportResponse(payload: [:] as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: 0))
         }
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         syncMOC.performGroupedBlockAndWait {

--- a/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
@@ -113,16 +113,19 @@ public class MockMessageDependencyResolverInterface: MessageDependencyResolverIn
     // MARK: - waitForDependenciesToResolve
 
     public var waitForDependenciesToResolveFor_Invocations: [any SendableMessage] = []
-    public var waitForDependenciesToResolveFor_MockMethod: ((any SendableMessage) async -> Void)?
+    public var waitForDependenciesToResolveFor_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageDependencyResolverError>)?
+    public var waitForDependenciesToResolveFor_MockValue: Swift.Result<Void, MessageDependencyResolverError>?
 
-    public func waitForDependenciesToResolve(for message: any SendableMessage) async {
+    public func waitForDependenciesToResolve(for message: any SendableMessage) async -> Swift.Result<Void, MessageDependencyResolverError> {
         waitForDependenciesToResolveFor_Invocations.append(message)
 
-        guard let mock = waitForDependenciesToResolveFor_MockMethod else {
+        if let mock = waitForDependenciesToResolveFor_MockMethod {
+            return await mock(message)
+        } else if let mock = waitForDependenciesToResolveFor_MockValue {
+            return mock
+        } else {
             fatalError("no mock for `waitForDependenciesToResolveFor`")
         }
-
-        await mock(message)            
     }
 
 }

--- a/wire-ios-sync-engine/Source/Calling/VoiceChannelV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/VoiceChannelV3.swift
@@ -196,12 +196,6 @@ extension VoiceChannelV3: CallActions {
     public func leaveAndDecreaseConversationSecurity(userSession: ZMUserSession) {
         guard let conversation = conversation else { return }
         conversation.acknowledgePrivacyWarning(withResendIntent: false)
-        userSession.syncManagedObjectContext.performGroupedBlock {
-            let conversationId = conversation.objectID
-            if let syncConversation = (try? userSession.syncManagedObjectContext.existingObject(with: conversationId)) as? ZMConversation {
-                userSession.syncStrategy?.callingRequestStrategy?.dropPendingCallMessages(for: syncConversation)
-            }
-        }
         leave(userSession: userSession, completion: nil)
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -20,13 +20,6 @@ import Foundation
 import WireRequestStrategy
 import WireDataModel
 
-// sourcery: AutoMockable
-public protocol MessageSenderInterface_ {
-    func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError>
-}
-
-extension MessageSender: MessageSenderInterface_ {}
-
 @objcMembers
 public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequestTranscoder, ZMContextChangeTracker, ZMContextChangeTrackerSource, ZMEventConsumer {
 
@@ -36,7 +29,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
     private let zmLog = ZMSLog(tag: "calling")
 
-    private let messageSender: MessageSenderInterface_
+    private let messageSender: MessageSenderInterface
     private let flowManager: FlowManagerType
     private let decoder = JSONDecoder()
 
@@ -64,7 +57,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
         flowManager: FlowManagerType,
         callEventStatus: CallEventStatus,
         fetchUserClientsUseCase: FetchUserClientsUseCaseProtocol = FetchUserClientsUseCase(),
-        messageSender: MessageSenderInterface_
+        messageSender: MessageSenderInterface
     ) {
         self.messageSender = messageSender
         self.flowManager = flowManager

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -21,15 +21,11 @@ import WireRequestStrategy
 import WireDataModel
 
 // sourcery: AutoMockable
-public protocol GenericMessageSyncInterface {
-
-    var contextChangeTrackers: [ZMContextChangeTracker] { get }
-    func sync(_ message: GenericMessageEntity, completion: @escaping EntitySyncHandler)
-    func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest?
-    func expireMessages(withDependency dependency: NSObject)
+public protocol MessageSenderInterface_ {
+    func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError>
 }
 
-extension MessageSync<GenericMessageEntity>: GenericMessageSyncInterface {}
+extension MessageSender: MessageSenderInterface_ {}
 
 @objcMembers
 public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequestTranscoder, ZMContextChangeTracker, ZMContextChangeTrackerSource, ZMEventConsumer {
@@ -40,7 +36,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
     private let zmLog = ZMSLog(tag: "calling")
 
-    private let messageSender: MessageSenderInterface
+    private let messageSender: MessageSenderInterface_
     private let flowManager: FlowManagerType
     private let decoder = JSONDecoder()
 
@@ -68,7 +64,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
         flowManager: FlowManagerType,
         callEventStatus: CallEventStatus,
         fetchUserClientsUseCase: FetchUserClientsUseCaseProtocol = FetchUserClientsUseCase(),
-        messageSender: MessageSenderInterface
+        messageSender: MessageSenderInterface_
     ) {
         self.messageSender = messageSender
         self.flowManager = flowManager

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -40,7 +40,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
     private let zmLog = ZMSLog(tag: "calling")
 
-    private let messageSync: GenericMessageSyncInterface
+    private let messageSender: MessageSenderInterface
     private let flowManager: FlowManagerType
     private let decoder = JSONDecoder()
 
@@ -68,9 +68,9 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
         flowManager: FlowManagerType,
         callEventStatus: CallEventStatus,
         fetchUserClientsUseCase: FetchUserClientsUseCaseProtocol = FetchUserClientsUseCase(),
-        messageSync: GenericMessageSyncInterface? = nil
+        messageSender: MessageSenderInterface
     ) {
-        self.messageSync = messageSync ?? MessageSync(context: managedObjectContext, appStatus: applicationStatus)
+        self.messageSender = messageSender
         self.flowManager = flowManager
         self.callEventStatus = callEventStatus
         self.fetchUserClientsUseCase = fetchUserClientsUseCase
@@ -101,14 +101,9 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
 
     public override func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
         let request = callConfigRequestSync.nextRequest(for: apiVersion) ??
-        clientDiscoverySync.nextRequest(for: apiVersion) ??
-        messageSync.nextRequest(for: apiVersion)
+        clientDiscoverySync.nextRequest(for: apiVersion)
 
         return request
-    }
-
-    public func dropPendingCallMessages(for conversation: ZMConversation) {
-        messageSync.expireMessages(withDependency: conversation)
     }
 
     // MARK: - Single Request Transcoder
@@ -197,7 +192,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
     // MARK: - Context Change Tracker
 
     public var contextChangeTrackers: [ZMContextChangeTracker] {
-        return [self] + messageSync.contextChangeTrackers
+        return [self]
     }
 
     public func fetchRequestForTrackedObjects() -> NSFetchRequest<NSFetchRequestResult>? {
@@ -383,17 +378,14 @@ extension CallingRequestStrategy: WireCallCenterTransport {
                 )
             }
 
-            switch (conversation.messageProtocol, recipients) {
-            case (.proteus, _), (.mls, .conversationParticipants):
-                message.send(with: self.messageSync, completion: completionHandler)
+            Task {
+                let result = await self.messageSender.sendMessage(message: message)
 
-            case (.mls, _):
-                // TODO: review the `isConferenceKey` case once subconversations are available
-                // to target all conference members
-                if message.isConferenceKey || overMLSSelfConversation {
-                    message.send(with: self.messageSync, completion: completionHandler)
-                } else {
-                    Logging.mls.info("ignoring targeted outgoing calling message b/c it's not CONFKEY nor sent over self conversation")
+                switch result {
+                case .success:
+                    completionHandler(200)
+                case .failure:
+                    completionHandler(400)
                 }
             }
         }
@@ -643,15 +635,6 @@ extension CallingRequestStrategy {
 
 private extension GenericMessageEntity {
 
-    var isConferenceKey: Bool {
-        guard
-            message.hasCalling else {
-            return false
-        }
-
-        return message.calling.isConferenceKey
-    }
-
     var isRejected: Bool {
         guard
             message.hasCalling else {
@@ -660,28 +643,9 @@ private extension GenericMessageEntity {
 
         return message.calling.isRejected
     }
-
-    func send(with messageSync: GenericMessageSyncInterface, completion: @escaping (Int) -> Void) {
-        messageSync.sync(self) { result, response in
-            if case .success = result {
-                completion(response.httpStatus)
-            }
-        }
-    }
 }
 
 private extension Calling {
-
-    var isConferenceKey: Bool {
-        guard
-            let payload = content.data(using: .utf8, allowLossyConversion: false),
-            let callContent = CallEventContent(from: payload)
-        else {
-            return false
-        }
-
-        return callContent.isConferenceKey
-    }
 
     var isRejected: Bool {
         guard

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -170,8 +170,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 messageSender: messageSender),
             DeliveryReceiptRequestStrategy(
                 managedObjectContext: syncMOC,
-                applicationStatus: applicationStatusDirectory,
-                clientRegistrationDelegate: applicationStatusDirectory.clientRegistrationDelegate),
+                messageSender: messageSender),
             AvailabilityRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -232,7 +232,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 applicationStatus: applicationStatusDirectory,
                 clientRegistrationDelegate: applicationStatusDirectory.clientRegistrationStatus,
                 flowManager: flowManager,
-                callEventStatus: applicationStatusDirectory.callEventStatus),
+                callEventStatus: applicationStatusDirectory.callEventStatus,
+                messageSender: messageSender),
             LegalHoldRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -190,8 +190,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),
             LinkPreviewUpdateRequestStrategy(
-                withManagedObjectContext: syncMOC,
-                applicationStatus: applicationStatusDirectory),
+                managedObjectContext: syncMOC,
+                messageSender: messageSender),
             ImageV2DownloadRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -158,8 +158,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),
             AssetClientMessageRequestStrategy(
-                withManagedObjectContext: syncMOC,
-                applicationStatus: applicationStatusDirectory),
+                managedObjectContext: syncMOC,
+                messageSender: messageSender),
             AssetV3PreviewDownloadRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -293,8 +293,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 clientUpdateStatus: applicationStatusDirectory.clientUpdateStatus),
             ResetSessionRequestStrategy(
                 managedObjectContext: syncMOC,
-                applicationStatus: applicationStatusDirectory,
-                clientRegistrationDelegate: applicationStatusDirectory.clientRegistrationDelegate),
+                messageSender: messageSender),
             UserImageAssetUpdateStrategy(
                 managedObjectContext: syncMOC,
                 applicationStatusDirectory: applicationStatusDirectory,

--- a/wire-ios-sync-engine/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -633,7 +633,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     ZMConversation *conversation = message.conversation;
-    ZMSystemMessage *lastMessage = (ZMSystemMessage *)[conversation lastMessagesWithLimit:10][0];
+    ZMSystemMessage *lastMessage = (ZMSystemMessage *)[conversation lastMessagesWithLimit:10][1]; // second to last
     XCTAssertTrue([lastMessage isKindOfClass:[ZMSystemMessage class]]);
     
     NSArray<ZMUser *> *expectedUsers = @[[self userForMockUser:self.user1]];
@@ -654,7 +654,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     ZMConversation *conversation = message.conversation;
-    ZMSystemMessage *lastMessage = (ZMSystemMessage *)[conversation lastMessagesWithLimit:10][4];
+    ZMSystemMessage *lastMessage = (ZMSystemMessage *)[conversation lastMessagesWithLimit:10][5];
     XCTAssertTrue([lastMessage isKindOfClass:[ZMSystemMessage class]]);
     
     NSArray<ZMUser *> *expectedUsers = @[[self userForMockUser:self.user1]];
@@ -755,7 +755,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // THEN
-    ZMSystemMessage *lastMessage = (ZMSystemMessage *)[conversation lastMessagesWithLimit:10][0];
+    ZMSystemMessage *lastMessage = (ZMSystemMessage *)[conversation lastMessagesWithLimit:10][1]; // second to last
     XCTAssertEqual(conversation.securityLevel, ZMConversationSecurityLevelSecureWithIgnored);
     XCTAssertEqual(conversation.allMessages.count, 3lu); // 2x system message (secured & new client) + appended client message
     XCTAssertEqual(lastMessage.systemMessageData.systemMessageType, ZMSystemMessageTypeNewClient);

--- a/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests.m
@@ -338,6 +338,7 @@
     [self performIgnoringZMLogError:^{
         [self.mockTransportSession completeAllBlockedRequests];
     }];
+    WaitForAllGroupsToBeEmpty(0.5);
 }
 
 - (void)testThatSystemEventsAreAddedToAConversationWhenTheyAreGeneratedRemotely

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -26,7 +26,7 @@ class CallingRequestStrategyTests: MessagingTest {
     var mockApplicationStatus: MockApplicationStatus!
     var mockRegistrationDelegate: ClientRegistrationDelegate!
     var mockFetchUserClientsUseCase: MockFetchUserClientsUseCase!
-    var mockMessageSync: MockGenericMessageSyncInterface!
+    var mockMessageSender: MockMessageSenderInterface_!
 
     override class func setUp() {
         super.setUp()
@@ -40,7 +40,7 @@ class CallingRequestStrategyTests: MessagingTest {
         mockApplicationStatus.mockSynchronizationState = .online
         mockRegistrationDelegate = MockClientRegistrationDelegate()
         mockFetchUserClientsUseCase = MockFetchUserClientsUseCase()
-        mockMessageSync = MockGenericMessageSyncInterface()
+        mockMessageSender = MockMessageSenderInterface_()
 
         sut = CallingRequestStrategy(
             managedObjectContext: syncMOC,
@@ -49,7 +49,7 @@ class CallingRequestStrategyTests: MessagingTest {
             flowManager: FlowManagerMock(),
             callEventStatus: CallEventStatus(),
             fetchUserClientsUseCase: mockFetchUserClientsUseCase,
-            messageSync: mockMessageSync
+            messageSender: mockMessageSender
         )
         sut.callCenter = WireCallCenterV3Mock(
             userId: .stub,
@@ -434,7 +434,8 @@ class CallingRequestStrategyTests: MessagingTest {
             clientRegistrationDelegate: mockRegistrationDelegate,
             flowManager: FlowManagerMock(),
             callEventStatus: CallEventStatus(),
-            fetchUserClientsUseCase: mockFetchUserClientsUseCase
+            fetchUserClientsUseCase: mockFetchUserClientsUseCase,
+            messageSender: mockMessageSender
         )
         // Given
         let selfClient = createSelfClient()
@@ -466,7 +467,11 @@ class CallingRequestStrategyTests: MessagingTest {
         let avsClient2 = AVSClient(userId: user2.avsIdentifier, clientId: client2.remoteIdentifier!)
         let targets = [avsClient1, avsClient2]
 
-        var nextRequest: ZMTransportRequest?
+        var sentMessage: GenericMessageEntity?
+        mockMessageSender.sendMessageMessage_MockMethod = { message in
+            sentMessage = message as? GenericMessageEntity
+            return .success(Void())
+        }
 
         // When we schedule the targeted message
         syncMOC.performGroupedBlock {
@@ -475,38 +480,30 @@ class CallingRequestStrategyTests: MessagingTest {
 
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        syncMOC.performGroupedBlock {
-            nextRequest = self.sut.nextRequest(for: .v0)
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        guard let request = nextRequest else { return XCTFail("Expected next request") }
-
-        // Then we tell backend to ignore missing clients (the non targeted conversation participants)
-        XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages?ignore_missing=true")
-
-        guard
-            let data = request.binaryData,
-            let otrMessage = try? Proteus_NewOtrMessage(serializedData: data)
-        else {
-            return XCTFail("Expected OTR message")
-        }
-
         // Then we send the message to the targeted clients
-        XCTAssertEqual(otrMessage.recipients.count, 2)
+        let targetRecipients = if case .clients(let recipients) = sentMessage?.targetRecipients {
+            recipients.mapValues { clients in
+                clients.map { userClient in
+                    userClient.clientId
+                }
+            }
+        } else {
+            [:] as [ZMUser: [Proteus_ClientId]]
+        }
 
-        guard let recipient1 = otrMessage.recipients.first(where: { $0.user == user1.userId }) else {
+        XCTAssertEqual(targetRecipients.count, 2)
+
+        guard let recipient1 = targetRecipients.first(where: {  $0.key == user1 }) else {
             return XCTFail("Expected user1 to be recipient")
         }
 
-        XCTAssertEqual(recipient1.clients.map(\.client), [client1.clientId])
+        XCTAssertEqual(recipient1.value, [client1.clientId])
 
-        guard let recipient2 = otrMessage.recipients.first(where: { $0.user == user2.userId }) else {
+        guard let recipient2 = targetRecipients.first(where: { $0.key == user2 }) else {
             return XCTFail("Expected user2 to be recipient")
         }
 
-        XCTAssertEqual(recipient2.clients.map(\.client), [client2.clientId])
+        XCTAssertEqual(recipient2.value, [client2.clientId])
     }
 
     func testThatItDoesNotTargetCallMessagesIfNoTargetClientsAreSpecified() {
@@ -536,9 +533,9 @@ class CallingRequestStrategyTests: MessagingTest {
         syncMOC.saveOrRollback()
 
         var sentMessage: GenericMessageEntity?
-        mockMessageSync.syncCompletion_MockMethod = { message, completion in
-            sentMessage = message
-            completion(.success(()), ZMTransportResponse())
+        mockMessageSender.sendMessageMessage_MockMethod = { message in
+            sentMessage = message as? GenericMessageEntity
+            return .success(Void())
         }
 
         // When we schedule the message with no targets
@@ -582,136 +579,6 @@ class CallingRequestStrategyTests: MessagingTest {
         XCTAssertTrue(userClient.establishSessionWithClient(client, usingPreKey: try! syncMOC.zm_cryptKeyStore.lastPreKey()))
 
         return client
-    }
-
-    // MARK: - MLS messages
-
-    // Note: at the moment, all mls messages are sent to every participant in the group.
-    // When we implement subgroups, then we may be able to assert who the recipients are.
-
-    func test_ThatItSendsMLSConfStartMessage_ToAllParticipants_WhenNoTargetRecipientsAreSpecified() {
-        // Given
-        let selfClient = createSelfClient()
-
-        // One user with two clients connected to self
-        let user1 = ZMUser.insertNewObject(in: syncMOC)
-        user1.remoteIdentifier = .create()
-
-        _ = createClient(for: user1, connectedTo: selfClient)
-        _ = createClient(for: user1, connectedTo: selfClient)
-
-        // Another user with two clients connected to self
-        let user2 = ZMUser.insertNewObject(in: syncMOC)
-        user2.remoteIdentifier = .create()
-
-        _ = createClient(for: user2, connectedTo: selfClient)
-        _ = createClient(for: user2, connectedTo: selfClient)
-
-        // An MLS conversation with both users and self
-        let conversation = ZMConversation.insertNewObject(in: syncMOC)
-        conversation.remoteIdentifier = .create()
-        conversation.mlsGroupID = MLSGroupID(Data([1, 2, 3]))
-        conversation.messageProtocol = .mls
-        conversation.addParticipantsAndUpdateConversationState(users: [ZMUser.selfUser(in: syncMOC), user1, user2], role: nil)
-        conversation.needsToBeUpdatedFromBackend = false
-
-        syncMOC.saveOrRollback()
-
-        let mockMLSService = MockMLSService()
-
-        syncMOC.performGroupedBlock {
-            self.syncMOC.mlsService = mockMLSService
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        var nextRequest: ZMTransportRequest?
-        let expectation = self.expectation(description: "wait for send message")
-        // When we schedule the message with no targets
-        syncMOC.performGroupedBlock {
-            self.sut.send(data: self.callMessage(withType: "CONFSTART"), conversationId: conversation.avsIdentifier!, targets: nil, overMLSSelfConversation: false) { _ in
-                expectation.fulfill()
-            }
-        }
-
-        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        syncMOC.performGroupedBlock {
-            nextRequest = self.sut.nextRequest(for: .v5)
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        guard let request = nextRequest else { return XCTFail("Expected next request") }
-    }
-
-    // Note: at the moment, all mls messages are sent to every participant in the group.
-    // When we implement subgroups, then we may be able to assert who the recipients are.
-
-    func test_ThatItSendsMLSConfKeyMessage_ToAllParticipants_EvenIfTargetRecipientsAreSpecified() {
-        // Given
-        createMLSSelfConversation()
-        let selfClient = createSelfClient()
-
-        // One user with two clients connected to self
-        let user1 = ZMUser.insertNewObject(in: syncMOC)
-        user1.remoteIdentifier = .create()
-
-        let client1 = createClient(for: user1, connectedTo: selfClient)
-        _ = createClient(for: user1, connectedTo: selfClient)
-
-        // Another user with two clients connected to self
-        let user2 = ZMUser.insertNewObject(in: syncMOC)
-        user2.remoteIdentifier = .create()
-
-        let client3 = createClient(for: user2, connectedTo: selfClient)
-        _ = createClient(for: user2, connectedTo: selfClient)
-
-        // Targeting two specific clients
-        let avsClient1 = AVSClient(userId: user1.avsIdentifier, clientId: client1.remoteIdentifier!)
-        let avsClient2 = AVSClient(userId: user2.avsIdentifier, clientId: client3.remoteIdentifier!)
-        let targets = [avsClient1, avsClient2]
-
-        // An MLS conversation with both users and self
-        let conversation = ZMConversation.insertNewObject(in: syncMOC)
-        conversation.remoteIdentifier = .create()
-        conversation.mlsGroupID = MLSGroupID(Data([1, 2, 3]))
-        conversation.messageProtocol = .mls
-        conversation.addParticipantsAndUpdateConversationState(users: [ZMUser.selfUser(in: syncMOC), user1, user2], role: nil)
-        conversation.needsToBeUpdatedFromBackend = false
-
-        syncMOC.saveOrRollback()
-
-        let mockMLSService = MockMLSService()
-
-        syncMOC.performGroupedBlock {
-            self.syncMOC.mlsService = mockMLSService
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        var nextRequest: ZMTransportRequest?
-
-        let didEnqueueMessage = expectation(description: "didEnqueueMessage")
-
-        // When we schedule the message
-        syncMOC.performGroupedBlock {
-            self.sut.send(data: self.callMessage(withType: "CONFKEY"), conversationId: conversation.avsIdentifier!, targets: targets, overMLSSelfConversation: true) { _ in
-                didEnqueueMessage.fulfill()
-            }
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
-
-        syncMOC.performGroupedBlock {
-            nextRequest = self.sut.nextRequest(for: .v5)
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        guard let request = nextRequest else { return XCTFail("Expected next request") }
     }
 
     private func callMessage(withType type: String) -> Data {
@@ -782,15 +649,17 @@ class CallingRequestStrategyTests: MessagingTest {
 
         syncMOC.saveOrRollback()
 
+        var sentMessage: GenericMessageEntity?
+        mockMessageSender.sendMessageMessage_MockMethod = { message in
+            sentMessage = message as? GenericMessageEntity
+            return .success(Void())
+        }
+
         let mockMLSService = MockMLSService()
 
         syncMOC.performGroupedBlock {
             self.syncMOC.mlsService = mockMLSService
         }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        var nextRequest: ZMTransportRequest?
 
         // Targeting one client
         let avsClient1 = AVSClient(userId: user1.avsIdentifier, clientId: client1.remoteIdentifier!)
@@ -799,33 +668,23 @@ class CallingRequestStrategyTests: MessagingTest {
         let expectation = self.expectation(description: "reject message is sent to MLS self conversation")
         // When we schedule the message
         syncMOC.performGroupedBlock {
-            self.sut.send(data: self.callMessage(withType: "REJECT"), conversationId: conversation.avsIdentifier!, targets: targets, overMLSSelfConversation: true) { _ in
+            self.sut.send(
+                data: self.callMessage(withType: "REJECT"),
+                conversationId: conversation.avsIdentifier!,
+                targets: targets,
+                overMLSSelfConversation: true
+            ) { _ in
                 expectation.fulfill()
             }
         }
 
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        syncMOC.performGroupedBlock {
-            nextRequest = self.sut.nextRequest(for: .v5)
-        }
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        XCTAssertNotNil(nextRequest)
+        XCTAssertEqual(ZMConversationType.`self`, sentMessage?.conversation?.conversationType)
+        XCTAssertEqual(.mls, sentMessage?.conversation?.messageProtocol)
     }
 
     private func setupMockMessageSyncForMLSSuccessfully() {
-        mockMessageSync.syncCompletion_MockMethod = { _, completion in
-            completion(.success(()), ZMTransportResponse())
-        }
-        mockMessageSync.nextRequestFor_MockMethod = { apiVersion in
-            if apiVersion == .v5 {
-                return ZMTransportRequest()
-            }
-            return nil
-        }
+        mockMessageSender.sendMessageMessage_MockValue = .success(Void())
     }
 }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -26,7 +26,7 @@ class CallingRequestStrategyTests: MessagingTest {
     var mockApplicationStatus: MockApplicationStatus!
     var mockRegistrationDelegate: ClientRegistrationDelegate!
     var mockFetchUserClientsUseCase: MockFetchUserClientsUseCase!
-    var mockMessageSender: MockMessageSenderInterface_!
+    var mockMessageSender: MockMessageSenderInterface!
 
     override class func setUp() {
         super.setUp()
@@ -40,7 +40,7 @@ class CallingRequestStrategyTests: MessagingTest {
         mockApplicationStatus.mockSynchronizationState = .online
         mockRegistrationDelegate = MockClientRegistrationDelegate()
         mockFetchUserClientsUseCase = MockFetchUserClientsUseCase()
-        mockMessageSender = MockMessageSenderInterface_()
+        mockMessageSender = MockMessageSenderInterface()
 
         sut = CallingRequestStrategy(
             managedObjectContext: syncMOC,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -249,6 +249,7 @@
 		16A702D01E92998100B8410D /* ApplicationStatusDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A702CF1E92998100B8410D /* ApplicationStatusDirectoryTests.swift */; };
 		16A764611F3E0B0B00564F21 /* CallKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A764601F3E0B0B00564F21 /* CallKitManager.swift */; };
 		16AD86B81F7292EB00E4C797 /* TypingChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AD86B71F7292EB00E4C797 /* TypingChange.swift */; };
+		16BA78712B04D98A006D8CCF /* AutoMockable.manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BA78702B04D98A006D8CCF /* AutoMockable.manual.swift */; };
 		16C22BA41BF4D5D7007099D9 /* NSError+ZMUserSessionInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E05F254192A50CC00F22D80 /* NSError+ZMUserSessionInternal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16C4BDA020A309CD00BCDB17 /* CallParticipantSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C4BD9F20A309CD00BCDB17 /* CallParticipantSnapshot.swift */; };
 		16D0A119234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D0A118234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift */; };
@@ -878,6 +879,7 @@
 		16A764601F3E0B0B00564F21 /* CallKitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallKitManager.swift; sourceTree = "<group>"; };
 		16A86B8322A7E57100A674F8 /* ConversationTests+LegalHold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationTests+LegalHold.swift"; sourceTree = "<group>"; };
 		16AD86B71F7292EB00E4C797 /* TypingChange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypingChange.swift; sourceTree = "<group>"; };
+		16BA78702B04D98A006D8CCF /* AutoMockable.manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMockable.manual.swift; sourceTree = "<group>"; };
 		16C4BD9F20A309CD00BCDB17 /* CallParticipantSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallParticipantSnapshot.swift; sourceTree = "<group>"; };
 		16D0A118234B999600A83F87 /* LabelUpstreamRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelUpstreamRequestStrategyTests.swift; sourceTree = "<group>"; };
 		16D0A11C234C8CD700A83F87 /* LabelUpstreamRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelUpstreamRequestStrategy.swift; sourceTree = "<group>"; };
@@ -1475,6 +1477,7 @@
 			isa = PBXGroup;
 			children = (
 				014C7AA42ADD4DEA00CDEC45 /* AutoMockable.generated.swift */,
+				16BA78702B04D98A006D8CCF /* AutoMockable.manual.swift */,
 			);
 			path = generated;
 			sourceTree = "<group>";
@@ -3177,6 +3180,7 @@
 				16849B1C23EDA1FD00C025A8 /* MockUpdateEventProcessor.swift in Sources */,
 				63D5655528B52D0300BDFB49 /* MockCoreCrypto.swift in Sources */,
 				545F601C1D6C336D00C2C55B /* AddressBookSearchTests.swift in Sources */,
+				16BA78712B04D98A006D8CCF /* AutoMockable.manual.swift in Sources */,
 				162A81D6202B5BC600F6200C /* SessionManagerAVSTests.swift in Sources */,
 				169BA1F825ECF8F700374343 /* MockAppLock.swift in Sources */,
 				06F98D602437916B007E914A /* SignatureRequestStrategyTests.swift in Sources */,

--- a/wire-ios-sync-engine/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/sourcery/generated/AutoMockable.generated.swift
@@ -33,29 +33,3 @@ import AppKit
 
 
 
-public class MockMessageSenderInterface_: MessageSenderInterface_ {
-
-    // MARK: - Life cycle
-
-    public init() {}
-
-
-    // MARK: - sendMessage
-
-    public var sendMessageMessage_Invocations: [any SendableMessage] = []
-    public var sendMessageMessage_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageSendError>)?
-    public var sendMessageMessage_MockValue: Swift.Result<Void, MessageSendError>?
-
-    public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
-        sendMessageMessage_Invocations.append(message)
-
-        if let mock = sendMessageMessage_MockMethod {
-            return await mock(message)
-        } else if let mock = sendMessageMessage_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `sendMessageMessage`")
-        }
-    }
-
-}

--- a/wire-ios-sync-engine/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/sourcery/generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.0.3 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
 // swiftlint:disable variable_name
@@ -10,62 +10,52 @@ import UIKit
 import AppKit
 #endif
 
+
 @testable import WireSyncEngine
 
-class MockGenericMessageSyncInterface: GenericMessageSyncInterface {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+public class MockMessageSenderInterface_: MessageSenderInterface_ {
 
     // MARK: - Life cycle
 
-    // MARK: - contextChangeTrackers
+    public init() {}
 
-    var contextChangeTrackers: [ZMContextChangeTracker] = []
 
-    // MARK: - sync
+    // MARK: - sendMessage
 
-    var syncCompletion_Invocations: [(message: GenericMessageEntity, completion: EntitySyncHandler)] = []
-    var syncCompletion_MockMethod: ((GenericMessageEntity, @escaping EntitySyncHandler) -> Void)?
+    public var sendMessageMessage_Invocations: [any SendableMessage] = []
+    public var sendMessageMessage_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageSendError>)?
+    public var sendMessageMessage_MockValue: Swift.Result<Void, MessageSendError>?
 
-    func sync(_ message: GenericMessageEntity, completion: @escaping EntitySyncHandler) {
-        syncCompletion_Invocations.append((message: message, completion: completion))
+    public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
+        sendMessageMessage_Invocations.append(message)
 
-        guard let mock = syncCompletion_MockMethod else {
-            fatalError("no mock for `syncCompletion`")
-        }
-
-        mock(message, completion)
-    }
-
-    // MARK: - nextRequest
-
-    var nextRequestFor_Invocations: [APIVersion] = []
-    var nextRequestFor_MockMethod: ((APIVersion) -> ZMTransportRequest?)?
-    var nextRequestFor_MockValue: ZMTransportRequest??
-
-    func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
-        nextRequestFor_Invocations.append(apiVersion)
-
-        if let mock = nextRequestFor_MockMethod {
-            return mock(apiVersion)
-        } else if let mock = nextRequestFor_MockValue {
+        if let mock = sendMessageMessage_MockMethod {
+            return await mock(message)
+        } else if let mock = sendMessageMessage_MockValue {
             return mock
         } else {
-            fatalError("no mock for `nextRequestFor`")
+            fatalError("no mock for `sendMessageMessage`")
         }
-    }
-
-    // MARK: - expireMessages
-
-    var expireMessagesWithDependency_Invocations: [NSObject] = []
-    var expireMessagesWithDependency_MockMethod: ((NSObject) -> Void)?
-
-    func expireMessages(withDependency dependency: NSObject) {
-        expireMessagesWithDependency_Invocations.append(dependency)
-
-        guard let mock = expireMessagesWithDependency_MockMethod else {
-            fatalError("no mock for `expireMessagesWithDependency`")
-        }
-
-        mock(dependency)
     }
 
 }

--- a/wire-ios-sync-engine/sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/sourcery/generated/AutoMockable.manual.swift
@@ -1,0 +1,52 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(OSX)
+import AppKit
+#endif
+
+@testable import WireSyncEngine
+
+public class MockMessageSenderInterface: MessageSenderInterface {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+    // MARK: - sendMessage
+
+    public var sendMessageMessage_Invocations: [any SendableMessage] = []
+    public var sendMessageMessage_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageSendError>)?
+    public var sendMessageMessage_MockValue: Swift.Result<Void, MessageSendError>?
+
+    public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
+        sendMessageMessage_Invocations.append(message)
+
+        if let mock = sendMessageMessage_MockMethod {
+            return await mock(message)
+        } else if let mock = sendMessageMessage_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `sendMessageMessage`")
+        }
+    }
+
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Previously  the replace MessageSender was only used in `ClientMessageRequestStrategy`, This PR replaces MessageSync with MessageSender in all remaining strategies.

While integrating `MessageSender` in the `CallingRequestStrategy` I realised that we need fail a message due to a degraded security level in a conversation also after the sending flow has started. This removes the need for the manually calling `dropPendingCallMessages` when security level degrades.

Also since these strategies are no longer request strategies and is there for no longer bound the request strategy configuration:
```
configuration = [.allowsRequestsWhileOnline,
                         .allowsRequestsWhileInBackground]
```

This means that message sending is no longer guaranteed to be done after we've synchronised incoming events, which is an invariant we must up hold. I'll add a way for the message sender to observe the application status in an upcoming PR.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
