### PR TITLE
fix: remove misleading function XCTAssertArrayEqual [WPB-4920]

### DIFF
--- a/wire-ios/Wire-iOS Tests/AudioButtonOverlayTests.swift
+++ b/wire-ios/Wire-iOS Tests/AudioButtonOverlayTests.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
+import XCTest
 @testable import Wire
 
 class AudioButtonOverlayTests: ZMSnapshotTestCase {
@@ -71,10 +72,10 @@ class AudioButtonOverlayTests: ZMSnapshotTestCase {
 
     func testThatItCallsTheButtonHandlerWithTheCorrectButtonType() {
         sut.playButton.sendActions(for: .touchUpInside)
-        XCTAssertArrayEqual(buttonTapHistory, [AudioButtonOverlay.AudioButtonOverlayButtonType.play])
+        XCTAssertEqual(buttonTapHistory, [AudioButtonOverlay.AudioButtonOverlayButtonType.play])
 
         sut.sendButton.sendActions(for: .touchUpInside)
-        XCTAssertArrayEqual(buttonTapHistory, [AudioButtonOverlay.AudioButtonOverlayButtonType.play, AudioButtonOverlay.AudioButtonOverlayButtonType.send])
+        XCTAssertEqual(buttonTapHistory, [AudioButtonOverlay.AudioButtonOverlayButtonType.play, AudioButtonOverlay.AudioButtonOverlayButtonType.send])
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
@@ -33,12 +33,6 @@ extension ConversationMessageContext {
                                                                        spacing: 0)
 }
 
-func XCTAssertArrayEqual(_ descriptions: [Any], _ expectedDescriptions: [Any], file: StaticString = #file, line: UInt = #line) {
-    let classes = descriptions.map { String(describing: $0) }
-    let expectedClasses = expectedDescriptions.map { String(describing: $0) }
-    XCTAssertEqual(classes, expectedClasses, file: file, line: line)
-}
-
 class ConversationMessageSnapshotTestCase: ZMSnapshotTestCase {
 
     var userSession: UserSessionMock!

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/EmoliRepositoryTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/EmoliRepositoryTests.swift
@@ -52,7 +52,7 @@ final class EmojiRepositoryTests: XCTestCase {
         sut.registerRecentlyUsedEmojis(emojis)
 
         // Then
-        XCTAssertArrayEqual(sut.fetchRecentlyUsedEmojis().map(\.value), emojis)
+        XCTAssertEqual(sut.fetchRecentlyUsedEmojis().map(\.value), emojis)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/MessageActionsViewControllerTests.swift
@@ -69,7 +69,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         // WHEN
         let actionsTitles = actionsTitlesForMessage(message: message)
         // THEN
-        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+        XCTAssertEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
     }
 
     func testMenuActionsForImageMessage() {
@@ -78,7 +78,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         // WHEN
         let actionsTitles = actionsTitlesForMessage(message: message)
         // THEN
-        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Save", "Share", "Delete", "Cancel"])
+        XCTAssertEqual(actionsTitles, ["Copy", "Reply", "Details", "Save", "Share", "Delete", "Cancel"])
     }
 
     func testMenuActionsForAudioMessage() {
@@ -90,7 +90,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         // WHEN
         let actionsTitles = actionsTitlesForMessage(message: message)
         // THEN
-        XCTAssertArrayEqual(actionsTitles, ["Reply", "Details", "Download", "Delete", "Cancel"])
+        XCTAssertEqual(actionsTitles, ["Reply", "Details", "Download", "Delete", "Cancel"])
     }
 
     func testMenuActionsForLocationMessage() {
@@ -99,7 +99,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         // WHEN
         let actionsTitles = actionsTitlesForMessage(message: message)
         // THEN
-        XCTAssertArrayEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+        XCTAssertEqual(actionsTitles, ["Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
     }
 
     func testMenuActionsForLinkMessage() {
@@ -108,7 +108,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         // WHEN
         let actionsTitles = actionsTitlesForMessage(message: message)
         // THEN
-        XCTAssertArrayEqual(actionsTitles, ["Visit Link", "Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
+        XCTAssertEqual(actionsTitles, ["Visit Link", "Copy", "Reply", "Details", "Share", "Delete", "Cancel"])
     }
 
     func testMenuActionsForPingMessage() {
@@ -117,7 +117,7 @@ final class MessageActionsViewControllerTests: XCTestCase {
         // WHEN
         let actionsTitles = actionsTitlesForMessage(message: message)
         // THEN
-        XCTAssertArrayEqual(actionsTitles, ["Delete", "Cancel"])
+        XCTAssertEqual(actionsTitles, ["Delete", "Cancel"])
     }
 
     func actionsTitlesForMessage(message: MockMessage) -> [String] {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4920" title="WPB-4920" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-4920</a>  [iOS] Crash when sending message in C1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is a function `XCTAssertArrayEqual` which creates string representations of its arguments and compares only the resulting string value. This is not needed for types which conform to `Equatable`.

### Solutions

Remove the function and use `XCTAssertEqual`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
