### PR TITLE
refactor(message-sending): add support for sending MLS messages #8

### DIFF
--- a/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
@@ -64,7 +64,7 @@ class MessageAPIV0: MessageAPI {
     ) async throws -> (Payload.MessageSendingStatus, ZMTransportResponse) {
         let path = "/" + ["conversations", conversationID.uuid.transportString(), "otr", "messages"].joined(separator: "/")
 
-        // FIXME: [jacob] move encryption out of the API
+        // FIXME: [jacob] move encryption out of the API WPB-5499
         guard let encryptedPayload = await message.context.perform({
             message.encryptForTransport()
         }) else {

--- a/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
@@ -23,6 +23,8 @@ public protocol MessageAPI {
 
     func sendProteusMessage(message: any ProteusMessage, conversationID: QualifiedID) async throws -> (Payload.MessageSendingStatus, ZMTransportResponse)
 
+    func sendMLSMessage(message encryptedMessage: Data, conversationID: QualifiedID, expirationDate: Date?) async throws -> (Payload.MLSMessageSendingStatus, ZMTransportResponse)
+
 }
 
 extension Payload.ClientListByUserID {
@@ -62,8 +64,9 @@ class MessageAPIV0: MessageAPI {
     ) async throws -> (Payload.MessageSendingStatus, ZMTransportResponse) {
         let path = "/" + ["conversations", conversationID.uuid.transportString(), "otr", "messages"].joined(separator: "/")
 
+        // FIXME: [jacob] move encryption out of the API
         guard let encryptedPayload = await message.context.perform({
-            message.encryptForTransportQualified()
+            message.encryptForTransport()
         }) else {
             WireLogger.messaging.error("failed to encrypt message for transport")
             throw NetworkError.errorEncodingRequest
@@ -97,6 +100,10 @@ class MessageAPIV0: MessageAPI {
             let payload: Payload.MessageSendingStatusV0 = try mapResponse(response)
             return (payload.toMessageSendingStatus(domain: ""), response)
         }
+    }
+
+    func sendMLSMessage(message encryptedMessage: Data, conversationID: QualifiedID, expirationDate: Date?) async throws -> (Payload.MLSMessageSendingStatus, ZMTransportResponse) {
+        throw NetworkError.endpointNotAvailable
     }
 }
 
@@ -191,5 +198,26 @@ class MessageAPIV4: MessageAPIV3 {
 class MessageAPIV5: MessageAPIV4 {
     override var apiVersion: APIVersion {
         .v5
+    }
+
+    override func sendMLSMessage(message encryptedMessage: Data, conversationID: QualifiedID, expirationDate: Date?) async throws -> (Payload.MLSMessageSendingStatus, ZMTransportResponse) {
+
+        let request = ZMTransportRequest(
+            path: "/mls/messages",
+            method: .methodPOST,
+            binaryData: encryptedMessage,
+            type: "message/mls",
+            contentDisposition: nil,
+            apiVersion: apiVersion.rawValue
+        )
+
+        if let expirationDate {
+            request.expire(at: expirationDate)
+        }
+
+        let response = await httpClient.send(request)
+        let payload: Payload.MLSMessageSendingStatus = try mapResponse(response)
+
+        return (payload, response)
     }
 }

--- a/wire-ios-request-strategy/Sources/APIs/NetworkError.swift
+++ b/wire-ios-request-strategy/Sources/APIs/NetworkError.swift
@@ -22,6 +22,7 @@ public enum NetworkError: Error, Equatable {
 
     case errorEncodingRequest
     case errorDecodingResponse(ZMTransportResponse)
+    case endpointNotAvailable
     case missingClients(Payload.MessageSendingStatus, ZMTransportResponse)
     case invalidRequestError(Payload.ResponseFailure, ZMTransportResponse)
 
@@ -43,6 +44,8 @@ public enum NetworkError: Error, Equatable {
     var response: ZMTransportResponse? {
         return switch self {
         case .errorEncodingRequest:
+            nil
+        case .endpointNotAvailable:
             nil
         case .errorDecodingResponse(let response):
             response

--- a/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/SessionEstablisher.swift
@@ -36,11 +36,11 @@ public class SessionEstablisher: SessionEstablisherInterface {
     ) {
         self.processor = processor
         self.apiProvider = apiProvider
-        self.managedObjectContext = context
+        self.context = context
     }
 
     private let apiProvider: APIProviderInterface
-    private let managedObjectContext: NSManagedObjectContext
+    private let context: NSManagedObjectContext
     private let requestFactory = MissingClientsRequestFactory()
     private let processor: PrekeyPayloadProcessorInterface
     private let batchSize = 28
@@ -53,16 +53,16 @@ public class SessionEstablisher: SessionEstablisherInterface {
     }
 
     private func internalEstablishSessions(for clients: Set<QualifiedClientID>, apiVersion: APIVersion) async throws {
-        guard let selfClient = await managedObjectContext.perform({
-            ZMUser.selfUser(in: self.managedObjectContext).selfClient()
+        guard let selfClient = await context.perform({
+            ZMUser.selfUser(in: self.context).selfClient()
         }) else {
             throw SessionEstablisherError.missingSelfClient
         }
 
         let prekeys = try await apiProvider.prekeyAPI(apiVersion: apiVersion).fetchPrekeys(for: clients)
 
-        await managedObjectContext.perform {
-            _ = self.processor.establishSessions(from: prekeys, with: selfClient, context: self.managedObjectContext)
+        await context.perform {
+            _ = self.processor.establishSessions(from: prekeys, with: selfClient, context: self.context)
         }
     }
 }

--- a/wire-ios-request-strategy/Sources/Payloads/Payload.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload.swift
@@ -397,12 +397,18 @@ public enum Payload {
         let failedToConfirm: ClientListByQualifiedUserID
     }
 
-    struct MLSMessageSendingStatus: Codable {
+    public struct MLSMessageSendingStatus: Codable {
 
         enum CodingKeys: String, CodingKey {
             case time
             case events
             case failedToSend = "failed_to_send"
+        }
+
+        public init(time: Date, events: [Data], failedToSend: [QualifiedID]?) {
+            self.time = time
+            self.events = events
+            self.failedToSend = failedToSend
         }
 
         /// Time of sending message.

--- a/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
@@ -107,6 +107,29 @@ public class MockMessageAPI: MessageAPI {
         }
     }
 
+    // MARK: - sendMLSMessage
+
+    public var sendMLSMessageMessageConversationIDExpirationDate_Invocations: [(encryptedMessage: Data, conversationID: QualifiedID, expirationDate: Date?)] = []
+    public var sendMLSMessageMessageConversationIDExpirationDate_MockError: Error?
+    public var sendMLSMessageMessageConversationIDExpirationDate_MockMethod: ((Data, QualifiedID, Date?) async throws -> (Payload.MLSMessageSendingStatus, ZMTransportResponse))?
+    public var sendMLSMessageMessageConversationIDExpirationDate_MockValue: (Payload.MLSMessageSendingStatus, ZMTransportResponse)?
+
+    public func sendMLSMessage(message encryptedMessage: Data, conversationID: QualifiedID, expirationDate: Date?) async throws -> (Payload.MLSMessageSendingStatus, ZMTransportResponse) {
+        sendMLSMessageMessageConversationIDExpirationDate_Invocations.append((encryptedMessage: encryptedMessage, conversationID: conversationID, expirationDate: expirationDate))
+
+        if let error = sendMLSMessageMessageConversationIDExpirationDate_MockError {
+            throw error
+        }
+
+        if let mock = sendMLSMessageMessageConversationIDExpirationDate_MockMethod {
+            return try await mock(encryptedMessage, conversationID, expirationDate)
+        } else if let mock = sendMLSMessageMessageConversationIDExpirationDate_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `sendMLSMessageMessageConversationIDExpirationDate`")
+        }
+    }
+
 }
 public class MockMessageDependencyResolverInterface: MessageDependencyResolverInterface {
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add support for sending MLS messages, this deprecates the `MLSMessageSync` which will be removed later.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
