### PR TITLE
fix: ZMTransportRequestMethod case names [WPB-5266]

### DIFF
--- a/wire-ios-mocktransport/Source/API Version/MockTransportSession+APIVersion.m
+++ b/wire-ios-mocktransport/Source/API Version/MockTransportSession+APIVersion.m
@@ -27,7 +27,7 @@
 
 - (ZMTransportResponse *)processAPIVersionRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/api-version" method:ZMMethodGET]) {
+    if ([request matchesWithPath:@"/api-version" method:ZMTransportRequestMethodGet]) {
         return [self processAPIVersionGetRequest:request];
     }
 

--- a/wire-ios-mocktransport/Source/Assets/MockTransportSession+assets.m
+++ b/wire-ios-mocktransport/Source/Assets/MockTransportSession+assets.m
@@ -33,13 +33,13 @@
 
 - (ZMTransportResponse *)processAssetRequest:(ZMTransportRequest *)request;
 {
-    if([request matchesWithPath:@"/conversations/*/assets/*" method:ZMMethodGET]) {
+    if([request matchesWithPath:@"/conversations/*/assets/*" method:ZMTransportRequestMethodGet]) {
         return [self processAssetGetRequestInConversation:[request RESTComponentAtIndex:1] asset:[request RESTComponentAtIndex:3] apiVersion:request.apiVersion];
     }
-    else if([request matchesWithPath:@"/assets/*" method:ZMMethodGET]) {
+    else if([request matchesWithPath:@"/assets/*" method:ZMTransportRequestMethodGet]) {
         return [self processAssetGetRequestInConversation:request.queryParameters[@"conv_id"] asset:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/otr/assets/*" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/conversations/*/otr/assets/*" method:ZMTransportRequestMethodGet]) {
         return [self processAssetGetRequestInConversation:[request RESTComponentAtIndex:1] asset:[request RESTComponentAtIndex:4] apiVersion:request.apiVersion];
     }
     return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil apiVersion:request.apiVersion];
@@ -67,11 +67,11 @@
 
 - (ZMTransportResponse *)processAssetV3Request:(ZMTransportRequest *)request
 {
-    if ([request matchesWithPath:@"/assets/v3" method:ZMMethodPOST]) {
+    if ([request matchesWithPath:@"/assets/v3" method:ZMTransportRequestMethodPost]) {
         return [self processAssetV3PostWithMultipartData:[request multipartBodyItemsFromRequestOrFile] apiVersion:request.apiVersion];
-    } else if ([request matchesWithPath:@"/assets/v3/*" method:ZMMethodGET]) {
+    } else if ([request matchesWithPath:@"/assets/v3/*" method:ZMTransportRequestMethodGet]) {
         return [self processAssetV3GetWithKey:[request RESTComponentAtIndex:2] apiVersion:request.apiVersion];
-    } else if ([request matchesWithPath:@"/assets/v3/*" method:ZMMethodDELETE]) {
+    } else if ([request matchesWithPath:@"/assets/v3/*" method:ZMTransportRequestMethodDelete]) {
         return [self processAssetV3DeleteWithKey:[request RESTComponentAtIndex:2] apiVersion:request.apiVersion];
     }
     return nil;
@@ -123,11 +123,11 @@
 
 - (ZMTransportResponse *)processAssetV4Request:(ZMTransportRequest *)request
 {
-    if ([request matchesWithPath:@"/assets/v4/*" method:ZMMethodPOST]) {
+    if ([request matchesWithPath:@"/assets/v4/*" method:ZMTransportRequestMethodPost]) {
         return [self processAssetV4PostWithDomain:[request RESTComponentAtIndex:2] multipart:[request multipartBodyItemsFromRequestOrFile] apiVersion:request.apiVersion];
-    } else if ([request matchesWithPath:@"/assets/v4/*/*" method:ZMMethodGET]) {
+    } else if ([request matchesWithPath:@"/assets/v4/*/*" method:ZMTransportRequestMethodGet]) {
         return [self processAssetV4GetWithDomain:[request RESTComponentAtIndex:2] key:[request RESTComponentAtIndex:3] apiVersion:request.apiVersion];
-    } else if ([request matchesWithPath:@"/assets/v4/*/*" method:ZMMethodDELETE]) {
+    } else if ([request matchesWithPath:@"/assets/v4/*/*" method:ZMTransportRequestMethodDelete]) {
         return [self processAssetV4DeleteWithDomain:[request RESTComponentAtIndex:2] key:[request RESTComponentAtIndex:3] apiVersion:request.apiVersion];
     }
     return nil;

--- a/wire-ios-mocktransport/Source/Broadcast/MockTransportSession+Broadcast.m
+++ b/wire-ios-mocktransport/Source/Broadcast/MockTransportSession+Broadcast.m
@@ -26,7 +26,7 @@
 
 - (ZMTransportResponse *)processBroadcastRequest:(ZMTransportRequest *)request
 {
-    if ([request matchesWithPath:@"/broadcast/otr/messages" method:ZMMethodPOST])
+    if ([request matchesWithPath:@"/broadcast/otr/messages" method:ZMTransportRequestMethodPost])
     {
         if (request.binaryData != nil) {
             return [self processBroascastOTRMessageToConversationWithProtobuffData:request.binaryData

--- a/wire-ios-mocktransport/Source/Clients and OTR/MockTransportSession+Clients.m
+++ b/wire-ios-mocktransport/Source/Clients and OTR/MockTransportSession+Clients.m
@@ -30,22 +30,22 @@
 // /clients
 - (ZMTransportResponse *)processClientsRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/clients" method:ZMMethodPOST]) {
+    if ([request matchesWithPath:@"/clients" method:ZMTransportRequestMethodPost]) {
         return [self processRegisterClientWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/clients" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/clients" method:ZMTransportRequestMethodGet]) {
         return [self processGetClientsListRequestWithApiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/clients/*" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/clients/*" method:ZMTransportRequestMethodGet]) {
         return [self processGetClientById:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/clients/*" method:ZMMethodPUT]) {
+    else if ([request matchesWithPath:@"/clients/*" method:ZMTransportRequestMethodPut]) {
         return [self processUpdateClient:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/clients/*" method:ZMMethodDELETE]) {
+    else if ([request matchesWithPath:@"/clients/*" method:ZMTransportRequestMethodDelete]) {
         return [self processDeleteClientRequest:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/clients/*/prekeys" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/clients/*/prekeys" method:ZMTransportRequestMethodGet]) {
         return [self processClientPreKeysForClient:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
     return [self errorResponseWithCode:404 reason:@"no-endpoint" apiVersion:request.apiVersion];

--- a/wire-ios-mocktransport/Source/Connections/MockTransportSession+connections.m
+++ b/wire-ios-mocktransport/Source/Connections/MockTransportSession+connections.m
@@ -33,16 +33,16 @@
 /// handles /connections
 - (ZMTransportResponse *)processSelfConnectionsRequest:(ZMTransportRequest *)sessionRequest;
 {
-    if ([sessionRequest matchesWithPath:@"/connections" method:ZMMethodGET]) {
+    if ([sessionRequest matchesWithPath:@"/connections" method:ZMTransportRequestMethodGet]) {
         return [self processGetConnections:sessionRequest.queryParameters apiVersion:sessionRequest.apiVersion];
     }
-    if ([sessionRequest matchesWithPath:@"/connections/*" method:ZMMethodGET]) {
+    if ([sessionRequest matchesWithPath:@"/connections/*" method:ZMTransportRequestMethodGet]) {
         return [self processGetSpecifiedConnection:sessionRequest];
     }
-    if ([sessionRequest matchesWithPath:@"/connections" method:ZMMethodPOST]) {
+    if ([sessionRequest matchesWithPath:@"/connections" method:ZMTransportRequestMethodPost]) {
         return [self processPostConnection:sessionRequest];
     }
-    if ([sessionRequest matchesWithPath:@"/connections/*" method:ZMMethodPUT]) {
+    if ([sessionRequest matchesWithPath:@"/connections/*" method:ZMTransportRequestMethodPut]) {
         return [self processPutConnection:sessionRequest];
     }
     

--- a/wire-ios-mocktransport/Source/Conversations/MockTransportSession+conversations.m
+++ b/wire-ios-mocktransport/Source/Conversations/MockTransportSession+conversations.m
@@ -38,26 +38,26 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
 // handles /conversations
 - (ZMTransportResponse *)processConversationsRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/conversations" method:ZMMethodGET]) {
+    if ([request matchesWithPath:@"/conversations" method:ZMTransportRequestMethodGet]) {
         return [self processConversationsGetConversationsIDs:request.queryParameters[@"ids"] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/ids" method:ZMMethodGET])
+    else if ([request matchesWithPath:@"/conversations/ids" method:ZMTransportRequestMethodGet])
     {
         return [self processConversationIDsQuery:request.queryParameters apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/join" method:ZMMethodGET])
+    else if ([request matchesWithPath:@"/conversations/join" method:ZMTransportRequestMethodGet])
     {
         return [self processFetchConversationIdAndNameWith:request.queryParameters apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*" method:ZMMethodGET])
+    else if ([request matchesWithPath:@"/conversations/*" method:ZMTransportRequestMethodGet])
     {
         return [self processConversationsGetConversation:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations" method:ZMMethodPOST])
+    else if ([request matchesWithPath:@"/conversations" method:ZMTransportRequestMethodPost])
     {
         return [self processConversationsPostConversationsRequest:request];
     }
-    else if ([request matchesWithPath:@"/conversations/*/otr/messages" method:ZMMethodPOST])
+    else if ([request matchesWithPath:@"/conversations/*/otr/messages" method:ZMTransportRequestMethodPost])
     {
         if (request.binaryData != nil) {
             return [self processAddOTRMessageToConversation:[request RESTComponentAtIndex:1]
@@ -72,66 +72,66 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransport";
                                                  apiVersion:request.apiVersion];
         }
     }
-    else if ([request matchesWithPath:@"/conversations/*/members" method:ZMMethodPOST])
+    else if ([request matchesWithPath:@"/conversations/*/members" method:ZMTransportRequestMethodPost])
     {
         return [self processAddMembersToConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*" method:ZMMethodPUT])
+    else if ([request matchesWithPath:@"/conversations/*" method:ZMTransportRequestMethodPut])
     {
         return [self processPutConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/members/*" method:ZMMethodPUT])
+    else if ([request matchesWithPath:@"/conversations/*/members/*" method:ZMTransportRequestMethodPut])
     {
         return [self processPutMembersInConversation:[request RESTComponentAtIndex:1] member:[request RESTComponentAtIndex:3] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/self" method:ZMMethodPUT])
+    else if ([request matchesWithPath:@"/conversations/*/self" method:ZMTransportRequestMethodPut])
     {
         return [self processPutConversationSelf:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/members/*" method:ZMMethodDELETE])
+    else if ([request matchesWithPath:@"/conversations/*/members/*" method:ZMTransportRequestMethodDelete])
     {
         return [self processDeleteConversation:[request RESTComponentAtIndex:1] member:[request RESTComponentAtIndex:3] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/typing" method:ZMMethodPOST])
+    else if ([request matchesWithPath:@"/conversations/*/typing" method:ZMTransportRequestMethodPost])
     {
         return [self processConversationTyping:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/assets/*" method:ZMMethodGET])
+    else if ([request matchesWithPath:@"/conversations/*/assets/*" method:ZMTransportRequestMethodGet])
     {
         return [self processAssetRequest:request];
     }
-    else if ([request matchesWithPath:@"/conversations/*/otr/assets/*" method:ZMMethodGET])
+    else if ([request matchesWithPath:@"/conversations/*/otr/assets/*" method:ZMTransportRequestMethodGet])
     {
         return [self processAssetRequest:request];
     }
-    else if ([request matchesWithPath:@"/conversations/*/bots" method:ZMMethodPOST]) {
+    else if ([request matchesWithPath:@"/conversations/*/bots" method:ZMTransportRequestMethodPost]) {
         return [self processServiceRequest:request];
     }
-    else if ([request matchesWithPath:@"/conversations/*/bots/*" method:ZMMethodDELETE]) {
+    else if ([request matchesWithPath:@"/conversations/*/bots/*" method:ZMTransportRequestMethodDelete]) {
         return [self processDeleteBotRequest:request];
     }
-    else if ([request matchesWithPath:@"/conversations/*/access" method:ZMMethodPUT]) {
+    else if ([request matchesWithPath:@"/conversations/*/access" method:ZMTransportRequestMethodPut]) {
         return [self processAccessModeUpdateForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/code" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/conversations/*/code" method:ZMTransportRequestMethodGet]) {
         return [self processFetchLinkForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/code" method:ZMMethodPOST]) {
+    else if ([request matchesWithPath:@"/conversations/*/code" method:ZMTransportRequestMethodPost]) {
         return [self processCreateLinkForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/code" method:ZMMethodDELETE]) {
+    else if ([request matchesWithPath:@"/conversations/*/code" method:ZMTransportRequestMethodDelete]) {
         return [self processDeleteLinkForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/features/conversationGuestLinks" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/conversations/*/features/conversationGuestLinks" method:ZMTransportRequestMethodGet]) {
         return [self processGuestLinkFeatureStatusForConversation:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/receipt-mode" method:ZMMethodPUT]) {
+    else if ([request matchesWithPath:@"/conversations/*/receipt-mode" method:ZMTransportRequestMethodPut]) {
         return [self processReceiptModeUpdateForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/*/roles" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/conversations/*/roles" method:ZMTransportRequestMethodGet]) {
         return [self processFetchRolesForConversation:[request RESTComponentAtIndex:1] payload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/conversations/join" method:ZMMethodPOST]) {
+    else if ([request matchesWithPath:@"/conversations/join" method:ZMTransportRequestMethodPost]) {
         return [self processJoinConversationWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
 

--- a/wire-ios-mocktransport/Source/Feature Configs/MockTransportSession+FeatureConfigs.m
+++ b/wire-ios-mocktransport/Source/Feature Configs/MockTransportSession+FeatureConfigs.m
@@ -26,7 +26,7 @@
 
 - (ZMTransportResponse *)processFeatureConfigsRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/feature-configs" method:ZMMethodGET]) {
+    if ([request matchesWithPath:@"/feature-configs" method:ZMTransportRequestMethodGet]) {
         return [self processGetFeatureConfigsRequest: request];
     } else {
         return [ZMTransportResponse responseWithPayload:nil HTTPStatus:404 transportSessionError:nil apiVersion:request.apiVersion];

--- a/wire-ios-mocktransport/Source/Login/MockTransportSession+login.m
+++ b/wire-ios-mocktransport/Source/Login/MockTransportSession+login.m
@@ -31,7 +31,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
 /// handles /login
 - (ZMTransportResponse *)processLoginRequest:(ZMTransportRequest *)request;
 {
-    if([request matchesWithPath:@"/login" method:ZMMethodPOST]) {
+    if([request matchesWithPath:@"/login" method:ZMTransportRequestMethodPost]) {
         NSString *password = [request.payload.asDictionary optionalStringForKey:@"password"];
         NSString *email = [request.payload.asDictionary optionalStringForKey:@"email"];
         NSString *phone = [request.payload.asDictionary optionalStringForKey:@"phone"];
@@ -109,7 +109,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
 /// handles /login/send
 - (ZMTransportResponse *)processLoginCodeRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/login/send" method:ZMMethodPOST]) {
+    if ([request matchesWithPath:@"/login/send" method:ZMTransportRequestMethodPost]) {
         NSString *phone = [request.payload.asDictionary optionalStringForKey:@"phone"];
         
         if(phone == nil) {
@@ -135,7 +135,7 @@ static NSString * const HardcodedAccessToken = @"5hWQOipmcwJvw7BVwikKKN4glSue1Q7
 /// handles /verification-code/send
 - (ZMTransportResponse *)processVerificationCodeSendRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/verification-code/send" method:ZMMethodPOST]) {
+    if ([request matchesWithPath:@"/verification-code/send" method:ZMTransportRequestMethodPost]) {
         NSString *email = [request.payload.asDictionary optionalStringForKey:@"email"];
         NSString *action = [request.payload.asDictionary optionalStringForKey:@"action"];
 

--- a/wire-ios-mocktransport/Source/Notification Stream/MockTransportSession+notifications.m
+++ b/wire-ios-mocktransport/Source/Notification Stream/MockTransportSession+notifications.m
@@ -24,7 +24,7 @@
 // handles /push/fallback
 - (ZMTransportResponse *)processNotificationFallbackRequest:(ZMTransportRequest *)request
 {
-    if([request matchesWithPath:@"/push/fallback" method:ZMMethodPOST]) {
+    if([request matchesWithPath:@"/push/fallback" method:ZMTransportRequestMethodPost]) {
         return [ZMTransportResponse responseWithPayload:nil HTTPStatus:200 transportSessionError:nil apiVersion:request.apiVersion];
     }
     
@@ -36,7 +36,7 @@
 - (ZMTransportResponse *)processNotificationsRequest:(ZMTransportRequest *)request
 {
     // /notifications
-    if ([request matchesWithPath:@"/notifications" method:ZMMethodGET]) {
+    if ([request matchesWithPath:@"/notifications" method:ZMTransportRequestMethodGet]) {
         
         NSUUID *since = [request.queryParameters optionalUuidForKey:@"since"];
         if (self.overrideNextSinceParameter != nil) {
@@ -77,7 +77,7 @@
         return [ZMTransportResponse responseWithPayload:@{@"notifications":payload} HTTPStatus:statusCode transportSessionError:nil apiVersion:request.apiVersion];
     }
     // /notifications/last
-    else if([request matchesWithPath:@"/notifications/last" method:ZMMethodGET])
+    else if([request matchesWithPath:@"/notifications/last" method:ZMTransportRequestMethodGet])
     {
         MockPushEvent *last = self.generatedPushEvents.lastObject;
         if(last != nil) {

--- a/wire-ios-mocktransport/Source/Push Token/MockTransportSession+PushToken.swift
+++ b/wire-ios-mocktransport/Source/Push Token/MockTransportSession+PushToken.swift
@@ -27,11 +27,11 @@ extension MockTransportSession {
         }
 
         switch (request, request.method) {
-        case ("/push/tokens", .methodGET):
+        case ("/push/tokens", .get):
             return processGetPushTokens(apiVersion: apiVersion)
-        case ("/push/tokens", .methodPOST):
+        case ("/push/tokens", .post):
             return processPostPushToken(request.payload, apiVersion: apiVersion)
-        case ("/push/tokens/*", .methodDELETE):
+        case ("/push/tokens/*", .delete):
             return processDeletePushToken(request.RESTComponents(index: 2), apiVersion: apiVersion)
         default:
             return ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil, apiVersion: request.apiVersion)

--- a/wire-ios-mocktransport/Source/Registration/MockTransportSession+registration.m
+++ b/wire-ios-mocktransport/Source/Registration/MockTransportSession+registration.m
@@ -49,7 +49,7 @@
 /// Handles "/register"
 - (ZMTransportResponse *)processRegistrationRequest:(ZMTransportRequest *)request
 {
-    if(request.method == ZMMethodPOST) {
+    if(request.method == ZMTransportRequestMethodPost) {
         
         NSDictionary *userDetails = [request.payload asDictionary];
         
@@ -136,7 +136,7 @@
 /// Handles "/activate"
 - (ZMTransportResponse *)processPhoneActivationRequest:(ZMTransportRequest *)request;
 {
-    if (request.method == ZMMethodPOST) {
+    if (request.method == ZMTransportRequestMethodPost) {
         NSDictionary *userDetails = [request.payload asDictionary];
         
         NSString *code = [userDetails optionalStringForKey:@"code"];
@@ -198,7 +198,7 @@
 /// Handles "/active/send"
 - (ZMTransportResponse *)processVerificationCodeRequest:(ZMTransportRequest *)request
 {
-    if (request.method == ZMMethodPOST) {
+    if (request.method == ZMTransportRequestMethodPost) {
         NSDictionary *userDetails = [request.payload asDictionary];
         
         NSString *email = [userDetails optionalStringForKey:@"email"];

--- a/wire-ios-mocktransport/Source/Search/MockTransportSession+search.m
+++ b/wire-ios-mocktransport/Source/Search/MockTransportSession+search.m
@@ -29,7 +29,7 @@
 /// handles /search/contacts/
 - (ZMTransportResponse *)processSearchRequest:(ZMTransportRequest *)request;
 {
-    if (request.method == ZMMethodGET) {
+    if (request.method == ZMTransportRequestMethodGet) {
         NSString *query = request.queryParameters[@"q"];
         NSUInteger limit = (NSUInteger) [request.queryParameters[@"l"] integerValue];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(name CONTAINS[cd] %@) AND (identifier != %@)", query, self.selfUser.identifier];
@@ -68,7 +68,7 @@
 // handles /onboarding
 - (ZMTransportResponse *)processOnboardingRequest:(ZMTransportRequest *)request
 {
-    if(request.method == ZMMethodPOST) {
+    if(request.method == ZMTransportRequestMethodPost) {
         NSArray *selfEmailArray = [[request.payload asDictionary] arrayForKey:@"self"];
         if(selfEmailArray.count == 0) {
             return [self errorResponseWithCode:400 reason:@"no self email" apiVersion:request.apiVersion];

--- a/wire-ios-mocktransport/Source/Teams/MockTransportSession+teams.swift
+++ b/wire-ios-mocktransport/Source/Teams/MockTransportSession+teams.swift
@@ -52,9 +52,9 @@ extension MockTransportSession {
             response = fetchAllTeams(query: request.queryParameters, apiVersion: apiVersion)
         case "/teams/*":
             response = fetchTeam(with: request.RESTComponents(index: 1), apiVersion: apiVersion)
-        case "/teams/*/conversations/*" where request.method == .methodDELETE:
+        case "/teams/*/conversations/*" where request.method == .delete:
             response = deleteTeamConversation(teamId: request.RESTComponents(index: 1), conversationId: request.RESTComponents(index: 3), apiVersion: apiVersion)
-        case "/teams/*/conversations/roles"/* where request.method == .methodGET*/:
+        case "/teams/*/conversations/roles"/* where request.method == .get*/:
             response = fetchRolesForTeam(with: request.RESTComponents(index: 1), apiVersion: apiVersion)
         case "/teams/*/services/whitelisted":
             response = fetchWhitelistedServicesForTeam(with: request.RESTComponents(index: 1), query: request.queryParameters, apiVersion: apiVersion)
@@ -64,7 +64,7 @@ extension MockTransportSession {
             response = fetchMembersForTeam(with: request.RESTComponents(index: 1), apiVersion: apiVersion)
         case "/teams/*/members/*":
             response = fetchMemberForTeam(withTeamId: request.RESTComponents(index: 1), userId: request.RESTComponents(index: 3), apiVersion: apiVersion)
-        case "/teams/*/get-members-by-ids-using-post" where request.method == .methodPOST:
+        case "/teams/*/get-members-by-ids-using-post" where request.method == .post:
             let payload = request.payload?.asDictionary()
             let userIDs = payload?["user_ids"] as? [String]
             response = fetchMembersForTeam(with: request.RESTComponents(index: 1), userIds: userIDs, apiVersion: apiVersion)
@@ -236,7 +236,7 @@ extension MockTransportSession {
     private func approveUserLegalHold(inTeam teamId: String?, forUser userId: String?, payload: ZMTransportData?, method: ZMTransportRequestMethod, apiVersion: APIVersion) -> ZMTransportResponse? {
         // 1) Assert request contents
         guard let teamId = teamId, let userId = userId else { return nil }
-        guard method == .methodPUT else { return nil }
+        guard method == .put else { return nil }
 
         // 2) Check the user in the team
         let predicate = MockTeam.predicateWithIdentifier(identifier: teamId)

--- a/wire-ios-mocktransport/Source/Users/MockTransportSession+users.m
+++ b/wire-ios-mocktransport/Source/Users/MockTransportSession+users.m
@@ -49,41 +49,41 @@
 /// handles /users/
 - (ZMTransportResponse *)processUsersRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/users/*/rich-info" method:ZMMethodGET]) {
+    if ([request matchesWithPath:@"/users/*/rich-info" method:ZMTransportRequestMethodGet]) {
         return [self processRichProfileFetchForUser:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/*" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users/*" method:ZMTransportRequestMethodGet]) {
         return [self processUserIDRequest:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users" method:ZMTransportRequestMethodGet]) {
         return [self processUsersRequestWithHandles:request.queryParameters[@"handles"] orIDs:request.queryParameters[@"ids"] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/prekeys" method:ZMMethodPOST]) {
+    else if ([request matchesWithPath:@"/users/prekeys" method:ZMTransportRequestMethodPost]) {
         return [self processUsersPreKeysRequestWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/handles/*" method:ZMMethodGET]
-             || [request matchesWithPath:@"/users/handles/*" method:ZMMethodHEAD]) {
+    else if ([request matchesWithPath:@"/users/handles/*" method:ZMTransportRequestMethodGet]
+             || [request matchesWithPath:@"/users/handles/*" method:ZMTransportRequestMethodHead]) {
         return [self processUserHandleRequest:[request RESTComponentAtIndex:2] path:request.path apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/handles" method:ZMMethodPOST]) {
+    else if ([request matchesWithPath:@"/users/handles" method:ZMTransportRequestMethodPost]) {
         return [self processUserHandleAvailabilityRequest:request.payload apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/by-handle/*/*" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users/by-handle/*/*" method:ZMTransportRequestMethodGet]) {
         return [self processFederatedUserHandleRequest:[request RESTComponentAtIndex:2]
                                                 handle:[request RESTComponentAtIndex:3]
                                                   path:request.path
                                             apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/*/prekeys" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users/*/prekeys" method:ZMTransportRequestMethodGet]) {
         return [self processSingleUserPreKeysRequest:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/*/prekeys/*" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users/*/prekeys/*" method:ZMTransportRequestMethodGet]) {
         return [self processUserPreKeysRequest:[request RESTComponentAtIndex:1] client:[request RESTComponentAtIndex:3] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/*/clients/*" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users/*/clients/*" method:ZMTransportRequestMethodGet]) {
         return [self getUserClient:[request RESTComponentAtIndex:3] forUser:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
-    else if ([request matchesWithPath:@"/users/*/clients" method:ZMMethodGET]) {
+    else if ([request matchesWithPath:@"/users/*/clients" method:ZMTransportRequestMethodGet]) {
         return [self getUserClientsForUser:[request RESTComponentAtIndex:1] apiVersion:request.apiVersion];
     }
 
@@ -221,22 +221,22 @@
 /// handles /self
 - (ZMTransportResponse *)processSelfUserRequest:(ZMTransportRequest *)request;
 {
-    if ([request matchesWithPath:@"/self" method:ZMMethodGET]) {
+    if ([request matchesWithPath:@"/self" method:ZMTransportRequestMethodGet]) {
         return [self getSelfUserWithApiVersion:request.apiVersion];
     }
-    else if([request matchesWithPath:@"/self" method:ZMMethodPUT]) {
+    else if([request matchesWithPath:@"/self" method:ZMTransportRequestMethodPut]) {
         return [self putSelfResponseWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if([request matchesWithPath:@"/self/phone" method:ZMMethodPUT]) {
+    else if([request matchesWithPath:@"/self/phone" method:ZMTransportRequestMethodPut]) {
         return [self putSelfPhoneWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if([request matchesWithPath:@"/self/email" method:ZMMethodPUT]) {
+    else if([request matchesWithPath:@"/self/email" method:ZMTransportRequestMethodPut]) {
         return [self putSelfEmailWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if([request matchesWithPath:@"/self/password" method:ZMMethodPUT]) {
+    else if([request matchesWithPath:@"/self/password" method:ZMTransportRequestMethodPut]) {
         return [self putSelfPasswordWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
-    else if([request matchesWithPath:@"/self/handle" method:ZMMethodPUT]) {
+    else if([request matchesWithPath:@"/self/handle" method:ZMTransportRequestMethodPut]) {
         return [self putSelfHandleWithPayload:[request.payload asDictionary] apiVersion:request.apiVersion];
     }
     return [self errorResponseWithCode:404 reason:@"no-endpoint" apiVersion:request.apiVersion];

--- a/wire-ios-mocktransport/Tests/Source/API Version/MockTransportSessionAPIVersionTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/API Version/MockTransportSessionAPIVersionTests.swift
@@ -31,7 +31,7 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
         // Then
         let response = self.response(forPayload: [:] as ZMTransportData,
                                      path: path,
-                                     method: .methodGET,
+                                     method: .get,
                                      apiVersion: .v0)
 
         // Then
@@ -55,7 +55,7 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
         // Then
         let response = self.response(forPayload: [:] as ZMTransportData,
                                      path: path,
-                                     method: .methodGET,
+                                     method: .get,
                                      apiVersion: .v0)
 
         // Then
@@ -76,7 +76,7 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
         // Then
         let response = self.response(forPayload: [:] as ZMTransportData,
                                      path: path,
-                                     method: .methodGET,
+                                     method: .get,
                                      apiVersion: .v0)
 
         // Then
@@ -90,7 +90,7 @@ class MockTransportSessionAPIVersionTests: MockTransportSessionTests {
         // Then
         let response = self.response(forPayload: [:] as ZMTransportData,
                                      path: path,
-                                     method: .methodGET,
+                                     method: .get,
                                      apiVersion: .v1)
 
         // Then

--- a/wire-ios-mocktransport/Tests/Source/Assets/MockTransportSessionAssetsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Assets/MockTransportSessionAssetsTests.swift
@@ -65,7 +65,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
 
     func testDownloadingNonexistingAssetRequestV3() {
         // when
-        let response = self.response(forPayload: nil, path: "/assets/v3/12345", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v3/12345", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertNotNil(response)
@@ -84,7 +84,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
         XCTAssertNotNil(asset)
 
         // when
-        let response = self.response(forPayload: nil, path: "/assets/v3/\(asset!.identifier)", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v3/\(asset!.identifier)", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertNotNil(response)
@@ -93,7 +93,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
 
     func testDeletingNonexistingAssetRequestV3() {
         // when
-        let response = self.response(forPayload: nil, path: "/assets/v3/12345", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v3/12345", method: .delete, apiVersion: .v0)
 
         // then
         XCTAssertNotNil(response)
@@ -111,7 +111,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
         XCTAssertNotNil(asset)
 
         // when
-        let response = self.response(forPayload: nil, path: "/assets/v3/\(asset!.identifier)", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v3/\(asset!.identifier)", method: .delete, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
 
@@ -145,7 +145,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
         // when
         let key = UUID.create().transportString()
         let domain = UUID.create().transportString()
-        let response = self.response(forPayload: nil, path: "/assets/v4/\(domain)/\(key)", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v4/\(domain)/\(key)", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertNotNil(response)
@@ -164,7 +164,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
         XCTAssertNotNil(asset)
 
         // when
-        let response = self.response(forPayload: nil, path: "/assets/v4/\(asset!.domain!)/\(asset!.identifier)", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v4/\(asset!.domain!)/\(asset!.identifier)", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertNotNil(response)
@@ -175,7 +175,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
         // when
         let key = UUID.create().transportString()
         let domain = UUID.create().transportString()
-        let response = self.response(forPayload: nil, path: "/assets/v4/\(domain)/\(key)", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v4/\(domain)/\(key)", method: .delete, apiVersion: .v0)
 
         // then
         XCTAssertNotNil(response)
@@ -193,7 +193,7 @@ class MockTransportSessionAssetsTests: MockTransportSessionTests {
         XCTAssertNotNil(asset)
 
         // when
-        let response = self.response(forPayload: nil, path: "/assets/v4/\(asset!.domain!)/\(asset!.identifier)", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/assets/v4/\(asset!.domain!)/\(asset!.identifier)", method: .delete, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
 

--- a/wire-ios-mocktransport/Tests/Source/Broadcast/MockTransportSessionBroadcastTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Broadcast/MockTransportSessionBroadcastTests.swift
@@ -65,8 +65,8 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         }
 
         // when
-        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
-        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
 
         // then
         for response in [responseJSON, responsePROTO] {
@@ -114,8 +114,8 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         let protoPayload = try? selfClient.newOtrMessageWithRecipients(for: [], plainText: messageData).serializedData()
 
         // when
-        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
-        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
 
         // then
         for response in [responseJSON, responsePROTO] {
@@ -164,8 +164,8 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         let protoPayload = try? selfClient.newOtrMessageWithRecipients(for: [otherUserClient], plainText: messageData).serializedData()
 
         // when
-        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
-        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
 
         // then
         for response in [responseJSON, responsePROTO] {
@@ -214,8 +214,8 @@ class MockTransportSessionBroadcastTests: MockTransportSessionTests {
         let protoPayload = try? selfClient.newOtrMessageWithRecipients(for: [otherUserClient], plainText: messageData).serializedData()
 
         // when
-        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
-        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .methodPOST, apiVersion: .v0)
+        let responseJSON = self.response(forPayload: payload as ZMTransportData, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
+        let responsePROTO = self.response(forProtobufData: protoPayload, path: "/broadcast/otr/messages", method: .post, apiVersion: .v0)
 
         // then
         for response in [responseJSON, responsePROTO] {

--- a/wire-ios-mocktransport/Tests/Source/Clients and OTR/MockTransportSessionClientsTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Clients and OTR/MockTransportSessionClientsTests.m
@@ -86,7 +86,7 @@
     NSMutableDictionary *payload = [self payloadtoRegisterClient:keysCount password:selfUser.password];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -151,7 +151,7 @@
     NSUInteger keysCount = 100;
     NSMutableDictionary *payload = [self payloadtoRegisterClient:keysCount];
 
-    (void)[self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    (void)[self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // WHEN
     //uploading second client
@@ -160,7 +160,7 @@
     payload[@"label"] = secondLabel;
     payload[@"password"] = selfUser.password;
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -214,7 +214,7 @@
     NSUInteger keysCount = 100;
     NSMutableDictionary *payload = [self payloadtoRegisterClient:keysCount];
     
-    (void)[self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    (void)[self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // WHEN
     //uploading second client
@@ -222,7 +222,7 @@
     NSString *secondLabel = @"anotherClient";
     payload[@"label"] = secondLabel;
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -247,7 +247,7 @@
     NSUInteger keysCount = 100;
     NSMutableDictionary *payload = [self payloadtoRegisterClient:keysCount];
     
-    (void)[self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    (void)[self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // WHEN
     //uploading second client
@@ -256,7 +256,7 @@
     payload[@"label"] = secondLabel;
     payload[@"password"] = @"wrong pass";
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -281,7 +281,7 @@
     NSUInteger keysCount = 100;
     NSMutableDictionary *payload = [self payloadtoRegisterClient:keysCount];
     
-    (void)[self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    (void)[self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // WHEN
     //uploading second client
@@ -290,11 +290,11 @@
     payload[@"label"] = secondLabel;
     payload[@"password"] = selfUser.password;
     
-    (void)[self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    (void)[self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // uploading third client
     payload[@"label"] = @"third client";
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
 
     XCTAssertNotNil(response);
     if (!response) {
@@ -384,7 +384,7 @@
     final[@"password"] = selfUser.password;
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:[final copy] path:@"/clients" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:[final copy] path:@"/clients" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -419,7 +419,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:nil path:@"/clients" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:@"/clients" method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -454,7 +454,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/users/%@/clients", user1.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -502,7 +502,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/clients/%@", client.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -534,7 +534,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/clients/%@", client.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodDELETE apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodDelete apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -542,7 +542,7 @@
     XCTAssertNil(response.transportSessionError);
     
     // and when
-    ZMTransportResponse *response2 = [self responseForPayload:nil path:@"/clients" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response2 = [self responseForPayload:nil path:@"/clients" method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response2);

--- a/wire-ios-mocktransport/Tests/Source/Connections/MockTransportSessionConnectionsTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Connections/MockTransportSessionConnectionsTests.m
@@ -52,7 +52,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:nil path:@"/connections" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:@"/connections" method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -94,7 +94,7 @@
                               @"name": @"",
                               @"message": message
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 201);
@@ -137,7 +137,7 @@
                               @"name": @"",
                               @"message": @""
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMTransportRequestMethodPost apiVersion:0];
     
     
     // THEN
@@ -181,7 +181,7 @@
     NSDictionary *payload = @{
                               @"status": @"sent"
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:[NSString stringWithFormat:@"/connections/%@", connection.to.identifier] method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:[NSString stringWithFormat:@"/connections/%@", connection.to.identifier] method:ZMTransportRequestMethodPut apiVersion:0];
     XCTAssertEqual(response.HTTPStatus, 403);
 }
 
@@ -211,7 +211,7 @@
                               @"name": @"",
                               @"message": @""
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 201);
@@ -247,7 +247,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/connections" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);

--- a/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationAccessTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationAccessTests.swift
@@ -44,7 +44,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
 
     func testThatSettingAccessModeReturnsErrorWhenConversationDoesNotExist() {
         // when
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/123456/access", method: .methodPUT, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/123456/access", method: .put, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 404)
@@ -57,7 +57,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         ] as ZMTransportData
 
         // when
-        let response = self.response(forPayload: payload, path: "/conversations/\(self.conversation.identifier)/access", method: .methodPUT, apiVersion: .v0)
+        let response = self.response(forPayload: payload, path: "/conversations/\(self.conversation.identifier)/access", method: .put, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 400)
@@ -70,7 +70,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
             ] as ZMTransportData
 
         // when
-        let response = self.response(forPayload: payload, path: "/conversations/\(self.conversation.identifier)/access", method: .methodPUT, apiVersion: .v0)
+        let response = self.response(forPayload: payload, path: "/conversations/\(self.conversation.identifier)/access", method: .put, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 400)
@@ -89,7 +89,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
             ] as ZMTransportData
 
         // when
-        let response = self.response(forPayload: payload, path: "/conversations/\(self.conversation.identifier)/access", method: .methodPUT, apiVersion: .v0)
+        let response = self.response(forPayload: payload, path: "/conversations/\(self.conversation.identifier)/access", method: .put, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -110,7 +110,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         // given
         self.conversation.accessMode = ["code", "invite"]
         // when
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .post, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 201)
@@ -130,7 +130,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         // given
         self.conversation.accessMode = ["invite"]
         // when
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .post, apiVersion: .v0)
         // then
         XCTAssertEqual(response?.httpStatus, 403)
     }
@@ -141,7 +141,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         self.conversation.accessMode = ["code", "invite"]
         self.conversation.link = existingLink
         // when
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .post, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -158,7 +158,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         let status = self.conversation.guestLinkFeatureStatus
 
         // WHEN
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/features/conversationGuestLinks", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/features/conversationGuestLinks", method: .get, apiVersion: .v0)
 
         // THEN
         XCTAssertEqual(response?.httpStatus, 200)
@@ -172,7 +172,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         self.conversation.guestLinkFeatureStatus = "enabled"
 
         // WHEN
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(UUID.create())/features/conversationGuestLinks", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(UUID.create())/features/conversationGuestLinks", method: .get, apiVersion: .v0)
 
         // THEN
         XCTAssertEqual(response?.httpStatus, 404)
@@ -185,7 +185,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         self.conversation.accessMode = ["code", "invite"]
         self.conversation.link = existingLink
         // when
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -202,7 +202,7 @@ class MockTransportSessionConversationAccessTests: MockTransportSessionTests {
         self.conversation.accessMode = ["code", "invite"]
         self.conversation.link = existingLink
         // when
-        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: [:] as ZMTransportData, path: "/conversations/\(self.conversation.identifier)/code", method: .delete, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)

--- a/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationsTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationsTests.m
@@ -43,7 +43,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:groupConversation.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -64,7 +64,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:groupConversation.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     [self checkThatTransportData:response.payload selfUserHasGroupRole:@"wire_admin"];
@@ -85,7 +85,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:groupConversation.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     [self checkThatTransportData:response.payload selfUserHasGroupRole:@"wire_member"];
@@ -111,7 +111,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:groupConversation.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     [self checkThatTransportData:response.payload firstOtherUserHasGroupRole:@"wire_admin"];
@@ -136,7 +136,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:groupConversation.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     [self checkThatTransportData:response.payload firstOtherUserHasGroupRole:@"wire_member"];
@@ -158,7 +158,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:groupConversation.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 403);
@@ -176,7 +176,7 @@
     
     // WHEN
     NSString *path = [@"/conversations/" stringByAppendingPathComponent:NSUUID.createUUID.transportString];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -213,7 +213,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:nil path:@"/conversations/" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:@"/conversations/" method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -265,7 +265,7 @@
     
     NSDictionary *payload = @{ @"users": @[user1ID, user2ID] };
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/conversations/" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/conversations/" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -315,7 +315,7 @@
                                @"conversation_role" : @"wire_member"
                                };
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/conversations/" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/conversations/" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -366,7 +366,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSString *requestPath = [NSString pathWithComponents:@[@"/", @"conversations", oneOnOneConversationID, path]];
-    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -385,7 +385,7 @@
     AssertDateIsRecent([responsePayload dateFor:@"time"]);
     
     path = @"/notifications";
-    ZMTransportResponse *eventsResponse = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *eventsResponse = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(eventsResponse);
@@ -453,7 +453,7 @@
     
     // WHEN
     NSString *requestPath = [NSString pathWithComponents:@[@"/", @"conversations", conversation.identifier, @"otr", @"messages"]];
-    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     XCTAssertNotNil(response);
     XCTAssertNil(response.transportSessionError);
@@ -522,7 +522,7 @@
     // WHEN
     NSString *requestBasePath = [NSString pathWithComponents:@[@"/", @"conversations", conversation.identifier, @"otr", @"messages"]];
     NSString *requestPath = [NSString stringWithFormat:@"%@?report_missing=%@", requestBasePath, otherUser.identifier];
-    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     XCTAssertNotNil(response);
     XCTAssertNil(response.transportSessionError);
@@ -584,7 +584,7 @@
     // WHEN
     NSString *requestBasePath = [NSString pathWithComponents:@[@"/", @"conversations", conversation.identifier, @"otr", @"messages"]];
     NSString *requestPath = [NSString stringWithFormat:@"%@?report_missing=%@", requestBasePath, otherUser.identifier];
-    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     XCTAssertNotNil(response);
     XCTAssertNil(response.transportSessionError);
@@ -645,7 +645,7 @@
     
     // WHEN
     NSString *requestPath = [NSString pathWithComponents:@[@"/", @"conversations", conversation.identifier, @"otr", @"messages"]];
-    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:requestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -951,7 +951,7 @@
     NSString *path = [@"/conversations/" stringByAppendingString:conversationID];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     [self.sut.managedObjectContext performBlockAndWait:^{
@@ -976,7 +976,7 @@
     NSString *path = [[@"/conversations/" stringByAppendingString:conversation.identifier] stringByAppendingString:@"/receipt-mode"];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     [self.sut.managedObjectContext performBlockAndWait:^{
@@ -1010,7 +1010,7 @@
     
     NSString *path = [NSString pathWithComponents:@[@"/", @"conversations", groupConversationID, @"members", user1ID]];
     
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodDELETE apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodDelete apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -1052,7 +1052,7 @@
                               };
     
     //WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -1103,7 +1103,7 @@
                               };
     
     //WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -1151,7 +1151,7 @@
                               };
 
     //WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -1192,7 +1192,7 @@
                               @"users": @[user3ID.lowercaseString]
                               };
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -1228,7 +1228,7 @@
     
     // WHEN
     NSString *path = @"/conversations/ids";
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -1270,7 +1270,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/conversations?ids=%@", [requestedConversationIDs componentsJoinedByString:@","]];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -1315,7 +1315,7 @@
     NSString *path = [NSString stringWithFormat:@"/conversations/%@/self", conversationID];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     [self.sut.managedObjectContext performBlockAndWait:^{
@@ -1347,7 +1347,7 @@
     NSString *path = [NSString stringWithFormat:@"/conversations/%@/self", conversationID];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     [self.sut.managedObjectContext performBlockAndWait:^{
@@ -1379,7 +1379,7 @@
     NSString *path = [NSString stringWithFormat:@"/conversations/%@/self", conversationID];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     [self.sut.managedObjectContext performBlockAndWait:^{
@@ -1414,7 +1414,7 @@
     NSString *path = [NSString stringWithFormat:@"/conversations/%@/self", conversationID];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:path method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     [self.sut.managedObjectContext performBlockAndWait:^{

--- a/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationsTests.swift
@@ -190,7 +190,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
 
         // when
         let path = "/conversations/\(conversation.identifier)/roles"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)
@@ -235,7 +235,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
 
         // when
         let path = "/conversations/\(conversation.identifier)/roles"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)
@@ -305,7 +305,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
 
         // WHEN
         let requestPath = "/conversations/\(conversation!.identifier)/otr/messages"
-        let response = self.response(forProtobufData: messageData, path: requestPath, method: ZMTransportRequestMethod.methodPOST, apiVersion: .v0)
+        let response = self.response(forProtobufData: messageData, path: requestPath, method: ZMTransportRequestMethod.post, apiVersion: .v0)
 
         // THEN
         XCTAssertEqual(response!.httpStatus, 201)
@@ -354,7 +354,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
 
         // WHEN
         let requestPath = "/conversations/\(conversation.identifier)/otr/messages"
-        let response = self.response(forProtobufData: messageData, path: requestPath, method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forProtobufData: messageData, path: requestPath, method: .post, apiVersion: .v0)
 
         // THEN
         XCTAssertNotNil(response)
@@ -410,7 +410,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
 
         // WHEN
         let requestPath = "/conversations/\(conversation.identifier)/otr/messages"
-        let response = self.response(forProtobufData: messageData, path: requestPath, method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forProtobufData: messageData, path: requestPath, method: .post, apiVersion: .v0)
 
         // THEN
         XCTAssertNotNil(response)

--- a/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionJoinConversationTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionJoinConversationTests.swift
@@ -49,7 +49,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
         ] as ZMTransportData
 
         // when
-        let response = self.response(forPayload: payload, path: "/conversations/join", method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: payload, path: "/conversations/join", method: .post, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -73,7 +73,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
         ] as ZMTransportData
 
         // when
-        let response = self.response(forPayload: payload, path: "/conversations/join", method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: payload, path: "/conversations/join", method: .post, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 204)
@@ -87,7 +87,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
         ] as ZMTransportData
 
         // when
-        let response = self.response(forPayload: payload, path: "/conversations/join", method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: payload, path: "/conversations/join", method: .post, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 404)
@@ -106,7 +106,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
         let path = String(format: "/conversations/join?code=%@&key=%@", "test-code", "test-key")
 
         // when
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -126,7 +126,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
         let path = String(format: "/conversations/join?code=%@&key=%@", "existing-conversation-code", "test-key")
 
         // when
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -146,7 +146,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
         let path = String(format: "/conversations/join?code=%@&key=%@", "wrong-code", "test-key")
 
         // when
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 404)

--- a/wire-ios-mocktransport/Tests/Source/Login/MockTransportSessionLoginTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Login/MockTransportSessionLoginTests.m
@@ -49,7 +49,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": password
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertNotNil(response);
@@ -75,13 +75,13 @@
     [[(id) self.sut.cookieStorage expect] setAuthenticationCookieData:OCMOCK_ANY];
 
     // WHEN
-    [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // and when
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"phone": phone,
                                                                @"code": self.sut.phoneVerificationCodeForLogin
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertNotNil(response);
@@ -111,17 +111,17 @@
     // WHEN
     ZMTransportResponse *verificationCodeSendResponse = [self responseForPayload:@{@"email":email, @"action":action}
                                                                             path:@"/verification-code/send"
-                                                                          method:ZMMethodPOST
+                                                                          method:ZMTransportRequestMethodPost
                                                                       apiVersion:0];
 
-    [self responseForPayload:@{@"email":email} path:@"/login/send" method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:@{@"email":email} path:@"/login/send" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // and when
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": password,
                                                                @"verification_code": self.sut.generatedEmailVerificationCode
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertNotNil(response);
@@ -153,7 +153,7 @@
     ZMTransportResponse *verificationCodeSendResponse = [self responseForPayload:@{
                                                                                   @"email":email,
                                                                                   @"action":action
-                                                                                  } path:@"/verification-code/send" method:ZMMethodPOST apiVersion:0];
+                                                                                  } path:@"/verification-code/send" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertNotNil(verificationCodeSendResponse);
@@ -163,7 +163,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": password,
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertNotNil(verificationCodeSendResponse);
@@ -189,13 +189,13 @@
     [[(id) self.sut.cookieStorage reject] setAuthenticationCookieData:OCMOCK_ANY];
 
     // WHEN
-    [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // and when
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"phone": phone,
                                                                @"code": self.sut.invalidPhoneVerificationCode
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertNotNil(response);
@@ -225,7 +225,7 @@
     // WHEN
     ZMTransportResponse *verificationCodeSendResponse = [self responseForPayload:@{@"email":email, @"action":action}
                                                                             path:@"/verification-code/send"
-                                                                          method:ZMMethodPOST
+                                                                          method:ZMTransportRequestMethodPost
                                                                       apiVersion:0];
 
     // THEN
@@ -238,7 +238,7 @@
                                                                @"email": email,
                                                                @"password": password,
                                                                @"verification_code": verificationCode,
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
 
     XCTAssertNotNil(response);
     XCTAssertEqual(response.HTTPStatus, 403);
@@ -263,13 +263,13 @@
     [[(id) self.sut.cookieStorage reject] setAuthenticationCookieData:OCMOCK_ANY];
 
     // WHEN
-    [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // and when
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"phone": phone,
                                                                @"code": self.sut.phoneVerificationCodeForLogin
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -292,7 +292,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
 
      // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -314,7 +314,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
 
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/login/send" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -341,7 +341,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"phone": phone,
                                                                @"code": self.sut.phoneVerificationCodeForLogin
-                                                               } path:@"/login" method:ZMMethodPOST apiVersion:0];
+                                                               } path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -372,7 +372,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": password
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -401,7 +401,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": @"invalid"
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -434,7 +434,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": @"invalid@example.com",
                                                                @"password": password
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionPushChannelTests.m
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionPushChannelTests.m
@@ -53,7 +53,7 @@
         
         payload = @{@"email" : selfUser.email, @"password" : selfUser.password};
     }];
-    [self responseForPayload:payload path:@"/login" method:ZMMethodPOST apiVersion:0]; // this will simulate the user logging in
+    [self responseForPayload:payload path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0]; // this will simulate the user logging in
     
     // WHEN
     [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
@@ -529,7 +529,7 @@
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
                                                                @"password": password
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
     [self.sut.mockedTransportSession.pushChannel setKeepOpen:YES];
     
     WaitForAllGroupsToBeEmpty(0.5);
@@ -626,7 +626,7 @@
     NSArray *expectedTypes = [self createConversationAndReturnExpectedNotificationTypes];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:nil path:@"/notifications" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:@"/notifications" method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.result, ZMTransportResponseStatusSuccess);
@@ -652,7 +652,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/notifications?since=%@", [NSUUID createUUID].transportString];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -678,14 +678,14 @@
     NSArray *expectedTypes = [self createConversationAndReturnExpectedNotificationTypes];
     XCTAssertTrue(eventsOffset < expectedTypes.count);
     
-    ZMTransportResponse *response = [self responseForPayload:nil path:@"/notifications" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:@"/notifications" method:ZMTransportRequestMethodGet apiVersion:0];
     
     NSArray *allEvents = [[[response.payload asDictionary] arrayForKey:@"notifications" ] asDictionaries];
     NSUUID *startingEventID = [allEvents[eventsOffset-1] uuidForKey:@"id"];
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/notifications?since=%@", startingEventID.transportString];
-    response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     NSArray *expectedEvents = [allEvents subarrayWithRange:NSMakeRange(eventsOffset, allEvents.count - eventsOffset)];
@@ -723,7 +723,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:nil path:@"/notifications/last" method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:@"/notifications/last" method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.result, ZMTransportResponseStatusSuccess);

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionRequestsTests.m
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionRequestsTests.m
@@ -34,7 +34,7 @@
     NSInteger expectedStatus = 451;
     
     NSString *requestPath =@"/connections";
-    ZMTransportRequestMethod requestMethod = ZMMethodPUT;
+    ZMTransportRequestMethod requestMethod = ZMTransportRequestMethodPut;
     NSArray *requestPayload = @[@3,@4,@5];
     
     __block ZMTransportRequest *receivedRequest;
@@ -72,7 +72,7 @@
         selfUser.phone = @"456456456";
     }];
     NSString *requestPath = [NSString stringWithFormat:@"/users?ids=%@", self.sut.selfUser.identifier];
-    ZMTransportRequestMethod requestMethod = ZMMethodGET;
+    ZMTransportRequestMethod requestMethod = ZMTransportRequestMethodGet;
     NSArray *requestPayload = nil;
     
     // GIVEN
@@ -110,7 +110,7 @@
         completed = YES;
     }];
     
-    ZMTransportRequestGenerator generator = [self createGeneratorForPayload:nil path:@"/foo" method:ZMMethodGET apiVersion:0 handler:handler];
+    ZMTransportRequestGenerator generator = [self createGeneratorForPayload:nil path:@"/foo" method:ZMTransportRequestMethodGet apiVersion:0 handler:handler];
     
     ZMTransportEnqueueResult* result = [self.sut.mockedTransportSession attemptToEnqueueSyncRequestWithGenerator:generator];
     WaitForAllGroupsToBeEmpty(0.2);
@@ -149,7 +149,7 @@
     NSString *path = [NSString pathWithComponents:@[@"/", @"assets", [NSString stringWithFormat:@"%@?conv_id=%@", assetID, convID]]];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -202,7 +202,7 @@
             XCTFail(@"Shouldn't respond");
         }];
         
-        ZMTransportRequestGenerator generator = [self createGeneratorForPayload:payload path:path method:ZMMethodPOST apiVersion:0 handler:handler];
+        ZMTransportRequestGenerator generator = [self createGeneratorForPayload:payload path:path method:ZMTransportRequestMethodPost apiVersion:0 handler:handler];
         
         ZMTransportEnqueueResult *result = [self.sut.mockedTransportSession attemptToEnqueueSyncRequestWithGenerator:generator];
         
@@ -218,7 +218,7 @@
         self.sut.doNotRespondToRequests = NO;
         
         NSString *path = @"/notifications";
-        ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+        ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
         
         // THEN
         XCTAssertNotNil(response);
@@ -254,7 +254,7 @@
     }];
     
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodGET payload:nil apiVersion:0];
+        ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
         [request addCompletionHandler:handler];
         return request;
     };
@@ -296,7 +296,7 @@
     }];
     
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodGET payload:nil apiVersion:0];
+        ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
         [request expireAfterInterval:0.2]; //This is the important bit
         [request addCompletionHandler:handler];
         return request;
@@ -339,8 +339,8 @@
 {
     // GIVEN
     ZMTransportRequest *req1 = [ZMTransportRequest requestGetFromPath:@"/this/path" apiVersion:0];
-    ZMTransportRequest *req2 = [ZMTransportRequest requestWithPath:@"/foo/bar" method:ZMMethodDELETE payload:nil apiVersion:0];
-    ZMTransportRequest *req3 = [ZMTransportRequest requestWithPath:@"/arrrr" method:ZMMethodPUT payload:@{@"name":@"Johnny"} apiVersion:0];
+    ZMTransportRequest *req2 = [ZMTransportRequest requestWithPath:@"/foo/bar" method:ZMTransportRequestMethodDelete payload:nil apiVersion:0];
+    ZMTransportRequest *req3 = [ZMTransportRequest requestWithPath:@"/arrrr" method:ZMTransportRequestMethodPut payload:@{@"name":@"Johnny"} apiVersion:0];
     
     NSArray *requests = @[req1, req2, req3];
     
@@ -358,8 +358,8 @@
 {
     // GIVEN
     ZMTransportRequest *req1 = [ZMTransportRequest requestGetFromPath:@"/this/path" apiVersion:0];
-    ZMTransportRequest *req2 = [ZMTransportRequest requestWithPath:@"/foo/bar" method:ZMMethodDELETE payload:nil apiVersion:0];
-    ZMTransportRequest *req3 = [ZMTransportRequest requestWithPath:@"/arrrr" method:ZMMethodPUT payload:@{@"name":@"Johnny"} apiVersion:0];
+    ZMTransportRequest *req2 = [ZMTransportRequest requestWithPath:@"/foo/bar" method:ZMTransportRequestMethodDelete payload:nil apiVersion:0];
+    ZMTransportRequest *req3 = [ZMTransportRequest requestWithPath:@"/arrrr" method:ZMTransportRequestMethodPut payload:@{@"name":@"Johnny"} apiVersion:0];
     for(ZMTransportRequest *request in @[req1, req2]) {
         [self sendRequestToMockTransportSession:request];
     }

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.m
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.m
@@ -175,7 +175,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
-    [self responseForPayload:payload path:@"/login" method:ZMMethodPOST apiVersion:0]; // this will simulate the user logging in
+    [self responseForPayload:payload path:@"/login" method:ZMTransportRequestMethodPost apiVersion:0]; // this will simulate the user logging in
     WaitForAllGroupsToBeEmpty(0.5);
     
     [self.sut.mockedTransportSession configurePushChannelWithConsumer:self groupQueue:self.fakeSyncContext];
@@ -361,9 +361,9 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 - (ZMTransportRequestGenerator)createGeneratorForPayload:(id<ZMTransportData>)payload path:(NSString *)path method:(ZMTransportRequestMethod)method apiVersion:(APIVersion)apiVersion handler:(ZMCompletionHandler *)handler
 {
     switch (method) {
-        case ZMMethodGET:
-        case ZMMethodDELETE:
-        case ZMMethodHEAD:
+        case ZMTransportRequestMethodGet:
+        case ZMTransportRequestMethodDelete:
+        case ZMTransportRequestMethodHead:
             payload = nil;
             break;
         default:

--- a/wire-ios-mocktransport/Tests/Source/Push Token/MockTransportPushTokenTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Push Token/MockTransportPushTokenTests.m
@@ -34,7 +34,7 @@
                               @"transport" : @"APNS_VOIP"};
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/push/tokens" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/push/tokens" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, (NSInteger) 400);
@@ -49,7 +49,7 @@
                               @"transport" : @"APNS"};
 
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/push/tokens" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/push/tokens" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, (NSInteger) 201);
@@ -71,7 +71,7 @@
         // WHEN
         __block ZMTransportResponse *response;
         [self performIgnoringZMLogError:^{
-            response = [self responseForPayload:p2 path:@"/push/tokens" method:ZMMethodPOST apiVersion:0];
+            response = [self responseForPayload:p2 path:@"/push/tokens" method:ZMTransportRequestMethodPost apiVersion:0];
         }];
         
         // THEN
@@ -93,7 +93,7 @@
                               @"transport" : @"sfkhhksdf"};
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/push/tokens" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/push/tokens" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, (NSInteger) 400);

--- a/wire-ios-mocktransport/Tests/Source/Push Token/MockTransportPushTokenTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Push Token/MockTransportPushTokenTests.swift
@@ -31,10 +31,10 @@ class MockTransportPushTokenTests_Swift: MockTransportSessionTests {
     func testThatWeCanDeletePushToken() {
         // given
         let token = "abcdef"
-        _ = response(forPayload: payload(token: token), path: "/push/tokens", method: .methodPOST, apiVersion: .v0)
+        _ = response(forPayload: payload(token: token), path: "/push/tokens", method: .post, apiVersion: .v0)
 
         // when
-        let result = response(forPayload: nil, path: "/push/tokens/\(token)", method: .methodDELETE, apiVersion: .v0)
+        let result = response(forPayload: nil, path: "/push/tokens/\(token)", method: .delete, apiVersion: .v0)
 
         // then
         XCTAssertEqual(result?.httpStatus, 204)
@@ -45,7 +45,7 @@ class MockTransportPushTokenTests_Swift: MockTransportSessionTests {
         let token = "abcdef"
 
         // when
-        let result = response(forPayload: nil, path: "/push/tokens/\(token)", method: .methodDELETE, apiVersion: .v0)
+        let result = response(forPayload: nil, path: "/push/tokens/\(token)", method: .delete, apiVersion: .v0)
 
         // then
         XCTAssertEqual(result?.httpStatus, 404)
@@ -54,13 +54,13 @@ class MockTransportPushTokenTests_Swift: MockTransportSessionTests {
     func testThatWeCanDeleteMultiplePushTokens() {
         // given
         let token1 = "abcdef"
-        _ = response(forPayload: payload(token: token1), path: "/push/tokens", method: .methodPOST, apiVersion: .v0)
+        _ = response(forPayload: payload(token: token1), path: "/push/tokens", method: .post, apiVersion: .v0)
         let token2 = "bcdes"
-        _ = response(forPayload: payload(token: token2), path: "/push/tokens", method: .methodPOST, apiVersion: .v0)
+        _ = response(forPayload: payload(token: token2), path: "/push/tokens", method: .post, apiVersion: .v0)
 
         // when
-        let result1 = response(forPayload: nil, path: "/push/tokens/\(token1)", method: .methodDELETE, apiVersion: .v0)
-        let result2 = response(forPayload: nil, path: "/push/tokens/\(token2)", method: .methodDELETE, apiVersion: .v0)
+        let result1 = response(forPayload: nil, path: "/push/tokens/\(token1)", method: .delete, apiVersion: .v0)
+        let result2 = response(forPayload: nil, path: "/push/tokens/\(token2)", method: .delete, apiVersion: .v0)
 
         // then
         XCTAssertEqual(result1?.httpStatus, 204)
@@ -71,11 +71,11 @@ class MockTransportPushTokenTests_Swift: MockTransportSessionTests {
         // given
         let payload1 = payload(token: "some token")
         let payload2 = payload(token: "other token")
-        _ = response(forPayload: payload1, path: "/push/tokens", method: .methodPOST, apiVersion: .v0)
-        _ = response(forPayload: payload2, path: "/push/tokens", method: .methodPOST, apiVersion: .v0)
+        _ = response(forPayload: payload1, path: "/push/tokens", method: .post, apiVersion: .v0)
+        _ = response(forPayload: payload2, path: "/push/tokens", method: .post, apiVersion: .v0)
 
         // when
-        let result = response(forPayload: nil, path: "/push/tokens", method: .methodGET, apiVersion: .v0)
+        let result = response(forPayload: nil, path: "/push/tokens", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertEqual(result?.httpStatus, 200)

--- a/wire-ios-mocktransport/Tests/Source/Registration/MockTransportSessionEmailPhoneVerificationTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Registration/MockTransportSessionEmailPhoneVerificationTests.m
@@ -47,7 +47,7 @@
     
     // WHEN
     NSString *path = @"/activate/send";
-    ZMTransportResponse *response = [self responseForPayload:@{} path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{} path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -74,7 +74,7 @@
     NSString *path = @"/activate/send";
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -102,7 +102,7 @@
     NSString *path = @"/activate/send";
     ZMTransportResponse *response = [self responseForPayload:@{
                                                                @"email": email,
-                                                               } path:path method:ZMMethodPOST apiVersion:0];
+                                                               } path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -116,7 +116,7 @@
 
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
-    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -134,7 +134,7 @@
 
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
-    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -148,10 +148,10 @@
     NSDictionary *validationPayload = @{@"email":email,@"code":self.sut.emailActivationCode,@"dryrun":@YES};
     NSString *codeRequestPath = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
     NSString *validationPath = [NSString pathWithComponents:@[@"/", @"activate"]];
-    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMTransportRequestMethodPost apiVersion:0];
 
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -167,7 +167,7 @@
     NSString *validationPath = [NSString pathWithComponents:@[@"/", @"activate"]];
 
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -181,10 +181,10 @@
     NSDictionary *validationPayload = @{@"email":email,@"code":self.sut.emailActivationCode};
     NSString *codeRequestPath = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
     NSString *validationPath = [NSString pathWithComponents:@[@"/", @"activate"]];
-    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMTransportRequestMethodPost apiVersion:0];
 
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -200,7 +200,7 @@
     
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
-    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -218,7 +218,7 @@
     
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
-    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:requestPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -232,10 +232,10 @@
     NSDictionary *validationPayload = @{@"phone":phone,@"code":self.sut.phoneVerificationCodeForRegistration,@"dryrun":@YES};
     NSString *codeRequestPath = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
     NSString *validationPath = [NSString pathWithComponents:@[@"/", @"activate"]];
-    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -251,7 +251,7 @@
     NSString *validationPath = [NSString pathWithComponents:@[@"/", @"activate"]];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -265,10 +265,10 @@
     NSDictionary *validationPayload = @{@"phone":phone,@"code":self.sut.phoneVerificationCodeForRegistration};
     NSString *codeRequestPath = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
     NSString *validationPath = [NSString pathWithComponents:@[@"/", @"activate"]];
-    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:codeRequestPayload path:codeRequestPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:validationPayload path:validationPath method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);

--- a/wire-ios-mocktransport/Tests/Source/Registration/MockTransportSessionRegistrationTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Registration/MockTransportSessionRegistrationTests.m
@@ -63,7 +63,7 @@
 - (void)testThatRegistrationReturns404OnWrongMethod
 {
     // GIVEN
-    ZMTransportRequestMethod methods[] = {ZMMethodHEAD, ZMMethodGET, ZMMethodDELETE, ZMMethodPUT};
+    ZMTransportRequestMethod methods[] = {ZMTransportRequestMethodHead, ZMTransportRequestMethodGet, ZMTransportRequestMethodDelete, ZMTransportRequestMethodPut};
     NSDictionary *payload = @{
                               @"name" : @"Someone someone",
                               @"email" : @"someone@example.com",
@@ -91,7 +91,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -117,7 +117,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     NSURL *url = [NSURL URLWithString:@"/register" relativeToURL:self.sut.baseURL];
     
     // THEN
@@ -137,7 +137,7 @@
                               };
     
     // WHEN
-    __unused ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    __unused ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // expect
     __block NSData *cookieData;
@@ -157,7 +157,7 @@
                               };
     
     // WHEN
-    __unused ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    __unused ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // expect
     __block NSData *cookieData;
@@ -177,7 +177,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -200,7 +200,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertNil([[response.payload asDictionary] optionalStringForKey:@"email"]);
@@ -220,7 +220,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     XCTAssertEqualObjects([[response.payload asDictionary] optionalStringForKey:@"email"], payload[@"email"]);
 
     // THEN
@@ -243,7 +243,7 @@
                               @"password" : @"supersecure",
                               };
     
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     XCTAssertNotNil(response);
     
     // WHEN
@@ -272,7 +272,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -304,7 +304,7 @@
         [dictionaryWithoutAKey removeObjectForKey:key];
         
         // WHEN
-        ZMTransportResponse *response = [self responseForPayload:dictionaryWithoutAKey path:@"/register" method:ZMMethodPOST apiVersion:0];
+        ZMTransportResponse *response = [self responseForPayload:dictionaryWithoutAKey path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
         
         // THEN
         XCTAssertEqual(response.HTTPStatus, 400);
@@ -329,7 +329,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -339,7 +339,7 @@
 - (void)requestVerificationCodeForPhone:(NSString *)phone {
     NSDictionary *requestPayload = @{@"phone":phone};
     NSString *path = [NSString pathWithComponents:@[@"/", @"activate", @"send"]];
-    [self responseForPayload:requestPayload path:path method:ZMMethodPOST apiVersion:0];
+    [self responseForPayload:requestPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
 }
 
 - (void)testThatRegistrationWithPhoneNumberReturns201AndCreatesAUserIfItHasAValidPhoneVerificationCode
@@ -354,7 +354,7 @@
     [self requestVerificationCodeForPhone:phone];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -380,7 +380,7 @@
     [[(id) self.sut.cookieStorage expect] setAuthenticationCookieData:ZM_ARG_SAVE(cookieData)];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -403,7 +403,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -421,7 +421,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -439,7 +439,7 @@
     [self requestVerificationCodeForPhone:phone];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/register" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);

--- a/wire-ios-mocktransport/Tests/Source/Search/MockTransportSessionAddressBookTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Search/MockTransportSessionAddressBookTests.m
@@ -46,7 +46,7 @@
                                       @"cards": @[@{@"contact":@[]}]
                                       };
     NSString *path = [NSString pathWithComponents:@[@"/", @"onboarding", @"v3"]];
-    ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     NSDictionary *expectedPayload = @{
@@ -69,7 +69,7 @@
     NSString *path = [NSString pathWithComponents:@[@"/", @"onboarding", @"v3"]];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 400);
@@ -85,7 +85,7 @@
     
     // WHEN
     [self performIgnoringZMLogError:^{
-        ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMMethodPOST apiVersion:0];
+        ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
         
         // THEN
         XCTAssertEqual(response.HTTPStatus, 400);
@@ -103,7 +103,7 @@
     
     // WHEN
     [self performIgnoringZMLogError:^{
-        ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMMethodPOST apiVersion:0];
+        ZMTransportResponse *response = [self responseForPayload:upstreamPayload path:path method:ZMTransportRequestMethodPost apiVersion:0];
         
         // THEN
         XCTAssertEqual(response.HTTPStatus, 400);

--- a/wire-ios-mocktransport/Tests/Source/Search/MockTransportSessionSearchTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Search/MockTransportSessionSearchTests.m
@@ -61,7 +61,7 @@
     
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"search", @"contacts?q=AA&l=200&d=1"]];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     
     // THEN
@@ -131,7 +131,7 @@
     
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"search", @"contacts?q=aa&l=3&d=1"]];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     
     // THEN
@@ -194,7 +194,7 @@
     
     // WHEN
     NSString *path = [NSString pathWithComponents:@[@"/", @"search", @"contacts?q=User&l=200&d=1"]];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     
     // THEN

--- a/wire-ios-mocktransport/Tests/Source/Services/MockServicesTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Services/MockServicesTests.swift
@@ -28,7 +28,7 @@ class MockServicesTests: MockTransportSessionTests {
 
         // when
 
-        let response = sut.processTeamsRequest(ZMTransportRequest(path: "/teams/\(teamID.transportString())/services/whitelisted?prefix=Normal", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue))
+        let response = sut.processTeamsRequest(ZMTransportRequest(path: "/teams/\(teamID.transportString())/services/whitelisted?prefix=Normal", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue))
         // then
         XCTAssertEqual(response.httpStatus, 200)
         XCTAssertNotNil(response.payload?.asDictionary()?["services"])
@@ -82,7 +82,7 @@ class MockServicesTests: MockTransportSessionTests {
         // when
         let payload = ["service": service.identifier,
                        "provider": service.provider]
-        let response = sut.processServiceRequest(ZMTransportRequest(path: "/conversations/\(conversation.identifier)/bots", method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue))
+        let response = sut.processServiceRequest(ZMTransportRequest(path: "/conversations/\(conversation.identifier)/bots", method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue))
 
         // then
         XCTAssertEqual(response.httpStatus, 201)
@@ -153,7 +153,7 @@ class MockServicesTests: MockTransportSessionTests {
         XCTAssertEqual(conversation.activeUsers.count, 1)
         let payload = ["service": service.identifier,
                        "provider": service.provider]
-        _ = sut.processServiceRequest(ZMTransportRequest(path: "/conversations/\(conversation.identifier)/bots", method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue))
+        _ = sut.processServiceRequest(ZMTransportRequest(path: "/conversations/\(conversation.identifier)/bots", method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue))
 
         let predicate = NSPredicate(format: "%K == %@", #keyPath(MockUser.serviceIdentifier), service.identifier)
 
@@ -163,7 +163,7 @@ class MockServicesTests: MockTransportSessionTests {
         }
 
         // when
-        let request = ZMTransportRequest(path: "/conversations/\(conversation.identifier)/bots/\(botUser.identifier)", method: .methodDELETE, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let request = ZMTransportRequest(path: "/conversations/\(conversation.identifier)/bots/\(botUser.identifier)", method: .delete, payload: nil, apiVersion: APIVersion.v0.rawValue)
         let response = sut.processDeleteBotRequest(request)
 
         // then

--- a/wire-ios-mocktransport/Tests/Source/Teams/MockTransportSessionTeamTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Teams/MockTransportSessionTeamTests.swift
@@ -124,7 +124,7 @@ class MockTransportSessionTeamTests: MockTransportSessionTests {
 
         // When
         let path = "/teams/\(team.identifier)"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)
@@ -153,7 +153,7 @@ class MockTransportSessionTeamTests: MockTransportSessionTests {
 
         // When
         let path = "/teams"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // Then
         checkThat(response: response, contains: [team2, team1], hasMore: false)
@@ -173,7 +173,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/1234"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // Then
         XCTAssertNotNil(response)
@@ -194,7 +194,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/\(team.identifier)"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // Then
         XCTAssertNotNil(response)
@@ -215,7 +215,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/\(team.identifier)/members"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // Then
         XCTAssertNotNil(response)
@@ -238,7 +238,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/\(team.identifier)/members"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
 
         // Then
         XCTAssertNotNil(response)
@@ -269,7 +269,7 @@ extension MockTransportSessionTeamTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // When
-        let response = self.response(forPayload: nil, path: "/teams/\(team.identifier)/conversations/\(conversation.identifier)", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/teams/\(team.identifier)/conversations/\(conversation.identifier)", method: .delete, apiVersion: .v0)
 
         // Then
         XCTAssertEqual(response?.httpStatus, 403)
@@ -293,7 +293,7 @@ extension MockTransportSessionTeamTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // When
-        let response = self.response(forPayload: nil, path: "/teams/\(team.identifier)/conversations/\(conversation.identifier)", method: .methodDELETE, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/teams/\(team.identifier)/conversations/\(conversation.identifier)", method: .delete, apiVersion: .v0)
 
         // Then
         XCTAssertEqual(response?.httpStatus, 200)
@@ -376,7 +376,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/\(team.identifier)/members"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)
@@ -412,7 +412,7 @@ extension MockTransportSessionTeamTests {
         // When
         let requestPayload = ["user_ids": [user1.identifier, user2.identifier]]
         let path = "/teams/\(team.identifier)/get-members-by-ids-using-post"
-        let response = self.response(forPayload: requestPayload as ZMTransportData, path: path, method: .methodPOST, apiVersion: .v0)
+        let response = self.response(forPayload: requestPayload as ZMTransportData, path: path, method: .post, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)
@@ -447,7 +447,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/\(team.identifier)/members/\(user1.identifier)"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)
@@ -475,7 +475,7 @@ extension MockTransportSessionTeamTests {
 
         // Then
         let path = "/teams/\(team.identifier)/legalhold/\(user.identifier)/approve"
-        let response = self.response(forPayload: ["password": "Ex@mple!"] as NSDictionary, path: path, method: .methodPUT, apiVersion: .v0)
+        let response = self.response(forPayload: ["password": "Ex@mple!"] as NSDictionary, path: path, method: .put, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 412)
         XCTAssertEqual(response?.payload as? NSDictionary, ["label": "legalhold-not-pending"])
@@ -500,7 +500,7 @@ extension MockTransportSessionTeamTests {
 
         // Then
         let path = "/teams/\(team.identifier)/legalhold/\(user.identifier)/approve"
-        let response = self.response(forPayload: ["password": "Ex@mple!"] as NSDictionary, path: path, method: .methodPUT, apiVersion: .v0)
+        let response = self.response(forPayload: ["password": "Ex@mple!"] as NSDictionary, path: path, method: .put, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNil(response?.payload)
@@ -523,7 +523,7 @@ extension MockTransportSessionTeamTests {
 
         // When
         let path = "/teams/\(team.identifier)/conversations/roles"
-        let response = self.response(forPayload: nil, path: path, method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: path, method: .get, apiVersion: .v0)
         XCTAssertNotNil(response)
         XCTAssertEqual(response?.httpStatus, 200)
         XCTAssertNotNil(response?.payload)

--- a/wire-ios-mocktransport/Tests/Source/Users/MockTransportSessionUsersTests.m
+++ b/wire-ios-mocktransport/Tests/Source/Users/MockTransportSessionUsersTests.m
@@ -94,7 +94,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/users/?ids=%@,%@,%@", [user1ID lowercaseString], [user2ID uppercaseString], user3ID];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -171,7 +171,7 @@
     
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/users/?handles=%@,%@,%@", [user1Handle lowercaseString], [user2Handle uppercaseString], user3Handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -209,7 +209,7 @@
     
     // WHEN
     NSString *path = @"/self";
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -236,7 +236,7 @@
     
     // WHEN
     NSString *path = @"/self";
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -264,7 +264,7 @@
     
     // WHEN
     NSString *path = [@"/users/" stringByAppendingPathComponent:user.identifier];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -307,7 +307,7 @@
     
     // WHEN
     NSString *path = [@"/users/" stringByAppendingPathComponent:user1ID];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -341,7 +341,7 @@
     
     // WHEN
     NSString *path = [@"/users/" stringByAppendingPathComponent:userID];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -382,7 +382,7 @@
     
     // WHEN
     NSString *path = [@"/users/" stringByAppendingPathComponent:user1ID];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -418,7 +418,7 @@
     
     // WHEN
     NSString *path = [@"/users/" stringByAppendingPathComponent:user1ID];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertNotNil(response);
@@ -455,7 +455,7 @@
                               };
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/self" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/self" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -487,7 +487,7 @@
     NSString *email = @"foo@bar.bar";
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"email":email} path:@"/self/email" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"email":email} path:@"/self/email" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -504,7 +504,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/email" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/email" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 400);
@@ -523,7 +523,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"email":email} path:@"/self/email" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"email":email} path:@"/self/email" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -540,7 +540,7 @@
     NSString *password = @"12%$#%";
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"new_password":password} path:@"/self/password" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"new_password":password} path:@"/self/password" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -556,7 +556,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/passwprd" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/passwprd" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -574,7 +574,7 @@
     NSString *password = @"12%$#%";
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"old_password":password, @"new_password":password} path:@"/self/password" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"old_password":password, @"new_password":password} path:@"/self/password" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 403);
@@ -593,7 +593,7 @@
     NSString *password = @"12%$#%";
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"old_password":formerPassword, @"new_password":password} path:@"/self/password" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"old_password":formerPassword, @"new_password":password} path:@"/self/password" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -610,14 +610,14 @@
     NSString *phone = @"+99123245";
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/self/phone" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/self/phone" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
     XCTAssertTrue([self.sut.phoneNumbersWaitingForVerificationForProfile containsObject:phone]);
     
     // and when
-    response = [self responseForPayload:@{@"phone":phone, @"code":self.sut.phoneVerificationCodeForUpdatingProfile} path:@"/activate" method:ZMMethodPOST apiVersion:0];
+    response = [self responseForPayload:@{@"phone":phone, @"code":self.sut.phoneVerificationCodeForUpdatingProfile} path:@"/activate" method:ZMTransportRequestMethodPost apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -637,7 +637,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/self/phone" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"phone":phone} path:@"/self/phone" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -653,7 +653,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/phone" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{} path:@"/self/phone" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 400);
@@ -669,7 +669,7 @@
     NSString *handle = @"aaa12";
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"handle":handle} path:@"/self/handle" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"handle":handle} path:@"/self/handle" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -691,7 +691,7 @@
     }];
     
     // WHEN
-    ZMTransportResponse *response = [self responseForPayload:@{@"handle":handle} path:@"/self/handle" method:ZMMethodPUT apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:@{@"handle":handle} path:@"/self/handle" method:ZMTransportRequestMethodPut apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 409);
@@ -713,7 +713,7 @@
     
     // WHEN
     NSString *path = [@"/users/handles/" stringByAppendingPathComponent:handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -732,7 +732,7 @@
     
     // WHEN
     NSString *path = [@"/users/handles/" stringByAppendingPathComponent:handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodHEAD apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodHead apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -747,7 +747,7 @@
     
     // WHEN
     NSString *path = [@"/users/handles/" stringByAppendingPathComponent:handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -769,7 +769,7 @@
 
     // WHEN
     NSString *path = [[@"/users/by-handle/" stringByAppendingPathComponent:domain] stringByAppendingPathComponent:handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -785,7 +785,7 @@
 
     // WHEN
     NSString *path = [[@"/users/by-handle/" stringByAppendingPathComponent:domain] stringByAppendingPathComponent:handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 404);
@@ -800,7 +800,7 @@
 
     // WHEN
     NSString *path = [[@"/users/by-handle/" stringByAppendingPathComponent:domain] stringByAppendingPathComponent:handle];
-    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMMethodGET apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:nil path:path method:ZMTransportRequestMethodGet apiVersion:0];
 
     // THEN
     XCTAssertEqual(response.HTTPStatus, 422);
@@ -823,7 +823,7 @@
                               @"return" : @1,
                               @"handles" : @[existingHandle, nonExistingHandle]
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);
@@ -846,7 +846,7 @@
     NSDictionary *payload = @{
                               @"handles" : @[existingHandle, nonExistingHandle]
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 400);
@@ -866,7 +866,7 @@
     NSDictionary *payload = @{
                               @"return" : @12
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 400);
@@ -887,7 +887,7 @@
                               @"return" : @1,
                               @"handles" : @[existingHandle]
                               };
-    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMMethodPOST apiVersion:0];
+    ZMTransportResponse *response = [self responseForPayload:payload path:@"/users/handles/" method:ZMTransportRequestMethodPost apiVersion:0];
     
     // THEN
     XCTAssertEqual(response.HTTPStatus, 200);

--- a/wire-ios-mocktransport/Tests/Source/Users/MockTransportSessionUsersTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Users/MockTransportSessionUsersTests.swift
@@ -53,7 +53,7 @@ final class MockTransportSessionUsersTests_Swift: MockTransportSessionTests {
             otherUser.identifier: [otherUserClient.identifier!, secondOtherUserClient.identifier!],
             thirdUser.identifier: [redunduntClientId]] as ZMTransportData
 
-        let response: ZMTransportResponse = self.response(forPayload: payload, path: "/users/prekeys", method: .methodPOST, apiVersion: .v0)
+        let response: ZMTransportResponse = self.response(forPayload: payload, path: "/users/prekeys", method: .post, apiVersion: .v0)
         XCTAssertEqual(response.httpStatus, 200)
 
         let expectedUsers: NSArray = [selfUser.identifier, otherUser.identifier, thirdUser.identifier]
@@ -82,7 +82,7 @@ final class MockTransportSessionUsersTests_Swift: MockTransportSessionTests {
         let userId = "1234"
 
         // when
-        let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .methodGET, apiVersion: .v0)
+        let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .get, apiVersion: .v0)
 
         // then
         XCTAssertEqual(response?.httpStatus, 404)
@@ -97,7 +97,7 @@ final class MockTransportSessionUsersTests_Swift: MockTransportSessionTests {
         }
 
         // when
-        guard let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .methodGET, apiVersion: .v0) else { XCTFail(); return }
+        guard let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .get, apiVersion: .v0) else { XCTFail(); return }
 
         // then
         XCTAssertEqual(response.httpStatus, 200)
@@ -120,7 +120,7 @@ final class MockTransportSessionUsersTests_Swift: MockTransportSessionTests {
         }
 
         // when
-        guard let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .methodGET, apiVersion: .v0) else { XCTFail(); return }
+        guard let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .get, apiVersion: .v0) else { XCTFail(); return }
 
         // then
         XCTAssertEqual(response.httpStatus, 200)
@@ -151,7 +151,7 @@ final class MockTransportSessionUsersTests_Swift: MockTransportSessionTests {
         }
 
         // when
-        guard let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .methodGET, apiVersion: .v0) else { XCTFail(); return }
+        guard let response = self.response(forPayload: nil, path: "/users/\(userId)/rich-info", method: .get, apiVersion: .v0) else { XCTFail(); return }
 
         // then
         XCTAssertEqual(response.httpStatus, 403)

--- a/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactory.swift
@@ -81,7 +81,7 @@ public final class AssetRequestFactory: NSObject {
             path = "/assets"
         }
 
-        return ZMTransportRequest(path: path, method: .methodPOST, binaryData: multipartData, type: Constant.ContentType.multipart, contentDisposition: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, binaryData: multipartData, type: Constant.ContentType.multipart, contentDisposition: nil, apiVersion: apiVersion.rawValue)
     }
 
     func dataForMultipartAssetUploadRequest(_ data: Data, shareable: Bool, retention: Retention) throws -> Data {

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginatorTests.m
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginatorTests.m
@@ -204,7 +204,7 @@
     // after
     NSString *expectedURL = [NSString stringWithFormat:@"%@?size=%lu", self.basePath, (unsigned long) self.pageSize];
     XCTAssertNotNil(request);
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
     XCTAssertEqualObjects(request.path, expectedURL);
     XCTAssertTrue(request.needsAuthentication);
 }
@@ -229,7 +229,7 @@
     // after
     NSString *expectedURL = [NSString stringWithFormat:@"%@?size=%lu&%@=%@", self.basePath, (unsigned long) self.pageSize, startKey, startUUID.transportString];
     XCTAssertNotNil(request);
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
     XCTAssertEqualObjects(request.path, expectedURL);
     XCTAssertTrue(request.needsAuthentication);
 }
@@ -251,7 +251,7 @@
         // after
         NSString *expectedURL = [NSString stringWithFormat:@"%@?size=%lu&%@=%@", self.basePath, (unsigned long) self.pageSize, @"client", selfClientID];
         XCTAssertNotNil(request);
-        XCTAssertEqual(request.method, ZMMethodGET);
+        XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
         XCTAssertEqualObjects(request.path, expectedURL);
         XCTAssertTrue(request.needsAuthentication);
     }];
@@ -584,7 +584,7 @@
     // then
     NSString *expectedURL = [NSString stringWithFormat:@"%@?size=%lu", self.basePath, (unsigned long) self.pageSize];
     XCTAssertNotNil(followingRequest);
-    XCTAssertEqual(followingRequest.method, ZMMethodGET);
+    XCTAssertEqual(followingRequest.method, ZMTransportRequestMethodGet);
     XCTAssertEqualObjects(followingRequest.path, expectedURL);
     XCTAssertTrue(followingRequest.needsAuthentication);
 }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.Transcoder.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSync.Transcoder.swift
@@ -60,7 +60,7 @@ extension MLSMessageSync {
 
             let request = ZMTransportRequest(
                 path: "/mls/messages",
-                method: .methodPOST,
+                method: .post,
                 binaryData: encryptedMessage,
                 type: "message/mls",
                 contentDisposition: nil,

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSyncTests.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MLSMessageSyncTests.swift
@@ -167,7 +167,7 @@ final class MLSMessageSyncTests: MessagingTestBase {
             }
 
             XCTAssertEqual(request.path, "/v\(apiVersion.rawValue)/mls/messages")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
             XCTAssertEqual(request.binaryDataType, "message/mls")
             XCTAssertEqual(request.apiVersion, apiVersion.rawValue)
 

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSyncTests.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSyncTests.swift
@@ -65,7 +65,7 @@ final class MessageSyncTests: MessagingTestBase {
             }
 
             XCTAssertEqual(request.path, "/v1/conversations/example.com/\(self.conversationID.transportString())/proteus/messages")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
             XCTAssertEqual(request.binaryDataType, "application/x-protobuf")
         }
     }
@@ -91,7 +91,7 @@ final class MessageSyncTests: MessagingTestBase {
                 }
 
                 XCTAssertEqual(request.path, "/v5/mls/messages")
-                XCTAssertEqual(request.method, .methodPOST)
+                XCTAssertEqual(request.method, .post)
                 XCTAssertEqual(request.binaryDataType, "message/mls")
             }
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -172,7 +172,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             let converationID = conversation.remoteIdentifier!.transportString()
 
             XCTAssertEqual(request.path, "/conversations/\(converationID)/otr/messages", line: line)
-            XCTAssertEqual(request.method, .methodPOST, line: line)
+            XCTAssertEqual(request.method, .post, line: line)
             return request
 
         case .v1, .v2, .v3, .v4, .v5:
@@ -185,7 +185,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             let conversationID = conversation.remoteIdentifier!.transportString()
 
             XCTAssertEqual(request.path, "/v\(apiVersion.rawValue)/conversations/\(domain)/\(conversationID)/proteus/messages", line: line)
-            XCTAssertEqual(request.method, .methodPOST, line: line)
+            XCTAssertEqual(request.method, .post, line: line)
             return request
         }
     }
@@ -271,7 +271,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
             // THEN
             let expected = "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages"
             XCTAssertEqual(request.path, expected)
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
@@ -174,7 +174,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTestBase {
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
 
             // Then
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/assets/v3/\(expectedAssetId)")
             XCTAssert(request.needsAuthentication)
         }
@@ -209,7 +209,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTestBase {
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
 
             // Then
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/assets/v3/\(expectedAssetId)")
             XCTAssert(request.needsAuthentication)
         }
@@ -242,7 +242,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTestBase {
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
 
             // Then
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/v1/assets/v4/\(expectedDomain!)/\(expectedAssetId)")
             XCTAssert(request.needsAuthentication)
         }
@@ -279,7 +279,7 @@ class AssetV3DownloadRequestStrategyTests: MessagingTestBase {
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
 
             // Then
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/v1/assets/v4/\(expectedDomain!)/\(expectedAssetId)")
             XCTAssert(request.needsAuthentication)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3PreviewDownloadRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3PreviewDownloadRequestStrategyTests.swift
@@ -168,7 +168,7 @@ class AssetV3PreviewDownloadRequestStrategyTests: MessagingTestBase {
 
             // THEN
             XCTAssertEqual(request.path, "/assets/v3/\(previewMeta.assetId)")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -198,7 +198,7 @@ class AssetV3PreviewDownloadRequestStrategyTests: MessagingTestBase {
 
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
             XCTAssertEqual(request.path, "/assets/v3/\(previewMeta.assetId)")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
 
             // WHEN
             message.fileMessageData?.requestImagePreviewDownload()
@@ -241,7 +241,7 @@ class AssetV3PreviewDownloadRequestStrategyTests: MessagingTestBase {
 
             // THEN
             XCTAssertEqual(request.path, "/v1/assets/v4/\(previewMeta.domain)/\(previewMeta.assetId)")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -272,7 +272,7 @@ class AssetV3PreviewDownloadRequestStrategyTests: MessagingTestBase {
 
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { return XCTFail("No request generated") }
             XCTAssertEqual(request.path, "/v1/assets/v4/\(previewMeta.domain)/\(previewMeta.assetId)")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
 
             // WHEN
             message.fileMessageData?.requestImagePreviewDownload()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Helpers/AssetDownloadRequestFactoryTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Helpers/AssetDownloadRequestFactoryTests.swift
@@ -43,7 +43,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/assets/v3/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 0)
     }
 
@@ -63,7 +63,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/v1/assets/v4/domain/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 1)
     }
 
@@ -82,7 +82,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/v1/assets/v4/localDomain/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 1)
     }
 
@@ -101,7 +101,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/v1/assets/v4/localDomain/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 1)
     }
 
@@ -138,7 +138,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/v2/assets/domain/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 2)
     }
 
@@ -157,7 +157,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/v2/assets/localDomain/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 2)
     }
 
@@ -176,7 +176,7 @@ final class AssetDownloadRequestFactoryTests: XCTestCase {
 
         // Then
         XCTAssertEqual(request.path, "/v2/assets/localDomain/key")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.apiVersion, 2)
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetDownloadRequestStrategyTests.swift
@@ -135,7 +135,7 @@ extension LinkPreviewAssetDownloadRequestStrategyTests {
             // THEN
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { XCTFail("No request generated"); return }
             XCTAssertEqual(request.path, "/assets/v3/\(assetID)")
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
     }
@@ -160,7 +160,7 @@ extension LinkPreviewAssetDownloadRequestStrategyTests {
             // THEN
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { XCTFail("No request generated"); return }
             XCTAssertEqual(request.path, "/assets/v3/\(assetID)")
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
     }
@@ -187,7 +187,7 @@ extension LinkPreviewAssetDownloadRequestStrategyTests {
             // THEN
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { XCTFail("No request generated"); return }
             XCTAssertEqual(request.path, "/v1/assets/v4/\(assetDomain)/\(assetID)")
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
     }
@@ -214,7 +214,7 @@ extension LinkPreviewAssetDownloadRequestStrategyTests {
             // THEN
             guard let request = self.sut.nextRequest(for: self.apiVersion) else { XCTFail("No request generated"); return }
             XCTAssertEqual(request.path, "/v1/assets/v4/\(assetDomain)/\(assetID)")
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertNil(self.sut.nextRequest(for: self.apiVersion))
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategyTests.swift
@@ -140,7 +140,7 @@ extension LinkPreviewAssetUploadRequestStrategyTests {
             // THEN
             XCTAssertNotNil(request)
             XCTAssertEqual(request?.path, "/assets/v3")
-            XCTAssertEqual(request?.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request?.method, ZMTransportRequestMethod.post)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
@@ -202,7 +202,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
         let request = sut.nextRequest(for: apiVersion)
         let conversationID = conversation.remoteIdentifier!.transportString()
         XCTAssertNotNil(request, "No request generated", file: file, line: line)
-        XCTAssertEqual(request?.method, .methodPOST, file: file, line: line)
+        XCTAssertEqual(request?.method, .post, file: file, line: line)
 
         switch apiVersion! {
         case .v0:

--- a/wire-ios-request-strategy/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Availability/AvailabilityRequestStrategy.swift
@@ -61,7 +61,7 @@ extension AvailabilityRequestStrategy: ZMUpstreamTranscoder {
         let path = originalPath.pathWithMissingClientStrategy(strategy: dataAndMissingClientStrategy.strategy)
 
         let request = ZMTransportRequest(path: path,
-                                         method: .methodPOST,
+                                         method: .post,
                                          binaryData: dataAndMissingClientStrategy.data,
                                          type: protobufContentType,
                                          contentDisposition: nil,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
@@ -78,7 +78,7 @@ public final class ClientMessageRequestFactory: NSObject {
 
         return ZMTransportRequest(
             path: path,
-            method: .methodPOST,
+            method: .post,
             binaryData: data,
             type: protobufContentType,
             contentDisposition: nil,
@@ -106,7 +106,7 @@ public final class ClientMessageRequestFactory: NSObject {
         let originalPath = "/" + ["conversations", conversationID, "otr", "messages"].joined(separator: "/")
         guard let encryptedPayload = message.encryptForTransport() else { return nil }
         let path = originalPath.pathWithMissingClientStrategy(strategy: encryptedPayload.strategy)
-        let request = ZMTransportRequest(path: path, method: .methodPOST, binaryData: encryptedPayload.data, type: protobufContentType, contentDisposition: nil, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .post, binaryData: encryptedPayload.data, type: protobufContentType, contentDisposition: nil, apiVersion: apiVersion.rawValue)
         request.addContentDebugInformation(message.debugInfo)
         return request
     }
@@ -129,7 +129,7 @@ public final class ClientMessageRequestFactory: NSObject {
             return nil
         }
 
-        let request = ZMTransportRequest(path: path, method: .methodPOST, binaryData: encryptedPayload.data, type: protobufContentType, contentDisposition: nil, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .post, binaryData: encryptedPayload.data, type: protobufContentType, contentDisposition: nil, apiVersion: apiVersion.rawValue)
         request.addContentDebugInformation(message.debugInfo)
         return request
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestFactoryTests.swift
@@ -59,7 +59,7 @@ extension ClientMessageRequestFactoryTests {
             }
 
             // THEN
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages")
 
             guard let receivedMessage = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else {
@@ -89,7 +89,7 @@ extension ClientMessageRequestFactoryTests {
             }
 
             // THEN
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.path, "/conversations/\(self.oneToOneConversation.remoteIdentifier!.transportString())/otr/messages")
             guard let receivedMessage = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else {
                 return XCTFail("Invalid message")
@@ -115,7 +115,7 @@ extension ClientMessageRequestFactoryTests {
             }
 
             // THEN
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages")
             guard let receivedMessage = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else {
                 return XCTFail("Invalid message")
@@ -147,7 +147,7 @@ extension ClientMessageRequestFactoryTests {
             }
 
             // THEN
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages?ignore_missing=true")
 
             guard let receivedMessage = self.outgoingEncryptedMessage(from: request, for: self.otherClient) else {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
@@ -256,7 +256,7 @@ extension ClientMessageRequestStrategyTests {
 
             // THEN
             XCTAssertEqual(request.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
             XCTAssertNotNil(request.binaryData)
             XCTAssertEqual(request.binaryDataType, "application/x-protobuf")
 
@@ -288,7 +288,7 @@ extension ClientMessageRequestStrategyTests {
 
             // THEN
             XCTAssertEqual(request.path, "/v1/conversations/\(conversationDomain)/\(conversationID)/proteus/messages")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
             XCTAssertNotNil(request.binaryData)
             XCTAssertEqual(request.binaryDataType, "application/x-protobuf")
         }
@@ -311,7 +311,7 @@ extension ClientMessageRequestStrategyTests {
 
             // THEN
             XCTAssertEqual(request.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
             XCTAssertNotNil(request.binaryData)
             XCTAssertEqual(request.binaryDataType, "application/x-protobuf")
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandler.swift
@@ -46,7 +46,7 @@ class ConnectToUserActionHandler: ActionHandler<ConnectToUserAction> {
         }
 
         return ZMTransportRequest(path: "/connections",
-                                  method: .methodPOST,
+                                  method: .post,
                                   payload: payloadAsString as ZMTransportData,
                                   apiVersion: apiVersion.rawValue)
 
@@ -62,7 +62,7 @@ class ConnectToUserActionHandler: ActionHandler<ConnectToUserAction> {
         }
 
         return ZMTransportRequest(path: "/connections/\(domain)/\(action.userID.transportString())",
-                                  method: .methodPOST,
+                                  method: .post,
                                   payload: nil,
                                   apiVersion: apiVersion.rawValue)
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandlerTests.swift
@@ -48,7 +48,7 @@ class ConnectToUserActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/connections")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
             let payload = Payload.ConnectionRequest(request)
             XCTAssertEqual(payload?.userID, userID)
         }
@@ -66,7 +66,7 @@ class ConnectToUserActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/connections/\(domain)/\(userID.transportString())")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandler.swift
@@ -46,7 +46,7 @@ class UpdateConnectionActionHandler: ActionHandler<UpdateConnectionAction> {
 
         return ZMTransportRequest(
             path: "/connections/\(userID)",
-            method: .methodPUT,
+            method: .put,
             payload: payload,
             apiVersion: 0
         )
@@ -64,7 +64,7 @@ class UpdateConnectionActionHandler: ActionHandler<UpdateConnectionAction> {
 
         return ZMTransportRequest(
             path: "/connections/\(qualifiedID.domain)/\(qualifiedID.uuid.transportString())",
-            method: .methodPUT,
+            method: .put,
             payload: payload,
             apiVersion: 1
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandlerTests.swift
@@ -48,7 +48,7 @@ class UpdateConnectionActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/connections/\(userID.transportString())")
-            XCTAssertEqual(request.method, .methodPUT)
+            XCTAssertEqual(request.method, .put)
             let payload = Payload.ConnectionUpdate(request)
             XCTAssertEqual(payload?.status, .cancelled)
         }
@@ -66,7 +66,7 @@ class UpdateConnectionActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/connections/\(userID.domain)/\(userID.uuid.transportString())")
-            XCTAssertEqual(request.method, .methodPUT)
+            XCTAssertEqual(request.method, .put)
             let payload = Payload.ConnectionUpdate(request)
             XCTAssertEqual(payload?.status, .cancelled)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/ConnectionRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/ConnectionRequestStrategyTests.swift
@@ -70,7 +70,7 @@ class ConnectionRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/connections/\(self.otherUser.domain!)/\(self.otherUser.remoteIdentifier!.transportString())")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -87,7 +87,7 @@ class ConnectionRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/connections/\(self.otherUser.remoteIdentifier!.transportString())")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -105,7 +105,7 @@ class ConnectionRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/list-connections")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
         }
     }
 
@@ -119,7 +119,7 @@ class ConnectionRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/connections?size=200")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
@@ -80,7 +80,7 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
         }
 
         let path = "/conversations/\(conversationID)/members"
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payloadAsString as ZMTransportData, apiVersion: 0)
+        return ZMTransportRequest(path: path, method: .post, payload: payloadAsString as ZMTransportData, apiVersion: 0)
     }
 
     private func v1Request(for action: AddParticipantAction) -> ZMTransportRequest? {
@@ -97,7 +97,7 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
         }
 
         let path = "/conversations/\(conversationID.uuid)/members/v2"
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload, apiVersion: 1)
+        return ZMTransportRequest(path: path, method: .post, payload: payload, apiVersion: 1)
     }
 
     private func v2Request(for action: AddParticipantAction, apiVersion: APIVersion) -> ZMTransportRequest? {
@@ -114,7 +114,7 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
         }
 
         let path = "/conversations/\(conversationID.domain)/\(conversationID.uuid)/members"
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payload, apiVersion: apiVersion.rawValue)
     }
 
     private func payload(for action: AddParticipantAction) -> ZMTransportData? {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
@@ -98,7 +98,7 @@ final class CreateGroupConversationActionHandler: ActionHandler<CreateGroupConve
 
         return ZMTransportRequest(
             path: "/conversations",
-            method: .methodPOST,
+            method: .post,
             payload: payloadString as ZMTransportData?,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
@@ -156,7 +156,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
 
         // Then
         XCTAssertEqual(result.path, "/conversations")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 0)
 
         let payload = try XCTUnwrap(RequestPayload(result))
@@ -177,7 +177,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
 
         // Then
         XCTAssertEqual(result.path, "/v1/conversations")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 1)
 
         let payload = try XCTUnwrap(RequestPayload(result))
@@ -198,7 +198,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
 
         // Then
         XCTAssertEqual(result.path, "/v2/conversations")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 2)
 
         let payload = try XCTUnwrap(RequestPayload(result))
@@ -219,7 +219,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
 
         // Then
         XCTAssertEqual(result.path, "/v3/conversations")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 3)
 
         let payload = try XCTUnwrap(RequestPayload(result))
@@ -240,7 +240,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
 
         // Then
         XCTAssertEqual(result.path, "/v4/conversations")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 4)
 
         let payload = try XCTUnwrap(RequestPayload(result))

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandler.swift
@@ -59,7 +59,7 @@ class RemoveParticipantActionHandler: ActionHandler<RemoveParticipantAction> {
         }
 
         let path = "/conversations/\(conversationID)/members/\(userID)"
-        return ZMTransportRequest(path: path, method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     func federatedRequest(for action: RemoveParticipantAction, apiVersion: APIVersion) -> ZMTransportRequest? {
@@ -78,7 +78,7 @@ class RemoveParticipantActionHandler: ActionHandler<RemoveParticipantAction> {
         }
         let path = "/conversations/\(conversationID.domain)/\(conversationID.uuid)/members/\(qualifiedUserID.domain)/\(qualifiedUserID.uuid)"
 
-        return ZMTransportRequest(path: path, method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     override func handleResponse(_ response: ZMTransportResponse, action: RemoveParticipantAction) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandlerTests.swift
@@ -75,7 +75,7 @@ class RemoveParticipantActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/conversations/\(conversationID)/members/\(userID)")
-            XCTAssertEqual(request.method, .methodDELETE)
+            XCTAssertEqual(request.method, .delete)
         }
     }
 
@@ -92,7 +92,7 @@ class RemoveParticipantActionHandlerTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/conversations/\(domain)/\(conversationID)/members/\(domain)/\(userID)")
-            XCTAssertEqual(request.method, .methodDELETE)
+            XCTAssertEqual(request.method, .delete)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
@@ -45,7 +45,7 @@ final class SyncConversationActionHandler: ActionHandler<SyncConversationAction>
         case .v0, .v1:
             return ZMTransportRequest(
                 path: "/conversations/list/v2",
-                method: .methodPOST,
+                method: .post,
                 payload: payload as ZMTransportData,
                 apiVersion: apiVersion.rawValue
             )
@@ -53,7 +53,7 @@ final class SyncConversationActionHandler: ActionHandler<SyncConversationAction>
         case .v2, .v3, .v4, .v5:
             return ZMTransportRequest(
                 path: "/conversations/list",
-                method: .methodPOST,
+                method: .post,
                 payload: payload as ZMTransportData,
                 apiVersion: apiVersion.rawValue
             )

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandlerTests.swift
@@ -36,7 +36,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(result.path, "/conversations/list/v2")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 0)
 
         let payload = try XCTUnwrap(RequestPayload(result))
@@ -54,7 +54,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(result.path, "/v1/conversations/list/v2")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 1)
 
         let payload = try XCTUnwrap(RequestPayload(result))
@@ -72,7 +72,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(result.path, "/v2/conversations/list")
-        XCTAssertEqual(result.method, .methodPOST)
+        XCTAssertEqual(result.method, .post)
         XCTAssertEqual(result.apiVersion, 2)
 
         let payload = try XCTUnwrap(RequestPayload(result))

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateAccessRolesActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateAccessRolesActionHandler.swift
@@ -52,13 +52,13 @@ final class UpdateAccessRolesActionHandler: ActionHandler<UpdateAccessRolesActio
         switch apiVersion {
         case .v0:
             return ZMTransportRequest(path: "/conversations/\(conversationID)/access",
-                                      method: .methodPUT,
+                                      method: .put,
                                       payload: payloadAsString as ZMTransportData?,
                                       apiVersion: apiVersion.rawValue)
         case .v1, .v2, .v3, .v4, .v5:
             guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
             return ZMTransportRequest(path: "/conversations/\(domain)/\(conversationID)/access",
-                                      method: .methodPUT,
+                                      method: .put,
                                       payload: payloadAsString as ZMTransportData?,
                                       apiVersion: apiVersion.rawValue)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateRoleActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateRoleActionHandler.swift
@@ -37,7 +37,7 @@ class UpdateRoleActionHandler: ActionHandler<UpdateRoleAction> {
 
         let path = "/conversations/\(conversationId.transportString())/members/\(userId.transportString())"
 
-        let request = ZMTransportRequest(path: path, method: .methodPUT, payload: payloadString as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .put, payload: payloadString as ZMTransportData, apiVersion: apiVersion.rawValue)
         return request
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationByQualifiedIDListTranscoderTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationByQualifiedIDListTranscoderTests.swift
@@ -33,7 +33,7 @@ class ConversationByQualifiedIDListTranscoderTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/v1/conversations/list/v2")
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
 
         let payloadString = try XCTUnwrap(request.payload as? String)
         let payloadData = try XCTUnwrap(payloadString.data(using: .utf8))
@@ -51,7 +51,7 @@ class ConversationByQualifiedIDListTranscoderTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/v2/conversations/list")
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
 
         let payloadString = try XCTUnwrap(request.payload as? String)
         let payloadData = try XCTUnwrap(payloadString.data(using: .utf8))

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -385,14 +385,14 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
             switch apiVersion {
             case .v0:
                 request = ZMTransportRequest(path: "/conversations/\(conversationID)",
-                                             method: .methodPUT,
+                                             method: .put,
                                              payload: payloadAsString as ZMTransportData?,
                                              apiVersion: apiVersion.rawValue)
 
             case .v1, .v2, .v3, .v4, .v5:
                 guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
                 request = ZMTransportRequest(path: "/conversations/\(domain)/\(conversationID)/name",
-                                             method: .methodPUT,
+                                             method: .put,
                                              payload: payloadAsString as ZMTransportData?,
                                              apiVersion: apiVersion.rawValue)
             }
@@ -418,13 +418,13 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
             switch apiVersion {
             case .v0:
                 request = ZMTransportRequest(path: "/conversations/\(conversationID)/self",
-                                             method: .methodPUT,
+                                             method: .put,
                                              payload: payloadAsString as ZMTransportData?,
                                              apiVersion: apiVersion.rawValue)
             case .v1, .v2, .v3, .v4, .v5:
                 guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
                 request = ZMTransportRequest(path: "/conversations/\(domain)/\(conversationID)/self",
-                                             method: .methodPUT,
+                                             method: .put,
                                              payload: payloadAsString as ZMTransportData?,
                                              apiVersion: apiVersion.rawValue)
             }
@@ -726,7 +726,7 @@ class ConversationByQualifiedIDListTranscoder: IdentifierObjectSyncTranscoder {
 
         let path = apiVersion >= .v2 ? "/conversations/list" : "/conversations/list/v2"
 
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payloadAsString as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payloadAsString as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
     func didReceive(response: ZMTransportResponse, for identifiers: Set<QualifiedID>) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
@@ -72,7 +72,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/conversations/\(domain)/\(conversationID.transportString())")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -90,7 +90,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/conversations/\(conversationID.transportString())")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -111,7 +111,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/conversations/\(domain)/\(conversationID.transportString())/name")
-            XCTAssertEqual(request.method, .methodPUT)
+            XCTAssertEqual(request.method, .put)
             XCTAssertEqual(payload?.name, self.groupConversation.userDefinedName)
         }
     }
@@ -133,7 +133,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/conversations/\(domain)/\(conversationID.transportString())/self")
-            XCTAssertEqual(request.method, .methodPUT)
+            XCTAssertEqual(request.method, .put)
             XCTAssertEqual(payload?.archived, true)
         }
     }
@@ -155,7 +155,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/v1/conversations/\(domain)/\(conversationID.transportString())/self")
-            XCTAssertEqual(request.method, .methodPUT)
+            XCTAssertEqual(request.method, .put)
             XCTAssertEqual(payload?.mutedStatus, Int(MutedMessageTypes.all.rawValue))
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
@@ -53,7 +53,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/feature-configs")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
     }
 
     // MARK: - Response handling

--- a/wire-ios-request-strategy/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Generic Message/GenericMessageRequestStrategyTests.swift
@@ -102,7 +102,7 @@ class GenericMessageRequestStrategyTests: MessagingTestBase {
             let request = self.sut.nextRequest(for: .v0)
 
             // THEN
-            XCTAssertEqual(request!.method, .methodPOST)
+            XCTAssertEqual(request!.method, .post)
             XCTAssertEqual(request!.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages")
         }
     }
@@ -128,7 +128,7 @@ class GenericMessageRequestStrategyTests: MessagingTestBase {
             let request2 = self.sut.nextRequest(for: .v0)
 
             // THEN
-            XCTAssertEqual(request2!.method, .methodPOST)
+            XCTAssertEqual(request2!.method, .post)
             XCTAssertEqual(request2!.path, "/conversations/\(self.groupConversation.remoteIdentifier!.transportString())/otr/messages")
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/BaseFetchMLSGroupInfoActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/BaseFetchMLSGroupInfoActionHandler.swift
@@ -32,7 +32,7 @@ class BaseFetchMLSGroupInfoActionHandler<T: BaseFetchMLSGroupInfoAction>: Action
 
         return ZMTransportRequest(
             path: path,
-            method: .methodGET,
+            method: .get,
             binaryData: nil,
             type: nil,
             acceptHeaderType: .messageMLS,

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ClaimMLSKeyPackageActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ClaimMLSKeyPackageActionHandler.swift
@@ -44,7 +44,7 @@ class ClaimMLSKeyPackageActionHandler: ActionHandler<ClaimMLSKeyPackageAction> {
 
         return ZMTransportRequest(
             path: path,
-            method: .methodPOST,
+            method: .post,
             payload: payload,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ClaimMLSKeyPackageActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ClaimMLSKeyPackageActionHandlerTests.swift
@@ -47,7 +47,7 @@ class ClaimMLSKeyPackageActionHandlerTests: ActionHandlerTestBase<ClaimMLSKeyPac
             ),
             expectedPath: "/v5/mls/key-packages/claim/\(domain)/\(userId.transportString())",
             expectedPayload: ["skip_own": excludedSelfCliendId],
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             apiVersion: .v5
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/CountSelfMLSKeyPackagesActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/CountSelfMLSKeyPackagesActionHandler.swift
@@ -41,7 +41,7 @@ class CountSelfMLSKeyPackagesActionHandler: ActionHandler<CountSelfMLSKeyPackage
 
         return ZMTransportRequest(
             path: "/mls/key-packages/self/\(action.clientID)/count",
-            method: .methodGET,
+            method: .get,
             payload: nil,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/CountSelfMLSKeyPackagesActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/CountSelfMLSKeyPackagesActionHandlerTests.swift
@@ -37,7 +37,7 @@ class CountSelfMLSKeyPackagesActionHandlerTests: ActionHandlerTestBase<CountSelf
         try test_itGeneratesARequest(
             for: action,
             expectedPath: requestPath,
-            expectedMethod: .methodGET,
+            expectedMethod: .get,
             apiVersion: .v5
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/DeleteSubgroupActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/DeleteSubgroupActionHandler.swift
@@ -49,7 +49,7 @@ final class DeleteSubgroupActionHandler: ActionHandler<DeleteSubgroupAction> {
 
         return ZMTransportRequest(
             path: "/conversations/\(domain)/\(conversationID)/subconversations/\(subgroupType)",
-            method: .methodDELETE,
+            method: .delete,
             payload: nil,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/DeleteSubgroupActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/DeleteSubgroupActionHandlerTests.swift
@@ -46,7 +46,7 @@ final class DeleteSubgroupActionHandlerTests: ActionHandlerTestBase<DeleteSubgro
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v4/conversations/\(domain)/\(conversationID.transportString())/subconversations/\(subgroupType)",
-            expectedMethod: .methodDELETE,
+            expectedMethod: .delete,
             apiVersion: .v4
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandler.swift
@@ -35,7 +35,7 @@ class FetchBackendMLSPublicKeysActionHandler: ActionHandler<FetchBackendMLSPubli
         case .v5:
             return ZMTransportRequest(
                 path: "/mls/public-keys",
-                method: .methodGET,
+                method: .get,
                 payload: nil,
                 apiVersion: apiVersion.rawValue
             )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandlerTests.swift
@@ -37,7 +37,7 @@ class FetchBackendMLSPublicKeysActionHandlerTests: ActionHandlerTestBase<FetchBa
         try test_itGeneratesARequest(
             for: action,
                expectedPath: "/v5/mls/public-keys",
-               expectedMethod: .methodGET,
+               expectedMethod: .get,
                apiVersion: .v5
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSConversationGroupInfoActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSConversationGroupInfoActionHandlerTests.swift
@@ -31,7 +31,7 @@ class FetchMLSConversationGroupInfoActionHandlerTests: BaseFetchMLSGroupInfoActi
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v5/conversations/\(domain)/\(conversationId.transportString())/groupinfo",
-            expectedMethod: .methodGET,
+            expectedMethod: .get,
             expectedAcceptType: .messageMLS,
             apiVersion: .v5
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSSubconversationGroupInfoActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchMLSSubconversationGroupInfoActionHandlerTests.swift
@@ -33,7 +33,7 @@ class FetchMLSSubconversationGroupInfoActionHandlerTests: BaseFetchMLSGroupInfoA
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v5/conversations/\(domain)/\(conversationId.transportString())/subconversations/\(subgroupType.rawValue)/groupinfo",
-            expectedMethod: .methodGET,
+            expectedMethod: .get,
             expectedAcceptType: .messageMLS,
             apiVersion: .v5
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandler.swift
@@ -41,7 +41,7 @@ class FetchSubgroupActionHandler: ActionHandler<FetchSubgroupAction> {
 
         return ZMTransportRequest(
             path: "/conversations/\(action.domain)/\(action.conversationId.transportString())/subconversations/\(action.type.rawValue)",
-            method: .methodGET,
+            method: .get,
             payload: nil,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandlerTests.swift
@@ -42,7 +42,7 @@ class FetchSubroupActionHandlerTests: ActionHandlerTestBase<FetchSubgroupAction,
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v4/conversations/\(domain)/\(conversationId.transportString())/subconversations/\(type)",
-            expectedMethod: .methodGET,
+            expectedMethod: .get,
             apiVersion: .v4
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/LeaveSubconversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/LeaveSubconversationActionHandler.swift
@@ -49,7 +49,7 @@ final class LeaveSubconversationActionHandler: ActionHandler<LeaveSubconversatio
 
         return ZMTransportRequest(
             path: "/conversations/\(domain)/\(conversationID)/subconversations/\(subconversationType)/self",
-            method: .methodDELETE,
+            method: .delete,
             payload: nil,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/LeaveSubconversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/LeaveSubconversationActionHandlerTests.swift
@@ -46,7 +46,7 @@ final class LeaveSubconversationActionHandlerTests: ActionHandlerTestBase<LeaveS
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v4/conversations/\(domain)/\(conversationID.transportString())/subconversations/\(subconversationType)/self",
-            expectedMethod: .methodDELETE,
+            expectedMethod: .delete,
             apiVersion: .v4
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandler.swift
@@ -43,7 +43,7 @@ class SendCommitBundleActionHandler: ActionHandler<SendCommitBundleAction> {
 
         return ZMTransportRequest(
             path: "/mls/commit-bundles",
-            method: .methodPOST,
+            method: .post,
             binaryData: action.commitBundle,
             type: "message/mls",
             contentDisposition: nil,

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
@@ -33,7 +33,7 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v5/mls/commit-bundles",
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             expectedData: commitBundle,
             expectedContentType: "message/mls",
             apiVersion: .v5

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendMLSMessageActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendMLSMessageActionHandler.swift
@@ -44,7 +44,7 @@ class SendMLSMessageActionHandler: ActionHandler<SendMLSMessageAction> {
 
         return ZMTransportRequest(
             path: "/mls/messages",
-            method: .methodPOST,
+            method: .post,
             binaryData: action.message,
             type: "message/mls",
             contentDisposition: nil,

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendMLSMessageActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendMLSMessageActionHandlerTests.swift
@@ -33,7 +33,7 @@ class SendMLSMessageActionHandlerTests: ActionHandlerTestBase<SendMLSMessageActi
         try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v5/mls/messages",
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             expectedData: mlsMessage,
             expectedContentType: "message/mls",
             apiVersion: .v5

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/UploadSelfMLSKeyPackagesActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/UploadSelfMLSKeyPackagesActionHandler.swift
@@ -40,7 +40,7 @@ class UploadSelfMLSKeyPackagesActionHandler: ActionHandler<UploadSelfMLSKeyPacka
 
         return ZMTransportRequest(
             path: "/mls/key-packages/self/\(action.clientID)",
-            method: .methodPOST,
+            method: .post,
             payload: ["key_packages": action.keyPackages] as ZMTransportData,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/UploadSelfMLSKeyPackagesActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/UploadSelfMLSKeyPackagesActionHandlerTests.swift
@@ -40,7 +40,7 @@ class UploadSelfMLSKeyPackagesActionHandlerTests: ActionHandlerTestBase<UploadSe
             ),
             expectedPath: "/v5/mls/key-packages/self/\(clientId)",
             expectedPayload: ["key_packages": keyPackages],
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             apiVersion: .v5
         )
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/GetPushTokensActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/GetPushTokensActionHandler.swift
@@ -29,7 +29,7 @@ class GetPushTokensActionHandler: ActionHandler<GetPushTokensAction> {
 
         return ZMTransportRequest(
             path: "/push/tokens",
-            method: .methodGET,
+            method: .get,
             payload: nil,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/GetPushTokensActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/GetPushTokensActionHandlerTests.swift
@@ -57,7 +57,7 @@ class GetPushTokensActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/push/tokens")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
     }
 
     // MARK: - Response handling

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RegisterPushTokenActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RegisterPushTokenActionHandler.swift
@@ -36,7 +36,7 @@ class RegisterPushTokenActionHandler: ActionHandler<RegisterPushTokenAction> {
 
         return ZMTransportRequest(
             path: "/push/tokens",
-            method: .methodPOST,
+            method: .post,
             payload: payload as ZMTransportData,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RegisterPushTokenActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RegisterPushTokenActionHandlerTests.swift
@@ -51,7 +51,7 @@ class RegisterPushTokenActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/push/tokens")
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
 
         let actualPayload = request.payload?.asDictionary() as? [String: String]
         let expectedPayload: [String: String] = [

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RemovePushTokenActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RemovePushTokenActionHandler.swift
@@ -29,7 +29,7 @@ class RemovePushTokenActionHandler: ActionHandler<RemovePushTokenAction> {
 
         return ZMTransportRequest(
             path: "/push/tokens/\(action.deviceToken)",
-            method: .methodDELETE,
+            method: .delete,
             payload: nil,
             apiVersion: apiVersion.rawValue
         )

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RemovePushTokenActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RemovePushTokenActionHandlerTests.swift
@@ -46,7 +46,7 @@ class RemovePushTokenActionHandlerTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/push/tokens/\(deviceToken)")
-        XCTAssertEqual(request.method, .methodDELETE)
+        XCTAssertEqual(request.method, .delete)
     }
 
     // MARK: - Response handling

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
@@ -51,7 +51,7 @@ final class FetchUserClientsActionHandler: ActionHandler<FetchUserClientsAction>
 
             return ZMTransportRequest(
                 path: "/users/list-clients",
-                method: .methodPOST,
+                method: .post,
                 payload: payloadString as ZMTransportData,
                 apiVersion: apiVersion.rawValue
             )

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchUserClientsActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchUserClientsActionHandlerTests.swift
@@ -58,7 +58,7 @@ class FetchUserClientsActionHandlerTests: ActionHandlerTestBase<FetchUserClients
         let request = try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v3/users/list-clients",
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             apiVersion: .v3
         )
 
@@ -72,7 +72,7 @@ class FetchUserClientsActionHandlerTests: ActionHandlerTestBase<FetchUserClients
         let request = try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v2/users/list-clients",
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             apiVersion: .v2
         )
 
@@ -86,7 +86,7 @@ class FetchUserClientsActionHandlerTests: ActionHandlerTestBase<FetchUserClients
         let request = try test_itGeneratesARequest(
             for: action,
             expectedPath: "/v1/users/list-clients",
-            expectedMethod: .methodPOST,
+            expectedMethod: .post,
             apiVersion: .v1
         )
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -236,7 +236,7 @@ final class UserClientByUserClientIDTranscoder: IdentifierObjectSyncTranscoder {
         guard let identifier = identifiers.first else { return nil }
 
         let path = "/users/\(identifier.userId.transportString())/clients/\(identifier.clientId)"
-        return ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     public func didReceive(response: ZMTransportResponse, for identifiers: Set<UserClientID>) {
@@ -324,7 +324,7 @@ final class UserClientByQualifiedUserIDTranscoder: IdentifierObjectSyncTranscode
 
         return ZMTransportRequest(
             path: "/users/list-clients/v2",
-            method: .methodPOST,
+            method: .post,
             payload: payloadAsString as ZMTransportData?,
             apiVersion: 1
         )
@@ -340,7 +340,7 @@ final class UserClientByQualifiedUserIDTranscoder: IdentifierObjectSyncTranscode
 
         return ZMTransportRequest(
             path: "/users/list-clients",
-            method: .methodPOST,
+            method: .post,
             payload: payloadAsString as ZMTransportData?,
             apiVersion: apiVersion.rawValue
         )
@@ -443,7 +443,7 @@ final class UserClientByUserIDTranscoder: IdentifierObjectSyncTranscoder {
         guard let userId = identifiers.first?.transportString() else { return nil }
 
         let path = "/users/\(userId)/clients"
-        return ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     public func didReceive(response: ZMTransportResponse, for identifiers: Set<UUID>) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategyTests.swift
@@ -73,7 +73,7 @@ extension FetchClientRequestStrategyTests {
 
         createsARequest_WhenUserClientNeedsToBeUpdatedFromBackend(for: apiVersion, clientUUID: clientUUID) { request in
             XCTAssertEqual(request.path, "/users/\(self.otherUser.remoteIdentifier!.transportString())/clients/\(clientUUID.transportString())")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -84,7 +84,7 @@ extension FetchClientRequestStrategyTests {
 
         createsARequest_WhenUserClientNeedsToBeUpdatedFromBackend(for: apiVersion, clientUUID: clientUUID) { request in
             XCTAssertEqual(request.path, "/v1/users/\(self.otherUser.remoteIdentifier!.transportString())/clients/\(clientUUID.transportString())")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 
@@ -94,7 +94,7 @@ extension FetchClientRequestStrategyTests {
 
         createsARequest_WhenUserClientNeedsToBeUpdatedFromBackend(for: apiVersion) { request in
             XCTAssertEqual(request.path, "/v2/users/list-clients")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
         }
     }
 
@@ -107,7 +107,7 @@ extension FetchClientRequestStrategyTests {
             reportObjectsChanged: false
         ) { request in
             XCTAssertEqual(request.path, "/v2/users/list-clients")
-            XCTAssertEqual(request.method, .methodPOST)
+            XCTAssertEqual(request.method, .post)
         }
     }
 
@@ -445,7 +445,7 @@ extension FetchClientRequestStrategyTests {
             if let request = request {
                 let path = "/users/\(user.remoteIdentifier!.transportString())/clients"
                 XCTAssertEqual(request.path, path)
-                XCTAssertEqual(request.method, .methodGET)
+                XCTAssertEqual(request.method, .get)
             } else {
                 XCTFail("Failed to create request")
             }
@@ -472,7 +472,7 @@ extension FetchClientRequestStrategyTests {
             if let request = request {
                 let path = "/v1/users/list-clients/v2"
                 XCTAssertEqual(request.path, path)
-                XCTAssertEqual(request.method, .methodPOST)
+                XCTAssertEqual(request.method, .post)
             } else {
                 XCTFail("Failed to create request")
             }
@@ -499,7 +499,7 @@ extension FetchClientRequestStrategyTests {
             if let request = request {
                 let path = "/v2/users/list-clients"
                 XCTAssertEqual(request.path, path)
-                XCTAssertEqual(request.method, .methodPOST)
+                XCTAssertEqual(request.method, .post)
             } else {
                 XCTFail("Failed to create request")
             }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestFactory.swift
@@ -72,7 +72,7 @@ public final class MissingClientsRequestFactory {
         }
 
         let request = ZMTransportRequest(path: "/users/prekeys",
-                                         method: .methodPOST,
+                                         method: .post,
                                          payload: payloadAsString as ZMTransportData?,
                                          apiVersion: apiVersion.rawValue)
         let userClientMissingKeySet: Set<String> = [ZMUserClientMissingKey]
@@ -91,7 +91,7 @@ public final class MissingClientsRequestFactory {
         }
 
         let request = ZMTransportRequest(path: "/users/list-prekeys",
-                                         method: .methodPOST,
+                                         method: .post,
                                          payload: payloadAsString as ZMTransportData?,
                                          apiVersion: apiVersion.rawValue)
         let userClientMissingKeySet: Set<String> = [ZMUserClientMissingKey]

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/MissingClientsRequestStrategyTests.swift
@@ -65,7 +65,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             let request = self.sut.requestsFactory.fetchPrekeys(for: self.selfClient.missingClients!, apiVersion: .v0)!
 
             // THEN
-            XCTAssertEqual(request.transportRequest.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.transportRequest.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.transportRequest.path, "/users/prekeys")
 
             guard let payloadData = (request.transportRequest.payload as? String)?.data(using: .utf8) else {
@@ -100,7 +100,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             let request = self.sut.requestsFactory.fetchPrekeysFederated(for: self.selfClient.missingClients!, apiVersion: .v1)!
 
             // THEN
-            XCTAssertEqual(request.transportRequest.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.transportRequest.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.transportRequest.path, "/v1/users/list-prekeys")
 
             guard let payloadData = (request.transportRequest.payload as? String)?.data(using: .utf8) else {
@@ -235,7 +235,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             }
 
             // THEN
-            XCTAssertEqual(firstRequest.method, .methodPOST)
+            XCTAssertEqual(firstRequest.method, .post)
             XCTAssertEqual(firstRequest.path, "/users/prekeys")
             XCTAssertEqual(firstPayload.count, 1)
             guard let first = firstPayload.first else {
@@ -263,7 +263,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             }
 
             // THEN
-            XCTAssertEqual(secondRequest.method, .methodPOST)
+            XCTAssertEqual(secondRequest.method, .post)
             XCTAssertEqual(secondRequest.path, "/users/prekeys")
             XCTAssertEqual(secondPayload.count, 1)
             guard let second = secondPayload.first else {
@@ -324,7 +324,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             }
 
             // THEN
-            XCTAssertEqual(firstRequest.method, .methodPOST)
+            XCTAssertEqual(firstRequest.method, .post)
             XCTAssertEqual(firstRequest.path, "/v1/users/list-prekeys")
             XCTAssertEqual(firstPayload.count, 1)
             guard let first = firstPayload.first?.value.first else {
@@ -351,7 +351,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             }
 
             // THEN
-            XCTAssertEqual(secondRequest.method, .methodPOST)
+            XCTAssertEqual(secondRequest.method, .post)
             XCTAssertEqual(secondRequest.path, "/v1/users/list-prekeys")
             XCTAssertEqual(secondPayload.count, 1)
             guard let second = secondPayload.first?.value.first else {
@@ -667,7 +667,7 @@ class MissingClientsRequestStrategyTests: MessagingTestBase {
             }
 
             // THEN
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
             XCTAssertEqual(request.path, "/users/prekeys")
 
             let payloadData = (request.payload as? String)?.data(using: .utf8)
@@ -726,7 +726,7 @@ extension MissingClientsRequestStrategyTests {
             return XCTFail("Request should contain payload", file: file, line: line)
         }
 
-        XCTAssertEqual(request.method, .methodPOST, file: file, line: line)
+        XCTAssertEqual(request.method, .post, file: file, line: line)
         XCTAssertEqual(request.path, "/users/prekeys", file: file, line: line)
         expectedClients.forEach {
             guard let userKey = $0.user?.remoteIdentifier?.transportString() else {
@@ -757,7 +757,7 @@ extension MissingClientsRequestStrategyTests {
             return XCTFail("Request should contain payload", file: file, line: line)
         }
 
-        XCTAssertEqual(request.method, .methodPOST, file: file, line: line)
+        XCTAssertEqual(request.method, .post, file: file, line: line)
 
         switch apiVersion {
         case .v0:

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/UserClientByQualifiedUserIDTranscoderTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/UserClientByQualifiedUserIDTranscoderTests.swift
@@ -72,7 +72,7 @@ class UserClientByQualifiedUserIDTranscoderTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/v1/users/list-clients/v2")
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.apiVersion, 1)
 
         let payload = try payload(from: request)
@@ -88,7 +88,7 @@ class UserClientByQualifiedUserIDTranscoderTests: MessagingTestBase {
 
         // Then
         XCTAssertEqual(request.path, "/v2/users/list-clients")
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.apiVersion, 2)
 
         let payload = try payload(from: request)

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -308,7 +308,7 @@ class UserProfileByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
 
         // POST /list-users
         let path = NSString.path(withComponents: ["/list-users"])
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payloadAsString as ZMTransportData?, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payloadAsString as ZMTransportData?, apiVersion: apiVersion.rawValue)
     }
 
     func didReceive(response: ZMTransportResponse, for identifiers: Set<QualifiedID>) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
@@ -58,7 +58,7 @@ extension UserProperty {
 
     func upstreamRequest(newValue: ZMTransportData, apiVersion: APIVersion) -> ZMTransportRequest {
         let path = [UserProperty.propertiesPath, self.serverName].joined(separator: "/")
-        return ZMTransportRequest(path: path, method: .methodPUT, payload: newValue, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .put, payload: newValue, apiVersion: apiVersion.rawValue)
     }
 
     func downstreamRequest(apiVersion: APIVersion) -> ZMTransportRequest {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategyTests.swift
@@ -131,7 +131,7 @@ extension UserPropertyRequestStrategyTests {
             let request = self.sut.nextRequestIfAllowed(for: .v0)
 
             XCTAssertNotNil(request)
-            XCTAssertEqual(request!.method, .methodGET)
+            XCTAssertEqual(request!.method, .get)
             XCTAssertEqual(request!.path, "properties/WIRE_RECEIPT_MODE")
 
             let response = ZMTransportResponse(payload: "1" as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
@@ -154,7 +154,7 @@ extension UserPropertyRequestStrategyTests {
             let request = self.sut.nextRequestIfAllowed(for: .v0)
 
             XCTAssertNotNil(request)
-            XCTAssertEqual(request!.method, .methodGET)
+            XCTAssertEqual(request!.method, .get)
             XCTAssertEqual(request!.path, "properties/WIRE_RECEIPT_MODE")
 
             let response = ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserRichProfileRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserRichProfileRequestStrategy.swift
@@ -46,7 +46,7 @@ extension UserRichProfileRequestStrategy: ZMDownstreamTranscoder {
         guard let user = object as? ZMUser else { fatal("Object \(object.classForCoder) is not ZMUser") }
         guard let remoteIdentifier = user.remoteIdentifier else { fatal("User does not have remote identifier") }
         let path = "/users/\(remoteIdentifier)/rich-info"
-        return ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     public func delete(_ object: ZMManagedObject!, with response: ZMTransportResponse!, downstreamSync: ZMObjectSync!) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserRichProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserRichProfileRequestStrategyTests.swift
@@ -54,7 +54,7 @@ class UserRichProfileRequestStrategyTests: MessagingTestBase {
 
             // then
             XCTAssertEqual(request.path, "/users/\(userID)/rich-info")
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Syncs/PaginatedSync.swift
+++ b/wire-ios-request-strategy/Sources/Request Syncs/PaginatedSync.swift
@@ -123,7 +123,7 @@ class PaginatedSync<PayloadType: Paginatable>: NSObject, ZMRequestGenerator {
             return nil
         }
 
-        return ZMTransportRequest(path: basePath, method: .methodPOST, payload: payloadAsString as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: basePath, method: .post, payload: payloadAsString as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/wire-ios-share-engine/WireShareEngineTests/RequestGeneratorStoreTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/RequestGeneratorStoreTests.swift
@@ -76,7 +76,7 @@ final class RequestGeneratorStoreTests: ZMTBaseTest {
     func testThatItDoesNOTReturnARequestIfNoAPIVersionIsSelected() {
         // Given
         mockStrategy.requestGenerators.append(DummyGenerator(requestBlock: {
-            return ZMTransportRequest(path: "some path", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
+            return ZMTransportRequest(path: "some path", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
         }))
 
         sut = RequestGeneratorStore(strategies: [mockStrategy])
@@ -112,7 +112,7 @@ final class RequestGeneratorStoreTests: ZMTBaseTest {
 
     func testThatItReturnAProperRequest() {
 
-        let sourceRequest = ZMTransportRequest(path: "some path", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let sourceRequest = ZMTransportRequest(path: "some path", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
 
         let generator = DummyGenerator(requestBlock: {
             return sourceRequest
@@ -129,7 +129,7 @@ final class RequestGeneratorStoreTests: ZMTBaseTest {
 
     func testThatItReturnARequestWhenARequestGeneratorIsAddedDirectly() {
         // Given
-        let sourceRequest = ZMTransportRequest(path: "/path", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let sourceRequest = ZMTransportRequest(path: "/path", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
         let strategy = MockRequestStrategy(request: sourceRequest)
         sut = RequestGeneratorStore(strategies: [strategy])
 
@@ -143,7 +143,7 @@ final class RequestGeneratorStoreTests: ZMTBaseTest {
 
     func testThatItReturnAProperRequestAndNoRequestAfter() {
 
-        let sourceRequest = ZMTransportRequest(path: "some path", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let sourceRequest = ZMTransportRequest(path: "some path", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
 
         var requestCalled = false
 
@@ -170,8 +170,8 @@ final class RequestGeneratorStoreTests: ZMTBaseTest {
 
     func testThatItReturnsRequestFromMultipleGenerators() {
 
-        let sourceRequest = ZMTransportRequest(path: "some path", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
-        let sourceRequest2 = ZMTransportRequest(path: "some path 2", method: .methodPOST, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let sourceRequest = ZMTransportRequest(path: "some path", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let sourceRequest2 = ZMTransportRequest(path: "some path 2", method: .post, payload: nil, apiVersion: APIVersion.v0.rawValue)
 
         var requestCalled = false
 

--- a/wire-ios-sync-engine/Source/Data Model/Conversation+AccessMode.swift
+++ b/wire-ios-sync-engine/Source/Data Model/Conversation+AccessMode.swift
@@ -283,10 +283,10 @@ internal struct WirelessRequestFactory {
 
         switch apiVersion {
         case .v0, .v1, .v2, .v3:
-            return .init(path: "/conversations/\(identifier)/code", method: .methodPOST, payload: nil, apiVersion: apiVersion.rawValue)
+            return .init(path: "/conversations/\(identifier)/code", method: .post, payload: nil, apiVersion: apiVersion.rawValue)
         case .v4, .v5:
             let payload: [String: Any] = [:]
-            return .init(path: "/conversations/\(identifier)/code", method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+            return .init(path: "/conversations/\(identifier)/code", method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
         }
     }
 
@@ -294,7 +294,7 @@ internal struct WirelessRequestFactory {
         guard let identifier = conversation.remoteIdentifier?.transportString() else {
             fatal("conversation is not yet inserted on the backend")
         }
-        return .init(path: "/conversations/\(identifier)/code", method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+        return .init(path: "/conversations/\(identifier)/code", method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     static func setAccessRoles(allowGuests: Bool, allowServices: Bool, for conversation: ZMConversation, apiVersion: APIVersion) -> ZMTransportRequest {
@@ -336,7 +336,7 @@ internal struct WirelessRequestFactory {
             payload["access_role_v2"] = accessRoles.map(\.rawValue)
         }
 
-        return .init(path: path, method: .methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return .init(path: path, method: .put, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/wire-ios-sync-engine/Source/Data Model/Conversation+Deletion.swift
+++ b/wire-ios-sync-engine/Source/Data Model/Conversation+Deletion.swift
@@ -85,7 +85,7 @@ struct ConversationDeletionRequestFactory {
 
         let path = "/teams/\(teamRemoteIdentifier.transportString())/conversations/\(conversationId.transportString())"
 
-        return ZMTransportRequest(path: path, method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/wire-ios-sync-engine/Source/Data Model/Conversation+Join.swift
+++ b/wire-ios-sync-engine/Source/Data Model/Conversation+Join.swift
@@ -167,7 +167,7 @@ struct ConversationJoinRequestFactory {
             URLQueryItem.Key.conversationCode: code
         ]
 
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
     static func requestForGetConversation(key: String, code: String) -> ZMTransportRequest? {
@@ -181,7 +181,7 @@ struct ConversationJoinRequestFactory {
             return nil
         }
 
-        return ZMTransportRequest(path: urlString, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: urlString, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/wire-ios-sync-engine/Source/Data Model/Conversation+MessageDestructionTimeout.swift
+++ b/wire-ios-sync-engine/Source/Data Model/Conversation+MessageDestructionTimeout.swift
@@ -89,7 +89,7 @@ private struct MessageDestructionTimeoutRequestFactory {
             let timeoutInMS: Int64 = Int64(timeout) * 1000
             payload = ["message_timer": timeoutInMS]
         }
-        return .init(path: "/conversations/\(identifier)/message-timer", method: .methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return .init(path: "/conversations/\(identifier)/message-timer", method: .put, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/wire-ios-sync-engine/Source/Data Model/Conversation+ReadReceiptMode.swift
+++ b/wire-ios-sync-engine/Source/Data Model/Conversation+ReadReceiptMode.swift
@@ -45,7 +45,7 @@ extension ZMConversation {
         guard let conversationId = remoteIdentifier?.transportString() else { return completion(.failure(ReadReceiptModeError.noConversation)) }
 
         let payload = ["receipt_mode": enabled ? 1 : 0] as ZMTransportData
-        let request = ZMTransportRequest(path: "/conversations/\(conversationId)/receipt-mode", method: .methodPUT, payload: payload, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: "/conversations/\(conversationId)/receipt-mode", method: .put, payload: payload, apiVersion: apiVersion.rawValue)
 
         request.add(ZMCompletionHandler(on: managedObjectContext!) { response in
             if response.httpStatus == 200, let event = response.updateEvent {

--- a/wire-ios-sync-engine/Source/Data Model/ServiceUser.swift
+++ b/wire-ios-sync-engine/Source/Data Model/ServiceUser.swift
@@ -116,17 +116,17 @@ public extension ServiceUserData {
                                      "service": self.service.transportString(),
                                      "locale": NSLocale.formattedLocaleIdentifier()!]
 
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
     fileprivate func requestToFetchProvider(apiVersion: APIVersion) -> ZMTransportRequest {
         let path = "/providers/\(provider.transportString())/"
-        return ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
     }
 
     fileprivate func requestToFetchDetails(apiVersion: APIVersion) -> ZMTransportRequest {
         let path = "/providers/\(provider.transportString())/services/\(service.transportString())"
-        return ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
     }
 }
 

--- a/wire-ios-sync-engine/Source/Data Model/ZMUser+Consent.swift
+++ b/wire-ios-sync-engine/Source/Data Model/ZMUser+Consent.swift
@@ -140,7 +140,7 @@ struct ConsentRequestFactory {
             "source": sourceString
         ]
         return .init(path: consentPath,
-                     method: .methodPUT,
+                     method: .put,
                      payload: payload as ZMTransportData,
                      apiVersion: apiVersion.rawValue)
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/Asset Deletion/AssetDeletionRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/Asset Deletion/AssetDeletionRequestStrategy.swift
@@ -34,7 +34,7 @@ fileprivate extension AssetRequestFactory {
             path = "/assets/\(domain)/\(identifier)"
         }
 
-        let request = ZMTransportRequest(path: path, method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
         request.add(ZMCompletionHandler(on: queue, block: block))
         return request
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -119,7 +119,7 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
             zmLog.debug("Scheduling request to '/calls/config/v2'")
 
             return ZMTransportRequest(path: "/calls/config/v2",
-                                      method: .methodGET,
+                                      method: .get,
                                       binaryData: nil,
                                       type: "application/json",
                                       contentDisposition: nil,

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/DeleteAccountRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/DeleteAccountRequestStrategy.swift
@@ -53,7 +53,7 @@ public final class DeleteAccountRequestStrategy: AbstractRequestStrategy, ZMSing
     // MARK: - ZMSingleRequestTranscoder
 
     public func request(for sync: ZMSingleRequestSync, apiVersion: APIVersion) -> ZMTransportRequest? {
-        let request = ZMTransportRequest(path: type(of: self).path, method: .methodDELETE, payload: ([:] as ZMTransportData), shouldCompress: true, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: type(of: self).path, method: .delete, payload: ([:] as ZMTransportData), shouldCompress: true, apiVersion: apiVersion.rawValue)
         return request
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/LabelUpstreamRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/LabelUpstreamRequestStrategy.swift
@@ -79,7 +79,7 @@ public class LabelUpstreamRequestStrategy: AbstractRequestStrategy, ZMContextCha
             fatal("Couldn't encode label update: \(error)")
         }
 
-        let request = ZMTransportRequest(path: "/properties/labels", method: .methodPUT, payload: transportPayload as? ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: "/properties/labels", method: .put, payload: transportPayload as? ZMTransportData, apiVersion: apiVersion.rawValue)
         request.add(ZMCompletionHandler(on: managedObjectContext, block: { [weak self] (response) in
             self?.didReceive(response, updatedKeys: updatedKeys)
         }))

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -49,7 +49,7 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
             fatal("Generating request for invalid phase: \(currentStatus.phase)")
         }
 
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
     func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistrationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistrationStrategy.swift
@@ -35,9 +35,9 @@ extension RegistrationStrategy: ZMSingleRequestTranscoder {
     func request(for sync: ZMSingleRequestSync, apiVersion: APIVersion) -> ZMTransportRequest? {
         switch registrationStatus.phase {
         case let .createUser(user):
-            return ZMTransportRequest(path: "/register", method: .methodPOST, payload: user.payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/register", method: .post, payload: user.payload, apiVersion: apiVersion.rawValue)
         case let .createTeam(team):
-            return ZMTransportRequest(path: "/register", method: .methodPOST, payload: team.payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/register", method: .post, payload: team.payload, apiVersion: apiVersion.rawValue)
         default:
             fatal("Generating request for invalid phase: \(registrationStatus.phase)")
         }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/SignatureRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/SignatureRequestStrategy.swift
@@ -144,7 +144,7 @@ public final class SignatureRequestStrategy: AbstractRequestStrategy, ZMSingleRe
         }
 
         return ZMTransportRequest(path: "/signature/request",
-                                  method: .methodPOST,
+                                  method: .post,
                                   payload: payload as ZMTransportData,
                                   apiVersion: apiVersion.rawValue)
     }
@@ -156,7 +156,7 @@ public final class SignatureRequestStrategy: AbstractRequestStrategy, ZMSingleRe
         }
 
         return ZMTransportRequest(path: "/signature/pending/\(responseID)",
-                                  method: .methodGET,
+                                  method: .get,
                                   payload: nil,
                                   apiVersion: apiVersion.rawValue)
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamInvitationRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamInvitationRequestStrategy.swift
@@ -65,7 +65,7 @@ public final class TeamInvitationRequestStrategy: AbstractRequestStrategy {
             "inviter_name": ZMUser.selfUser(in: managedObjectContext).name
         ]
 
-        let request = ZMTransportRequest(path: "/teams/\(teamId.transportString())/invitations", method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: "/teams/\(teamId.transportString())/invitations", method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
 
         request.add(ZMCompletionHandler(on: managedObjectContext, block: { [weak self] (response) in
             self?.processResponse(response, for: email)

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TypingStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TypingStrategy.swift
@@ -202,7 +202,7 @@ public class TypingStrategy: AbstractRequestStrategy, TearDownCapable, ZMEventCo
         }
 
         let payload = [StatusKey: typingEvent.isTyping ? StartedKey : StoppedKey]
-        let request = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
         request.setDebugInformationTranscoder(self)
 
         return request

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -69,7 +69,7 @@ public final class UserClientRequestFactory {
             payload["verification_code"] = verificationCode
         }
 
-        let request = ZMTransportRequest(path: "/clients", method: ZMTransportRequestMethod.methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: "/clients", method: ZMTransportRequestMethod.post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
         request.add(storeMaxRangeID(client, maxRangeID: preKeysRangeMax))
         request.add(storeAPSSignalingKeys(client, signalingKeys: signalingKeys))
 
@@ -176,7 +176,7 @@ public final class UserClientRequestFactory {
             let payload: [String: Any] = [
                 "prekeys": preKeysPayloadData
             ]
-            let request = ZMTransportRequest(path: "/clients/\(remoteIdentifier)", method: ZMTransportRequestMethod.methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+            let request = ZMTransportRequest(path: "/clients/\(remoteIdentifier)", method: ZMTransportRequestMethod.put, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
             request.add(storeMaxRangeID(client, maxRangeID: preKeysRangeMax))
 
             let userClientNumberOfKeysRemainingKeySet: Set<String> = [ZMUserClientNumberOfKeysRemainingKey]
@@ -192,7 +192,7 @@ public final class UserClientRequestFactory {
                 "sigkeys": signalingKeysPayloadData,
                 "prekeys": [] // NOTE backend always expects 'prekeys' to be present atm
             ]
-            let request = ZMTransportRequest(path: "/clients/\(remoteIdentifier)", method: ZMTransportRequestMethod.methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+            let request = ZMTransportRequest(path: "/clients/\(remoteIdentifier)", method: ZMTransportRequestMethod.put, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
             request.add(storeAPSSignalingKeys(client, signalingKeys: signalingKeys))
 
             let userClientNeedsToUpdateSignalingKeysKeySet: Set<String> = [ZMUserClientNeedsToUpdateSignalingKeysKey]
@@ -215,7 +215,7 @@ public final class UserClientRequestFactory {
 
         let request = ZMTransportRequest(
             path: "/clients/\(clientID)",
-            method: .methodPUT,
+            method: .put,
             payload: payloadDataString as ZMTransportData,
             apiVersion: apiVersion.rawValue
         )
@@ -233,7 +233,7 @@ public final class UserClientRequestFactory {
         let payload: [String: Any] = [
             "capabilities": ["legalhold-implicit-consent"]
         ]
-        let request = ZMTransportRequest(path: "/clients/\(remoteIdentifier)", method: ZMTransportRequestMethod.methodPUT, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: "/clients/\(remoteIdentifier)", method: ZMTransportRequestMethod.put, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
         request.add(storeCapabilitiesHandler(client))
 
         let userClientNeedsToUpdateCapabilitiesKeySet: Set<String> = [ZMUserClientNeedsToUpdateCapabilitiesKey]
@@ -255,7 +255,7 @@ public final class UserClientRequestFactory {
             payload = [:]
         }
 
-        let request =  ZMTransportRequest(path: "/clients/\(client.remoteIdentifier!)", method: ZMTransportRequestMethod.methodDELETE, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request =  ZMTransportRequest(path: "/clients/\(client.remoteIdentifier!)", method: ZMTransportRequestMethod.delete, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
         let userClientMarkedToDeleteKeySet: Set<String> = [ZMUserClientMarkedToDeleteKey]
         return ZMUpstreamRequest(keys: userClientMarkedToDeleteKeySet, transportRequest: request)
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
@@ -221,7 +221,7 @@ public final class UserImageAssetUpdateStrategy: AbstractRequestStrategy, ZMCont
         } else if sync === deleteRequestSync {
             if let assetId = imageUploadStatus?.consumeAssetToDelete() {
                 let path = "/assets/v3/\(assetId)"
-                return ZMTransportRequest(path: path, method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+                return ZMTransportRequest(path: path, method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
             }
         }
         return nil

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserProfileUpdateRequestStrategy.swift
@@ -122,7 +122,7 @@ public class UserProfileUpdateRequestStrategy: AbstractRequestStrategy, ZMSingle
             let payload: NSDictionary = [
                 "phone": self.userProfileUpdateStatus.phoneNumberForWhichCodeIsRequested!
             ]
-            return ZMTransportRequest(path: "/self/phone", method: .methodPUT, payload: payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/self/phone", method: .put, payload: payload, apiVersion: apiVersion.rawValue)
 
         case self.phoneUpdateSync:
             let payload: NSDictionary = [
@@ -130,30 +130,30 @@ public class UserProfileUpdateRequestStrategy: AbstractRequestStrategy, ZMSingle
                 "code": self.userProfileUpdateStatus.phoneNumberToSet!.phoneNumberVerificationCode!,
                 "dryrun": false
             ]
-            return ZMTransportRequest(path: "/activate", method: .methodPOST, payload: payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/activate", method: .post, payload: payload, apiVersion: apiVersion.rawValue)
 
         case self.phoneNumberDeleteSync:
-            return ZMTransportRequest(path: "/self/phone", method: .methodDELETE, payload: nil, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/self/phone", method: .delete, payload: nil, apiVersion: apiVersion.rawValue)
 
         case self.passwordUpdateSync:
             let payload: NSDictionary = [
                 "new_password": self.userProfileUpdateStatus.passwordToSet!
             ]
-            return ZMTransportRequest(path: "/self/password", method: .methodPUT, payload: payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/self/password", method: .put, payload: payload, apiVersion: apiVersion.rawValue)
 
         case self.emailUpdateSync:
             let payload: NSDictionary = [
                 "email": self.userProfileUpdateStatus.emailToSet!
             ]
-            return ZMTransportRequest(path: "/access/self/email", method: .methodPUT, payload: payload, authentication: .needsCookieAndAccessToken, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/access/self/email", method: .put, payload: payload, authentication: .needsCookieAndAccessToken, apiVersion: apiVersion.rawValue)
 
         case self.handleCheckSync:
             let handle = self.userProfileUpdateStatus.handleToCheck!
-            return ZMTransportRequest(path: "/users/handles/\(handle)", method: .methodHEAD, payload: nil, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/users/handles/\(handle)", method: .head, payload: nil, apiVersion: apiVersion.rawValue)
 
         case self.handleSetSync:
             let payload: NSDictionary = ["handle": self.userProfileUpdateStatus.handleToSet!]
-            return ZMTransportRequest(path: "/self/handle", method: .methodPUT, payload: payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/self/handle", method: .put, payload: payload, apiVersion: apiVersion.rawValue)
 
         case self.handleSuggestionSearchSync:
             guard let handlesToCheck = self.userProfileUpdateStatus.suggestedHandlesToCheck else {
@@ -163,7 +163,7 @@ public class UserProfileUpdateRequestStrategy: AbstractRequestStrategy, ZMSingle
                     "handles": handlesToCheck,
                     "return": 1
                 ] as NSDictionary
-            return ZMTransportRequest(path: "/users/handles", method: .methodPOST, payload: payload, apiVersion: apiVersion.rawValue)
+            return ZMTransportRequest(path: "/users/handles", method: .post, payload: payload, apiVersion: apiVersion.rawValue)
 
         default:
             return nil

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoder.m
@@ -71,7 +71,7 @@
 {
     if (sync == self.emailVerificationCodeRequestSync) {
         ZMTransportRequest *emailVerficationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send"
-                                                                                            method:ZMMethodPOST
+                                                                                            method:ZMTransportRequestMethodPost
                                                                                            payload:@{@"email": self.authenticationStatus.loginEmailThatNeedsAValidationCode,
                                                                                                      @"action": @"login"
                                                                                                    }
@@ -81,7 +81,7 @@
     } else if (sync == self.phoneVerificationCodeRequestSync) {
 
         ZMTransportRequest *phoneVerificationCodeRequest = [[ZMTransportRequest alloc] initWithPath:@"/login/send"
-                                                                                             method:ZMMethodPOST
+                                                                                             method:ZMTransportRequestMethodPost
                                                                                             payload:@{@"phone": self.authenticationStatus.loginPhoneNumberThatNeedsAValidationCode}
                                                                                      authentication:ZMTransportRequestAuthNone
                                                                                          apiVersion:apiVersion];

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -30,7 +30,7 @@
 
 NSString * const ZMLoginURL = @"/login?persist=true";
 NSString * const ZMResendVerificationURL = @"/activate/send";
-static ZMTransportRequestMethod const LoginMethod = ZMMethodPOST;
+static ZMTransportRequestMethod const LoginMethod = ZMTransportRequestMethodPost;
 NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
 
 

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMSelfStrategy.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMSelfStrategy.m
@@ -202,7 +202,7 @@ NSTimeInterval ZMSelfStrategyPendingValidationRequestInterval = 5;
         payload[@"assets"] = [self profilePictureAssetsPayloadForUser:user];
     }
     
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"/self" method:ZMMethodPUT payload:payload apiVersion:apiVersion];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"/self" method:ZMTransportRequestMethodPut payload:payload apiVersion:apiVersion];
     return [[ZMUpstreamRequest alloc] initWithKeys:keys transportRequest:request];
 }
 

--- a/wire-ios-sync-engine/Source/UnauthenticatedSession/UnauthenticatedSession+DomainLookup.swift
+++ b/wire-ios-sync-engine/Source/UnauthenticatedSession/UnauthenticatedSession+DomainLookup.swift
@@ -68,7 +68,7 @@ extension UnauthenticatedSession {
         }
 
         let path = "/custom-backend/by-domain/\(domain.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)"
-        let request = ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
 
         request.add(ZMCompletionHandler(on: operationLoop.operationQueue!, block: { (response) in
 

--- a/wire-ios-sync-engine/Source/UnauthenticatedSession/UnauthenticatedSession+SSO.swift
+++ b/wire-ios-sync-engine/Source/UnauthenticatedSession/UnauthenticatedSession+SSO.swift
@@ -61,7 +61,7 @@ extension UnauthenticatedSession {
         }
 
         let path = "/sso/settings"
-        let request = ZMTransportRequest(path: path, method: .methodGET, payload: nil, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: path, method: .get, payload: nil, apiVersion: apiVersion.rawValue)
 
         request.add(ZMCompletionHandler(on: operationLoop.operationQueue!, block: { (response) in
 

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -436,7 +436,7 @@ extension SearchTask {
         let path = "/teams/\(teamID.transportString())/get-members-by-ids-using-post"
         let payload = ["user_ids": teamMemberIDs.map { $0.transportString() }]
 
-        return ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        return ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+Authentication.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+Authentication.swift
@@ -100,7 +100,7 @@ extension ZMUserSession {
             payload = [:]
         }
 
-        let request = ZMTransportRequest(path: "/clients/\(selfClientIdentifier)", method: .methodDELETE, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
+        let request = ZMTransportRequest(path: "/clients/\(selfClientIdentifier)", method: .delete, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
 
         request.add(ZMCompletionHandler(on: managedObjectContext, block: { [weak self] (response) in
             guard let strongSelf = self else { return }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+LegalHold.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+LegalHold.swift
@@ -78,7 +78,7 @@ extension ZMUserSession {
             payload["password"] = password
 
             let path = "/teams/\(teamID.transportString())/legalhold/\(userID.transportString())/approve"
-            let request = ZMTransportRequest(path: path, method: .methodPUT, payload: payload as NSDictionary, apiVersion: apiVersion.rawValue)
+            let request = ZMTransportRequest(path: path, method: .put, payload: payload as NSDictionary, apiVersion: apiVersion.rawValue)
 
             // 4) Handle the Response
             request.add(ZMCompletionHandler(on: self.syncManagedObjectContext, block: { response in

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -49,7 +49,7 @@ final class ZMUserConsentTests: DatabaseTest {
         let request = WireSyncEngine.ConsentRequestFactory.fetchConsentRequest(apiVersion: .v0)
 
         // then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/self/consent")
         XCTAssertNil(request.payload)
     }
@@ -58,7 +58,7 @@ final class ZMUserConsentTests: DatabaseTest {
         // given
         let request = WireSyncEngine.ConsentRequestFactory.setConsentRequest(for: .marketing, value: true, apiVersion: .v0)
         // then
-        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.method, .put)
         XCTAssertEqual(request.path, "/self/consent")
         let expectedPayload: [AnyHashable: Any] = ["type": 2, "value": 1, "source": "iOS 1.0"]
         XCTAssertEqual(request.payload!.asDictionary()! as NSDictionary, expectedPayload as NSDictionary)
@@ -68,7 +68,7 @@ final class ZMUserConsentTests: DatabaseTest {
         // given
         let request = WireSyncEngine.ConsentRequestFactory.setConsentRequest(for: .marketing, value: false, apiVersion: .v0)
         // then
-        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.method, .put)
         XCTAssertEqual(request.path, "/self/consent")
         let expectedPayload: [AnyHashable: Any] = ["type": 2, "value": 0, "source": "iOS 1.0"]
         XCTAssertEqual(request.payload!.asDictionary()! as NSDictionary, expectedPayload as NSDictionary)

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -137,7 +137,7 @@ class UserClientRequestFactoryTests: MessagingTest {
 
         // then
         let transportRequest = try XCTUnwrap(request.transportRequest)
-        assertRequest(transportRequest, path: "/clients", method: .methodPOST)
+        assertRequest(transportRequest, path: "/clients", method: .post)
 
         let payload = try XCTUnwrap(payload(from: transportRequest))
         try assertLastPrekey(payload, usingProteusService: usingProteusService)
@@ -246,7 +246,7 @@ class UserClientRequestFactoryTests: MessagingTest {
         assertRequest(
             transportRequest,
             path: "/clients/\(client.remoteIdentifier!)",
-            method: .methodPUT
+            method: .put
         )
 
         let payload = try XCTUnwrap(payload(from: transportRequest))
@@ -306,7 +306,7 @@ class UserClientRequestFactoryTests: MessagingTest {
         assertRequest(
             transportRequest,
             path: "/clients/\(client.remoteIdentifier!)",
-            method: .methodDELETE
+            method: .delete
         )
 
         let payload = try XCTUnwrap(payload(from: transportRequest))
@@ -333,7 +333,7 @@ class UserClientRequestFactoryTests: MessagingTest {
         assertRequest(
             transportRequest,
             path: "/v1/clients/\(client.remoteIdentifier!)",
-            method: .methodPUT
+            method: .put
         )
 
         let payload = try XCTUnwrap(payload(from: transportRequest))

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -569,7 +569,7 @@ extension UserClientRequestStrategyTests {
                     "email": self.clientUpdateStatus.mockCredentials.email!,
                     "password": self.clientUpdateStatus.mockCredentials.password!
                     ])
-                XCTAssertEqual($0.method, ZMTransportRequestMethod.methodDELETE)
+                XCTAssertEqual($0.method, ZMTransportRequestMethod.delete)
             }
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Integration/APNSTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/APNSTests.m
@@ -65,7 +65,7 @@
 
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
         NSString *path = [NSString stringWithFormat:@"/notifications?size=500&since=%@&client=%@", lastNotificationId.transportString ,selfUser.selfClient.remoteIdentifier];
-        if ([request.path isEqualToString:path] && request.method == ZMMethodGET) {
+        if ([request.path isEqualToString:path] && request.method == ZMTransportRequestMethodGet) {
             [fetchingExpectation fulfill];
             return [ZMTransportResponse responseWithPayload:notificationStreamPayload HTTPStatus:200 transportSessionError:nil apiVersion:0];
         };
@@ -120,7 +120,7 @@
     NSUUID *lastNotificationId = [self.lastEventIDRepository fetchLastEventID];
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
         NSString *path = [NSString stringWithFormat:@"/notifications?size=500&since=%@&client=%@", lastNotificationId.transportString, selfUser.selfClient.remoteIdentifier];
-        if ([request.path isEqualToString:path] && request.method == ZMMethodGET) {
+        if ([request.path isEqualToString:path] && request.method == ZMTransportRequestMethodGet) {
             if (++requestCount == 2) {
                 [fetchingExpectation fulfill];
                 return [ZMTransportResponse responseWithPayload:notificationStreamPayload HTTPStatus:200 transportSessionError:nil apiVersion:0];

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConnectionTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConnectionTests.m
@@ -74,7 +74,7 @@
     // then
     ZMTransportRequest *foundRequest = [self.mockTransportSession.receivedRequests firstObjectMatchingWithBlock:^BOOL(ZMTransportRequest *request) {
         return [request.path hasPrefix:@"/connections"] &&
-            (request.method == ZMMethodPOST)
+            (request.method == ZMTransportRequestMethodPost)
         && [[[request.payload asDictionary] uuidForKey:@"user"] isEqual:userID];
     }];
     XCTAssertNotNil(foundRequest);
@@ -141,7 +141,7 @@
     // then
     ZMTransportRequest *foundRequest = [self.mockTransportSession.receivedRequests firstObjectMatchingWithBlock:^BOOL(ZMTransportRequest *request) {
         return [request.path hasPrefix:@"/connections"] &&
-        (request.method == ZMMethodPOST)
+        (request.method == ZMTransportRequestMethodPost)
         && [[[request.payload asDictionary] uuidForKey:@"user"] isEqual:userID];
     }];
     XCTAssertNotNil(foundRequest);
@@ -869,7 +869,7 @@
 - (ZMCustomResponseGeneratorBlock)responseBlockForConnectionLimit;
 {
     return ^ZMTransportResponse *(ZMTransportRequest *request) {
-        if (![request.path hasPrefix:@"/connections"] || (request.method == ZMMethodGET)) {
+        if (![request.path hasPrefix:@"/connections"] || (request.method == ZMTransportRequestMethodGet)) {
             return nil;
         }
         NSInteger statusCode = 403;
@@ -906,7 +906,7 @@
 - (ZMCustomResponseGeneratorBlock)responseBlockForMissingLegalHoldConsent;
 {
     return ^ZMTransportResponse *(ZMTransportRequest *request) {
-        if (![request.path hasPrefix:@"/connections"] || (request.method == ZMMethodGET)) {
+        if (![request.path hasPrefix:@"/connections"] || (request.method == ZMTransportRequestMethodGet)) {
             return nil;
         }
         NSDictionary *payload = @{@"label": @"missing-legalhold-consent"};

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Guests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Guests.swift
@@ -86,7 +86,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
     }
 
     func testThatItSendsRequestToFetchTheGuestLinkStatus() {
@@ -117,7 +117,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/features/conversationGuestLinks")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
 
     }
 
@@ -185,7 +185,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(requestFirst.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/access")
         guard let requestLast = mockTransportSession.receivedRequests().last else { return }
         XCTAssertEqual(requestLast.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
-        XCTAssertEqual(requestLast.method, .methodPOST)
+        XCTAssertEqual(requestLast.method, .post)
     }
 
     func testThatItSendsRequestToFetchTheLink_NoLink() {
@@ -218,7 +218,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
     }
 
     func testThatItSendsRequestToFetchTheLink_LinkExists() {
@@ -254,7 +254,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
     }
 
     func testThatItSendsRequestToDeleteTheLink() {
@@ -290,7 +290,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
-        XCTAssertEqual(request.method, .methodDELETE)
+        XCTAssertEqual(request.method, .delete)
     }
 
     func testThatItSendsRequestToDeleteTheLink_LinkDoesNotExist() {
@@ -324,7 +324,7 @@ class ConversationTests_Guests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
-        XCTAssertEqual(request.method, .methodDELETE)
+        XCTAssertEqual(request.method, .delete)
     }
 
     func testThatAccessModeChangeEventIsHandled() {

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+MessageEditing.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+MessageEditing.m
@@ -66,7 +66,7 @@
     ZMTransportRequest *request = self.mockTransportSession.receivedRequests.lastObject;
     NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
 }
 
 - (void)testThatItCanEditAnEditedMessage
@@ -104,7 +104,7 @@
     ZMTransportRequest *request = self.mockTransportSession.receivedRequests.lastObject;
     NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", conversation.remoteIdentifier.transportString];
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
 }
 
 - (void)testThatItKeepsTheContentWhenMessageSendingFailsButOverwritesTheNonce

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+MessageTimer.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+MessageTimer.swift
@@ -141,6 +141,6 @@ class ConversationMessageTimerTests: IntegrationTest {
         XCTAssertEqual(mockTransportSession.receivedRequests().count, 1, "wrong request count", file: file, line: line)
         guard let request = mockTransportSession.receivedRequests().first else { return }
         XCTAssertEqual(request.path, "/conversations/\(identifier)/message-timer", "wrong path \(request.path)", file: file, line: line)
-        XCTAssertEqual(request.method, .methodPUT, "wrong method", file: file, line: line)
+        XCTAssertEqual(request.method, .put, "wrong method", file: file, line: line)
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationsTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationsTests.m
@@ -421,7 +421,7 @@
         ZMTransportRequest *request = self.mockTransportSession.receivedRequests.firstObject;
         NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/self", self.groupConversation.identifier];
         XCTAssertEqualObjects(request.path, expectedPath);
-        XCTAssertEqual(request.method, ZMMethodPUT);
+        XCTAssertEqual(request.method, ZMTransportRequestMethodPut);
         XCTAssertEqualObjects(request.payload.asDictionary[@"otr_archived_ref"], conversation.archivedChangedTimestamp.transportString);
         XCTAssertEqualObjects(request.payload.asDictionary[@"otr_archived"], @(conversation.isArchived));
     }
@@ -464,7 +464,7 @@
     ZMTransportRequest *request = self.mockTransportSession.receivedRequests.firstObject;
     NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/self", self.groupConversation.identifier];
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPUT);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPut);
     XCTAssertEqualObjects(conversation.lastServerTimeStamp, conversation.archivedChangedTimestamp);
     XCTAssertEqualObjects(request.payload.asDictionary[@"otr_archived_ref"], conversation.archivedChangedTimestamp.transportString);
     XCTAssertEqualObjects(request.payload.asDictionary[@"otr_archived"], @(conversation.isArchived));
@@ -489,7 +489,7 @@
         ZMTransportRequest *request = self.mockTransportSession.receivedRequests.firstObject;
         NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/self", self.groupConversation.identifier];
         XCTAssertEqualObjects(request.path, expectedPath);
-        XCTAssertEqual(request.method, ZMMethodPUT);
+        XCTAssertEqual(request.method, ZMTransportRequestMethodPut);
         XCTAssertEqualObjects(conversation.lastServerTimeStamp, conversation.silencedChangedTimestamp);
         XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_ref"], conversation.silencedChangedTimestamp.transportString);
         XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_status"], @(conversation.isFullyMuted ? 3 : 0));
@@ -527,7 +527,7 @@
         ZMTransportRequest *request = self.mockTransportSession.receivedRequests.firstObject;
         NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/self", self.groupConversation.identifier];
         XCTAssertEqualObjects(request.path, expectedPath);
-        XCTAssertEqual(request.method, ZMMethodPUT);
+        XCTAssertEqual(request.method, ZMTransportRequestMethodPut);
         XCTAssertEqualObjects(conversation.lastServerTimeStamp, conversation.silencedChangedTimestamp);
         XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_ref"], conversation.silencedChangedTimestamp.transportString);
         XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_status"], @(conversation.isFullyMuted ? 3 : 0));
@@ -571,7 +571,7 @@
     ZMTransportRequest *request = self.mockTransportSession.receivedRequests.firstObject;
     NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/self", self.groupConversation.identifier];
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPUT);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPut);
     XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_ref"], conversation.lastServerTimeStamp.transportString);
     XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_status"], @0);
 }
@@ -599,7 +599,7 @@
     ZMTransportRequest *request = self.mockTransportSession.receivedRequests.firstObject;
     NSString *expectedPath = [NSString stringWithFormat:@"/conversations/%@/self", self.groupConversation.identifier];
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPUT);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPut);
     XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_ref"], conversation.lastServerTimeStamp.transportString);
     XCTAssertEqualObjects(request.payload.asDictionary[@"otr_muted_status"], @0);
 }

--- a/wire-ios-sync-engine/Tests/Source/Integration/DeleteMessagesTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/DeleteMessagesTests.swift
@@ -45,7 +45,7 @@ class DeleteMessagesTests: ConversationTestsBase {
         let requests = mockTransportSession.receivedRequests()
         XCTAssertEqual(requests.count, 1)
         guard let request = requests.first else { return XCTFail() }
-        XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+        XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
         XCTAssertEqual(request.path, "/conversations/\(selfToUser1Conversation.identifier)/otr/messages")
         XCTAssertTrue(message.hasBeenDeleted)
     }
@@ -175,7 +175,7 @@ class DeleteMessagesTests: ConversationTestsBase {
         XCTAssertEqual(requests.count, 5)
         XCTAssertEqual(requestCount, 4)
         guard let request = requests.last else { return XCTFail() }
-        XCTAssertEqual(request.method, ZMTransportRequestMethod.methodPOST)
+        XCTAssertEqual(request.method, ZMTransportRequestMethod.post)
         XCTAssertEqual(request.path, "/conversations/\(selfToUser1Conversation.identifier)/otr/messages")
         XCTAssertTrue(message.hasBeenDeleted)
     }

--- a/wire-ios-sync-engine/Tests/Source/Integration/GiphyTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/GiphyTests.m
@@ -48,7 +48,7 @@
         ZM_STRONG(self);
         if([request.path hasPrefix:@"/proxy/giphy"]) {
             XCTAssertEqualObjects(request.path, @"/proxy/giphy/foo/bar/baz");
-            XCTAssertEqual(request.method, ZMMethodGET);
+            XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
             XCTAssertTrue(request.needsAuthentication);
             
             return [ZMTransportResponse responseWithPayload:expectedPayload HTTPStatus:202 transportSessionError:nil apiVersion:0];
@@ -63,7 +63,7 @@
         XCTAssertNil(error);
         [expectation fulfill];
     };
-    [self.userSession proxiedRequestWithPath:path method:ZMMethodGET type:ProxiedRequestTypeGiphy callback:callback];
+    [self.userSession proxiedRequestWithPath:path method:ZMTransportRequestMethodGet type:ProxiedRequestTypeGiphy callback:callback];
     WaitForAllGroupsToBeEmpty(0.5);
     [self spinMainQueueWithTimeout:0.2];
     

--- a/wire-ios-sync-engine/Tests/Source/Integration/LoginFlowTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/LoginFlowTests.m
@@ -388,11 +388,11 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse*(ZMTransportRequest *request) {
         ZM_STRONG(self);
         
-        if([request.path isEqualToString:@"/clients"] && request.method == ZMMethodPOST) {
+        if([request.path isEqualToString:@"/clients"] && request.method == ZMTransportRequestMethodPost) {
             XCTAssertTrue(didFetchSelfUser);
             didCreateSelfClient = YES;
         }
-        if (!didFetchSelfUser && [request.path isEqualToString:@"/self"] && request.method == ZMMethodGET) {
+        if (!didFetchSelfUser && [request.path isEqualToString:@"/self"] && request.method == ZMTransportRequestMethodGet) {
             XCTAssertFalse(didCreateSelfClient);
             didFetchSelfUser = YES;
         }
@@ -440,7 +440,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     __block BOOL didRun = NO;
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse*(ZMTransportRequest *request) {
         // when trying to register without email credentials, the BE tells us we need credentials
-        if(!didRun && [request.path isEqualToString:@"/clients"] && request.method == ZMMethodPOST) {
+        if(!didRun && [request.path isEqualToString:@"/clients"] && request.method == ZMTransportRequestMethodPost) {
             didRun = YES;
         }
         // the user updates the email address (currently does not work in MockTransportsession for some reason)
@@ -482,7 +482,7 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
         ZM_STRONG(self);
         
         // when trying to register without email credentials, the BE tells us we need credentials
-        if(runCount <= 1 && [request.path isEqualToString:@"/clients"] && request.method == ZMMethodPOST) {
+        if(runCount <= 1 && [request.path isEqualToString:@"/clients"] && request.method == ZMTransportRequestMethodPost) {
             NSDictionary *payload;
             if (runCount == 0) {
                 payload = @{@"label" : @"missing-auth"};
@@ -614,13 +614,13 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse*(ZMTransportRequest *request) {
         NSString *clientsPath = @"/clients";
         // BE tells us to select one of the clients to delete
-        if(!didTryToRegister && [request.path isEqualToString:clientsPath] && request.method == ZMMethodPOST) {
+        if(!didTryToRegister && [request.path isEqualToString:clientsPath] && request.method == ZMTransportRequestMethodPost) {
             didTryToRegister = YES;
             NSDictionary *tooManyClients = @{@"label" : @"too-many-clients"};
             return [ZMTransportResponse responseWithPayload:tooManyClients HTTPStatus:400 transportSessionError:nil apiVersion:0];
         }
         // we successfully delete the selected client (currently not working with MocktransportSession)
-        if(!didDeleteClient && [request.path isEqualToString:[NSString stringWithFormat:@"%@/%@",clientsPath, idToDelete]] && request.method == ZMMethodDELETE) {
+        if(!didDeleteClient && [request.path isEqualToString:[NSString stringWithFormat:@"%@/%@",clientsPath, idToDelete]] && request.method == ZMTransportRequestMethodDelete) {
             didDeleteClient = YES;
             return [ZMTransportResponse responseWithPayload:nil HTTPStatus:200 transportSessionError:nil apiVersion:0];
         }

--- a/wire-ios-sync-engine/Tests/Source/Integration/SearchTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SearchTests.swift
@@ -397,7 +397,7 @@ class SearchTests: IntegrationTest {
         let requests = mockTransportSession.receivedRequests()
         XCTAssertEqual(requests.count, 1)
         XCTAssertEqual(requests.first?.path, "/assets/v3/\(user1.previewProfileAssetIdentifier!)")
-        XCTAssertEqual(requests.first?.method, .methodGET)
+        XCTAssertEqual(requests.first?.method, .get)
     }
 
     func testThatItDownloadsV3PreviewAssetWhenOnlyV3AssetsArePresentInSearchUserResponse_UnconnectedUser() {
@@ -427,7 +427,7 @@ class SearchTests: IntegrationTest {
         let requests = mockTransportSession.receivedRequests()
         XCTAssertEqual(requests.count, 3)
         XCTAssertEqual(requests[2].path, "/assets/v3/\(user4.previewProfileAssetIdentifier!)")
-        XCTAssertEqual(requests[2].method, .methodGET)
+        XCTAssertEqual(requests[2].method, .get)
     }
 
     func testThatItDownloadsMediumAssetForSearchUserWhenAssetAndLegacyIdArePresentUsingV3() {
@@ -473,7 +473,7 @@ class SearchTests: IntegrationTest {
         let requests = mockTransportSession.receivedRequests()
         XCTAssertEqual(requests.count, 1)
         XCTAssertEqual(requests[0].path, "/assets/v3/\(user4.completeProfileAssetIdentifier!)")
-        XCTAssertEqual(requests[0].method, .methodGET)
+        XCTAssertEqual(requests[0].method, .get)
     }
 
     func testThatItRefetchesTheSearchUserIfTheMediumAssetIDIsNotSet_V3Asset() {
@@ -508,9 +508,9 @@ class SearchTests: IntegrationTest {
         let requests = mockTransportSession.receivedRequests()
         XCTAssertEqual(requests.count, 2)
         XCTAssertEqual(requests[0].path, "/users?ids=\(user4.identifier)")
-        XCTAssertEqual(requests[0].method, .methodGET)
+        XCTAssertEqual(requests[0].method, .get)
         XCTAssertEqual(requests[1].path, "/assets/v3/\(user4.completeProfileAssetIdentifier!)")
-        XCTAssertEqual(requests[1].method, .methodGET)
+        XCTAssertEqual(requests[1].method, .get)
     }
 
 }

--- a/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests+Swift.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests+Swift.swift
@@ -70,7 +70,7 @@ class SendAndReceiveMessagesTests_Swift: ConversationTestsBase {
         let convIDString = conversation?.remoteIdentifier?.transportString()
 
         self.mockTransportSession.responseGeneratorBlock = { request in
-            if request.path.contains("messages") && request.method == ZMTransportRequestMethod.methodPOST {
+            if request.path.contains("messages") && request.method == ZMTransportRequestMethod.post {
                 if request.path.contains(convIDString!) {
                     return ZMTransportResponse.init(transportSessionError: NSError.requestExpiredError(), apiVersion: APIVersion.v0.rawValue)
                 }

--- a/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests.m
@@ -96,7 +96,7 @@
     NSString *otrConversationPath = [NSString stringWithFormat:@"/conversations/%@/otr/messages", self.groupConversation.identifier];
 
     for (ZMTransportRequest *request in self.mockTransportSession.receivedRequests) {
-        if (request.method == ZMMethodPOST && [request.path isEqualToString:otrConversationPath]) {
+        if (request.method == ZMTransportRequestMethodPost && [request.path isEqualToString:otrConversationPath]) {
             otrResponseCount++;
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/AssetDeletionRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/AssetDeletionRequestStrategyTests.swift
@@ -126,7 +126,7 @@ extension AssetDeletionRequestStrategyTests {
             expectedPath = "/v\(apiVersion.rawValue)/assets/\(domain)/\(identifier)"
         }
         XCTAssertNotNil(request)
-        XCTAssertEqual(request?.method, .methodDELETE)
+        XCTAssertEqual(request?.method, .delete)
         XCTAssertEqual(request?.path, expectedPath)
         XCTAssertNil(request?.payload)
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ConversationRoleDownstreamRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ConversationRoleDownstreamRequestStrategyTests.swift
@@ -81,7 +81,7 @@ final class ConversationRoleDownstreamRequestStrategyTests: MessagingTest {
 
             // then
             guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/conversations/\(convo1.remoteIdentifier!.transportString())/roles")
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/DeleteAccountRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/DeleteAccountRequestStrategyTests.swift
@@ -54,7 +54,7 @@ class DeleteAccountRequestStrategyTests: MessagingTest, AccountDeletedObserver {
 
         // then
         if let request = request {
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodDELETE)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.delete)
             XCTAssertEqual(request.path, "/self")
             XCTAssertTrue(request.needsAuthentication)
         } else {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EmailVerificationStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EmailVerificationStrategyTests.swift
@@ -53,7 +53,7 @@ class RegistrationCredentialVerificationStrategyTests: MessagingTest {
         let payload = ["email": email,
                        "locale": NSLocale.formattedLocaleIdentifier()!]
 
-        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
+        let transportRequest = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
         registrationStatus.phase = .sendActivationCode(credentials: .email(email))
 
         // when
@@ -72,7 +72,7 @@ class RegistrationCredentialVerificationStrategyTests: MessagingTest {
         let payload = ["phone": phone,
                        "locale": NSLocale.formattedLocaleIdentifier()!]
 
-        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
+        let transportRequest = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
         registrationStatus.phase = .sendActivationCode(credentials: .phone(phone))
 
         // when
@@ -123,7 +123,7 @@ class RegistrationCredentialVerificationStrategyTests: MessagingTest {
                        "code": code,
                        "dryrun": true] as [String: Any]
 
-        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
+        let transportRequest = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
         registrationStatus.phase = .checkActivationCode(credentials: .email(email), code: code)
 
         // when
@@ -144,7 +144,7 @@ class RegistrationCredentialVerificationStrategyTests: MessagingTest {
                        "code": code,
                        "dryrun": true] as [String: Any]
 
-        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
+        let transportRequest = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
         registrationStatus.phase = .checkActivationCode(credentials: .phone(phone), code: code)
 
         // when

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/PermissionsDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/PermissionsDownloadRequestStrategyTests.swift
@@ -73,7 +73,7 @@ class PermissionsDownloadRequestStrategyTests: MessagingTest {
 
             // then
             guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/teams/\(teamId.transportString())/members/\(userId.transportString())")
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
@@ -46,14 +46,14 @@ class ProxiedRequestStrategyTests: MessagingTest {
     func testThatItGeneratesAGiphyRequest() {
 
         // given
-        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar", method: .methodGET, callback: { (_, _, _) -> Void in return}))
+        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar", method: .get, callback: { (_, _, _) -> Void in return}))
 
         // when
         let request: ZMTransportRequest? = self.sut.nextRequest(for: .v0)
 
         // then
         if let request = request {
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertEqual(request.path, "/proxy/giphy/foo/bar")
             XCTAssertTrue(request.needsAuthentication)
         } else {
@@ -64,14 +64,14 @@ class ProxiedRequestStrategyTests: MessagingTest {
     func testThatItGeneratesASoundcloudRequest() {
 
         // given
-        requestsStatus.add(request: ProxyRequest(type: .soundcloud, path: "/foo/bar", method: .methodGET, callback: { (_, _, _) -> Void in return}))
+        requestsStatus.add(request: ProxyRequest(type: .soundcloud, path: "/foo/bar", method: .get, callback: { (_, _, _) -> Void in return}))
 
         // when
         let request: ZMTransportRequest? = self.sut.nextRequest(for: .v0)
 
         // then
         if let request = request {
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertEqual(request.path, "/proxy/soundcloud/foo/bar")
             XCTAssertTrue(request.needsAuthentication)
             XCTAssertTrue(request.doesNotFollowRedirects)
@@ -83,14 +83,14 @@ class ProxiedRequestStrategyTests: MessagingTest {
     func testThatItGeneratesAYouTubeRequest() {
 
         // given
-        requestsStatus.add(request: ProxyRequest(type: .youTube, path: "/foo/bar", method: .methodGET, callback: { (_, _, _) -> Void in return}))
+        requestsStatus.add(request: ProxyRequest(type: .youTube, path: "/foo/bar", method: .get, callback: { (_, _, _) -> Void in return}))
 
         // when
         let request: ZMTransportRequest? = self.sut.nextRequest(for: .v0)
 
         // then
         if let request = request {
-            XCTAssertEqual(request.method, ZMTransportRequestMethod.methodGET)
+            XCTAssertEqual(request.method, ZMTransportRequestMethod.get)
             XCTAssertEqual(request.path, "/proxy/youtube/foo/bar")
             XCTAssertTrue(request.needsAuthentication)
         } else {
@@ -101,7 +101,7 @@ class ProxiedRequestStrategyTests: MessagingTest {
     func testThatItGeneratesARequestOnlyOnce() {
 
         // given
-        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .methodGET, callback: { (_, _, _) -> Void in return}))
+        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .get, callback: { (_, _, _) -> Void in return}))
 
         // when
         let request1: ZMTransportRequest? = self.sut.nextRequest(for: .v0)
@@ -127,7 +127,7 @@ class ProxiedRequestStrategyTests: MessagingTest {
         let response = ZMTransportResponse(httpurlResponse: HTTPResponse, data: data, error: error, apiVersion: APIVersion.v0.rawValue)
         let expectation = self.expectation(description: "Callback invoked")
 
-        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .methodGET, callback: { responseData, responseURLResponse, responseError in
+        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .get, callback: { responseData, responseURLResponse, responseError in
             XCTAssertEqual(data, responseData)
             XCTAssertEqual(error, responseError)
             XCTAssertEqual(HTTPResponse, responseURLResponse)
@@ -151,7 +151,7 @@ class ProxiedRequestStrategyTests: MessagingTest {
 
         // given
         let ExpectedDelay: TimeInterval = 20
-        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .methodGET, callback: { (_, _, _) -> Void in return}))
+        requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .get, callback: { (_, _, _) -> Void in return}))
 
         // when
         let request: ZMTransportRequest? = self.sut.nextRequest(for: .v0)
@@ -171,7 +171,7 @@ class ProxiedRequestStrategyTests: MessagingTest {
     func testThatItUpdateTheRequestStatusWhenTaskIsCreated() {
 
         // given
-        let proxyRequest = ProxyRequest(type: .giphy, path: "/foo/bar1", method: .methodGET, callback: { (_, _, _) -> Void in return})
+        let proxyRequest = ProxyRequest(type: .giphy, path: "/foo/bar1", method: .get, callback: { (_, _, _) -> Void in return})
         requestsStatus.add(request: proxyRequest)
         let request: ZMTransportRequest? = self.sut.nextRequest(for: .v0)
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
@@ -116,7 +116,7 @@ extension SearchUserImageStrategyTests {
 
         // then
         XCTAssertNotNil(request)
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertTrue(request.needsAuthentication)
 
         XCTAssertTrue(request.path.hasPrefix(UserRequestURL))
@@ -150,7 +150,7 @@ extension SearchUserImageStrategyTests {
 
         // then
         XCTAssertNotNil(request2)
-        XCTAssertEqual(request2.method, .methodGET)
+        XCTAssertEqual(request2.method, .get)
         XCTAssertTrue(request2.needsAuthentication)
 
         let expectedUserIDs = userIDs(from: searchSet2)
@@ -260,7 +260,7 @@ extension SearchUserImageStrategyTests {
 
         // then
         XCTAssertNotNil(request)
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertTrue(request.needsAuthentication)
 
         let expectedPath: String
@@ -317,11 +317,11 @@ extension SearchUserImageStrategyTests {
 
         // then
         XCTAssertNotNil(request1)
-        XCTAssertEqual(request1.method, .methodGET)
+        XCTAssertEqual(request1.method, .get)
         XCTAssertTrue(request1.needsAuthentication)
 
         XCTAssertNotNil(request2)
-        XCTAssertEqual(request2.method, .methodGET)
+        XCTAssertEqual(request2.method, .get)
         XCTAssertTrue(request2.needsAuthentication)
 
         let expectedPath1 = "/assets/v3/\(assetID1)" // requestPath(for:assetID1, of:searchUser1.remoteIdentifier!)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SignatureRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SignatureRequestStrategyTests.swift
@@ -58,7 +58,7 @@ class SignatureRequestStrategyTests: MessagingTest {
         XCTAssertEqual(payload?["name"] as? String, syncMOC.signatureStatus?.fileName)
         XCTAssertEqual(payload?["hash"] as? String, syncMOC.signatureStatus?.encodedHash)
         XCTAssertEqual(request?.path, "/signature/request")
-        XCTAssertEqual(request?.method, ZMTransportRequestMethod.methodPOST)
+        XCTAssertEqual(request?.method, ZMTransportRequestMethod.post)
     }
 
     func testThatItGeneratesCorrectRequestIfStateIsWaitingForSignature() {
@@ -76,7 +76,7 @@ class SignatureRequestStrategyTests: MessagingTest {
         // then
         XCTAssertNotNil(request)
         XCTAssertEqual(request?.path, "/signature/pending/\(responseId)")
-        XCTAssertEqual(request?.method, ZMTransportRequestMethod.methodGET)
+        XCTAssertEqual(request?.method, ZMTransportRequestMethod.get)
     }
 
     func testThatItNotifiesSignatureStatusAfterSuccessfulResponseToReceiveConsentURL() {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
@@ -128,7 +128,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
 
             // then
             guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/teams/\(team.remoteIdentifier!.transportString())")
         }
     }
@@ -355,7 +355,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
         let request = try XCTUnwrap(sut.nextRequest(for: .v0))
 
         // Then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/teams")
     }
 
@@ -367,7 +367,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
         let request = try XCTUnwrap(sut.nextRequest(for: .v1))
 
         // Then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/v1/teams")
     }
 
@@ -379,7 +379,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
         let request = try XCTUnwrap(sut.nextRequest(for: .v2))
 
         // Then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/v2/teams")
     }
 
@@ -391,7 +391,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
         let request = try XCTUnwrap(sut.nextRequest(for: .v3))
 
         // Then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/v3/teams")
     }
 
@@ -403,7 +403,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
         let request = try XCTUnwrap(sut.nextRequest(for: .v4))
 
         // Then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/v4/teams/\(teamID.transportString())")
     }
 
@@ -425,7 +425,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
         let request = try XCTUnwrap(sut.nextRequest(for: .v5))
 
         // Then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/v5/teams/\(teamID.transportString())")
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamImageAssetUpdateStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamImageAssetUpdateStrategyTests.swift
@@ -72,7 +72,7 @@ final class TeamImageAssetUpdateStrategyTests: MessagingTest {
         let request = sut.nextRequest(for: .v0)
         XCTAssertNotNil(request)
         XCTAssertEqual(request?.path, "/assets/v3/\(pictureAssetId)")
-        XCTAssertEqual(request?.method, .methodGET)
+        XCTAssertEqual(request?.method, .get)
     }
 
     func testThatItStoresTeamImageAsset_OnSuccessfulResponse() {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
@@ -65,7 +65,7 @@ class RegistrationStrategyTests: MessagingTest {
         let path = "/register"
         let payload = team.payload
 
-        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
+        let transportRequest = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
         registrationStatus.phase = .createTeam(team: team)
 
         // when
@@ -82,7 +82,7 @@ class RegistrationStrategyTests: MessagingTest {
         let path = "/register"
         let payload = user.payload
 
-        let transportRequest = ZMTransportRequest(path: path, method: .methodPOST, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
+        let transportRequest = ZMTransportRequest(path: path, method: .post, payload: payload as ZMTransportData, apiVersion: APIVersion.v0.rawValue)
         registrationStatus.phase = .createUser(user: user)
 
         // when

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRolesDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRolesDownloadRequestStrategyTests.swift
@@ -125,7 +125,7 @@ class TeamRolesDownloadRequestStrategyTests: MessagingTest {
 
             // then
             guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
-            XCTAssertEqual(request.method, .methodGET)
+            XCTAssertEqual(request.method, .get)
             XCTAssertEqual(request.path, "/teams/\(team.remoteIdentifier!.transportString())/conversations/roles")
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
@@ -138,7 +138,7 @@ class TypingStrategyTests: MessagingTest {
         let expectedPath = "/conversations/\(conversation.remoteIdentifier!.transportString())/typing"
         let expectedPayload = ["status": isTyping ? "started" : "stopped"]
 
-        if let request = request, (request.path == expectedPath) && (request.method == .methodPOST) {
+        if let request = request, (request.path == expectedPath) && (request.method == .post) {
             if let payload = request.payload as? [String: String] {
                 XCTAssertEqual(payload, expectedPayload)
             } else {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/UserImageAssetUpdateStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/UserImageAssetUpdateStrategyTests.swift
@@ -131,7 +131,7 @@ extension UserImageAssetUpdateStrategyTests {
         let previewRequest = sut.nextRequest(for: .v0)
         XCTAssertNotNil(previewRequest)
         XCTAssertEqual(previewRequest?.path, "/assets/v3")
-        XCTAssertEqual(previewRequest?.method, .methodPOST)
+        XCTAssertEqual(previewRequest?.method, .post)
 
         // WHEN
         updateStatus.dataToConsume.removeAll()
@@ -141,7 +141,7 @@ extension UserImageAssetUpdateStrategyTests {
         let completeRequest = sut.nextRequest(for: .v0)
         XCTAssertNotNil(completeRequest)
         XCTAssertEqual(completeRequest?.path, "/assets/v3")
-        XCTAssertEqual(completeRequest?.method, .methodPOST)
+        XCTAssertEqual(completeRequest?.method, .post)
 
     }
 
@@ -171,7 +171,7 @@ extension UserImageAssetUpdateStrategyTests {
     func testThatItCreatesDeleteRequestIfThereAreAssetsToDelete() {
         // GIVEN
         let assetId = "12344"
-        let deleteRequest = ZMTransportRequest(path: "/assets/v3/\(assetId)", method: .methodDELETE, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let deleteRequest = ZMTransportRequest(path: "/assets/v3/\(assetId)", method: .delete, payload: nil, apiVersion: APIVersion.v0.rawValue)
 
         // WHEN
         updateStatus.assetIdsToDelete = [assetId]
@@ -310,7 +310,7 @@ extension UserImageAssetUpdateStrategyTests {
         let request = self.sut.downstreamRequestSyncs[size]?.nextRequest(for: apiVersion)
         XCTAssertNotNil(request)
         XCTAssertEqual(request?.path, expectedPath)
-        XCTAssertEqual(request?.method, .methodGET)
+        XCTAssertEqual(request?.method, .get)
     }
 
     func testThatItCreatesRequestForCorrectAssetIdentifierForPreviewImage() {
@@ -369,7 +369,7 @@ extension UserImageAssetUpdateStrategyTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         guard let request = sut.nextRequestIfAllowed(for: .v0) else { return XCTFail("nil request generated") }
         XCTAssertEqual(request.path, "/assets/v3/\(assetId)")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
 
         // Given
         let response = ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
@@ -396,7 +396,7 @@ extension UserImageAssetUpdateStrategyTests {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         guard let request = sut.nextRequestIfAllowed(for: .v0) else { return XCTFail("nil request generated") }
         XCTAssertEqual(request.path, "/assets/v3/\(assetId)")
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
 
         // Given
         let response = ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/UserProfileUpdateRequestStrategyTests.swift
@@ -79,7 +79,7 @@ extension UserProfileUpdateRequestStrategyTests {
         let request = self.sut.nextRequest(for: .v0)
 
         // THEN
-        let expected = ZMTransportRequest(path: "/self/phone", method: .methodPUT, payload: ["phone": phone] as NSDictionary, apiVersion: APIVersion.v0.rawValue)
+        let expected = ZMTransportRequest(path: "/self/phone", method: .put, payload: ["phone": phone] as NSDictionary, apiVersion: APIVersion.v0.rawValue)
         XCTAssertEqual(request, expected)
     }
 
@@ -95,7 +95,7 @@ extension UserProfileUpdateRequestStrategyTests {
         let request = self.sut.nextRequest(for: .v0)
 
         // THEN
-        let expected = ZMTransportRequest(path: "/activate", method: .methodPOST, payload: [
+        let expected = ZMTransportRequest(path: "/activate", method: .post, payload: [
             "phone": credentials.phoneNumber!,
             "code": credentials.phoneNumberVerificationCode!,
             "dryrun": false
@@ -115,7 +115,7 @@ extension UserProfileUpdateRequestStrategyTests {
         let request = self.sut.nextRequest(for: .v0)
 
         // THEN
-        let expected = ZMTransportRequest(path: "/activate", method: .methodPOST, payload: [
+        let expected = ZMTransportRequest(path: "/activate", method: .post, payload: [
             "phone": credentials.phoneNumber!,
             "code": credentials.phoneNumberVerificationCode!,
             "dryrun": false
@@ -134,7 +134,7 @@ extension UserProfileUpdateRequestStrategyTests {
         let request = self.sut.nextRequest(for: .v0)
 
         // THEN
-        let expected = ZMTransportRequest(path: "/self/password", method: .methodPUT, payload: [
+        let expected = ZMTransportRequest(path: "/self/password", method: .put, payload: [
             "new_password": credentials.password!
             ] as NSDictionary, apiVersion: APIVersion.v0.rawValue)
         XCTAssertEqual(request, expected)
@@ -155,7 +155,7 @@ extension UserProfileUpdateRequestStrategyTests {
 
         // THEN
         XCTAssertEqual(request?.path, "/access/self/email")
-        XCTAssertEqual(request?.method, .methodPUT)
+        XCTAssertEqual(request?.method, .put)
         XCTAssertEqual(request?.needsCookie, true)
         let emailInPayload = request?.payload?.asDictionary()?["email"] as? String
         XCTAssertEqual(emailInPayload, newEmail)
@@ -175,7 +175,7 @@ extension UserProfileUpdateRequestStrategyTests {
 
         // THEN
         XCTAssertEqual(request?.path, "/self/phone")
-        XCTAssertEqual(request?.method, .methodDELETE)
+        XCTAssertEqual(request?.method, .delete)
         XCTAssertNil(request?.payload)
     }
 
@@ -191,7 +191,7 @@ extension UserProfileUpdateRequestStrategyTests {
         let request = self.sut.nextRequest(for: .v0)
 
         // THEN
-        let expected = ZMTransportRequest(path: "/access/self/email", method: .methodPUT, payload: [
+        let expected = ZMTransportRequest(path: "/access/self/email", method: .put, payload: [
             "email": credentials.email!
             ] as NSDictionary, apiVersion: APIVersion.v0.rawValue)
         XCTAssertEqual(request, expected)
@@ -209,7 +209,7 @@ extension UserProfileUpdateRequestStrategyTests {
         let request = self.sut.nextRequest(for: .v0)
 
         // THEN
-        let expected = ZMTransportRequest(path: "/users/handles/\(handle)", method: .methodHEAD, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let expected = ZMTransportRequest(path: "/users/handles/\(handle)", method: .head, payload: nil, apiVersion: APIVersion.v0.rawValue)
         XCTAssertEqual(request, expected)
     }
 
@@ -225,7 +225,7 @@ extension UserProfileUpdateRequestStrategyTests {
 
         // THEN
         let payload: NSDictionary = ["handle": handle]
-        let expected = ZMTransportRequest(path: "/self/handle", method: .methodPUT, payload: payload, apiVersion: APIVersion.v0.rawValue)
+        let expected = ZMTransportRequest(path: "/self/handle", method: .put, payload: payload, apiVersion: APIVersion.v0.rawValue)
         XCTAssertEqual(request, expected)
     }
 
@@ -248,7 +248,7 @@ extension UserProfileUpdateRequestStrategyTests {
             return
         }
 
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.path, "/users/handles")
         guard let payloadDictionary = request.payload?.asDictionary(),
             let payloadHandles = payloadDictionary["handles"] as? [String]

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLastUpdateEventIDTranscoderTests.m
@@ -225,7 +225,7 @@
     
     // then
     XCTAssertNotNil(request);
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
     XCTAssertEqualObjects(request.path, @"/notifications/last");
 }
 
@@ -240,7 +240,7 @@
     
     // then
     XCTAssertNotNil(request);
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
     NSString *expectedPath = [NSString stringWithFormat:@"/notifications/last?client=%@", selfClient.remoteIdentifier];
     XCTAssertEqualObjects(request.path, expectedPath);
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLoginCodeRequestTranscoderTests.m
@@ -71,7 +71,7 @@
     NSString *phoneNumber = @"+7123456789";
     [self.authenticationStatus prepareForRequestingPhoneVerificationCodeForLogin:phoneNumber];
 
-    ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:@"/login/send" method:ZMMethodPOST payload:@{@"phone": phoneNumber} authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:@"/login/send" method:ZMTransportRequestMethodPost payload:@{@"phone": phoneNumber} authentication:ZMTransportRequestAuthNone apiVersion:0];
     
     ZMTransportRequest *request = [self.sut nextRequestForAPIVersion:APIVersionV0];
     XCTAssertEqualObjects(request, expectedRequest);
@@ -84,7 +84,7 @@
     [self.authenticationStatus prepareForRequestingEmailVerificationCodeForLogin:email];
 
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:@"/verification-code/send"
-                                                                            method:ZMMethodPOST
+                                                                            method:ZMTransportRequestMethodPost
                                                                            payload:@{@"email": email, @"action": loginAction}
                                                                     authentication:ZMTransportRequestAuthNone
                                                                         apiVersion:APIVersionV0];

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -217,7 +217,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label": CookieLabel.current.value};
 
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL
-                                                                            method:ZMMethodPOST
+                                                                            method:ZMTransportRequestMethodPost
                                                                            payload:payload
                                                                     authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken
                                                                         apiVersion:0];
@@ -238,7 +238,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"code": self.testPhoneNumberCredentials.phoneNumberVerificationCode,
                               @"label": CookieLabel.current.value};
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL
-                                                                            method:ZMMethodPOST
+                                                                            method:ZMTransportRequestMethodPost
                                                                            payload:payload
                                                                     authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken
                                                                         apiVersion:0];
@@ -261,7 +261,7 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
                               @"label": CookieLabel.current.value};
 
     ZMTransportRequest *expectedRequest = [[ZMTransportRequest alloc] initWithPath:ZMLoginURL
-                                                                            method:ZMMethodPOST
+                                                                            method:ZMTransportRequestMethodPost
                                                                            payload:payload
                                                                     authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken
                                                                         apiVersion:0];

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoderTests.m
@@ -209,7 +209,7 @@ static NSString * const LastUpdateEventIDStoreKey = @"LastUpdateEventID";
     // then
     XCTAssertNotNil(request);
     XCTAssertEqualObjects([NSURLComponents componentsWithString:request.path].path, @"/notifications");
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
 }
 
 - (void)testThatItPassesTheDownloadedEventsToEventProcessorOnSuccess

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
@@ -117,7 +117,7 @@
     // then
     XCTAssertNotNil(request);
     XCTAssertEqualObjects(@"/self", request.path);
-    XCTAssertEqual(ZMMethodGET, request.method);
+    XCTAssertEqual(ZMTransportRequestMethodGet, request.method);
 }
 
 - (void)testThatItDoesNotRequestSelfUserIfSlowSyncIsDone
@@ -209,7 +209,7 @@
     // then
     XCTAssertNotNil(request);
     XCTAssertEqualObjects(request.path, @"/self");
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
     XCTAssertNil(request.payload);
 }
 
@@ -395,7 +395,7 @@
         // then
         XCTAssertNotNil(request);
         XCTAssertEqualObjects(request.transportRequest.path, @"/self");
-        XCTAssertEqual(request.transportRequest.method, ZMMethodPUT);
+        XCTAssertEqual(request.transportRequest.method, ZMTransportRequestMethodPut);
         XCTAssertEqualObjects(request.transportRequest.payload, expectedPayload);
         XCTAssertEqualObjects(request.keys, updatedKeys);
         
@@ -460,7 +460,7 @@
     // given
     [(ZMClientRegistrationStatus* )[[self.mockClientRegistrationStatus stub] andReturnValue:@(ZMClientRegistrationPhaseRegistered)] currentPhase];
     
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"/self" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"/self" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     [[[(OCMockObject *)self.upstreamObjectSync expect] andReturn:request] nextRequestForAPIVersion:APIVersionV0];
     [[[(OCMockObject *)self.upstreamObjectSync expect] andReturn:nil] nextRequestForAPIVersion:APIVersionV0];
     

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
@@ -67,7 +67,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         let request = WireSyncEngine.WirelessRequestFactory.setAccessRoles(allowGuests: true, allowServices: false, for: conversation, apiVersion: .v3)
 
         // then
-        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.method, .put)
         XCTAssertEqual(request.path, "/v3/conversations/example.com/\(conversation.remoteIdentifier!.transportString())/access")
         guard let payload = request.payload as? [String: AnyHashable] else {
             XCTFail("missing payload")
@@ -94,7 +94,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         let request = WireSyncEngine.WirelessRequestFactory.setAccessRoles(allowGuests: true, allowServices: false, for: conversation, apiVersion: apiVersion)
 
         // then
-        XCTAssertEqual(request.method, .methodPUT)
+        XCTAssertEqual(request.method, .put)
         switch apiVersion {
         case .v0:
             XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/access")
@@ -119,7 +119,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         // when
         let request = WireSyncEngine.WirelessRequestFactory.fetchLinkRequest(for: conversation, apiVersion: .v0)
         // then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
         XCTAssertNil(request.payload)
     }
@@ -133,7 +133,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         let request = WireSyncEngine.WirelessRequestFactory.guestLinkFeatureStatusRequest(for: conversation, apiVersion: .v0)
 
         // then
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/features/conversationGuestLinks")
         XCTAssertNil(request.payload)
     }
@@ -145,7 +145,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         // when
         let request = WireSyncEngine.WirelessRequestFactory.createLinkRequest(for: conversation, apiVersion: .v0)
         // then
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
         XCTAssertNil(request.payload)
     }
@@ -157,7 +157,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         // when
         let request = WireSyncEngine.WirelessRequestFactory.createLinkRequest(for: conversation, apiVersion: .v4)
         // then
-        XCTAssertEqual(request.method, .methodPOST)
+        XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.path, "/v4/conversations/\(conversation.remoteIdentifier!.transportString())/code")
         XCTAssertNotNil(request.payload)
     }
@@ -169,7 +169,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         // when
         let request = WireSyncEngine.WirelessRequestFactory.deleteLinkRequest(for: conversation, apiVersion: .v0)
         // then
-        XCTAssertEqual(request.method, .methodDELETE)
+        XCTAssertEqual(request.method, .delete)
         XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/code")
         XCTAssertNil(request.payload)
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -140,7 +140,7 @@
 
     // given
     ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:@"/test"
-                                                                   method:ZMMethodPOST
+                                                                   method:ZMTransportRequestMethodPost
                                                                   payload:@{@"foo": @"bar"}
                                                                 apiVersion:0];
     self.mockRequestStrategy.mockRequest = request;
@@ -174,7 +174,7 @@
     XCTAssertNil(self.sut.currentAPIVersion);
 
     self.mockRequestStrategy.mockRequest = [[ZMTransportRequest alloc] initWithPath:@"/test"
-                                                                             method:ZMMethodPOST
+                                                                             method:ZMTransportRequestMethodPost
                                                                             payload:@{@"foo": @"bar"}
                                                                           apiVersion:0];
 
@@ -190,7 +190,7 @@
 - (void)testThatItSendsAsManyCallsAsTheTransportSessionCanHandle
 {
     // given
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:@"/test" method:ZMMethodPOST payload:@{} apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:@"/test" method:ZMTransportRequestMethodPost payload:@{} apiVersion:0];
     self.mockRequestStrategy.mockRequestQueue = @[request, request, request];
 
     // when
@@ -204,7 +204,7 @@
 - (void)testThatExecuteNextOperationIsCalledWhenThePreviousRequestIsCompleted
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"/boo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"/boo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     self.mockRequestStrategy.mockRequest = request;
     [ZMRequestAvailableNotification notifyNewRequestsAvailable:self]; // this will enqueue `request`
     WaitForAllGroupsToBeEmpty(0.5);

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.swift
@@ -37,7 +37,7 @@ extension ZMOperationLoopTests {
 
     func testThatMOCIsSavedOnSuccessfulRequest() {
         // given
-        let request = ZMTransportRequest(path: "/boo", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let request = ZMTransportRequest(path: "/boo", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
         request.add(ZMCompletionHandler(on: syncMOC,
                                         block: { [weak self] _ in
                                             _ = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: self!.syncMOC)
@@ -65,7 +65,7 @@ extension ZMOperationLoopTests {
 
     func testThatMOCIsSavedOnFailedRequest() {
         // given
-        let request = ZMTransportRequest(path: "/boo", method: .methodGET, payload: nil, apiVersion: APIVersion.v0.rawValue)
+        let request = ZMTransportRequest(path: "/boo", method: .get, payload: nil, apiVersion: APIVersion.v0.rawValue)
         request.add(ZMCompletionHandler(on: syncMOC,
                                         block: { [weak self] _ in
                                             _ = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: self!.syncMOC)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ProxiedRequestStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ProxiedRequestStatusTests.swift
@@ -40,7 +40,7 @@ class ProxiedRequestsStatusTests: MessagingTest {
 
     func testThatRequestIsAddedToPendingRequest() {
         // given
-        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
+        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .get, callback: nil)
 
         // when
         self.sut.add(request: request)
@@ -52,7 +52,7 @@ class ProxiedRequestsStatusTests: MessagingTest {
 
     func testCancelRemovesRequestFromPendingRequests() {
         // given
-        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
+        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .get, callback: nil)
         sut.add(request: request)
 
         // when
@@ -64,7 +64,7 @@ class ProxiedRequestsStatusTests: MessagingTest {
 
     func testCancelCancelsAssociatedDataTask() {
         // given
-        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .methodGET, callback: nil)
+        let request = ProxyRequest(type: .giphy, path: "foo/bar", method: .get, callback: nil)
         let taskIdentifier = ZMTaskIdentifier(identifier: 0, sessionIdentifier: "123")!
         sut.executedRequests[request] = taskIdentifier
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -1119,7 +1119,7 @@ class SearchTaskTests: DatabaseTest {
 
         // then
         let request = try XCTUnwrap(mockTransportSession.receivedRequests().first)
-        XCTAssertEqual(request.method, .methodGET)
+        XCTAssertEqual(request.method, .get)
         XCTAssertEqual(request.path, "/v3/search/contacts?q=john&domain=example.com&size=10")
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+DomainLookup.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+DomainLookup.swift
@@ -63,7 +63,7 @@ public final class UnauthenticatedSessionTests_DomainLookup: ZMTBaseTest {
         // then
         XCTAssertNotNil(transportSession.lastEnqueuedRequest)
         XCTAssertEqual(transportSession.lastEnqueuedRequest?.path, "/custom-backend/by-domain/example.com")
-        XCTAssertEqual(transportSession.lastEnqueuedRequest?.method, ZMTransportRequestMethod.methodGET)
+        XCTAssertEqual(transportSession.lastEnqueuedRequest?.method, ZMTransportRequestMethod.get)
     }
 
     func testThatItURLEncodeRequest() {
@@ -76,7 +76,7 @@ public final class UnauthenticatedSessionTests_DomainLookup: ZMTBaseTest {
         // then
         XCTAssertNotNil(transportSession.lastEnqueuedRequest)
         XCTAssertEqual(transportSession.lastEnqueuedRequest?.path, "/custom-backend/by-domain/example%20com")
-        XCTAssertEqual(transportSession.lastEnqueuedRequest?.method, ZMTransportRequestMethod.methodGET)
+        XCTAssertEqual(transportSession.lastEnqueuedRequest?.method, ZMTransportRequestMethod.get)
     }
 
     func testThatItLookupReturnsNoAPiVersionError() {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+SSO.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+SSO.swift
@@ -60,7 +60,7 @@ public final class UnauthenticatedSessionTests_SSO: ZMTBaseTest {
         // then
         XCTAssertNotNil(transportSession.lastEnqueuedRequest)
         XCTAssertEqual(transportSession.lastEnqueuedRequest?.path, "/sso/settings")
-        XCTAssertEqual(transportSession.lastEnqueuedRequest?.method, ZMTransportRequestMethod.methodGET)
+        XCTAssertEqual(transportSession.lastEnqueuedRequest?.method, ZMTransportRequestMethod.get)
     }
 
     // MARK: Response handling

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UserSessionGiphyRequestStateTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UserSessionGiphyRequestStateTests.swift
@@ -33,7 +33,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         }
 
         // when
-        self.sut.proxiedRequest(path: url.absoluteString, method: .methodGET, type: .giphy, callback: callback)
+        self.sut.proxiedRequest(path: url.absoluteString, method: .get, type: .giphy, callback: callback)
 
         // then
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -57,7 +57,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         let callback: (Data?, URLResponse?, Error?) -> Void = { (_, _, _) -> Void in }
 
         // when
-        self.sut.proxiedRequest(path: url.absoluteString, method: .methodGET, type: .giphy, callback: callback)
+        self.sut.proxiedRequest(path: url.absoluteString, method: .get, type: .giphy, callback: callback)
 
         // then
         XCTAssertTrue(self.waitForCustomExpectations(withTimeout: 0.5))
@@ -79,7 +79,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         }
 
         // when
-        self.sut.proxiedRequest(path: url.absoluteString, method: .methodGET, type: .giphy, callback: callback)
+        self.sut.proxiedRequest(path: url.absoluteString, method: .get, type: .giphy, callback: callback)
 
         // then
         var request = self.sut.applicationStatusDirectory?.proxiedRequestStatus.pendingRequests.first

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
@@ -65,7 +65,7 @@ class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         // then
         let request = try XCTUnwrap(transportSession.lastEnqueuedRequest)
         let payload = request.payload as? [String: Any]
-        XCTAssertEqual(request.method, ZMTransportRequestMethod.methodDELETE)
+        XCTAssertEqual(request.method, ZMTransportRequestMethod.delete)
         XCTAssertEqual(request.path, "/clients/\(selfClient.remoteIdentifier!)")
         XCTAssertEqual(payload?["password"] as? String, credentials.password)
     }
@@ -82,7 +82,7 @@ class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         // then
         let request = try XCTUnwrap(transportSession.lastEnqueuedRequest)
         let payload = request.payload as? [String: Any]
-        XCTAssertEqual(request.method, ZMTransportRequestMethod.methodDELETE)
+        XCTAssertEqual(request.method, ZMTransportRequestMethod.delete)
         XCTAssertEqual(request.path, "/clients/\(selfClient.remoteIdentifier!)")
         XCTAssertEqual(payload?.keys.count, 0)
     }

--- a/wire-ios-transport/Source/Public/ZMTransportRequest.h
+++ b/wire-ios-transport/Source/Public/ZMTransportRequest.h
@@ -62,11 +62,11 @@ extern const NSTimeInterval ZMTransportRequestDefaultExpirationInterval;
 
 
 typedef NS_ENUM(uint8_t, ZMTransportRequestMethod) {
-    ZMMethodGET,
-    ZMMethodDELETE,
-    ZMMethodPUT,
-    ZMMethodPOST,
-    ZMMethodHEAD
+    ZMTransportRequestMethodGet,
+    ZMTransportRequestMethodDelete,
+    ZMTransportRequestMethodPut,
+    ZMTransportRequestMethodPost,
+    ZMTransportRequestMethodHead
 };
 
 typedef NS_ENUM(uint8_t, ZMTransportRequestAuth) {

--- a/wire-ios-transport/Source/Requests/ZMTransportRequest.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportRequest.m
@@ -205,18 +205,18 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 + (instancetype)requestGetFromPath:(NSString *)path apiVersion:(int)apiVersion
 {
-    return [self requestWithPath:path method:ZMMethodGET payload:nil apiVersion:apiVersion];
+    return [self requestWithPath:path method:ZMTransportRequestMethodGet payload:nil apiVersion:apiVersion];
 }
 
 + (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(int)apiVersion
 {
-    return [self requestWithPath:path method:ZMMethodGET payload:nil shouldCompress:YES apiVersion:apiVersion];
+    return [self requestWithPath:path method:ZMTransportRequestMethodGet payload:nil shouldCompress:YES apiVersion:apiVersion];
 }
 
 + (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(int)apiVersion;
 {
     ZMTransportRequest *request = [[self.class alloc] initWithPath:path
-                                                            method:ZMMethodPOST
+                                                            method:ZMTransportRequestMethodPost
                                                         binaryData:nil
                                                               type:contentType
                                                 contentDisposition:nil
@@ -230,7 +230,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 + (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(int)apiVersion;
 {
     NSString *type = (NSString *) UTTypeJSON.identifier;
-    return [[self alloc] initWithPath:path method:ZMMethodPUT binaryData:[NSData data] type:type contentDisposition:nil apiVersion:apiVersion];
+    return [[self alloc] initWithPath:path method:ZMTransportRequestMethodPut binaryData:[NSData data] type:type contentDisposition:nil apiVersion:apiVersion];
 }
 
 + (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(int)apiVersion;
@@ -299,15 +299,15 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 - (BOOL)hasRequiredPayload;
 {
     switch (self.method) {
-        case ZMMethodGET:
-        case ZMMethodHEAD:
+        case ZMTransportRequestMethodGet:
+        case ZMTransportRequestMethodHead:
             return ((self.payload == nil) &&
                     (self.binaryData == nil));
-        case ZMMethodPOST:
-        case ZMMethodDELETE:
+        case ZMTransportRequestMethodPost:
+        case ZMTransportRequestMethodDelete:
             // POST and DELETE payload is optional
             return YES;
-        case ZMMethodPUT:
+        case ZMTransportRequestMethodPut:
             return ((self.payload != nil) ||
                     (self.binaryData != nil));
     }
@@ -672,40 +672,40 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 + (ZMTransportRequestMethod)methodFromString:(NSString *)string
 {
     if([string isEqualToString:@"GET"]) {
-        return ZMMethodGET;
+        return ZMTransportRequestMethodGet;
     }
     if([string isEqualToString:@"POST"]) {
-        return ZMMethodPOST;
+        return ZMTransportRequestMethodPost;
     }
     if([string isEqualToString:@"DELETE"]) {
-        return ZMMethodDELETE;
+        return ZMTransportRequestMethodDelete;
     }
     if([string isEqualToString:@"PUT"]) {
-        return ZMMethodPUT;
+        return ZMTransportRequestMethodPut;
     }
     if([string isEqualToString:@"HEAD"]) {
-        return ZMMethodHEAD;
+        return ZMTransportRequestMethodHead;
     }
 
     RequireString(false, "Invalid HTTP method string");
-    return ZMMethodGET;
+    return ZMTransportRequestMethodGet;
 }
 
 + (NSString *)stringForMethod:(ZMTransportRequestMethod)method
 {
-    if(method == ZMMethodGET) {
+    if(method == ZMTransportRequestMethodGet) {
         return @"GET";
     }
-    if(method == ZMMethodPOST) {
+    if(method == ZMTransportRequestMethodPost) {
         return @"POST";
     }
-    if(method == ZMMethodDELETE) {
+    if(method == ZMTransportRequestMethodDelete) {
         return @"DELETE";
     }
-    if(method == ZMMethodPUT) {
+    if(method == ZMTransportRequestMethodPut) {
         return @"PUT";
     }
-    if(method == ZMMethodHEAD) {
+    if(method == ZMTransportRequestMethodHead) {
         return @"HEAD";
     }
     
@@ -758,7 +758,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     if (! [UTIHelper conformsToImageTypeWithUti:type]) {
         return nil;
     }
-    ZMTransportRequest *result = [[self alloc] initWithPath:path method:ZMMethodPOST binaryData:data type:type contentDisposition:contentDisposition apiVersion:apiVersion];
+    ZMTransportRequest *result = [[self alloc] initWithPath:path method:ZMTransportRequestMethodPost binaryData:data type:type contentDisposition:contentDisposition apiVersion:apiVersion];
     Require(result.hasRequiredPayload);
     return result;
 }
@@ -798,7 +798,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
                                                     boundary:boundary];
     
     ZMTransportRequest *result = [[self alloc] initWithPath:path
-                                                     method:ZMMethodPOST
+                                                     method:ZMTransportRequestMethodPost
                                                  binaryData:multipartData
                                                        type:contentType
                                          contentDisposition:nil

--- a/wire-ios-transport/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
+++ b/wire-ios-transport/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
@@ -34,7 +34,7 @@ final class ZMTransportRequestLoggingTests: ZMTBaseTest {
 
         // when
         let requestDescription = ZMTransportRequest(path: "/test",
-                                                    method: .methodGET,
+                                                    method: .get,
                                                     payload: payload as ZMTransportData,
                                                     apiVersion: 0).description
 

--- a/wire-ios-transport/Tests/Source/Requests/ZMTransportRequestTests.m
+++ b/wire-ios-transport/Tests/Source/Requests/ZMTransportRequestTests.m
@@ -53,46 +53,46 @@
 
 -(void)testThatNeedsAuthenticationIsSetByDefault;
 {
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].needsAuthentication);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} apiVersion:0].needsAuthentication);
     XCTAssertTrue([ZMTransportRequest requestGetFromPath:@"/bar" apiVersion:0].needsAuthentication);
-    XCTAssertTrue([ZMTransportRequest requestWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].needsAuthentication);
+    XCTAssertTrue([ZMTransportRequest requestWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} apiVersion:0].needsAuthentication);
 }
 
 -(void)testThatCreatesAccessTokenIsNotSetByDefault;
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} apiVersion:0].responseWillContainAccessToken);
     XCTAssertFalse([ZMTransportRequest requestGetFromPath:@"/bar" apiVersion:0].responseWillContainAccessToken);
-    XCTAssertFalse([ZMTransportRequest requestWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([ZMTransportRequest requestWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} apiVersion:0].responseWillContainAccessToken);
 }
 
 - (void)testThatNeedsAuthenticationIsSet
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].needsAuthentication);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].needsAuthentication);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].needsAuthentication);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken apiVersion:0].needsAuthentication);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].needsAuthentication);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].needsAuthentication);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].needsAuthentication);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken apiVersion:0].needsAuthentication);
 }
 
 - (void)testThatNeedsCookieIsSet
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].needsCookie);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].needsCookie);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].needsCookie);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken apiVersion:0].needsCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].needsCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].needsCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].needsCookie);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken apiVersion:0].needsCookie);
 }
 
 - (void)testThatCreatesAccessTokenIsSet
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].responseWillContainAccessToken);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].responseWillContainAccessToken);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].responseWillContainAccessToken);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].responseWillContainAccessToken);
 }
 
 - (void)testThatResponseWillContainCookieIsSet;
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].responseWillContainCookie);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].responseWillContainCookie);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].responseWillContainCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].responseWillContainCookie);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].responseWillContainCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMTransportRequestMethodPost payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].responseWillContainCookie);
 }
 
 -(void)testThatRequestGetFromPathSetsProperties
@@ -107,7 +107,7 @@
     
     // then
     XCTAssertEqualObjects(request.path, originalPath);
-    XCTAssertEqual(request.method, ZMMethodGET);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodGet);
     XCTAssertNil(request.payload);
     XCTAssertFalse(request.shouldFailInsteadOfRetry);
     XCTAssertEqual(request.contentDisposition.count, 0U);
@@ -117,7 +117,7 @@
 {
     // given
     NSString * const path = @"/some/path";
-    ZMTransportRequestMethod const method = ZMMethodPOST;
+    ZMTransportRequestMethod const method = ZMTransportRequestMethodPost;
     NSData * const data = [NSData dataWithBytes:((const char []){'z', 'q'}) length:2];
     NSDictionary * const disposition = @{@"zasset": [NSNull null], @"conv_id": [NSUUID createUUID].transportString};
     
@@ -141,7 +141,7 @@
     int apiVersion = 5;
     NSString * const path = @"/some/path";
     NSString * const expectedPath = [NSString stringWithFormat:@"/v%d%@", apiVersion, path];
-    ZMTransportRequestMethod const method = ZMMethodPOST;
+    ZMTransportRequestMethod const method = ZMTransportRequestMethodPost;
     NSData * const data = [NSData dataWithBytes:((const char []){'z', 'q'}) length:2];
     NSDictionary * const disposition = @{@"zasset": [NSNull null], @"conv_id": [NSUUID createUUID].transportString};
 
@@ -173,7 +173,7 @@
     XCTAssertNotNil(request);
     XCTAssertNil(request.payload);
     XCTAssertEqualObjects(request.path, path);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
     XCTAssertNil(request.contentDisposition);
     XCTAssertNil(request.binaryData);
     XCTAssertEqualObjects(fileURL, request.fileUploadURL);
@@ -197,7 +197,7 @@
     XCTAssertNotNil(request);
     XCTAssertNil(request.payload);
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
     XCTAssertNil(request.contentDisposition);
     XCTAssertNil(request.binaryData);
     XCTAssertEqualObjects(fileURL, request.fileUploadURL);
@@ -209,7 +209,7 @@
 {
     // given
     NSString * const path = @"/some/path";
-    ZMTransportRequestMethod const method = ZMMethodPUT;
+    ZMTransportRequestMethod const method = ZMTransportRequestMethodPut;
 
     // when
     ZMTransportRequest *request = [ZMTransportRequest emptyPutRequestWithPath:path apiVersion:0];
@@ -235,7 +235,7 @@
     int apiVersion = 5;
     NSString * const path = @"/some/path";
     NSString * const expectedPath = [NSString stringWithFormat:@"/v%d%@", apiVersion, path];
-    ZMTransportRequestMethod const method = ZMMethodPUT;
+    ZMTransportRequestMethod const method = ZMTransportRequestMethodPut;
 
     // when
     ZMTransportRequest *request = [ZMTransportRequest emptyPutRequestWithPath:path apiVersion:apiVersion];
@@ -269,7 +269,7 @@
     XCTAssertNotNil(request);
     XCTAssertNil(request.payload);
     XCTAssertEqualObjects(request.path, path);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
     XCTAssertEqualObjects(request.contentDisposition, disposition);
     XCTAssertEqualObjects(request.binaryData, data);
     XCTAssertFalse(request.shouldFailInsteadOfRetry);
@@ -292,7 +292,7 @@
     XCTAssertNotNil(request);
     XCTAssertNil(request.payload);
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
     XCTAssertEqualObjects(request.contentDisposition, disposition);
     XCTAssertEqualObjects(request.binaryData, data);
     XCTAssertFalse(request.shouldFailInsteadOfRetry);
@@ -329,7 +329,7 @@
     XCTAssertNotNil(request);
     XCTAssertNil(request.payload);
     XCTAssertEqualObjects(request.path, path);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
     XCTAssertNil(request.contentDisposition);
     XCTAssertFalse(request.shouldFailInsteadOfRetry);
     NSArray *items = [request multipartBodyItems];
@@ -369,7 +369,7 @@
     XCTAssertNotNil(request);
     XCTAssertNil(request.payload);
     XCTAssertEqualObjects(request.path, expectedPath);
-    XCTAssertEqual(request.method, ZMMethodPOST);
+    XCTAssertEqual(request.method, ZMTransportRequestMethodPost);
     XCTAssertNil(request.contentDisposition);
     XCTAssertFalse(request.shouldFailInsteadOfRetry);
     NSArray *items = [request multipartBodyItems];
@@ -407,7 +407,7 @@
 {
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task created handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     ZMTaskIdentifier *expectedIdentifier = [ZMTaskIdentifier identifierWithIdentifier:2 sessionIdentifier:@"test-session"];
     
     ZMTaskCreatedHandler *handler = [ZMTaskCreatedHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTaskIdentifier *identifier) {
@@ -430,7 +430,7 @@
     XCTestExpectation *firstExpectation = [self expectationWithDescription:@"First task created handler called"];
     XCTestExpectation *secondExpectation = [self expectationWithDescription:@"Second task created handler called"];;
     
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     ZMTaskIdentifier *expectedIdentifier = [ZMTaskIdentifier identifierWithIdentifier:2 sessionIdentifier:@"test-session"];
     
     ZMTaskCreatedHandler *firstHandler = [ZMTaskCreatedHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTaskIdentifier *identifier) {
@@ -456,7 +456,7 @@
 - (void)testThatItDoesNotAttemptToCallATaskCreatedHandlerIfNoneIsSet
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     // when
     XCTAssertNoThrow([transportRequest callTaskCreationHandlersWithIdentifier:0 sessionIdentifier:@""]);
@@ -465,7 +465,7 @@
 - (void)testThatItSetsStartOfUploadTimestamp
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     [transportRequest markStartOfUploadTimestamp];
     
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil apiVersion:transportRequest.apiVersion];
@@ -481,7 +481,7 @@
 {
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
 
     [transportRequest addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED){
@@ -501,7 +501,7 @@
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Completion 1 handler called"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Completion 2 handler called"];
 
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED){
@@ -524,7 +524,7 @@
 - (void)testThatItDoesNotAttemptToCallACompletionHandlerIfNoneIsSet
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
 
     // when
     XCTAssertNoThrow([transportRequest completeWithResponse:[[ZMTransportResponse alloc] init]]);
@@ -538,7 +538,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil apiVersion:0];
     __block ZMTransportResponse *receivedResponse;
     
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *actualResponse){
         receivedResponse = actualResponse;
@@ -565,7 +565,7 @@
     __block NSMutableString *responses = [[NSMutableString alloc] init];
 
 
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
 
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *resp) {
         NOT_USED(resp);
@@ -600,7 +600,7 @@
     const float expectedProgress = 0.5f;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -621,7 +621,7 @@
     const static size_t expectedProgressSize = sizeof(expectedProgress) / sizeof(expectedProgress[0]);
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     NSUInteger __block currentCallIndex = 0;
     
@@ -650,7 +650,7 @@
     const float expectedProgress = 1.0f;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -671,7 +671,7 @@
     const float expectedProgress = 0.0f;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -693,7 +693,7 @@
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Task progress handler 1 called"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Task progress handler 2 called"];
 
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -715,7 +715,7 @@
 - (void)testThatItDoesNotAttemptToCallATaskProgressHandlerIfNoneIsSet
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     // when
     XCTAssertNoThrow([transportRequest updateProgress:1.0f]);
@@ -768,19 +768,19 @@
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
     
     // (2) given
-    sut = [ZMTransportRequest requestWithPath:@"/foo2" method:ZMMethodPOST payload:@{@"f": @2} apiVersion:0];
+    sut = [ZMTransportRequest requestWithPath:@"/foo2" method:ZMTransportRequestMethodPost payload:@{@"f": @2} apiVersion:0];
     
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
 
     // (3) given
-    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMMethodPUT binaryData:[@"asdf" dataUsingEncoding:NSUTF8StringEncoding] type:@"image/jpeg" contentDisposition:@{@"asdf": @42} apiVersion:0];
+    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMTransportRequestMethodPut binaryData:[@"asdf" dataUsingEncoding:NSUTF8StringEncoding] type:@"image/jpeg" contentDisposition:@{@"asdf": @42} apiVersion:0];
     
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
 
     // (4) given
-    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMMethodPUT payload:@{@"A": @3} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
+    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMTransportRequestMethodPut payload:@{@"A": @3} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
 
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
@@ -796,7 +796,7 @@
 {
     // given
     NSDictionary *payload = @{@"A": @2};
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST payload:payload apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodPost payload:payload apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -811,7 +811,7 @@
 
 - (void)testThatItSetsAdditionalHeaderFieldsOnURLRequest;
 {
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     [sut addValue:@"as73e8f98a7==" forAdditionalHeaderField:@"Access-Token"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
 
@@ -862,7 +862,7 @@
         [payload addObject:a];
     }
     // The encoded transport data is approximately 46k bytes.
-    ZMTransportRequest *sut = [ZMTransportRequest requestWithPath:@"/foo" method:ZMMethodPOST payload:payload shouldCompress:YES apiVersion:0];
+    ZMTransportRequest *sut = [ZMTransportRequest requestWithPath:@"/foo" method:ZMTransportRequestMethodPost payload:payload shouldCompress:YES apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     NSString *expected = @"H4sIAAAAAAAAE4XaS08qWRhG4f/C1DMoLlVQJzkD+yjeFRCvn"
     @"R5wEwUUBRS10/+9k056sNdgffM9eJLlpeqt/effldFgNa78zH5UxoPNoPKzMpwUeWc2and"
@@ -903,7 +903,7 @@
 {
     // given
     NSData *data = [@"jhasdhjkadshjklad" dataUsingEncoding:NSUTF8StringEncoding];
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(NSString *) UTTypeJPEG.identifier contentDisposition:nil apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodPost binaryData:data type:(NSString *) UTTypeJPEG.identifier contentDisposition:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -917,7 +917,7 @@
 - (void)testThatItDoesNotSetMediaTypeForRequestWithoutPayload;
 {
     // given
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -952,7 +952,7 @@
     // given
     NSData *data = [@"jhasdhjkadshjklad" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *disposition = @{@"A": @YES, @"b": @1, @"c": @"foo bar", @"d": @"z", @"e": [NSNull null]};
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(NSString *) UTTypeJPEG contentDisposition:disposition apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodPost binaryData:data type:(NSString *) UTTypeJPEG contentDisposition:disposition apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -966,7 +966,7 @@
 {
     // given
     NSData *data = [@"jhasdhjkadshjklad" dataUsingEncoding:NSUTF8StringEncoding];
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(NSString *) UTTypeJPEG contentDisposition:nil apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodPost binaryData:data type:(NSString *) UTTypeJPEG contentDisposition:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -979,7 +979,7 @@
 - (void)testThatItSetsAnExpirationDate;
 {
     // given
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     NSTimeInterval interval = 35;
     
     // when
@@ -1002,7 +1002,7 @@
 - (void)testThatPOSTWithPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodPOST payload:@{} apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodPost payload:@{} apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -1011,7 +1011,7 @@
 - (void)testThatPOSTWithNoPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodPOST payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodPost payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -1020,7 +1020,7 @@
 - (void)testThatDELETEWithPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodDELETE payload:@{} apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMTransportRequestMethodDelete payload:@{} apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -1029,7 +1029,7 @@
 - (void)testThatDELETEWithNoPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodDELETE payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMTransportRequestMethodDelete payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -1038,7 +1038,7 @@
 - (void)testThatGETWithoutPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -1047,7 +1047,7 @@
 - (void)testThatHEADHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -1083,7 +1083,7 @@
                       usingBackgroundSession:(BOOL)usingBackgroundSession
 {
     // given
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST payload:nil apiVersion:0];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMTransportRequestMethodPost payload:nil apiVersion:0];
     if (usingBackgroundSession) {
         [sut forceToBackgroundSession];
     }
@@ -1111,7 +1111,7 @@
     // given
     NSString *info1 = @"....xxxXXXxxx....";
     NSString *info2 = @"32432525245345435";
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
     
     // when
     [request addContentDebugInformation:info1];
@@ -1127,7 +1127,7 @@
 - (void)testPrivateDescription
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
     
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1143,7 +1143,7 @@
     NSString *clientID = @"608b4f25ba2b193";
     NSString *uuid = @"9e86b08a-8de7-11e9-810f-22000a62954d";
     NSString *path = [NSString stringWithFormat:@"do/something/%@/useful?client=%@", uuid, clientID];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
     
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1161,7 +1161,7 @@
     NSString *clientID = @"608b4f25ba2b193";
     NSString *uuid = @"9e86b08a-8de7-11e9-810f-22000a62954d";
     NSString *path = [NSString stringWithFormat:@"with/%@/🤨/%@/emoji", clientID, uuid];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
 
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1180,7 +1180,7 @@
     NSString *clientID = @"608b4f25ba2b193";
     NSString *uuid = @"9e86b08a-8de7-11e9-810f-22000a62954d";
     NSString *path = [NSString stringWithFormat:@"ids/%@%@/overlapped", clientID, uuid];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
 
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1193,7 +1193,7 @@
 
     // given
     path = [NSString stringWithFormat:@"ids/%@%@/overlapped", uuid, clientID];
-    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
+    request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
 
     // when
     privateDescription = [request safeForLoggingDescription];
@@ -1206,7 +1206,7 @@
 
     // given
     path = [NSString stringWithFormat:@"ids/%@%@/overlapped", uuid, uuid];
-    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
+    request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
 
     // when
     privateDescription = [request safeForLoggingDescription];
@@ -1218,7 +1218,7 @@
 
     // given
     path = [NSString stringWithFormat:@"ids/%@%@/overlapped", clientID, clientID];
-    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
+    request = [ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodHead payload:nil apiVersion:0];
 
     // when
     privateDescription = [request safeForLoggingDescription];

--- a/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -490,12 +490,12 @@ static XCTestCase *currentTestCase;
 
 - (BOOL)requestMethodShouldHavePayload:(ZMTransportRequestMethod)method {
     switch(method) {
-        case ZMMethodDELETE:
-        case ZMMethodGET:
-        case ZMMethodHEAD:
+        case ZMTransportRequestMethodDelete:
+        case ZMTransportRequestMethodGet:
+        case ZMTransportRequestMethodHead:
             return NO;
-        case ZMMethodPOST:
-        case ZMMethodPUT:
+        case ZMTransportRequestMethodPost:
+        case ZMTransportRequestMethodPut:
             return YES;
     }
 }
@@ -510,11 +510,11 @@ static XCTestCase *currentTestCase;
     // given
     NSArray *expected = @[@"GET", @"POST", @"DELETE", @"PUT", @"HEAD"];
     NSArray *input = @[
-                       [NSNumber numberWithInt:ZMMethodGET],
-                       [NSNumber numberWithInt:ZMMethodPOST],
-                       [NSNumber numberWithInt:ZMMethodDELETE],
-                       [NSNumber numberWithInt:ZMMethodPUT],
-                       [NSNumber numberWithInt:ZMMethodHEAD],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodGet],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodPost],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodDelete],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodPut],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodHead],
                        ];
     
     // when
@@ -532,11 +532,11 @@ static XCTestCase *currentTestCase;
     // given
     NSArray *input = @[@"GET", @"POST", @"DELETE", @"PUT", @"HEAD"];
     NSArray *expected = @[
-                       [NSNumber numberWithInt:ZMMethodGET],
-                       [NSNumber numberWithInt:ZMMethodPOST],
-                       [NSNumber numberWithInt:ZMMethodDELETE],
-                       [NSNumber numberWithInt:ZMMethodPUT],
-                       [NSNumber numberWithInt:ZMMethodHEAD],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodGet],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodPost],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodDelete],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodPut],
+                       [NSNumber numberWithInt:ZMTransportRequestMethodHead],
                        ];
     
     // when
@@ -584,7 +584,7 @@ static XCTestCase *currentTestCase;
         return [TestResponse testResponse];
     }];
     
-    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:path method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:path method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED){
         [expectation fulfill];
@@ -601,7 +601,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItEnqueuesSearchRequests;
 {
     // given
-    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // when
     [self.sut enqueueOneTimeRequest:request];
@@ -615,7 +615,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItEnqueuesRequests;
 {
     // given
-    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // when
     [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
@@ -633,11 +633,11 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     ZMTransportRequestMethod const methods[] = {
-        ZMMethodGET,
-        ZMMethodPOST,
-        ZMMethodDELETE,
-        ZMMethodPUT,
-        ZMMethodHEAD,
+        ZMTransportRequestMethodGet,
+        ZMTransportRequestMethodPost,
+        ZMTransportRequestMethodDelete,
+        ZMTransportRequestMethodPut,
+        ZMTransportRequestMethodHead,
     };
     
     for (size_t i = 0; i < sizeof(methods) / sizeof(*methods); ++i) {
@@ -673,7 +673,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:@{} apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodPost payload:@{} apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -698,7 +698,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -760,7 +760,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:payload apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodPost payload:payload apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -805,7 +805,7 @@ static XCTestCase *currentTestCase;
     [[[(id)foregroundSession reject] andReturn:nil] taskWithRequest:OCMOCK_ANY bodyData:OCMOCK_ANY transportRequest:OCMOCK_ANY];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:payload apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodPost payload:payload apiVersion:0];
     [request forceToBackgroundSession];
     [sut sendSchedulerItem:request];
     
@@ -825,7 +825,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -852,7 +852,7 @@ static XCTestCase *currentTestCase;
     // when
     __block id<ZMTransportData> receivedPayload;
     
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         receivedPayload = response.payload;
@@ -882,7 +882,7 @@ static XCTestCase *currentTestCase;
     }];
     NSData *binaryData = [@"foo" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *contentDisposition = @{@"conv_id": @"912c7fc66cfb", @"width": @2};
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPOST binaryData:binaryData type:(NSString *) UTTypeJPEG.identifier contentDisposition:contentDisposition apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodPost binaryData:binaryData type:(NSString *) UTTypeJPEG.identifier contentDisposition:contentDisposition apiVersion:0];
     __block id<ZMTransportData> receivedPayload;
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
@@ -912,7 +912,7 @@ static XCTestCase *currentTestCase;
 
     // when
     __block NSInteger receivedStatusCode;
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         receivedStatusCode = response.HTTPStatus;
@@ -952,7 +952,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         return request;
     };
     
@@ -989,7 +989,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         return request;
     };
     
@@ -1042,7 +1042,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         [request addCompletionHandler:
          [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         }]];
@@ -1066,7 +1066,7 @@ static XCTestCase *currentTestCase;
     // when
     for(int i = 0; i < maxRequests + 1; ++i) {
         ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-            ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+            ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
             [request addCompletionHandler:
              [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
             }]];
@@ -1132,7 +1132,7 @@ static XCTestCase *currentTestCase;
     for (int i = 0; i < (maxRequests + 1); ++i) {
         NSString *path = [NSString stringWithFormat:@"/A/%d", i];
         ZMTransportEnqueueResult *result = [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
-            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:path method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:path method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
             [r addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse * ZM_UNUSED response) {
             }]];
             return r;
@@ -1164,7 +1164,7 @@ static XCTestCase *currentTestCase;
     
     {
         ZMTransportEnqueueResult *result = [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
-            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:@"/B" method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:@"/B" method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
             return r;
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -1195,7 +1195,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatARequestsThatNeedAuthenticationGeneratesAuthenticationHeaders
 {
     // given
-    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
+    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
     
     self.sut.accessToken = [[ZMAccessToken alloc] initWithToken:@"token-213" type:@"tokentype" expiresInSeconds:100000];
     
@@ -1219,7 +1219,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatARequestsThatDoesNotNeedAuthenticationDoesNotGenerateAuthenticationHeaders
 {
     // given
-    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     
     self.sut.accessToken = [[ZMAccessToken alloc] initWithToken:@"token-213" type:@"tokentype" expiresInSeconds:100000];
     
@@ -1241,7 +1241,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatARequestThatCreatesAnAccessTokenDoesNotGenerateAuthenticationHeaders
 {
     // given
-    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
+    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     
     self.sut.accessToken = [[ZMAccessToken alloc] initWithToken:@"token-213" type:@"tokentype" expiresInSeconds:100000];
     
@@ -1264,7 +1264,7 @@ static XCTestCase *currentTestCase;
 {
     // given
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPOST payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodPost payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     };
     
     // then
@@ -1276,7 +1276,7 @@ static XCTestCase *currentTestCase;
 {
     // given
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPUT payload:@[@34] authentication:ZMTransportRequestAuthNone apiVersion:0];
+        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodPut payload:@[@34] authentication:ZMTransportRequestAuthNone apiVersion:0];
     };
     
     // then
@@ -1287,7 +1287,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItDoesNotAssertIfARequestTypeWithPayloadHasAPayload
 {
     // given
-    static const ZMTransportRequestMethod methodsWithPayload [] = {ZMMethodPOST, ZMMethodPUT};
+    static const ZMTransportRequestMethod methodsWithPayload [] = {ZMTransportRequestMethodPost, ZMTransportRequestMethodPut};
     static const size_t size = sizeof(methodsWithPayload)/sizeof(methodsWithPayload[0]);
     
     for(size_t i = 0; i < size; ++i)
@@ -1304,7 +1304,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItDoesNotAssertIfARequestTypeWithoutPayloadDoesNotHaveAPayload
 {
     // given
-    static const ZMTransportRequestMethod methodsWithoutPayload [] = {ZMMethodHEAD, ZMMethodGET, ZMMethodDELETE};
+    static const ZMTransportRequestMethod methodsWithoutPayload [] = {ZMTransportRequestMethodHead, ZMTransportRequestMethodGet, ZMTransportRequestMethodDelete};
     static const size_t size = sizeof(methodsWithoutPayload)/sizeof(methodsWithoutPayload[0]);
     
     for(size_t i = 0; i < size; ++i)
@@ -1552,7 +1552,7 @@ static XCTestCase *currentTestCase;
     
     __block ZMTransportResponse *response;
     XCTestExpectation *requestCompletedExpectation = [self expectationWithDescription:@"request completed"];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPUT payload:dummyPayload apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodPut payload:dummyPayload apiVersion:0];
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *r) {
         response = r;
         [requestCompletedExpectation fulfill];
@@ -1582,7 +1582,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
+    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     
     [self.sut sendSchedulerItem:request];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1608,7 +1608,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
+    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
     
     [self.sut sendSchedulerItem:request];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1635,7 +1635,7 @@ static XCTestCase *currentTestCase;
     
     // when
     XCTestExpectation *didRun = [self expectationWithDescription:@"completion handler"];
-    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
+    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     ZMPersistentCookieStorage *cookieStorage = self.sut.cookieStorage;
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse * ZM_UNUSED r) {
         XCTAssertNotNil(cookieStorage.authenticationCookieData);
@@ -1753,7 +1753,7 @@ static XCTestCase *currentTestCase;
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
-    [self.sut sendSchedulerItem:[[ZMTransportRequest alloc] initWithPath:path method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0]];
+    [self.sut sendSchedulerItem:[[ZMTransportRequest alloc] initWithPath:path method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0]];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // after
@@ -1785,7 +1785,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         XCTAssertEqualObjects(response.imageData, jpegData);
@@ -2069,7 +2069,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     self.reachability.mayBeReachable = YES;
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // expect
     XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete response"];
@@ -2109,7 +2109,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     self.reachability.mayBeReachable = YES;
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodGET payload:nil apiVersion:0];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // expect
     XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete response"];

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+RequestProxy.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+RequestProxy.swift
@@ -31,7 +31,7 @@ extension ZMUserSession: ZiphyURLRequester {
         }
 
         return doRequest(withPath: requestPath,
-                         method: .methodGET,
+                         method: .get,
                          type: .giphy,
                          completionHandler: completionHandler)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5266" title="WPB-5266" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5266</a>  [iOS] Implement action + action handler for protocol update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The case names of the enum ZMTransportRequestMethod aren't bridged correctly into Swift.

### Causes (Optional)

The case names of the enum ZMTransportRequestMethod don't have the correct prefix.

### Solutions

Rename the cases in the Objective C code.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
