### PR TITLE
fix: App crashes when searching for the last message in a conversation - WPB-5398

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -70,7 +70,7 @@ final class CollectionsViewController: UIViewController {
         return sections == .all
     }
 
-    private lazy var textSearchController: TextSearchViewController =  TextSearchViewController(conversation: collection.conversation)
+    private lazy var textSearchController =  TextSearchViewController(conversation: collection.conversation, userSession: userSession)
 
     convenience init(conversation: ZMConversation, userSession: UserSession) {
         let matchImages = CategoryMatch(including: .image, excluding: .GIF)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -70,7 +70,7 @@ final class CollectionsViewController: UIViewController {
         return sections == .all
     }
 
-    private lazy var textSearchController =  TextSearchViewController(conversation: collection.conversation, userSession: userSession)
+    private lazy var textSearchController = TextSearchViewController(conversation: collection.conversation, userSession: userSession)
 
     convenience init(conversation: ZMConversation, userSession: UserSession) {
         let matchImages = CategoryMatch(including: .image, excluding: .GIF)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchResultCell.swift
@@ -38,14 +38,9 @@ final class TextSearchResultCell: UITableViewCell {
         return roundedTextBadge
     }()
 
-    private var userSession: UserSession
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        init(style: UITableViewCell.CellStyle, reuseIdentifier: String?, userSession: UserSession) {
-            self.userSession = userSession
-            super.init(style: style, reuseIdentifier: reuseIdentifier)
-            userImageView.userSession = self.userSession
-
-        userImageView.userSession = userSession
         userImageView.initialsFont = .systemFont(ofSize: 11, weight: .light)
 
         accessibilityIdentifier = "search result cell"
@@ -144,16 +139,15 @@ final class TextSearchResultCell: UITableViewCell {
         resultCountView.updateCollapseConstraints(isCollapsed: false)
     }
 
-    func configure(with newMessage: ZMConversationMessage, queries newQueries: [String]) {
+    func configure(with newMessage: ZMConversationMessage, queries newQueries: [String], userSession: UserSession) {
         message = newMessage
         queries = newQueries
-
+        userImageView.userSession = userSession
         userImageView.user = newMessage.senderUser
         footerView.message = newMessage
-        if let userSession = ZMUserSession.shared() {
-            observerToken = MessageChangeInfo.add(observer: self,
-                                                  for: newMessage,
-                                                  userSession: userSession)
+        if !ProcessInfo.processInfo.isRunningTests {
+            observerToken = userSession.addMessageObserver(self, for: newMessage)
+
         }
 
         updateTextView()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TextSearch/TextSearchViewController.swift
@@ -37,10 +37,13 @@ final class TextSearchViewController: NSObject {
         }
     }
 
+    private let userSession: UserSession
+
     private var searchStartedDate: Date?
 
-    init(conversation: ConversationLike) {
+    init(conversation: ConversationLike, userSession: UserSession) {
         self.conversation = conversation
+        self.userSession = userSession
         super.init()
         loadViews()
     }
@@ -160,7 +163,13 @@ extension TextSearchViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TextSearchResultCell.reuseIdentifier) as! TextSearchResultCell
-        cell.configure(with: results[indexPath.row], queries: searchQuery?.components(separatedBy: .whitespacesAndNewlines) ?? [])
+        cell.configure(
+            with: results[indexPath.row],
+            queries: searchQuery?.components(
+                separatedBy: .whitespacesAndNewlines
+            ) ?? [],
+            userSession: userSession
+        )
         return cell
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5398" title="WPB-5398" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5398</a>  [iOS] App crashes when searching for the last message in a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When it comes to cells we should avoid passing the userSession into the initializer or anything else. Instead, we should use a configure method such as we do in the case of `TextSearchResultCell`. That was the source of the crash. With the changes in this PR, the crash has been fixed. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
