### PR TITLE
feat: [MLS Migration] - Mixed Protocol and fetch all team conversations with `mixed` message protocol - WPB - 5210, WPB - 5211

### DIFF
--- a/wire-ios-data-model/Source/MLS/MessageProtocol.swift
+++ b/wire-ios-data-model/Source/MLS/MessageProtocol.swift
@@ -35,8 +35,10 @@ public enum MessageProtocol: Int16 {
 
     case mls
 
-    /// In this case, we have conversations using the MLS Protocol and conversations using
-    /// the Proteus Protocol
+    /// Conversations with the mixed message protocol are in the state of migrating from
+    /// proteus to mls. Message encryption is done using the proteus protocol,
+    /// while other operations (such as adding / removing participants) are reflected on the underlying mls group.
+    /// Calling is still done the proteus way until the migration is finalised
 
     case mixed
 

--- a/wire-ios-data-model/Source/MLS/MessageProtocol.swift
+++ b/wire-ios-data-model/Source/MLS/MessageProtocol.swift
@@ -35,12 +35,19 @@ public enum MessageProtocol: Int16 {
 
     case mls
 
+    /// In this case, we have conversations using the MLS Protocol and conversations using
+    /// the Proteus Protocol
+
+    case mixed
+
     public init?(string: String) {
         switch string {
         case "mls":
             self = .mls
         case "proteus":
             self = .proteus
+        case "mixed":
+            self = .mixed
         default:
             return nil
         }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -217,6 +217,9 @@ extension ZMConversation {
 
                 }
             }
+        case .mixed:
+            // break for now until this is implemented
+            break
         }
     }
 
@@ -291,6 +294,9 @@ extension ZMConversation {
                     }
                 }
             }
+        case (.mixed, _):
+            // break for now until this is implemented
+            break
         }
     }
 

--- a/wire-ios-data-model/Tests/MLS/MessageProtocolTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MessageProtocolTests.swift
@@ -26,5 +26,6 @@ final class MessageProtocolTests: XCTestCase {
     func testRawValues() {
         XCTAssertEqual(MessageProtocol.proteus.rawValue, 0)
         XCTAssertEqual(MessageProtocol.mls.rawValue, 1)
+        XCTAssertEqual(MessageProtocol.mixed.rawValue, 2)
     }
 }

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -107,16 +107,15 @@ final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
             // create specific conversations
             let conversations = try (0..<4).map { _ in
                 let conversation = try MLSGroupID.random().createConversation(in: syncMOC)
-                conversation.messageProtocol = .proteus
+                conversation.messageProtocol = .mixed
                 conversation.conversationType = .group
                 conversation.teamRemoteIdentifier = selfUser.teamIdentifier
                 return conversation
             }
 
-            // only conversations[0] should be fetched successfully
-            conversations[1].messageProtocol = .mls
-            conversations[2].conversationType = .`self`
-            conversations[3].teamRemoteIdentifier = .init()
+            conversations[1].messageProtocol = .mixed
+            conversations[2].messageProtocol = .mixed
+            conversations[3].messageProtocol = .mixed
             try syncMOC.save()
             return conversations
 
@@ -128,7 +127,7 @@ final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
         }
 
         // Then
-        XCTAssertEqual(fetchedConversations, [conversations[0], conversations[1]])
+        XCTAssertEqual(fetchedConversations, [conversations[0], conversations[1], conversations[2], conversations[3]])
     }
 
 }

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -97,7 +97,7 @@ final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
     }
 
     func test_fetchAllTeamGroupConversations_messageProtocolMixed() async throws {
-        // Given
+        // GIVEN
         let conversations = try await syncMOC.perform { [syncMOC] in
 
             // ensure selfUser has a teamIdentifier set
@@ -113,21 +113,23 @@ final class ZMConversationTests_MLS_Migration: ModelObjectsTests {
                 return conversation
             }
 
-            conversations[1].messageProtocol = .mixed
-            conversations[2].messageProtocol = .mixed
-            conversations[3].messageProtocol = .mixed
+            // only conversations[0] should be fetched successfully
+            conversations[1].conversationType = .`self`
+            conversations[2].conversationType = .`self`
+            conversations[3].teamRemoteIdentifier = .init()
+
             try syncMOC.save()
             return conversations
 
         }
 
-        // When
+        // WHEN
         let fetchedConversations = try await syncMOC.perform { [syncMOC] in
             try ZMConversation.fetchAllTeamGroupConversations(messageProtocol: .mixed, in: syncMOC)
         }
 
-        // Then
-        XCTAssertEqual(fetchedConversations, [conversations[0], conversations[1], conversations[2], conversations[3]])
+        // THEN
+        XCTAssertEqual(fetchedConversations, [conversations[0]])
     }
 
 }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSync.swift
@@ -72,14 +72,10 @@ public class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMCont
         }
 
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             proteusMessageSync.sync(message, completion: completion)
-
         case .mls:
             mlsMessageSync.sync(message, completion: completion)
-        case .mixed:
-            // TODO: - [AGIS] To be fixed when we're going to handle syncing in the mixed protocol
-            break
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/MessageSync.swift
@@ -77,6 +77,9 @@ public class MessageSync<Message: ProteusMessage & MLSMessage>: NSObject, ZMCont
 
         case .mls:
             mlsMessageSync.sync(message, completion: completion)
+        case .mixed:
+            // TODO: - [AGIS] To be fixed when we're going to handle syncing in the mixed protocol
+            break
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Payload+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload+Conversation.swift
@@ -69,6 +69,13 @@ extension Payload {
                 creatorClient = nil
                 qualifiedUsers = action.qualifiedUserIDs
                 users = action.unqualifiedUserIDs
+            case .mixed:
+                // TODO: - [AGIS] fix that with the proper values
+                // this is temorary so we can make the project to build
+                messageProtocol = "mixed"
+                creatorClient = nil
+                qualifiedUsers = nil
+                users = nil
             }
 
             name = action.name
@@ -101,6 +108,13 @@ extension Payload {
                     qualifiedUsers = nil
                     users = conversation.localParticipantsExcludingSelf.map(\.remoteIdentifier)
                 }
+            case .mixed:
+                // TODO: - [AGIS] fix that
+                // this is temorary so we can make the project to build
+                messageProtocol = "mixed"
+                creatorClient = nil
+                qualifiedUsers = nil
+                users = nil
             }
 
             name = conversation.userDefinedName

--- a/wire-ios-request-strategy/Sources/Payloads/Payload+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload+Conversation.swift
@@ -58,7 +58,7 @@ extension Payload {
 
         init(_ action: CreateGroupConversationAction) {
             switch action.messageProtocol {
-            case .mls:
+            case .mls, .mixed:
                 messageProtocol = "mls"
                 creatorClient = action.creatorClientID
                 qualifiedUsers = nil
@@ -69,13 +69,6 @@ extension Payload {
                 creatorClient = nil
                 qualifiedUsers = action.qualifiedUserIDs
                 users = action.unqualifiedUserIDs
-            case .mixed:
-                // TODO: - [AGIS] fix that with the proper values
-                // this is temorary so we can make the project to build
-                messageProtocol = "mixed"
-                creatorClient = nil
-                qualifiedUsers = nil
-                users = nil
             }
 
             name = action.name
@@ -91,7 +84,7 @@ extension Payload {
         @available(*, deprecated, message: "Use a CreateConversationAction instead")
         init(_ conversation: ZMConversation, selfClientID: String) {
             switch conversation.messageProtocol {
-            case .mls:
+            case .mls, .mixed:
                 messageProtocol = "mls"
                 creatorClient = selfClientID
                 qualifiedUsers = nil
@@ -108,13 +101,6 @@ extension Payload {
                     qualifiedUsers = nil
                     users = conversation.localParticipantsExcludingSelf.map(\.remoteIdentifier)
                 }
-            case .mixed:
-                // TODO: - [AGIS] fix that
-                // this is temorary so we can make the project to build
-                messageProtocol = "mixed"
-                creatorClient = nil
-                qualifiedUsers = nil
-                users = nil
             }
 
             name = conversation.userDefinedName

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
@@ -269,7 +269,7 @@ final class CreateGroupConversationActionHandler: ActionHandler<CreateGroupConve
                 }
             }
         case .mixed:
-            // It shouldn't happen that's why we break here
+            // Conversations should never be created with mixed protocol, that's why we break here
             break
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
@@ -269,7 +269,7 @@ final class CreateGroupConversationActionHandler: ActionHandler<CreateGroupConve
                 }
             }
         case .mixed:
-            // TODO: - [AGIS] Fix that when we're going to handle creating group conversation in mixed protocol
+            // It shouldn't happen that's why we break here
             break
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
@@ -268,6 +268,9 @@ final class CreateGroupConversationActionHandler: ActionHandler<CreateGroupConve
                     return
                 }
             }
+        case .mixed:
+            // TODO: - [AGIS] Fix that when we're going to handle creating group conversation in mixed protocol
+            break
         }
     }
 

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -524,14 +524,11 @@ extension WireCallCenterV3 {
         }
 
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             break
 
         case .mls:
             try setUpMLSConference(in: conversation)
-        case .mixed:
-            // TODO: - [AGIS] Fix that when we need to take care of calling while in mixed protocol
-            break
         }
     }
 
@@ -608,14 +605,10 @@ extension WireCallCenterV3 {
         }
 
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             break
-
         case .mls:
             try setUpMLSConference(in: conversation)
-        case .mixed:
-            // TODO: - [AGIS] fix that when we need to work on testing
-            break
         }
     }
 

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -529,6 +529,9 @@ extension WireCallCenterV3 {
 
         case .mls:
             try setUpMLSConference(in: conversation)
+        case .mixed:
+            // TODO: - [AGIS] Fix that when we need to take care of calling while in mixed protocol
+            break
         }
     }
 
@@ -610,6 +613,9 @@ extension WireCallCenterV3 {
 
         case .mls:
             try setUpMLSConference(in: conversation)
+        case .mixed:
+            // TODO: - [AGIS] fix that when we need to work on testing
+            break
         }
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -458,7 +458,7 @@ extension CallingRequestStrategy: WireCallCenterTransport {
             }
 
             switch conversation.messageProtocol {
-            case .proteus:
+            case .proteus, .mixed:
                 // With proteus, we discover clients by posting an otr message to no-one,
                 // then parse the error response that contains the list of all clients.
                 self.clientDiscoveryRequest = ClientDiscoveryRequest(
@@ -496,9 +496,6 @@ extension CallingRequestStrategy: WireCallCenterTransport {
                         Logging.mls.error("Failed to fetch client list for MLS conference: \(String(describing: error))")
                     }
                 }
-            case .mixed:
-                // TODO: - [AGIS] Fix that when we need to take care of calling while in mixed protocol
-                break
             }
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -384,7 +384,7 @@ extension CallingRequestStrategy: WireCallCenterTransport {
             }
 
             switch (conversation.messageProtocol, recipients) {
-            case (.proteus, _), (.mls, .conversationParticipants):
+            case (.proteus, _), (.mls, .conversationParticipants), (.mixed, _):
                 message.send(with: self.messageSync, completion: completionHandler)
 
             case (.mls, _):
@@ -395,9 +395,6 @@ extension CallingRequestStrategy: WireCallCenterTransport {
                 } else {
                     Logging.mls.info("ignoring targeted outgoing calling message b/c it's not CONFKEY nor sent over self conversation")
                 }
-            case (.mixed, _):
-                // TODO: - [AGIS] Fix that when we need to take care of calling while in mixed protocol
-                break
             }
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -395,6 +395,9 @@ extension CallingRequestStrategy: WireCallCenterTransport {
                 } else {
                     Logging.mls.info("ignoring targeted outgoing calling message b/c it's not CONFKEY nor sent over self conversation")
                 }
+            case (.mixed, _):
+                // TODO: - [AGIS] Fix that when we need to take care of calling while in mixed protocol
+                break
             }
         }
     }
@@ -493,6 +496,9 @@ extension CallingRequestStrategy: WireCallCenterTransport {
                         Logging.mls.error("Failed to fetch client list for MLS conference: \(String(describing: error))")
                     }
                 }
+            case .mixed:
+                // TODO: - [AGIS] Fix that when we need to take care of calling while in mixed protocol
+                break
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/MessageProtocolSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/MessageProtocolSectionController.swift
@@ -64,6 +64,9 @@ final class MessageProtocolSectionController: GroupDetailsSectionController {
 
         case .mls:
             return Bundle.developerModeEnabled ? 3 : 2
+        case .mixed:
+            // TODO: - [AGIS] To be checked and fixed
+            return 1
         }
     }
 
@@ -137,6 +140,8 @@ private extension MessageProtocol {
 
         case .mls:
             return "MLS"
+        case .mixed:
+            return "Mixed"
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/MessageProtocolSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/MessageProtocolSectionController.swift
@@ -62,11 +62,8 @@ final class MessageProtocolSectionController: GroupDetailsSectionController {
         case .proteus:
             return 1
 
-        case .mls:
+        case .mls, .mixed:
             return Bundle.developerModeEnabled ? 3 : 2
-        case .mixed:
-            // TODO: - [AGIS] To be checked and fixed
-            return 1
         }
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I introduced a new MessageProtocol called `mixed`. With the changes @caldrian made, we already have a method regarding fetching the conversations based on the MessageProtocol. To make sure it works well with the mixed protocol I added a unit test under `ZMConversationTests_MLS_Migration`

Those changes are needed so I can continue with the rest of the changes regarding the mixed protocol. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
