### PR TITLE
chore: implement fetch request for all team group proteus conversations [WPB-5265]

### DIFF
--- a/wire-ios-data-model/Source/MLS/MessageProtocol.swift
+++ b/wire-ios-data-model/Source/MLS/MessageProtocol.swift
@@ -16,8 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-
 /// Protocols for exchanging end-to-end-encrypted messages
 /// between clients.
 

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -209,7 +209,7 @@ public extension ZMConversation {
     static func fetchAllTeamGroupProteusConversations(in context: NSManagedObjectContext) throws -> [ZMConversation] {
         let selfUser = ZMUser.selfUser(in: context)
         guard let selfUserTeamIdentifier = selfUser.teamIdentifier else {
-            assertionFailure("selfUser.teamIdentifier == nil")
+            assertionFailure("this method is supposed to be called for users which are part of a team")
             return []
         }
 

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -206,10 +206,7 @@ public extension ZMConversation {
 
 public extension ZMConversation {
 
-    static func fetchAllTeamGroupProteusConversations(
-        from user: UserType,
-        in context: NSManagedObjectContext
-    ) -> [ZMConversation] {
+    static func fetchAllTeamGroupProteusConversations(in context: NSManagedObjectContext) throws -> [ZMConversation] {
         let selfUser = ZMUser.selfUser(in: context)
         guard let selfUserTeamIdentifier = selfUser.teamIdentifier else {
             assertionFailure("selfUser.teamIdentifier == nil")
@@ -224,7 +221,8 @@ public extension ZMConversation {
                 .teamRemoteIdentifier(matches: selfUserTeamIdentifier)
             ]
         )
-        return context.fetchOrAssert(request: request)
+
+        return try context.fetch(request)
     }
 }
 
@@ -276,7 +274,7 @@ private extension NSPredicate {
         .init(
             format: "%K == %@",
             argumentArray: [
-                ZMConversationRemoteIdentifierDataKey,
+                TeamRemoteIdentifierDataKey,
                 (teamRemoteIdentifier as NSUUID).data() as Data
             ]
         )

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -181,7 +181,7 @@ public extension ZMConversation {
 
     func joinNewMLSGroup(id mlsGroupID: MLSGroupID, completion: ((Error?) -> Void)?) {
         guard let syncContext = self.managedObjectContext?.zm_sync else {
-            completion?(ZMConversationError.couldNotFindSyncContext)
+            completion?(JoinNewMLSGroupError.couldNotFindSyncContext)
             return
         }
 
@@ -200,13 +200,17 @@ public extension ZMConversation {
             }
         }
     }
+
+    enum JoinNewMLSGroupError: Error {
+        case couldNotFindSyncContext
+    }
 }
 
 // MARK: - Migration releated fetch requests
 
 public extension ZMConversation {
 
-    static func fetchAllTeamGroupProteusConversations(in context: NSManagedObjectContext) throws -> [ZMConversation] {
+    static func fetchAllTeamGroupConversations(messageProtocol: MessageProtocol, in context: NSManagedObjectContext) throws -> [ZMConversation] {
         let selfUser = ZMUser.selfUser(in: context)
         guard let selfUserTeamIdentifier = selfUser.teamIdentifier else {
             assertionFailure("this method is supposed to be called for users which are part of a team")
@@ -217,7 +221,7 @@ public extension ZMConversation {
         request.predicate = NSCompoundPredicate(
             andPredicateWithSubpredicates: [
                 .hasConversationType(.group),
-                .hasMessageProtocol(.proteus),
+                .hasMessageProtocol(messageProtocol),
                 .teamRemoteIdentifier(matches: selfUserTeamIdentifier)
             ]
         )
@@ -226,16 +230,7 @@ public extension ZMConversation {
     }
 }
 
-// MARK: -
-
-extension ZMConversation {
-
-    enum ZMConversationError: Error {
-        case couldNotFindSyncContext
-    }
-}
-
-// MARK: -
+// MARK: - NSPredicate Extensions
 
 private extension NSPredicate {
 

--- a/wire-ios-data-model/Source/Public/ZMConversation.h
+++ b/wire-ios-data-model/Source/Public/ZMConversation.h
@@ -40,7 +40,6 @@
 
 typedef NS_CLOSED_ENUM(int16_t, ZMConversationType) {
     ZMConversationTypeInvalid = 0,
-
     ZMConversationTypeSelf,
     ZMConversationTypeOneOnOne,
     ZMConversationTypeGroup,

--- a/wire-ios-data-model/Tests/MLS/MessageProtocolTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MessageProtocolTests.swift
@@ -1,6 +1,6 @@
-//
+////
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -16,9 +16,16 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-public enum MLSGroupStatus: Int16 {
-    case pendingJoin
-    case pendingLeave
-    case ready
-    case outOfSync
+
+import XCTest
+
+@testable import WireDataModel
+
+final class MessageProtocolTests: XCTestCase {
+
+    /// Ensures these raw values never change.
+    func testRawValues() {
+        XCTAssertEqual(MessageProtocol.proteus.rawValue, 0)
+        XCTAssertEqual(MessageProtocol.mls.rawValue, 1)
+    }
 }

--- a/wire-ios-data-model/Tests/MLS/MessageProtocolTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MessageProtocolTests.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import XCTest
 
 @testable import WireDataModel

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -16,7 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import XCTest
+
 @testable import WireDataModel
 
 final class ZMConversationTests_MLS: ZMConversationTestsBase {
@@ -55,6 +56,14 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
             XCTAssertEqual(fetchedConversation, conversation)
         }
     }
+
+    // MARK: - Migration releated fetch requests
+
+    func testFetchingAllTeamGroupProteusConversations() {
+        XCTFail("TODO")
+    }
+
+    // MARK: - Helpers
 
     private func createConversation(groupID: MLSGroupID) -> ZMConversation? {
         let conversation = ZMConversation.insertNewObject(in: syncMOC)

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -59,8 +59,24 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
 
     // MARK: - Migration releated fetch requests
 
-    func testFetchingAllTeamGroupProteusConversations() {
-        XCTFail("TODO")
+    func testFetchingAllTeamGroupProteusConversationsSuccessfully() throws {
+        // Given
+        let conversation = try syncMOC.performAndWait { [self] in
+            let groupID = MLSGroupID.random()
+            let conversation = createConversation(groupID: groupID)
+            conversation?.messageProtocol = .proteus
+            try syncMOC.save()
+            return conversation
+        }
+
+        // When
+        let fetchedConversation = try syncMOC.performAndWait {
+            try ZMConversation.fetchAllTeamGroupProteusConversations(in: self.syncMOC)
+        }
+
+        // Then
+        XCTAssertEqual(fetchedConversation, [conversation])
+    }
     }
 
     // MARK: - Helpers

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -63,9 +63,9 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
 
 final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
 
-    func test_fetchAllTeamGroupProteusConversations() throws {
+    func test_fetchAllTeamGroupConversations_messageProtocolProteus() async throws {
         // Given
-        let conversations = try syncMOC.performGroupedAndWait { syncMOC in
+        let conversations = try await syncMOC.perform { [syncMOC] in
 
             // ensure selfUser has a teamIdentifier set
             let selfUser = ZMUser.selfUser(in: syncMOC)
@@ -88,8 +88,8 @@ final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
         }
 
         // When
-        let fetchedConversations = try syncMOC.performGroupedAndWait { syncMOC in
-            try ZMConversation.fetchAllTeamGroupProteusConversations(in: syncMOC)
+        let fetchedConversations = try await syncMOC.perform { [syncMOC] in
+            try ZMConversation.fetchAllTeamGroupConversations(messageProtocol: .proteus, in: syncMOC)
         }
 
         // Then

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -27,12 +27,12 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
         super.tearDown()
     }
 
-    func testThatItFetchesConversationWithGroupID() {
-        syncMOC.performGroupedBlockAndWait { [self] in
+    func testThatItFetchesConversationWithGroupID() throws {
+        try syncMOC.performGroupedAndWait { syncMOC in
             // Given
             BackendInfo.isFederationEnabled = false
             let groupID = MLSGroupID([1, 2, 3])
-            let conversation = self.createConversation(groupID: groupID)
+            let conversation = try groupID.createConversation(in: syncMOC)
 
             // When
             let fetchedConversation = ZMConversation.fetch(with: groupID, in: syncMOC)
@@ -42,12 +42,12 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
         }
     }
 
-    func testThatItFetchesConversationWithGroupID_FederationEnabled() {
-        syncMOC.performGroupedBlockAndWait { [self] in
+    func testThatItFetchesConversationWithGroupID_FederationEnabled() throws {
+        try syncMOC.performGroupedAndWait { syncMOC in
             // Given
             BackendInfo.isFederationEnabled = true
             let groupID = MLSGroupID([1, 2, 3])
-            let conversation = self.createConversation(groupID: groupID)
+            let conversation = try groupID.createConversation(in: syncMOC)
 
             // When
             let fetchedConversation = ZMConversation.fetch(with: groupID, in: syncMOC)
@@ -57,35 +57,56 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
         }
     }
 
-    // MARK: - Migration releated fetch requests
+}
 
-    func testFetchingAllTeamGroupProteusConversationsSuccessfully() throws {
+// MARK: - Migration releated fetch requests
+
+final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
+
+    func test_fetchAllTeamGroupProteusConversations() throws {
         // Given
-        let conversation = try syncMOC.performAndWait { [self] in
-            let groupID = MLSGroupID.random()
-            let conversation = createConversation(groupID: groupID)
-            conversation?.messageProtocol = .proteus
+        let conversations = try syncMOC.performGroupedAndWait { syncMOC in
+
+            // ensure selfUser has a teamIdentifier set
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.teamIdentifier = .init()
+
+            // create specific conversations
+            let conversations = try (0..<4).map { _ in
+                let conversation = try MLSGroupID.random().createConversation(in: syncMOC)
+                conversation.messageProtocol = .proteus
+                conversation.conversationType = .group
+                conversation.teamRemoteIdentifier = selfUser.teamIdentifier
+                return conversation
+            }
+            // only conversations[0] should be fetched successfully
+            conversations[1].messageProtocol = .mls
+            conversations[2].conversationType = .`self`
+            conversations[3].teamRemoteIdentifier = .init()
             try syncMOC.save()
-            return conversation
+            return conversations
         }
 
         // When
-        let fetchedConversation = try syncMOC.performAndWait {
-            try ZMConversation.fetchAllTeamGroupProteusConversations(in: self.syncMOC)
+        let fetchedConversations = try syncMOC.performGroupedAndWait { syncMOC in
+            try ZMConversation.fetchAllTeamGroupProteusConversations(in: syncMOC)
         }
 
         // Then
-        XCTAssertEqual(fetchedConversation, [conversation])
-    }
+        XCTAssertEqual(fetchedConversations, [conversations[0]])
     }
 
-    // MARK: - Helpers
+}
 
-    private func createConversation(groupID: MLSGroupID) -> ZMConversation? {
-        let conversation = ZMConversation.insertNewObject(in: syncMOC)
+// MARK: - MLSGroupID Helper
+
+extension MLSGroupID {
+
+    fileprivate func createConversation(in managedObjectContext: NSManagedObjectContext) throws -> ZMConversation {
+        let conversation = ZMConversation.insertNewObject(in: managedObjectContext)
         conversation.remoteIdentifier = NSUUID.create()
-        conversation.mlsGroupID = groupID
-        XCTAssert(syncMOC.saveOrRollback())
+        conversation.mlsGroupID = self
+        try managedObjectContext.save()
         return conversation
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
@@ -46,15 +46,20 @@ extension ZMBaseManagedObjectTest {
     @objc
     func createCoreDataStack() -> CoreDataStack {
         let account = Account(userName: "", userIdentifier: userIdentifier)
-        let stack = CoreDataStack(account: account,
-                                  applicationContainer: storageDirectory,
-                                  inMemoryStore: shouldUseInMemoryStore,
-                                  dispatchGroup: dispatchGroup)
-
-        stack.loadStores(completionHandler: { error in
+        let stack = CoreDataStack(
+            account: account,
+            applicationContainer: storageDirectory,
+            inMemoryStore: shouldUseInMemoryStore,
+            dispatchGroup: dispatchGroup
+        )
+        
+        let expectation = XCTestExpectation()
+        stack.loadStores { error in
             XCTAssertNil(error)
-        })
-
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+        
         return stack
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
@@ -52,14 +52,14 @@ extension ZMBaseManagedObjectTest {
             inMemoryStore: shouldUseInMemoryStore,
             dispatchGroup: dispatchGroup
         )
-        
+
         let expectation = XCTestExpectation()
         stack.loadStores { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5)
-        
+
         return stack
     }
 

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -258,6 +258,7 @@
 		55C40BCE22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C40BCD22B0316800EFD8BD /* ZMUser+LegalHoldRequest.swift */; };
 		55C40BD722B0F78500EFD8BD /* ZMUserLegalHoldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C40BD422B0F75C00EFD8BD /* ZMUserLegalHoldTests.swift */; };
 		55C40BDD22B24AA600EFD8BD /* store2-73-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 55C40BDC22B24AA600EFD8BD /* store2-73-0.wiredatabase */; };
+		59AAB6492AFCF541005B39E6 /* MessageProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AAB6482AFCF541005B39E6 /* MessageProtocolTests.swift */; };
 		5E0FB215205176B400FD9867 /* Set+ServiceUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */; };
 		5E36B45E21CA5BBA00B7063B /* UnverifiedCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36B45D21CA5BBA00B7063B /* UnverifiedCredentials.swift */; };
 		5E39FC67225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC66225F22BE00C682B8 /* ZMConversation+ExternalParticipant.swift */; };
@@ -1138,6 +1139,7 @@
 		55C40BD322B0F23000EFD8BD /* zmessaging2.73.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.73.0.xcdatamodel; sourceTree = "<group>"; };
 		55C40BD422B0F75C00EFD8BD /* ZMUserLegalHoldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserLegalHoldTests.swift; sourceTree = "<group>"; };
 		55C40BDC22B24AA600EFD8BD /* store2-73-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-73-0.wiredatabase"; sourceTree = "<group>"; };
+		59AAB6482AFCF541005B39E6 /* MessageProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageProtocolTests.swift; sourceTree = "<group>"; };
 		5E055B29228C46DA00E91314 /* zmessaging2.70.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.70.0.xcdatamodel; sourceTree = "<group>"; };
 		5E0FB214205176B400FD9867 /* Set+ServiceUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+ServiceUser.swift"; sourceTree = "<group>"; };
 		5E36B45D21CA5BBA00B7063B /* UnverifiedCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnverifiedCredentials.swift; sourceTree = "<group>"; };
@@ -2316,6 +2318,7 @@
 				EED6C7152A31AD1200CB8B60 /* MLSUserIDTests.swift */,
 				EE74E4DF2A37B3BF00B63E6E /* SubconversationGroupIDRepositoryTests.swift */,
 				6326E4712AEBB2E4006EEA28 /* ProteusToMLSMigrationCoordinatorTests.swift */,
+				59AAB6482AFCF541005B39E6 /* MessageProtocolTests.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -4166,6 +4169,7 @@
 				F9A7085C1CAEED1B00C2F5FE /* ZMBaseManagedObjectTest.m in Sources */,
 				1670D01E231825BE003A143B /* ZMUserTests+Permissions.swift in Sources */,
 				EE428C4E29F01E4800ECB715 /* EARServiceTests.swift in Sources */,
+				59AAB6492AFCF541005B39E6 /* MessageProtocolTests.swift in Sources */,
 				EE82625129A8D6BD0023B13A /* ZMClientMessageTests+OTR.swift in Sources */,
 				8767E8682163B9EE00390F75 /* ZMConversationTests+Mute.swift in Sources */,
 				163CE6AF25BEB9680013C12D /* ZMMessageTests+SystemMessages.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5265" title="WPB-5265" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5265</a>  [iOS] Method to fetch all team group proteus conversations 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Solutions

Create a fetch request and a unit test.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
