### PR TITLE
fix: crash during fetchOrAssert on NSObjectContext [WPB-5393]

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+FetchRequest.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+FetchRequest.swift
@@ -27,7 +27,8 @@ public extension NSManagedObjectContext {
             return result
         } catch let error {
             WireLogger.localStorage.error("CoreData: Error in fetching request : \(request),  \(error.localizedDescription)")
-            fatal("Error in fetching \(error.localizedDescription)")
+            assertionFailure("Error in fetching \(error.localizedDescription)")
+            return []
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5393" title="WPB-5393" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5393</a>  [iOS] Crash during fetchOrAssert on NSObjectContext
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We found crashes stack traces in Xcode organizer that crashes the app hard, whenever an object can not be fetched from Core Data

### Solutions

Use `assertionFailure` to crash only in debug over `fatalError` that crashes also in production.

### Testing

#### How to Test

See ticket, unfortunately it does not crash always.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
