### PR TITLE
fix: same name of github action job

### DIFF
--- a/.github/workflows/public_app_release.yml
+++ b/.github/workflows/public_app_release.yml
@@ -6,7 +6,7 @@ permissions:
   checks: write
 
 jobs:
-  development:
+  public_app_release:
     uses: ./.github/workflows/_reusable_app_release.yml
     with:
       fastlane_action: appstore_public

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  trigger_tests:
+  trigger_tests_develop:
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:
       all: true

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -70,7 +70,7 @@ jobs:
             carthage:
               - 'Cartfile.resolved'
 
-  trigger_tests:
+  trigger_tests_pr:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.any == 'true' }}
     uses: ./.github/workflows/_reusable_run_tests.yml


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometime Github is stuck on required checks. 

### Causes (Optional)

It could be because we have same name of job in our actions.

### Solutions

Use unique names

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
