### PR TITLE
fix: Method should not be called on the main thread as it may lead to UI Unresponsiveness

### DIFF
--- a/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
@@ -76,14 +76,14 @@ final class MessagePresenterTests: XCTestCase {
 
     // MARK: - Pass
 
-    func testThatCreateAddPassesViewControllerThrowsAnErrorForFileMessage() async throws {
+    func testThatMakePassesViewControllerThrowsErrorForInvalidFileURL() async throws {
         // GIVEN
-        let message = MockMessageFactory.fileTransferMessage()
-        let fileMessageData = try XCTUnwrap(message.fileMessageData)
+        let message = MockMessageFactory.passFileTransferMessage()
+        let fileURL = try XCTUnwrap(URL(string: "https://apple.com"))
 
         // WHEN && THEN
         do {
-            _ = try await sut.makePassesViewController(fileMessageData: fileMessageData)
+            _ = try await sut.makePassesViewController(fileURL: fileURL)
             XCTFail("expected to throw an error!")
         } catch {
             // success
@@ -93,13 +93,13 @@ final class MessagePresenterTests: XCTestCase {
     func testThatCreateAddPassesViewControllerReturnsAViewControllerForPassFileMessage() async throws {
         // GIVEN
         let message = MockMessageFactory.passFileTransferMessage()
-        let fileMessageData = try XCTUnwrap(message.fileMessageData)
+        let fileURL = try XCTUnwrap(message.fileMessageData?.fileURL)
 
-        // WHEN
-        let viewController = try await sut.makePassesViewController(fileMessageData: fileMessageData)
-
-        // THEN
-        XCTAssertNotNil(viewController)
+        // WHEN && THEN
+        do {
+            _ = try await sut.makePassesViewController(fileURL: fileURL)
+        } catch {
+            XCTFail("expected not to throw an error!")
+        }
     }
-
 }

--- a/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
@@ -76,7 +76,7 @@ final class MessagePresenterTests: XCTestCase {
 
     // MARK: - Pass
 
-    func testThatCreateAddPassesViewControllerReturnsNilForFileMessage() async throws {
+    func testThatCreateAddPassesViewControllerThrowsAnErrorForFileMessage() async throws {
         // GIVEN
         let message = MockMessageFactory.fileTransferMessage()
         let fileMessageData = try XCTUnwrap(message.fileMessageData)

--- a/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
@@ -93,7 +93,6 @@ final class MessagePresenterTests: XCTestCase {
         XCTAssertNil(addPassesViewControllerResult)
     }
 
-
     func testThatCreateAddPassesViewControllerReturnsAViewControllerForPassFileMessage() {
         // GIVEN
         let message = MockMessageFactory.passFileTransferMessage()

--- a/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
@@ -76,43 +76,30 @@ final class MessagePresenterTests: XCTestCase {
 
     // MARK: - Pass
 
-    func testThatCreateAddPassesViewControllerReturnsNilForFileMessage() {
+    func testThatCreateAddPassesViewControllerReturnsNilForFileMessage() async throws {
         // GIVEN
         let message = MockMessageFactory.fileTransferMessage()
-        let expectation = self.expectation(description: "Load pass data and create addPassesViewController")
+        let fileMessageData = try XCTUnwrap(message.fileMessageData)
 
-        // WHEN
-        var addPassesViewControllerResult: PKAddPassesViewController?
-        sut.loadPassDataAndCreateAddPassesViewController(fileMessageData: message.fileMessageData!) { addPassesViewController in
-            addPassesViewControllerResult = addPassesViewController
-            expectation.fulfill()
+        // WHEN && THEN
+        do {
+            _ = try await sut.makePassesViewController(fileMessageData: fileMessageData)
+            XCTFail("expected to throw an error!")
+        } catch {
+            // success
         }
-
-        // THEN
-        waitForExpectations(timeout: 5, handler: nil)
-        XCTAssertNil(addPassesViewControllerResult)
     }
 
-    func testThatCreateAddPassesViewControllerReturnsAViewControllerForPassFileMessage() {
+    func testThatCreateAddPassesViewControllerReturnsAViewControllerForPassFileMessage() async throws {
         // GIVEN
         let message = MockMessageFactory.passFileTransferMessage()
-        let expectation = self.expectation(description: "Should receive a PKAddPassesViewController")
+        let fileMessageData = try XCTUnwrap(message.fileMessageData)
 
         // WHEN
-        var addPassesViewControllerResult: PKAddPassesViewController?
-        sut.loadPassDataAndCreateAddPassesViewController(fileMessageData: message.fileMessageData!) { addPassesViewController in
-            addPassesViewControllerResult = addPassesViewController
-            expectation.fulfill()
-        }
+        let viewController = try await sut.makePassesViewController(fileMessageData: fileMessageData)
 
         // THEN
-        waitForExpectations(timeout: 5) { error in
-            if let error = error {
-                XCTFail("waitForExpectationsWithError: \(error)")
-            }
-
-            XCTAssertNotNil(addPassesViewControllerResult)
-        }
+        XCTAssertNotNil(viewController)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
@@ -78,7 +78,6 @@ final class MessagePresenterTests: XCTestCase {
 
     func testThatMakePassesViewControllerThrowsErrorForInvalidFileURL() async throws {
         // GIVEN
-        let message = MockMessageFactory.passFileTransferMessage()
         let fileURL = try XCTUnwrap(URL(string: "https://apple.com"))
 
         // WHEN && THEN

--- a/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessagePresenterTests.swift
@@ -79,22 +79,41 @@ final class MessagePresenterTests: XCTestCase {
     func testThatCreateAddPassesViewControllerReturnsNilForFileMessage() {
         // GIVEN
         let message = MockMessageFactory.fileTransferMessage()
+        let expectation = self.expectation(description: "Load pass data and create addPassesViewController")
 
         // WHEN
-        let addPassesViewController = sut.createAddPassesViewController(fileMessageData: message.fileMessageData!)
+        var addPassesViewControllerResult: PKAddPassesViewController?
+        sut.loadPassDataAndCreateAddPassesViewController(fileMessageData: message.fileMessageData!) { addPassesViewController in
+            addPassesViewControllerResult = addPassesViewController
+            expectation.fulfill()
+        }
 
         // THEN
-        XCTAssertNil(addPassesViewController)
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertNil(addPassesViewControllerResult)
     }
+
 
     func testThatCreateAddPassesViewControllerReturnsAViewControllerForPassFileMessage() {
         // GIVEN
         let message = MockMessageFactory.passFileTransferMessage()
+        let expectation = self.expectation(description: "Should receive a PKAddPassesViewController")
 
         // WHEN
-        let addPassesViewController = sut.createAddPassesViewController(fileMessageData: message.fileMessageData!)
+        var addPassesViewControllerResult: PKAddPassesViewController?
+        sut.loadPassDataAndCreateAddPassesViewController(fileMessageData: message.fileMessageData!) { addPassesViewController in
+            addPassesViewControllerResult = addPassesViewController
+            expectation.fulfill()
+        }
 
         // THEN
-        XCTAssertNotNil(addPassesViewController)
+        waitForExpectations(timeout: 5) { error in
+            if let error = error {
+                XCTFail("waitForExpectationsWithError: \(error)")
+            }
+
+            XCTAssertNotNil(addPassesViewControllerResult)
+        }
     }
+
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

As I was working on a different issue I stumbled upon:


![Screenshot 2023-11-08 at 10 10 59](https://github.com/wireapp/wire-ios/assets/10944108/4581c90e-072a-4e57-8c22-0f28eafac33b)


With this PR I got rid of that warning by refactoring that method and updating the tests. 


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
