### PR TITLE
refactor(message-sending): switch to try/catch based error handling #7

### DIFF
--- a/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolver.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolver.swift
@@ -20,13 +20,14 @@ import Foundation
 
 // sourcery: AutoMockable
 public protocol MessageDependencyResolverInterface {
-    func waitForDependenciesToResolve(for message: any SendableMessage) async -> Swift.Result<Void, MessageDependencyResolverError>
+    func waitForDependenciesToResolve(for message: any SendableMessage) async throws
 }
 
 public enum MessageDependencyResolverError: Error, Equatable {
     case securityLevelDegraded
 }
 
+// swiftlint:disable for_where
 public class MessageDependencyResolver: MessageDependencyResolverInterface {
 
     public init(context: NSManagedObjectContext) {
@@ -35,13 +36,15 @@ public class MessageDependencyResolver: MessageDependencyResolverInterface {
 
     let context: NSManagedObjectContext
 
-    public func waitForDependenciesToResolve(for message: any SendableMessage) async -> Swift.Result<Void, MessageDependencyResolverError> {
+    public func waitForDependenciesToResolve(for message: any SendableMessage) async throws {
 
-        @Sendable func dependenciesAreResolved() async -> Swift.Result<Bool, MessageDependencyResolverError> {
-            if await self.context.perform {
+        @Sendable func dependenciesAreResolved() async throws -> Bool {
+            let isSecurityLevelDegraded = await self.context.perform {
                 message.conversation?.securityLevel == .secureWithIgnored
-            } {
-                return .failure(MessageDependencyResolverError.securityLevelDegraded)
+            }
+
+            if isSecurityLevelDegraded {
+                throw MessageDependencyResolverError.securityLevelDegraded
             }
 
             let hasDependencies = await self.context.perform {
@@ -50,36 +53,27 @@ public class MessageDependencyResolver: MessageDependencyResolverInterface {
 
             if !hasDependencies {
                 WireLogger.messaging.debug("Message dependency resolved")
-                return .success(true)
+                return true
             } else {
                 WireLogger.messaging.debug("Message has dependency, waiting")
-                return .success(false)
+                return false
             }
         }
 
-        let result = await dependenciesAreResolved()
-        let continueWaiting = result.isOne(of: .success(false))
-
-        if !continueWaiting {
-            return result.map { _ in Void() }
+        if try await dependenciesAreResolved() {
+            return
         }
 
         return await withCheckedContinuation { continuation in
             Task {
-                let result = await dependenciesAreResolved()
-                let continueWaiting = result.isOne(of: .success(false))
-
-                if !continueWaiting {
-                    continuation.resume(returning: result.map({ _ in Void() }))
+                if try await dependenciesAreResolved() {
+                    continuation.resume()
                     return
                 }
 
                 for await _ in NotificationCenter.default.notifications(named: .requestAvailableNotification) {
-                    let result = await dependenciesAreResolved()
-                    let continueWaiting = result.isOne(of: .success(false))
-
-                    if !continueWaiting {
-                        continuation.resume(returning: result.map({ _ in Void() }))
+                    if try await dependenciesAreResolved() {
+                        continuation.resume()
                         break
                     }
                 }
@@ -87,3 +81,4 @@ public class MessageDependencyResolver: MessageDependencyResolverInterface {
         }
     }
 }
+// swiftlint:enable for_where

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolver.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolver.swift
@@ -27,7 +27,6 @@ public enum MessageDependencyResolverError: Error, Equatable {
     case securityLevelDegraded
 }
 
-// swiftlint:disable for_where
 public class MessageDependencyResolver: MessageDependencyResolverInterface {
 
     public init(context: NSManagedObjectContext) {
@@ -71,14 +70,15 @@ public class MessageDependencyResolver: MessageDependencyResolverInterface {
                     return
                 }
 
+                // swiftlint:disable for_where
                 for await _ in NotificationCenter.default.notifications(named: .requestAvailableNotification) {
                     if try await dependenciesAreResolved() {
                         continuation.resume()
                         break
                     }
                 }
+                // swiftlint:enable for_where
             }
         }
     }
 }
-// swiftlint:enable for_where

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolverTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolverTests.swift
@@ -30,7 +30,7 @@ final class MessageDependencyResolverTests: MessagingTestBase {
             .arrange()
 
         // when
-        _ = await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+        try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
 
         // then test completes
     }
@@ -60,7 +60,7 @@ final class MessageDependencyResolverTests: MessagingTestBase {
         }
 
         // when
-        _ = await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+        try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
 
         // then test completes
     }

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -102,17 +102,16 @@ public class MessageSender: MessageSenderInterface {
     }
 
     private func attemptToSend(message: any SendableMessage) async throws {
+        let messageProtocol = await managedObjectContext.perform {message.conversation?.messageProtocol }
+
         guard let apiVersion = BackendInfo.apiVersion else { throw MessageSendError.unresolvedApiVersion }
-        guard let messageProtocol = await managedObjectContext.perform({
-            message.conversation?.messageProtocol
-        }) else {
+        guard let messageProtocol else {
             throw MessageSendError.messageProtocolMissing
         }
 
         return switch messageProtocol {
         case .proteus:
             try await attemptToSendWithProteus(message: message, apiVersion: apiVersion)
-
         case .mls:
             try await attemptToSendWithMLS(message: message, apiVersion: apiVersion)
         }

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -18,18 +18,6 @@
 
 import Foundation
 
-// FIXME: [jacob] use existing packages
-extension Swift.Result {
-    func flatMapAsync<NewSuccess>(_ transform: (Success) async -> Swift.Result<NewSuccess, Failure>) async -> Swift.Result<NewSuccess, Failure> {
-        switch self {
-        case .success(let success):
-            return await transform(success)
-        case .failure(let failure):
-            return .failure(failure)
-        }
-    }
-}
-
 public protocol HttpClient {
 
     func send(_ request: ZMTransportRequest) async -> ZMTransportResponse
@@ -60,10 +48,7 @@ public class HttpClientImpl: HttpClient {
 public enum MessageSendError: Error, Equatable {
     case messageProtocolMissing
     case unresolvedApiVersion
-    case missingSelfClient
     case messageExpired
-    case securityLevelDegraded
-    case networkError(NetworkError)
 }
 
 public typealias SendableMessage = ProteusMessage & MLSMessage
@@ -71,7 +56,7 @@ public typealias SendableMessage = ProteusMessage & MLSMessage
 // sourcery: AutoMockable
 public protocol MessageSenderInterface {
 
-    func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError>
+    func sendMessage(message: any SendableMessage) async throws
 
 }
 
@@ -98,100 +83,75 @@ public class MessageSender: MessageSenderInterface {
     private let messageDependencyResolver: MessageDependencyResolverInterface
     private let processor = MessageSendingStatusPayloadProcessor()
 
-    public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
+    public func sendMessage(message: any SendableMessage) async throws {
         WireLogger.messaging.debug("send message")
 
         // TODO: [jacob] we need to wait until we are "online"
 
-        return await messageDependencyResolver.waitForDependenciesToResolve(for: message)
-            .mapError { dependencyError in
-                switch dependencyError {
-                case .securityLevelDegraded:
-                    MessageSendError.securityLevelDegraded
-                }
-            }
-            .flatMapAsync { _ in
-                await attemptToSend(message: message)
-                    .map({ success in
-                        // Triggering request polling to re-evalute dependencies, other messages
-                        // might have been waiting for this message to be sent.
-                        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
-                        return success
-                    })
-            }
-            .mapError { error in
-                WireLogger.messaging.debug("send message failed: \(error)")
-                return error
-            }
+        do {
+            try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+            try await attemptToSend(message: message)
+        } catch {
+            WireLogger.messaging.debug("send message failed: \(error)")
+            throw error
+        }
+
+        // Triggering request polling to re-evalute dependencies, other messages
+        // might have been waiting for this message to be sent.
+        RequestAvailableNotification.notifyNewRequestsAvailable(nil)
     }
 
-    private func attemptToSend(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
-        guard let apiVersion = BackendInfo.apiVersion else { return .failure(MessageSendError.unresolvedApiVersion)}
+    private func attemptToSend(message: any SendableMessage) async throws {
+        guard let apiVersion = BackendInfo.apiVersion else { throw MessageSendError.unresolvedApiVersion }
         guard let messageProtocol = await managedObjectContext.perform({
             message.conversation?.messageProtocol
         }) else {
-            return .failure(MessageSendError.messageProtocolMissing)
+            throw MessageSendError.messageProtocolMissing
         }
 
         return switch messageProtocol {
         case .proteus:
-            await attemptToSendWithProteus(message: message, apiVersion: apiVersion)
+            try await attemptToSendWithProteus(message: message, apiVersion: apiVersion)
 
         case .mls:
-            await attemptToSendWithMLS(message: message, apiVersion: apiVersion)
+            try await attemptToSendWithMLS(message: message, apiVersion: apiVersion)
         }
     }
 
-    private func attemptToSendWithProteus(message: any SendableMessage, apiVersion: APIVersion) async -> Swift.Result<Void, MessageSendError> {
+    private func attemptToSendWithProteus(message: any SendableMessage, apiVersion: APIVersion) async throws {
         guard let conversationID = await managedObjectContext.perform({
             message.conversation?.qualifiedID
         }) else {
-            return .failure(MessageSendError.messageProtocolMissing)
+            throw MessageSendError.messageProtocolMissing
         }
 
-        let result = await apiProvider.messageAPI(apiVersion: apiVersion).sendProteusMessage(
-            message: message,
-            conversationID: conversationID
-        )
-
-        return switch result {
-        case .success((let messageSendingStatus, let response)):
-            await managedObjectContext.perform {
-                self.handleProteusSuccess(
-                    message: message,
-                    messageSendingStatus: messageSendingStatus,
-                    response: response)
+        do {
+            let (messageStatus, response) = try await apiProvider.messageAPI(apiVersion: apiVersion).sendProteusMessage(
+                message: message,
+                conversationID: conversationID
+            )
+            await managedObjectContext.perform { [self] in
+                handleProteusSuccess(message: message, messageSendingStatus: messageStatus, response: response)
             }
-        case .failure(let networkError):
-            await (await managedObjectContext.perform {
-                self.handleProteusFailure(message: message, networkError)
-            }).flatMapAsync { missingClients in
-                await sessionEstablisher.establishSession(with: missingClients, apiVersion: apiVersion)
-                    .mapError({ error in
-                        switch error {
-                        case .missingSelfClient: MessageSendError.missingSelfClient
-                        case .networkError(let networkError): MessageSendError.networkError(networkError)
-                        }
-                    })
-                    .flatMapAsync { _ in
-                        await sendMessage(message: message)
-                    }
+        } catch let networkError as NetworkError {
+            let missingClients = try await managedObjectContext.perform { [self] in
+                try handleProteusFailure(message: message, networkError)
             }
+            try await sessionEstablisher.establishSession(with: missingClients, apiVersion: apiVersion)
+            try await sendMessage(message: message)
         }
     }
 
-    private func handleProteusSuccess(message: any ProteusMessage, messageSendingStatus: Payload.MessageSendingStatus, response: ZMTransportResponse) -> Swift.Result<Void, MessageSendError> {
+    private func handleProteusSuccess(message: any ProteusMessage, messageSendingStatus: Payload.MessageSendingStatus, response: ZMTransportResponse) {
         message.delivered(with: response) // FIXME: jacob refactor to not use raw response
 
         processor.updateClientsChanges(
             from: messageSendingStatus,
             for: message
         )
-
-        return .success(Void())
     }
 
-    private func handleProteusFailure(message: any ProteusMessage, _ failure: NetworkError) -> Swift.Result<Set<QualifiedClientID>, MessageSendError> {
+    private func handleProteusFailure(message: any ProteusMessage, _ failure: NetworkError) throws -> Set<QualifiedClientID> {
         switch failure {
         case .missingClients(let messageSendingStatus, _):
             processor.updateClientsChanges(
@@ -201,9 +161,9 @@ public class MessageSender: MessageSenderInterface {
             managedObjectContext.enqueueDelayedSave()
 
             if message.isExpired {
-                return .failure(MessageSendError.messageExpired)
+                throw MessageSendError.messageExpired
             } else {
-                return .success(Set(messageSendingStatus.missing.qualifiedClientIDs))
+                return Set(messageSendingStatus.missing.qualifiedClientIDs)
             }
         case .invalidRequestError(let responseFailure, _):
             switch (responseFailure.code, responseFailure.label) {
@@ -211,7 +171,7 @@ public class MessageSender: MessageSenderInterface {
                 guard
                     let data = responseFailure.data
                 else {
-                    return .failure(MessageSendError.networkError(failure))
+                    throw failure
                 }
 
                 switch data.type {
@@ -221,25 +181,25 @@ public class MessageSender: MessageSenderInterface {
                     responseFailure.updateExpirationReason(for: message, with: .unknown)
                 }
 
-                return .failure(MessageSendError.networkError(failure))
+                throw failure
             default:
-                return .failure(MessageSendError.networkError(failure))
+                throw failure
             }
         default:
             if case .tryAgainLater = failure.response?.result {
                 if message.isExpired {
-                    return .failure(MessageSendError.messageExpired)
+                    throw MessageSendError.messageExpired
                 } else {
-                    return .success(Set()) // FIXME: [jacob] it's dangerous to retry indefinitely like this WPB-5454
+                    return Set() // FIXME: [jacob] it's dangerous to retry indefinitely like this WPB-5454
                 }
             } else {
-                return .failure(MessageSendError.networkError(failure))
+                throw failure
             }
         }
     }
 
-    private func attemptToSendWithMLS(message: any MLSMessage, apiVersion: APIVersion) async -> Swift.Result<Void, MessageSendError> {
-        return .failure(MessageSendError.messageProtocolMissing)
+    private func attemptToSendWithMLS(message: any MLSMessage, apiVersion: APIVersion) async throws {
+        throw MessageSendError.messageProtocolMissing
     }
 }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
@@ -20,12 +20,11 @@ import Foundation
 
 public enum SessionEstablisherError: Error, Equatable {
     case missingSelfClient
-    case networkError(NetworkError)
 }
 
 // sourcery: AutoMockable
 public protocol SessionEstablisherInterface {
-    func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async -> Swift.Result<Void, SessionEstablisherError>
+    func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async throws
 }
 
 public class SessionEstablisher: SessionEstablisherInterface {
@@ -46,33 +45,24 @@ public class SessionEstablisher: SessionEstablisherInterface {
     private let processor: PrekeyPayloadProcessorInterface
     private let batchSize = 28
 
-    public func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async -> Swift.Result<Void, SessionEstablisherError> {
-
-        // Establish sessions in chunks and return on first error
+    public func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async throws {
+        // Establish sessions in chunks
         for chunk in Array(clients).chunked(into: batchSize) {
-            let result = await internalEstablishSessions(for: Set(chunk), apiVersion: apiVersion)
-            if case Swift.Result.failure = result {
-                return result
-            }
+            try await internalEstablishSessions(for: Set(chunk), apiVersion: apiVersion)
         }
-
-        return .success(Void())
     }
 
-    private func internalEstablishSessions(for clients: Set<QualifiedClientID>, apiVersion: APIVersion) async -> Swift.Result<Void, SessionEstablisherError> {
+    private func internalEstablishSessions(for clients: Set<QualifiedClientID>, apiVersion: APIVersion) async throws {
         guard let selfClient = await managedObjectContext.perform({
             ZMUser.selfUser(in: self.managedObjectContext).selfClient()
         }) else {
-            return .failure(SessionEstablisherError.missingSelfClient)
+            throw SessionEstablisherError.missingSelfClient
         }
 
-        return await apiProvider.prekeyAPI(apiVersion: apiVersion).fetchPrekeys(for: clients)
-            .mapError({ error in SessionEstablisherError.networkError(error) })
-            .flatMapAsync { prekeys in
-            await managedObjectContext.perform {
-                _ = self.processor.establishSessions(from: prekeys, with: selfClient, context: self.managedObjectContext)
-                return Swift.Result.success(Void())
-            }
+        let prekeys = try await apiProvider.prekeyAPI(apiVersion: apiVersion).fetchPrekeys(for: clients)
+
+        await managedObjectContext.perform {
+            _ = self.processor.establishSessions(from: prekeys, with: selfClient, context: self.managedObjectContext)
         }
     }
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -151,7 +151,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotScheduleAMessageForAnImageMessageUploadedByOtherUser() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let message = self.createMessage(uploaded: true, sender: self.otherUser)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -164,7 +164,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotCreateARequestForAnImageMessageWhichIsExpired() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let message = self.createMessage(uploaded: true, expired: true)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -176,7 +176,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotCreateARequestForAnImageMessageWithoutUploaded() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             self.createMessage(uploaded: false)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -188,7 +188,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotCreateARequestForAnImageMessageWithUploadedAndAssetIdInTheWrongTransferState() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let message = self.createMessage()
             message.updateTransferState(.uploaded, synchronize: true)
         }
@@ -201,7 +201,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     func testThatItCreatesARequestForAnUploadedImageMessage() {
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             self.createMessage(uploaded: true, assetId: true)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -214,7 +214,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
 
         self.syncMOC.performGroupedBlockAndWait {
             // GIVEN
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             self.groupConversation.setMessageDestructionTimeoutValue(.custom(15), for: .selfUser)
             self.createMessage(uploaded: true, assetId: true)
         }
@@ -227,7 +227,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
 
     func testThatItExpiresAMessageWhenItReceivesAFailureResponse() {
         // GIVEN
-        mockMessageSender.sendMessageMessage_MockValue = .failure(MessageSendError.messageExpired)
+        mockMessageSender.sendMessageMessage_MockError = MessageSendError.messageExpired
         var message: ZMAssetClientMessage!
         self.syncMOC.performGroupedBlockAndWait {
             message = self.createMessage(uploaded: true, assetId: true)
@@ -249,8 +249,8 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             label: .missingLegalholdConsent,
             message: "",
             data: nil)
-        let failure = MessageSendError.networkError(NetworkError.invalidRequestError(missingLegalholdConsentFailure, response))
-        mockMessageSender.sendMessageMessage_MockValue = .failure(failure)
+        let failure = NetworkError.invalidRequestError(missingLegalholdConsentFailure, response)
+        mockMessageSender.sendMessageMessage_MockError = failure
         var token: Any?
         self.syncMOC.performGroupedBlockAndWait {
             self.createMessage(uploaded: true, assetId: true)
@@ -269,10 +269,9 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
     }
 
     func testThatItMarksAnImageMessageAsSentWhenItReceivesASuccesfulResponse() {
-
         // GIVEN
         var message: ZMAssetClientMessage!
-        mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+        self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
         self.syncMOC.performGroupedBlockAndWait {
             message = self.createMessage(uploaded: true, assetId: true)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
@@ -58,8 +58,8 @@ extension LinkPreviewUpdateRequestStrategy: ModifiedKeyObjectSyncTranscoder {
         // Enter groups to enable waiting for message sending to complete in tests
         let groups = managedObjectContext.enterAllGroupsExceptSecondary()
         Task {
-            let result = await messageSender.sendMessage(message: object)
-            managedObjectContext.performAndWait {
+            try? await messageSender.sendMessage(message: object)
+            await managedObjectContext.perform {
                 object.linkPreviewState = .done
                 completion()
             }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
@@ -73,7 +73,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
     func testThatItDoesNotScheduleMessageInState_Uploaded_ForOtherUser() {
         self.syncMOC.performGroupedAndWait { _ in
             // Given
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let message = self.insertMessage(with: .uploaded)
             message.sender = self.otherUser
 
@@ -91,7 +91,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
 
         self.syncMOC.performGroupedAndWait { _ in
             // Given
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let message = self.insertMessage(with: .uploaded)
 
             // When
@@ -107,7 +107,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
         var message: ZMClientMessage!
         self.syncMOC.performGroupedAndWait { _ in
             // Given
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             message = self.insertMessage(with: .uploaded)
             self.process(message)
         }
@@ -135,7 +135,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
     func verifyThatItDoesNotScheduleMessageUpdate(for state: ZMLinkPreviewState, file: StaticString = #file, line: UInt = #line) {
         self.syncMOC.performGroupedAndWait { _ in
             // Given
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let message = self.insertMessage(with: state)
 
             // When

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
@@ -103,7 +103,7 @@ extension ClientMessageRequestStrategyTests {
 
             // WHEN
             self.syncMOC.saveOrRollback()
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([message])) }
 
             // THEN
@@ -119,7 +119,7 @@ extension ClientMessageRequestStrategyTests {
 
             confirmationMessage = try! self.oneToOneConversation.appendClientMessage(with: GenericMessage(content: Confirmation(messageId: UUID(), type: .delivered)))
             self.syncMOC.saveOrRollback()
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
 
             // WHEN
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
@@ -143,12 +143,12 @@ extension ClientMessageRequestStrategyTests {
             label: .missingLegalholdConsent,
             message: "",
             data: nil)
-        let failure = MessageSendError.networkError(NetworkError.invalidRequestError(missingLegalholdConsentFailure, response))
+        let failure = NetworkError.invalidRequestError(missingLegalholdConsentFailure, response)
         self.syncMOC.performGroupedBlockAndWait {
 
             confirmationMessage = try! self.oneToOneConversation.appendClientMessage(with: GenericMessage(content: Confirmation(messageId: UUID(), type: .delivered)))
             self.syncMOC.saveOrRollback()
-            self.mockMessageSender.sendMessageMessage_MockValue = .failure(failure)
+            self.mockMessageSender.sendMessageMessage_MockError = failure
 
             // WHEN
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategy.swift
@@ -81,10 +81,10 @@ extension DeliveryReceiptRequestStrategy: ZMEventConsumer {
         // Enter groups to enable waiting for message sending to complete in tests
         let groups = managedObjectContext.enterAllGroupsExceptSecondary()
         Task {
-            _ = await messageSender.sendMessage(message: GenericMessageEntity(conversation: deliveryReceipt.conversation,
-                                                                    message: GenericMessage(content: confirmation),
-                                                                    targetRecipients: .users(senderUserSet),
-                                                                    completionHandler: nil))
+            try? await messageSender.sendMessage(message: GenericMessageEntity(conversation: deliveryReceipt.conversation,
+                                                                               message: GenericMessage(content: confirmation),
+                                                                               targetRecipients: .users(senderUserSet),
+                                                                               completionHandler: nil))
             managedObjectContext.leaveAllGroups(groups)
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Delivery Receipts/DeliveryReceiptRequestStrategyTests.swift
@@ -60,7 +60,7 @@ class DeliveryReceiptRequestStrategyTests: MessagingTestBase {
 
     func testThatDeliveryReceiptIsScheduled_WhenProcessingEventWhichNeedsDeliveryReceipt() throws {
         syncMOC.performGroupedAndWait { _ in
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
             let conversationID = self.oneToOneConversation.remoteIdentifier!.transportString()
             let conversationDomain = self.oneToOneConversation.domain!
             let event = self.createTextUpdateEvent(from: self.otherUser, in: self.oneToOneConversation)

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/ResetSessionRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/ResetSessionRequestStrategy.swift
@@ -64,7 +64,9 @@ extension ResetSessionRequestStrategy: KeyPathObjectSyncTranscoder {
                 await managedObjectContext.perform {
                     userClient.resolveDecryptionFailedSystemMessages()
                 }
-            } catch { }
+            } catch {
+                WireLogger.messaging.error("Failed to send reset session message: \(error)")
+            }
 
             await managedObjectContext.perform {
                 completion()

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/ResetSessionRequestStrategyTests.swift
@@ -53,7 +53,7 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
             let conversationID = conversation.remoteIdentifier!.transportString()
             let conversationDomain = conversation.domain!
             otherClient.needsToNotifyOtherUserAboutSessionReset = true
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
 
             // WHEN
             self.sut.contextChangeTrackers.forEach {
@@ -77,7 +77,7 @@ class ResetSessionRequestStrategyTests: MessagingTestBase {
             _ = self.setupOneToOneConversation(with: otherUser)
             otherClient = self.createClient(user: otherUser)
             otherClient.needsToNotifyOtherUserAboutSessionReset = true
-            self.mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+            self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
 
             // WHEN
             self.sut.contextChangeTrackers.forEach {

--- a/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
@@ -87,14 +87,19 @@ public class MockMessageAPI: MessageAPI {
     // MARK: - sendProteusMessage
 
     public var sendProteusMessageMessageConversationID_Invocations: [(message: any ProteusMessage, conversationID: QualifiedID)] = []
-    public var sendProteusMessageMessageConversationID_MockMethod: ((any ProteusMessage, QualifiedID) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError>)?
-    public var sendProteusMessageMessageConversationID_MockValue: Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError>?
+    public var sendProteusMessageMessageConversationID_MockError: Error?
+    public var sendProteusMessageMessageConversationID_MockMethod: ((any ProteusMessage, QualifiedID) async throws -> (Payload.MessageSendingStatus, ZMTransportResponse))?
+    public var sendProteusMessageMessageConversationID_MockValue: (Payload.MessageSendingStatus, ZMTransportResponse)?
 
-    public func sendProteusMessage(message: any ProteusMessage, conversationID: QualifiedID) async -> Swift.Result<(Payload.MessageSendingStatus, ZMTransportResponse), NetworkError> {
+    public func sendProteusMessage(message: any ProteusMessage, conversationID: QualifiedID) async throws -> (Payload.MessageSendingStatus, ZMTransportResponse) {
         sendProteusMessageMessageConversationID_Invocations.append((message: message, conversationID: conversationID))
 
+        if let error = sendProteusMessageMessageConversationID_MockError {
+            throw error
+        }
+
         if let mock = sendProteusMessageMessageConversationID_MockMethod {
-            return await mock(message, conversationID)
+            return try await mock(message, conversationID)
         } else if let mock = sendProteusMessageMessageConversationID_MockValue {
             return mock
         } else {
@@ -113,19 +118,21 @@ public class MockMessageDependencyResolverInterface: MessageDependencyResolverIn
     // MARK: - waitForDependenciesToResolve
 
     public var waitForDependenciesToResolveFor_Invocations: [any SendableMessage] = []
-    public var waitForDependenciesToResolveFor_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageDependencyResolverError>)?
-    public var waitForDependenciesToResolveFor_MockValue: Swift.Result<Void, MessageDependencyResolverError>?
+    public var waitForDependenciesToResolveFor_MockError: Error?
+    public var waitForDependenciesToResolveFor_MockMethod: ((any SendableMessage) async throws -> Void)?
 
-    public func waitForDependenciesToResolve(for message: any SendableMessage) async -> Swift.Result<Void, MessageDependencyResolverError> {
+    public func waitForDependenciesToResolve(for message: any SendableMessage) async throws {
         waitForDependenciesToResolveFor_Invocations.append(message)
 
-        if let mock = waitForDependenciesToResolveFor_MockMethod {
-            return await mock(message)
-        } else if let mock = waitForDependenciesToResolveFor_MockValue {
-            return mock
-        } else {
+        if let error = waitForDependenciesToResolveFor_MockError {
+            throw error
+        }
+
+        guard let mock = waitForDependenciesToResolveFor_MockMethod else {
             fatalError("no mock for `waitForDependenciesToResolveFor`")
         }
+
+        try await mock(message)            
     }
 
 }
@@ -139,19 +146,21 @@ public class MockMessageSenderInterface: MessageSenderInterface {
     // MARK: - sendMessage
 
     public var sendMessageMessage_Invocations: [any SendableMessage] = []
-    public var sendMessageMessage_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageSendError>)?
-    public var sendMessageMessage_MockValue: Swift.Result<Void, MessageSendError>?
+    public var sendMessageMessage_MockError: Error?
+    public var sendMessageMessage_MockMethod: ((any SendableMessage) async throws -> Void)?
 
-    public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
+    public func sendMessage(message: any SendableMessage) async throws {
         sendMessageMessage_Invocations.append(message)
 
-        if let mock = sendMessageMessage_MockMethod {
-            return await mock(message)
-        } else if let mock = sendMessageMessage_MockValue {
-            return mock
-        } else {
+        if let error = sendMessageMessage_MockError {
+            throw error
+        }
+
+        guard let mock = sendMessageMessage_MockMethod else {
             fatalError("no mock for `sendMessageMessage`")
         }
+
+        try await mock(message)            
     }
 
 }
@@ -165,14 +174,19 @@ public class MockPrekeyAPI: PrekeyAPI {
     // MARK: - fetchPrekeys
 
     public var fetchPrekeysFor_Invocations: [Set<QualifiedClientID>] = []
-    public var fetchPrekeysFor_MockMethod: ((Set<QualifiedClientID>) async -> Swift.Result<Payload.PrekeyByQualifiedUserID, NetworkError>)?
-    public var fetchPrekeysFor_MockValue: Swift.Result<Payload.PrekeyByQualifiedUserID, NetworkError>?
+    public var fetchPrekeysFor_MockError: Error?
+    public var fetchPrekeysFor_MockMethod: ((Set<QualifiedClientID>) async throws -> Payload.PrekeyByQualifiedUserID)?
+    public var fetchPrekeysFor_MockValue: Payload.PrekeyByQualifiedUserID?
 
-    public func fetchPrekeys(for clients: Set<QualifiedClientID>) async -> Swift.Result<Payload.PrekeyByQualifiedUserID, NetworkError> {
+    public func fetchPrekeys(for clients: Set<QualifiedClientID>) async throws -> Payload.PrekeyByQualifiedUserID {
         fetchPrekeysFor_Invocations.append(clients)
 
+        if let error = fetchPrekeysFor_MockError {
+            throw error
+        }
+
         if let mock = fetchPrekeysFor_MockMethod {
-            return await mock(clients)
+            return try await mock(clients)
         } else if let mock = fetchPrekeysFor_MockValue {
             return mock
         } else {
@@ -217,19 +231,21 @@ public class MockSessionEstablisherInterface: SessionEstablisherInterface {
     // MARK: - establishSession
 
     public var establishSessionWithApiVersion_Invocations: [(clients: Set<QualifiedClientID>, apiVersion: APIVersion)] = []
-    public var establishSessionWithApiVersion_MockMethod: ((Set<QualifiedClientID>, APIVersion) async -> Swift.Result<Void, SessionEstablisherError>)?
-    public var establishSessionWithApiVersion_MockValue: Swift.Result<Void, SessionEstablisherError>?
+    public var establishSessionWithApiVersion_MockError: Error?
+    public var establishSessionWithApiVersion_MockMethod: ((Set<QualifiedClientID>, APIVersion) async throws -> Void)?
 
-    public func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async -> Swift.Result<Void, SessionEstablisherError> {
+    public func establishSession(with clients: Set<QualifiedClientID>, apiVersion: APIVersion) async throws {
         establishSessionWithApiVersion_Invocations.append((clients: clients, apiVersion: apiVersion))
 
-        if let mock = establishSessionWithApiVersion_MockMethod {
-            return await mock(clients, apiVersion)
-        } else if let mock = establishSessionWithApiVersion_MockValue {
-            return mock
-        } else {
+        if let error = establishSessionWithApiVersion_MockError {
+            throw error
+        }
+
+        guard let mock = establishSessionWithApiVersion_MockMethod else {
             fatalError("no mock for `establishSessionWithApiVersion`")
         }
+
+        try await mock(clients, apiVersion)            
     }
 
 }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -368,12 +368,10 @@ extension CallingRequestStrategy: WireCallCenterTransport {
             }
 
             Task {
-                let result = await self.messageSender.sendMessage(message: message)
-
-                switch result {
-                case .success:
+                do {
+                    try await self.messageSender.sendMessage(message: message)
                     completionHandler(200)
-                case .failure:
+                } catch {
                     completionHandler(400)
                 }
             }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -470,7 +470,6 @@ class CallingRequestStrategyTests: MessagingTest {
         var sentMessage: GenericMessageEntity?
         mockMessageSender.sendMessageMessage_MockMethod = { message in
             sentMessage = message as? GenericMessageEntity
-            return .success(Void())
         }
 
         // When we schedule the targeted message
@@ -535,7 +534,6 @@ class CallingRequestStrategyTests: MessagingTest {
         var sentMessage: GenericMessageEntity?
         mockMessageSender.sendMessageMessage_MockMethod = { message in
             sentMessage = message as? GenericMessageEntity
-            return .success(Void())
         }
 
         // When we schedule the message with no targets
@@ -652,7 +650,6 @@ class CallingRequestStrategyTests: MessagingTest {
         var sentMessage: GenericMessageEntity?
         mockMessageSender.sendMessageMessage_MockMethod = { message in
             sentMessage = message as? GenericMessageEntity
-            return .success(Void())
         }
 
         let mockMLSService = MockMLSService()
@@ -684,7 +681,7 @@ class CallingRequestStrategyTests: MessagingTest {
     }
 
     private func setupMockMessageSyncForMLSSuccessfully() {
-        mockMessageSender.sendMessageMessage_MockValue = .success(Void())
+        mockMessageSender.sendMessageMessage_MockMethod = { _ in }
     }
 }
 

--- a/wire-ios-sync-engine/sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/sourcery/generated/AutoMockable.manual.swift
@@ -31,22 +31,25 @@ public class MockMessageSenderInterface: MessageSenderInterface {
 
     public init() {}
 
+
     // MARK: - sendMessage
 
     public var sendMessageMessage_Invocations: [any SendableMessage] = []
-    public var sendMessageMessage_MockMethod: ((any SendableMessage) async -> Swift.Result<Void, MessageSendError>)?
-    public var sendMessageMessage_MockValue: Swift.Result<Void, MessageSendError>?
+    public var sendMessageMessage_MockError: Error?
+    public var sendMessageMessage_MockMethod: ((any SendableMessage) async throws -> Void)?
 
-    public func sendMessage(message: any SendableMessage) async -> Swift.Result<Void, MessageSendError> {
+    public func sendMessage(message: any SendableMessage) async throws {
         sendMessageMessage_Invocations.append(message)
 
-        if let mock = sendMessageMessage_MockMethod {
-            return await mock(message)
-        } else if let mock = sendMessageMessage_MockValue {
-            return mock
-        } else {
+        if let error = sendMessageMessage_MockError {
+            throw error
+        }
+
+        guard let mock = sendMessageMessage_MockMethod else {
             fatalError("no mock for `sendMessageMessage`")
         }
+
+        try await mock(message)
     }
 
 }

--- a/wire-ios-testing/Source/Public/XCTestCase+Helpers.swift
+++ b/wire-ios-testing/Source/Public/XCTestCase+Helpers.swift
@@ -50,12 +50,15 @@ extension XCTestCase {
     public typealias ThrowingBlock = () throws -> Void
     public typealias EquatableError = Error & Equatable
 
-    public func assertItThrows<T: EquatableError>(error expectedError: T, block: AsyncThrowingBlock) async {
+    public func assertItThrows<T: EquatableError>(error expectedError: T,
+                                                  file: StaticString = #filePath,
+                                                  line: UInt = #line,
+                                                  block: AsyncThrowingBlock) async {
         do {
             try await block()
-            XCTFail("No error was thrown")
+            XCTFail("No error was thrown", file: file, line: line)
         } catch {
-            assertError(error, equals: expectedError)
+            assertError(error, equals: expectedError, file: file, line: line)
         }
     }
 
@@ -65,12 +68,15 @@ extension XCTestCase {
         }
     }
 
-    public func assertError<T: EquatableError>(_ error: Error, equals expectedError: T) {
+    public func assertError<T: EquatableError>(_ error: Error,
+                                               equals expectedError: T,
+                                               file: StaticString = #filePath,
+                                               line: UInt = #line) {
         guard let error = error as? T else {
-            return XCTFail("Unexpected error: \(String(describing: error))")
+            return XCTFail("Unexpected error: \(String(describing: error))", file: file, line: line)
         }
 
-        XCTAssertEqual(error, expectedError)
+        XCTAssertEqual(error, expectedError, file: file, line: line)
     }
 
     public func assertSuccess<Value, Failure>(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Switch to try/catch based error handling as requested by @netbe
- Replace blocking `performAndWait` call with async `perform` as pointed out by @markusfassbender 


### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
