### PR TITLE
refactor(message-sending): wait for session to be online before sending a message #9

### DIFF
--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -510,7 +510,6 @@
 		EE3EFE95253053B1009499E5 /* PotentialChangeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */; };
 		EE3EFE9725305A84009499E5 /* ModifiedObjects+Mergeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */; };
 		EE3EFEA1253090E0009499E5 /* PotentialChangeDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3EFEA0253090E0009499E5 /* PotentialChangeDetectorTests.swift */; };
-		EE403ECA28D357AD00F78A36 /* ZMBaseTest+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE403EC928D357AD00F78A36 /* ZMBaseTest+Async.swift */; };
 		EE428C4E29F01E4800ECB715 /* EARServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE428C4D29F01E4800ECB715 /* EARServiceTests.swift */; };
 		EE428C5029F1247400ECB715 /* EARKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE428C4F29F1247400ECB715 /* EARKeyGenerator.swift */; };
 		EE428C5229F1533000ECB715 /* EARKeyEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE428C5129F1533000ECB715 /* EARKeyEncryptor.swift */; };
@@ -1414,7 +1413,6 @@
 		EE3EFE94253053B1009499E5 /* PotentialChangeDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetector.swift; sourceTree = "<group>"; };
 		EE3EFE9625305A84009499E5 /* ModifiedObjects+Mergeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModifiedObjects+Mergeable.swift"; sourceTree = "<group>"; };
 		EE3EFEA0253090E0009499E5 /* PotentialChangeDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotentialChangeDetectorTests.swift; sourceTree = "<group>"; };
-		EE403EC928D357AD00F78A36 /* ZMBaseTest+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMBaseTest+Async.swift"; sourceTree = "<group>"; };
 		EE428C4D29F01E4800ECB715 /* EARServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EARServiceTests.swift; path = Tests/Source/EAR/EARServiceTests.swift; sourceTree = SOURCE_ROOT; };
 		EE428C4F29F1247400ECB715 /* EARKeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARKeyGenerator.swift; sourceTree = "<group>"; };
 		EE428C5129F1533000ECB715 /* EARKeyEncryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARKeyEncryptor.swift; sourceTree = "<group>"; };
@@ -2887,7 +2885,6 @@
 				16E70F97270F1F5700718E5D /* ZMConnection+Helper.h */,
 				16E70FA6270F212000718E5D /* ZMConnection+Helper.m */,
 				169FF3A427157B3800330C2E /* MockActionHandler.swift */,
-				EE403EC928D357AD00F78A36 /* ZMBaseTest+Async.swift */,
 			);
 			name = Helper;
 			path = Tests/Source/Helper;
@@ -4123,7 +4120,6 @@
 				EEC3BC742888403000BFDC35 /* MockCoreCrypto.swift in Sources */,
 				CEE525AA1CCA4C97001D06F9 /* NSString+RandomString.m in Sources */,
 				165E141825CC516B00F0B075 /* ZMClientMessageTests+Prefetching.swift in Sources */,
-				EE403ECA28D357AD00F78A36 /* ZMBaseTest+Async.swift in Sources */,
 				A9FA524A23A1598B003AD4C6 /* ActionTests.swift in Sources */,
 				0191513A29ACB3CA00920D04 /* SpyUserClientKeyStore.swift in Sources */,
 				16E7DA2A1FDABE440065B6A6 /* ZMOTRMessage+SelfConversationUpdateTests.swift in Sources */,

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolverTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageDependencyResolverTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 final class MessageDependencyResolverTests: MessagingTestBase {
 
-    func testThatGivenMessageWithoutDependencies_thenDontWait() async throws {
+    func testThatGivenMessageWithoutDependencies_thenDontWait() throws {
         // given
         let message = GenericMessageEntity(
             conversation: groupConversation,
@@ -29,13 +29,13 @@ final class MessageDependencyResolverTests: MessagingTestBase {
         let (_, messageDependencyResolver) = Arrangement(coreDataStack: coreDataStack)
             .arrange()
 
-        // when
-        try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
-
         // then test completes
+        wait(timeout: 0.5) {
+            try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+        }
     }
 
-    func testThatGivenMessageWithDependencies_thenWaitUntilDependencyIsResolved() async throws {
+    func testThatGivenMessageWithDependencies_thenWaitUntilDependencyIsResolved() throws {
         // given
         syncMOC.performAndWait {
             // make conversatio sync a dependency
@@ -59,10 +59,10 @@ final class MessageDependencyResolverTests: MessagingTestBase {
             RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         }
 
-        // when
-        try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
-
         // then test completes
+        wait(timeout: 0.5) {
+            try await messageDependencyResolver.waitForDependenciesToResolve(for: message)
+        }
     }
 
     struct Arrangement {

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -70,13 +70,15 @@ public class MessageSender: MessageSenderInterface {
         clientRegistrationDelegate: ClientRegistrationDelegate,
         sessionEstablisher: SessionEstablisherInterface,
         messageDependencyResolver: MessageDependencyResolverInterface,
+        quickSyncObserver: QuickSyncObserverInterface,
         context: NSManagedObjectContext
     ) {
         self.apiProvider = apiProvider
         self.clientRegistrationDelegate = clientRegistrationDelegate
         self.sessionEstablisher = sessionEstablisher
-        self.context = context
         self.messageDependencyResolver = messageDependencyResolver
+        self.quickSyncObserver = quickSyncObserver
+        self.context = context
     }
 
     private let apiProvider: APIProviderInterface
@@ -84,13 +86,14 @@ public class MessageSender: MessageSenderInterface {
     private let clientRegistrationDelegate: ClientRegistrationDelegate
     private let sessionEstablisher: SessionEstablisherInterface
     private let messageDependencyResolver: MessageDependencyResolverInterface
+    private let quickSyncObserver: QuickSyncObserverInterface
     private let proteusPayloadProcessor = MessageSendingStatusPayloadProcessor()
     private let mlsPayloadProcessor = MLSMessageSendingStatusPayloadProcessor()
 
     public func sendMessage(message: any SendableMessage) async throws {
         WireLogger.messaging.debug("send message")
 
-        // TODO: [jacob] we need to wait until we are "online"
+        await quickSyncObserver.waitForQuickSyncToFinish()
 
         do {
             try await messageDependencyResolver.waitForDependenciesToResolve(for: message)

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -34,6 +34,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .failure(.securityLevelDegraded))
             .arrange()
 
@@ -51,6 +52,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: nil)
             .arrange()
@@ -62,6 +64,26 @@ final class MessageSenderTests: MessagingTestBase {
         XCTAssertEqual(1, arrangement.messageDependencyResolver.waitForDependenciesToResolveFor_Invocations.count)
     }
 
+    func testThatBeforeSendingMessage_thenWaitForQuickSyncToFinish() async throws {
+        // given
+        let message = GenericMessageEntity(
+            conversation: groupConversation,
+            message: GenericMessage(content: Text(content: "Hello World")),
+            completionHandler: nil)
+
+        let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(Void()))
+            .withApiVersionResolving(to: nil)
+            .arrange()
+
+        // when
+        try? await messageSender.sendMessage(message: message)
+
+        // then
+        XCTAssertEqual(1, arrangement.quickSyncObserver.waitForQuickSyncToFinish_Invocations.count)
+    }
+
     func testThatWhenApiVersionIsNotResolved_thenFailWithUnresolvedApiVersion() async throws {
         // given
         let message = GenericMessageEntity(
@@ -70,6 +92,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: nil)
             .arrange()
@@ -98,6 +121,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessage(returning: .success((messageSendingStatus, response)))
@@ -118,6 +142,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: NetworkError.missingClients(
@@ -144,6 +169,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: NetworkError.errorDecodingResponse(response))
@@ -167,6 +193,7 @@ final class MessageSenderTests: MessagingTestBase {
         message.isExpired = true
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: NetworkError.errorDecodingResponse(response))
@@ -188,6 +215,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: networkError)
@@ -220,6 +248,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: networkError)
@@ -255,6 +284,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v0)
             .withSendProteusMessageFailing(with: networkError)
@@ -288,6 +318,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v5)
             .withMLServiceConfigured()
@@ -319,6 +350,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v5)
             .withMLServiceConfigured()
@@ -346,6 +378,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v5)
             .withMLServiceConfigured()
@@ -370,6 +403,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v5)
             .arrange()
@@ -391,6 +425,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil)
 
         let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withQuickSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(Void()))
             .withApiVersionResolving(to: .v5)
             .withMLServiceConfigured()
@@ -433,6 +468,7 @@ final class MessageSenderTests: MessagingTestBase {
         let clientRegistrationDelegate = MockClientRegistrationStatus()
         let sessionEstablisher = MockSessionEstablisherInterface()
         let messageDependencyResolver = MockMessageDependencyResolverInterface()
+        let quickSyncObserver = MockQuickSyncObserverInterface()
         let mlsService = MockMLSService()
         let coreDataStack: CoreDataStack
 
@@ -444,6 +480,11 @@ final class MessageSenderTests: MessagingTestBase {
 
         func withApiVersionResolving(to apiVersion: APIVersion?) -> Arrangement {
             BackendInfo.apiVersion = apiVersion
+            return self
+        }
+
+        func withQuickSyncObserverCompleting() -> Arrangement {
+            quickSyncObserver.waitForQuickSyncToFinish_MockMethod = { }
             return self
         }
 
@@ -512,6 +553,7 @@ final class MessageSenderTests: MessagingTestBase {
                 clientRegistrationDelegate: clientRegistrationDelegate,
                 sessionEstablisher: sessionEstablisher,
                 messageDependencyResolver: messageDependencyResolver,
+                quickSyncObserver: quickSyncObserver,
                 context: coreDataStack.syncContext)
             )
         }

--- a/wire-ios-request-strategy/Sources/Synchronization/QuickSyncCompletedNotification.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/QuickSyncCompletedNotification.swift
@@ -1,6 +1,6 @@
-//
+////
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,22 +18,6 @@
 
 import Foundation
 
-extension ZMTBaseTest {
-
-    func wait(timeout: TimeInterval = 0.5, forAsyncBlock block: @escaping () async throws -> Void) {
-        let expectation = self.expectation(description: "isDone")
-
-        Task {
-            do {
-                try await block()
-            } catch {
-                XCTFail("test failed: \(String(describing: error))")
-            }
-
-            expectation.fulfill()
-        }
-
-        XCTAssert(waitForCustomExpectations(withTimeout: timeout))
-    }
-
+public extension NSNotification.Name {
+    static let quickSyncCompletedNotification = NSNotification.Name(rawValue: "QuickSyncCompletedNotification")
 }

--- a/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserver.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserver.swift
@@ -36,31 +36,21 @@ public class QuickSyncObserver: QuickSyncObserverInterface {
     }
 
     public func waitForQuickSyncToFinish() async {
-        @Sendable func quickHasCompleted() async -> Bool {
+        func quickSyncHasCompleted() async -> Bool {
             await context.perform {
                 return self.applicationStatus.synchronizationState == .online
             }
         }
 
-        if await quickHasCompleted() {
+        if await quickSyncHasCompleted() {
             return
         }
 
-        return await withCheckedContinuation { continuation in
-            Task {
-                if await quickHasCompleted() {
-                    continuation.resume()
-                    return
-                }
-
-                for await _ in NotificationCenter.default.notifications(
-                    named: .quickSyncCompletedNotification,
-                    object: notificationContext
-                ) {
-                    continuation.resume()
-                    break
-                }
-            }
+        for await _ in NotificationCenter.default.notifications(
+            named: .quickSyncCompletedNotification,
+            object: notificationContext
+        ) {
+            break
         }
     }
 }

--- a/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserver.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserver.swift
@@ -1,0 +1,66 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+// sourcery: AutoMockable
+public protocol QuickSyncObserverInterface {
+    func waitForQuickSyncToFinish() async
+}
+
+public class QuickSyncObserver: QuickSyncObserverInterface {
+
+    let context: NSManagedObjectContext
+    let applicationStatus: ApplicationStatus
+    let notificationContext: NotificationContext
+
+    public init(context: NSManagedObjectContext, applicationStatus: ApplicationStatus, notificationContext: NotificationContext) {
+        self.context = context
+        self.applicationStatus = applicationStatus
+        self.notificationContext = notificationContext
+    }
+
+    public func waitForQuickSyncToFinish() async {
+        @Sendable func quickHasCompleted() async -> Bool {
+            await context.perform {
+                return self.applicationStatus.synchronizationState == .online
+            }
+        }
+
+        if await quickHasCompleted() {
+            return
+        }
+
+        return await withCheckedContinuation { continuation in
+            Task {
+                if await quickHasCompleted() {
+                    continuation.resume()
+                    return
+                }
+
+                for await _ in NotificationCenter.default.notifications(
+                    named: .quickSyncCompletedNotification,
+                    object: notificationContext
+                ) {
+                    continuation.resume()
+                    break
+                }
+            }
+        }
+    }
+}

--- a/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserverTests.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserverTests.swift
@@ -39,6 +39,7 @@ final class QuickSyncObserverTests: MessagingTestBase {
             .arrange()
 
         Task {
+            // Sleeping in order to hit the code path where we start observing .quickSyncCompletedNotification
             try await Task.sleep(nanoseconds: 250_000_000)
             NotificationInContext(name: .quickSyncCompletedNotification, context: syncMOC.notificationContext).post()
         }

--- a/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserverTests.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/QuickSyncObserverTests.swift
@@ -1,0 +1,75 @@
+////
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+final class QuickSyncObserverTests: MessagingTestBase {
+
+    func testThatSynchronisationStateIsOnline_thenDontWait() async {
+        // given
+        let (_, quickSyncObserver) = Arrangement(coreDataStack: coreDataStack)
+            .withSynchronizationState(.online)
+            .arrange()
+
+        // then test completes
+        wait(timeout: 0.5) {
+            await quickSyncObserver.waitForQuickSyncToFinish()
+        }
+    }
+
+    func testThatSynchronisationStateIsNotOnline_thenWaitUntilQuickSyncCompletes() throws {
+        // given
+        let (_, quickSyncObserver) = Arrangement(coreDataStack: coreDataStack)
+            .withSynchronizationState(.quickSyncing)
+            .arrange()
+
+        Task {
+            try await Task.sleep(nanoseconds: 250_000_000)
+            NotificationInContext(name: .quickSyncCompletedNotification, context: syncMOC.notificationContext).post()
+        }
+
+        // then test completes
+        wait(timeout: 0.5) {
+            await quickSyncObserver.waitForQuickSyncToFinish()
+        }
+    }
+
+    struct Arrangement {
+
+        struct Scaffolding {
+        }
+
+        let coreDataStack: CoreDataStack
+        let applicationStatus = MockApplicationStatus()
+
+        func withSynchronizationState(_ state: SynchronizationState) -> Arrangement {
+            applicationStatus.mockSynchronizationState = state
+            return self
+        }
+
+        func arrange() -> (Arrangement, QuickSyncObserver) {
+            return (self, QuickSyncObserver(
+                context: coreDataStack.syncContext,
+                applicationStatus: applicationStatus,
+                notificationContext: coreDataStack.syncContext.notificationContext
+                )
+            )
+        }
+    }
+
+}

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -168,6 +168,9 @@
 		16BBA1F22AF2678200CDF38A /* SessionEstablisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1F12AF2678200CDF38A /* SessionEstablisherTests.swift */; };
 		16BBA1F42AF3952300CDF38A /* MessageSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1F32AF3952300CDF38A /* MessageSenderTests.swift */; };
 		16BBA1F62AF3D41200CDF38A /* MessageDependencyResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1F52AF3D41200CDF38A /* MessageDependencyResolverTests.swift */; };
+		16BBA1F82AFC36DF00CDF38A /* QuickSyncCompletedNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1F72AFC36DF00CDF38A /* QuickSyncCompletedNotification.swift */; };
+		16BBA1FA2AFC3BAB00CDF38A /* QuickSyncObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1F92AFC3BAB00CDF38A /* QuickSyncObserver.swift */; };
+		16BBA1FC2AFC44B100CDF38A /* QuickSyncObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1FB2AFC44B100CDF38A /* QuickSyncObserverTests.swift */; };
 		16CC0833268DC32D00C0613C /* LinkPreviewUpdateRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CC0832268DC32D00C0613C /* LinkPreviewUpdateRequestStrategyTests.swift */; };
 		16CC083B268E075100C0613C /* ClientMessageRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CC083A268E075100C0613C /* ClientMessageRequestStrategyTests.swift */; };
 		16D0E07F1DF88B430075DF8F /* EntityTranscoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D0E07E1DF88B430075DF8F /* EntityTranscoder.swift */; };
@@ -621,6 +624,9 @@
 		16BBA1F12AF2678200CDF38A /* SessionEstablisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEstablisherTests.swift; sourceTree = "<group>"; };
 		16BBA1F32AF3952300CDF38A /* MessageSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageSenderTests.swift; sourceTree = "<group>"; };
 		16BBA1F52AF3D41200CDF38A /* MessageDependencyResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageDependencyResolverTests.swift; sourceTree = "<group>"; };
+		16BBA1F72AFC36DF00CDF38A /* QuickSyncCompletedNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSyncCompletedNotification.swift; sourceTree = "<group>"; };
+		16BBA1F92AFC3BAB00CDF38A /* QuickSyncObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSyncObserver.swift; sourceTree = "<group>"; };
+		16BBA1FB2AFC44B100CDF38A /* QuickSyncObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSyncObserverTests.swift; sourceTree = "<group>"; };
 		16CC0832268DC32D00C0613C /* LinkPreviewUpdateRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPreviewUpdateRequestStrategyTests.swift; sourceTree = "<group>"; };
 		16CC083A268E075100C0613C /* ClientMessageRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientMessageRequestStrategyTests.swift; sourceTree = "<group>"; };
 		16D0E07C1DF872FD0075DF8F /* DependencyEntitySyncTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DependencyEntitySyncTests.swift; sourceTree = "<group>"; };
@@ -867,6 +873,9 @@
 			isa = PBXGroup;
 			children = (
 				06474D4924AF683E002C695D /* Decoding */,
+				16BBA1F72AFC36DF00CDF38A /* QuickSyncCompletedNotification.swift */,
+				16BBA1F92AFC3BAB00CDF38A /* QuickSyncObserver.swift */,
+				16BBA1FB2AFC44B100CDF38A /* QuickSyncObserverTests.swift */,
 			);
 			path = Synchronization;
 			sourceTree = "<group>";
@@ -1998,6 +2007,7 @@
 				16A4893F268B0C82001F9127 /* ClientMessageRequestStrategy.swift in Sources */,
 				F18401BD2073BE0800E9F4CC /* LinkPreviewAssetUploadRequestStrategy.swift in Sources */,
 				F18401AA2073BE0800E9F4CC /* FetchingClientRequestStrategy.swift in Sources */,
+				16BBA1FA2AFC3BAB00CDF38A /* QuickSyncObserver.swift in Sources */,
 				06A9FDD228B36FF500B3C730 /* UpdateAccessRolesAction.swift in Sources */,
 				63CC83B12859D488008549AD /* ClaimMLSKeyPackageActionHandler.swift in Sources */,
 				EE4C5FBE27D2C5CD000C0D45 /* BundledMessageNotificationBuilder.swift in Sources */,
@@ -2105,6 +2115,7 @@
 				06A9FDD428B3701000B3C730 /* UpdateAccessRolesActionHandler.swift in Sources */,
 				EE90C2AC282EA1D200474379 /* GetPushTokensAction.swift in Sources */,
 				F18401B02073BE0800E9F4CC /* AbstractRequestStrategy.swift in Sources */,
+				16BBA1F82AFC36DF00CDF38A /* QuickSyncCompletedNotification.swift in Sources */,
 				0649D14F24F63DCC001DDC78 /* ZMSound.swift in Sources */,
 				F18401C22073BE0800E9F4CC /* AssetV2DownloadRequestStrategy.swift in Sources */,
 				EEAC16D4281AE5F700B7A34D /* CallEventContent.swift in Sources */,
@@ -2283,6 +2294,7 @@
 				F18401E72073C26200E9F4CC /* MissingClientsRequestStrategyTests.swift in Sources */,
 				1621D2671D75C776007108C2 /* ZMRemoteIdentifierObjectSyncTests.m in Sources */,
 				1621D26A1D75C782007108C2 /* ZMTimedSingleRequestSyncTests.m in Sources */,
+				16BBA1FC2AFC44B100CDF38A /* QuickSyncObserverTests.swift in Sources */,
 				16751EBB24D1BDA00099AE09 /* DeliveryReceiptRequestStrategyTests.swift in Sources */,
 				16CC0833268DC32D00C0613C /* LinkPreviewUpdateRequestStrategyTests.swift in Sources */,
 				167BCBC426087F8900E9D7E3 /* ZMTBaseTests+CoreDataStack.swift in Sources */,

--- a/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
@@ -244,6 +244,28 @@ public class MockPrekeyPayloadProcessorInterface: PrekeyPayloadProcessorInterfac
     }
 
 }
+class MockQuickSyncObserverInterface: QuickSyncObserverInterface {
+
+    // MARK: - Life cycle
+
+
+
+    // MARK: - waitForQuickSyncToFinish
+
+    var waitForQuickSyncToFinish_Invocations: [Void] = []
+    var waitForQuickSyncToFinish_MockMethod: (() async -> Void)?
+
+    func waitForQuickSyncToFinish() async {
+        waitForQuickSyncToFinish_Invocations.append(())
+
+        guard let mock = waitForQuickSyncToFinish_MockMethod else {
+            fatalError("no mock for `waitForQuickSyncToFinish`")
+        }
+
+        await mock()            
+    }
+
+}
 public class MockSessionEstablisherInterface: SessionEstablisherInterface {
 
     // MARK: - Life cycle

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -106,11 +106,15 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             context: syncMOC,
             apiProvider: apiProvider)
         let messageDependencyResolver = MessageDependencyResolver(context: syncMOC)
+        let quickSyncObserver = QuickSyncObserver(context: syncMOC,
+                                                  applicationStatus: applicationStatusDirectory,
+                                                  notificationContext: syncMOC.notificationContext)
         let messageSender = MessageSender(
             apiProvider: apiProvider,
             clientRegistrationDelegate: applicationStatusDirectory.clientRegistrationStatus,
             sessionEstablisher: sessionEstablisher,
             messageDependencyResolver: messageDependencyResolver,
+            quickSyncObserver: quickSyncObserver,
             context: syncMOC)
         let strategies: [Any] = [
             // TODO: [John] use flag here

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -635,6 +635,11 @@ extension ZMUserSession: ZMSyncStateDelegate {
             self?.notifyThirdPartyServices()
         }
 
+        NotificationInContext(
+            name: .quickSyncCompletedNotification,
+            context: syncContext.notificationContext
+        ).post()
+
         commitPendingProposalsIfNeeded()
         fetchFeatureConfigs()
         recurringActionService.performActionsIfNeeded()

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -27,4 +27,23 @@ extension ZMTBaseTest {
         }
     }
 
+    public func wait(timeout: TimeInterval = 0.5,
+                     file: StaticString = #filePath,
+                     line: UInt = #line,
+                     forAsyncBlock block: @escaping () async throws -> Void) {
+        let expectation = self.expectation(description: "isDone")
+
+        Task {
+            do {
+                try await block()
+            } catch {
+                XCTFail("test failed: \(String(describing: error))", file: file, line: line)
+            }
+
+            expectation.fulfill()
+        }
+
+        XCTAssert(waitForCustomExpectations(withTimeout: timeout), file: file, line: line)
+    }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We always want be sure that we've decrypting all incoming messages before send any outgoing message so the message sender should wait for the synchronisation state to reach `.online` before attempting to send any messages.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
