### PR TITLE
fix: add scroll view to the EmptySearchResultsView

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ xcodebuild test \
   -workspace wire-ios-mono.xcworkspace \
   -scheme Wire-iOS \
   -testPlan SecurityTests \
-  -destination 'platform=iOS Simulator,name=iPhone 8,OS=15.2'
+  -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.0.1'
 
   xcodebuild test \
   -workspace wire-ios-mono.xcworkspace \
   -scheme WireSyncEngine \
   -testPlan SecurityTests \
-  -destination 'platform=iOS Simulator,name=iPhone 8,OS=15.2'
+  -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.0.1'
 
   xcodebuild test \
   -workspace wire-ios-mono.xcworkspace \
   -scheme WireDataModel \
   -testPlan SecurityTests \
-  -destination 'platform=iOS Simulator,name=iPhone 8,OS=15.2'
+  -destination 'platform=iOS Simulator,name=iPhone 14,OS=17.0.1'
 ```
 
 `xcodebuild` will print the test results to the console. It will also log the location of the test result (in `.xcresult` format), which you can open

--- a/scripts/run-swiftlint.sh
+++ b/scripts/run-swiftlint.sh
@@ -24,7 +24,7 @@ SCRIPTS_DIR="$REPO_ROOT/scripts"
 SWIFTLINT="$SCRIPTS_DIR/.build/artifacts/scripts/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-0.53.0-macos/bin/swiftlint"
 
 if [ -z "${CI-}" ]; then
-    xcrun --sdk macosx swift package --sdk macos --package-path "$SCRIPTS_DIR" resolve
+    xcrun --sdk macosx swift package --package-path "$SCRIPTS_DIR" resolve
     "$SWIFTLINT" --config "$REPO_ROOT/.swiftlint.yml" "$@"
 else
     echo "Skipping SwiftLint in CI environment"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
@@ -85,9 +85,8 @@ final class EmptySearchResultsView: UIView {
     /// Contains the `stackView`.
     private let scrollView = UIScrollView()
     private let stackView = UIStackView()
-    private let iconView     = UIImageView()
-    private let statusLabel  = DynamicFontLabel(fontSpec: .normalRegularFont,
-                                                color: LabelColors.textSettingsPasswordPlaceholder)
+    private let iconView = UIImageView()
+    private let statusLabel = DynamicFontLabel(fontSpec: .normalRegularFont, color: LabelColors.textSettingsPasswordPlaceholder)
     private let actionButton = LinkButton()
     private let iconColor = LabelColors.textSettingsPasswordPlaceholder
 
@@ -105,19 +104,23 @@ final class EmptySearchResultsView: UIView {
         [iconView, statusLabel, actionButton].forEach(stackView.addArrangedSubview)
 
         addSubview(scrollView)
-
-        scrollView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        scrollView.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        trailingAnchor.constraint(equalTo: scrollView.trailingAnchor).isActive = true
-        bottomAnchor.constraint(equalTo: scrollView.bottomAnchor).isActive = true
-
         scrollView.addSubview(stackView)
 
-        stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor).isActive = true
-        stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor).isActive = true
-        scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor).isActive = true
-        scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor).isActive = true
-        stackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor).isActive = true
+        NSLayoutConstraint.activate([
+
+            // scroll view with empty search results view
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+
+            // stack view within scroll view
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+            stackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor)
+        ])
 
         stackView.alignment = .center
         stackView.spacing = 16

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/EmptySearchResultsView.swift
@@ -82,36 +82,47 @@ final class EmptySearchResultsView: UIView {
     private let isSelfUserAdmin: Bool
     private let isFederationEnabled: Bool
 
-    private let stackView: UIStackView
+    /// Contains the `stackView`.
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
     private let iconView     = UIImageView()
     private let statusLabel  = DynamicFontLabel(fontSpec: .normalRegularFont,
                                                 color: LabelColors.textSettingsPasswordPlaceholder)
-    private let actionButton: LinkButton
+    private let actionButton = LinkButton()
     private let iconColor = LabelColors.textSettingsPasswordPlaceholder
 
     weak var delegate: EmptySearchResultsViewDelegate?
 
-    init(isSelfUserAdmin: Bool,
-         isFederationEnabled: Bool) {
+    init(
+        isSelfUserAdmin: Bool,
+        isFederationEnabled: Bool
+    ) {
         self.isSelfUserAdmin = isSelfUserAdmin
         self.isFederationEnabled = isFederationEnabled
-        stackView = UIStackView()
-        actionButton = LinkButton()
         super.init(frame: .zero)
+
+        [scrollView, stackView, iconView, statusLabel, actionButton].prepareForLayout()
+        [iconView, statusLabel, actionButton].forEach(stackView.addArrangedSubview)
+
+        addSubview(scrollView)
+
+        scrollView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        scrollView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        trailingAnchor.constraint(equalTo: scrollView.trailingAnchor).isActive = true
+        bottomAnchor.constraint(equalTo: scrollView.bottomAnchor).isActive = true
+
+        scrollView.addSubview(stackView)
+
+        stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor).isActive = true
+        stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor).isActive = true
+        scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor).isActive = true
+        scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor).isActive = true
+        stackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor).isActive = true
 
         stackView.alignment = .center
         stackView.spacing = 16
         stackView.axis = .vertical
         stackView.alignment = .center
-
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        [iconView, statusLabel, actionButton].prepareForLayout()
-        [iconView, statusLabel, actionButton].forEach(stackView.addArrangedSubview)
-
-        addSubview(stackView)
-
-        stackView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
-        stackView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
         statusLabel.numberOfLines = 0
         statusLabel.preferredMaxLayoutWidth = 200


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The text in the `EmptySearchResultsView` can be larger than the available area. Until now, the view overlapped with other component and/or was not fully readable.

### Causes (Optional)

There was no scroll view and the view couldn't shrink. Also only center-constraints were set.

### Solutions

Embed the stack view in a scroll view.

### Testing

#### How to Test

Create a new conversation and try to add participants which don't exist.

### Attachments (Optional)

<img width="225" alt="Screenshot 2023-11-10 at 13 41 29" src="https://github.com/wireapp/wire-ios/assets/15628584/da6d100e-d2da-4fed-86f9-efc8a2781d1e"> 
<img width="225" alt="Screenshot 2023-11-10 at 13 47 02" src="https://github.com/wireapp/wire-ios/assets/15628584/3338cc23-7dd8-45c3-bcdb-c58bef0bfc44">
<img width="225" alt="Screenshot 2023-11-10 at 13 47 35" src="https://github.com/wireapp/wire-ios/assets/15628584/3b6f84b0-0095-46fb-a6c8-aa5d6364a26f"> 
<img width="146" alt="Screenshot 2023-11-10 at 13 41 50" src="https://github.com/wireapp/wire-ios/assets/15628584/108a7735-c035-41c1-a6b5-fe7c33179d17">

fixed:

<img width="225" alt="Screenshot 2023-11-10 at 14 43 47" src="https://github.com/wireapp/wire-ios/assets/15628584/3a49c67f-16fc-4a20-8581-297430f1bc36"> 
<img width="225" alt="Screenshot 2023-11-10 at 14 58 37" src="https://github.com/wireapp/wire-ios/assets/15628584/57f9ed2d-1ef2-49fe-b903-1ecaaaf74c65">


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
