### PR TITLE
fix: build errors in sync engine tests WPB-4920

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
@@ -53,7 +53,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: [otherUser])
+        let classification = sut.classification(with: [otherUser], conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .none)
@@ -74,7 +74,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: [otherUser])
+        let classification = sut.classification(with: [otherUser], conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .none)
@@ -99,7 +99,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: otherUsers)
+        let classification = sut.classification(with: otherUsers, conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .classified)
@@ -126,7 +126,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: otherUsers)
+        let classification = sut.classification(with: otherUsers, conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .notClassified)
@@ -152,7 +152,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: otherUsers)
+        let classification = sut.classification(with: otherUsers, conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .notClassified)
@@ -188,7 +188,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: otherUsers)
+        let classification = sut.classification(with: otherUsers, conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .notClassified)
@@ -224,7 +224,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: otherUsers)
+        let classification = sut.classification(with: otherUsers, conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .classified)
@@ -255,7 +255,7 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
-        let classification = sut.classification(with: otherUsers)
+        let classification = sut.classification(with: otherUsers, conversationDomain: nil)
 
         // then
         XCTAssertEqual(classification, .notClassified)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4920" title="WPB-4920" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4920</a>  [iOS] Crash when sending message in C1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The WireSyncEngine tests currently don't build. This PR fixes it.

### Causes (Optional)

The `conversationDomain` argument is missing for some calls to `classification(with:conversationDomain:)`.

### Solutions

Adds the missing arguments.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
