### PR TITLE
fix: revert stop maintaining a list of team members [WPB-4552]

### DIFF
--- a/wire-ios-request-strategy/Sources/Protocols/SyncProgress.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/SyncProgress.swift
@@ -22,6 +22,7 @@ import Foundation
 
     case fetchingLastUpdateEventID
     case fetchingTeams
+    case fetchingTeamMembers
     case fetchingTeamRoles
     case fetchingConnections
     case fetchingConversations
@@ -58,6 +59,8 @@ import Foundation
             return "fetchingConversations"
         case .fetchingTeams:
             return "fetchingTeams"
+        case .fetchingTeamMembers:
+            return "fetchingTeamMembers"
         case .fetchingTeamRoles:
             return "fetchingTeamRoles"
         case .fetchingUsers:

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -1,0 +1,82 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Downloads all team members during the slow sync.
+
+public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, ZMSingleRequestTranscoder {
+
+    let syncStatus: SyncStatus
+    var sync: ZMSingleRequestSync!
+
+    public init(withManagedObjectContext managedObjectContext: NSManagedObjectContext,
+                applicationStatus: ApplicationStatus,
+                syncStatus: SyncStatus) {
+
+        self.syncStatus = syncStatus
+
+        super.init(withManagedObjectContext: managedObjectContext,
+                   applicationStatus: applicationStatus)
+
+        configuration = [.allowsRequestsDuringSlowSync]
+        sync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: managedObjectContext)
+    }
+
+    override public func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
+        guard syncStatus.currentSyncPhase == .fetchingTeamMembers else { return nil }
+
+        sync.readyForNextRequestIfNotBusy()
+
+        return sync.nextRequest(for: apiVersion)
+    }
+
+// MARK: - ZMSingleRequestTranscoder
+
+    public func request(for sync: ZMSingleRequestSync, apiVersion: APIVersion) -> ZMTransportRequest? {
+        guard let teamID = ZMUser.selfUser(in: managedObjectContext).teamIdentifier else {
+            completeSyncPhase() // Skip sync phase if user doesn't belong to a team
+            return nil
+        }
+        return ZMTransportRequest(getFromPath: "/teams/\(teamID.transportString())/members", apiVersion: apiVersion.rawValue)
+    }
+
+    public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
+        guard
+            response.result == .success,
+            let team = ZMUser.selfUser(in: managedObjectContext).team,
+            let rawData = response.rawData,
+            let payload = MembershipListPayload(rawData)
+        else {
+            return
+        }
+
+        if !payload.hasMore {
+            payload.members.forEach { (membershipPayload) in
+                membershipPayload.createOrUpdateMember(team: team, in: managedObjectContext)
+            }
+        }
+
+        completeSyncPhase()
+    }
+
+    func completeSyncPhase() {
+        syncStatus.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
+    }
+
+}

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -226,6 +226,10 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,
                 syncStatus: applicationStatusDirectory.syncStatus),
+            TeamMembersDownloadRequestStrategy(
+                withManagedObjectContext: syncMOC,
+                applicationStatus: applicationStatusDirectory,
+                syncStatus: applicationStatusDirectory.syncStatus),
             PermissionsDownloadRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -1,0 +1,203 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireSyncEngine
+
+class TeamMembersDownloadRequestStrategyTests: MessagingTest {
+
+    var sut: TeamMembersDownloadRequestStrategy!
+    var mockApplicationStatus: MockApplicationStatus!
+    var mockSyncStatus: MockSyncStatus!
+    var mockSyncStateDelegate: MockSyncStateDelegate!
+
+    override func setUp() {
+        super.setUp()
+        mockApplicationStatus = MockApplicationStatus()
+        mockSyncStateDelegate = MockSyncStateDelegate()
+        mockSyncStatus = MockSyncStatus(
+            managedObjectContext: syncMOC,
+            syncStateDelegate: mockSyncStateDelegate,
+            lastEventIDRepository: lastEventIDRepository
+        )
+        sut = TeamMembersDownloadRequestStrategy(withManagedObjectContext: syncMOC, applicationStatus: mockApplicationStatus, syncStatus: mockSyncStatus)
+
+        syncMOC.performGroupedBlockAndWait {
+            let user = ZMUser.selfUser(in: self.syncMOC)
+            user.remoteIdentifier = UUID()
+        }
+    }
+
+    override func tearDown() {
+        mockApplicationStatus = nil
+        mockSyncStateDelegate = nil
+        mockSyncStatus = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    let sampleResponseForSmallTeam: [String: Any] = [
+        "hasMore": false,
+        "members": [
+            [
+                "user": UUID().transportString(),
+                "permissions": [
+                    "copy": 1587,
+                    "self": 1587
+                ]
+            ]
+        ]
+    ]
+
+    let sampleResponseForLargeTeam: [String: Any] = [
+        "hasMore": true,
+        "members": [
+            [
+                "user": UUID().transportString(),
+                "permissions": [
+                    "copy": 1587,
+                    "self": 1587
+                ]
+            ]
+        ]
+    ]
+
+    func createTeam() -> Team {
+        let selfUser = ZMUser.selfUser(in: syncMOC)
+        let teamID = UUID()
+        selfUser.teamIdentifier = teamID
+        let team = Team.insertNewObject(in: syncMOC)
+        team.remoteIdentifier = teamID
+        _ = Member.getOrCreateMember(for: selfUser, in: team, context: syncMOC)
+
+        return team
+    }
+
+    func testThatItDoesNotGenerateARequestInitially() {
+        XCTAssertNil(sut.nextRequest(for: .v0))
+    }
+
+    func testThatItCreatesRequestToFetchTeamMembers() {
+
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.mockApplicationStatus.mockSynchronizationState = .slowSyncing
+            self.mockSyncStatus.mockPhase = .fetchingTeamMembers
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            let teamID = UUID()
+            selfUser.teamIdentifier = teamID
+
+            // when
+            let request = self.sut.nextRequest(for: .v0)
+
+            // then
+            XCTAssertNotNil(request)
+            XCTAssertEqual(request?.path, "/teams/\(teamID.transportString())/members")
+        }
+    }
+
+    func testThatItFinishSyncStep_IfSelfUserDoesntBelongToTeam() {
+
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.mockApplicationStatus.mockSynchronizationState = .slowSyncing
+            self.mockSyncStatus.mockPhase = .fetchingTeamMembers
+
+            // when
+            let request = self.sut.nextRequest(for: .v0)
+
+            // then
+            XCTAssertNil(request)
+            XCTAssertTrue(self.mockSyncStatus.didCallFinishCurrentSyncPhase)
+        }
+    }
+
+    func testThatItFinishSyncStep_OnSuccessfulResponse() {
+//        var team: Team!
+
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.mockApplicationStatus.mockSynchronizationState = .slowSyncing
+            self.mockSyncStatus.mockPhase = .fetchingTeamMembers
+            _ = self.createTeam()
+
+            guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
+
+            // when
+            let response = ZMTransportResponse(payload: self.sampleResponseForSmallTeam as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
+            request.complete(with: response)
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        syncMOC.performGroupedBlockAndWait {
+            // then
+            XCTAssertNil(self.sut.nextRequest(for: .v0))
+            XCTAssertTrue(self.mockSyncStatus.didCallFinishCurrentSyncPhase)
+        }
+    }
+
+    func testThatItCreatesTeamMembers_WhenHasMoreIsFalse() {
+        var team: Team!
+
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.mockApplicationStatus.mockSynchronizationState = .slowSyncing
+            self.mockSyncStatus.mockPhase = .fetchingTeamMembers
+            team = self.createTeam()
+
+            guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
+
+            // when
+            let response = ZMTransportResponse(payload: self.sampleResponseForSmallTeam as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
+            request.complete(with: response)
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        syncMOC.performGroupedBlockAndWait {
+            // then
+            XCTAssertEqual(team.members.count, 2)
+        }
+    }
+
+    func testThatItDoesNotCreateTeamMembers_WhenHasMoreIsTrue() {
+        var team: Team!
+
+        syncMOC.performGroupedBlockAndWait {
+            // given
+            self.mockApplicationStatus.mockSynchronizationState = .slowSyncing
+            self.mockSyncStatus.mockPhase = .fetchingTeamMembers
+            team = self.createTeam()
+
+            guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
+
+            // when
+            let response = ZMTransportResponse(payload: self.sampleResponseForLargeTeam as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
+            request.complete(with: response)
+        }
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
+
+        syncMOC.performGroupedBlockAndWait {
+            // then
+            XCTAssertEqual(team.members.count, 1)
+        }
+    }
+
+}

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
@@ -69,6 +69,7 @@ final class SyncStatusTests: MessagingTest {
     private var syncPhases: [SyncPhase] {
         return [.fetchingLastUpdateEventID,
                 .fetchingTeams,
+                .fetchingTeamMembers,
                 .fetchingTeamRoles,
                 .fetchingConnections,
                 .fetchingConversations,
@@ -104,6 +105,8 @@ final class SyncStatusTests: MessagingTest {
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertNil(lastEventIDRepository.fetchLastEventID())
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
         // then
         XCTAssertNil(lastEventIDRepository.fetchLastEventID())
         // when
@@ -154,6 +157,10 @@ final class SyncStatusTests: MessagingTest {
         // when
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingTeamMembers)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
+        // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeamRoles)
         // when
         sut.finishCurrentSyncPhase(phase: .fetchingTeamRoles)
@@ -191,6 +198,8 @@ final class SyncStatusTests: MessagingTest {
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishQuickSync)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishQuickSync)
         // when
@@ -451,6 +460,8 @@ extension SyncStatusTests {
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertNotEqual(lastEventIDRepository.fetchLastEventID(), newID)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
         // then
         XCTAssertNotEqual(lastEventIDRepository.fetchLastEventID(), newID)
         // when

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		163FB9942052EA4C00E74F83 /* OperationLoopNewRequestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB9922052EA4600E74F83 /* OperationLoopNewRequestObserver.swift */; };
 		163FB9992057E3F200E74F83 /* AuthenticationStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163FB9982057E3F200E74F83 /* AuthenticationStatusProvider.swift */; };
 		1645ECF82448A0A3007A82D6 /* Decodable+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ECF72448A0A3007A82D6 /* Decodable+JSON.swift */; };
+		1645ECFC2449CE75007A82D6 /* TeamMembersDownloadRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ECFB2449CE75007A82D6 /* TeamMembersDownloadRequestStrategy.swift */; };
+		1645ED1B244DE345007A82D6 /* TeamMembersDownloadRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1645ED1A244DE345007A82D6 /* TeamMembersDownloadRequestStrategy.swift */; };
 		164A55D820F4FE4A00AE62A6 /* SearchUserImageStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95706581DE5F6D40087442C /* SearchUserImageStrategyTests.swift */; };
 		164B8C211E254AD00060AB26 /* WireCallCenterV3Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165D3A1A1E1D43870052E654 /* WireCallCenterV3Mock.swift */; };
 		164C29A31ECF437E0026562A /* SearchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164C29A21ECF437E0026562A /* SearchRequestTests.swift */; };
@@ -794,6 +796,8 @@
 		163FB9922052EA4600E74F83 /* OperationLoopNewRequestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationLoopNewRequestObserver.swift; sourceTree = "<group>"; };
 		163FB9982057E3F200E74F83 /* AuthenticationStatusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStatusProvider.swift; sourceTree = "<group>"; };
 		1645ECF72448A0A3007A82D6 /* Decodable+JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+JSON.swift"; sourceTree = "<group>"; };
+		1645ECFB2449CE75007A82D6 /* TeamMembersDownloadRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMembersDownloadRequestStrategy.swift; sourceTree = "<group>"; };
+		1645ED1A244DE345007A82D6 /* TeamMembersDownloadRequestStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeamMembersDownloadRequestStrategy.swift; sourceTree = "<group>"; };
 		164C29A21ECF437E0026562A /* SearchRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchRequestTests.swift; sourceTree = "<group>"; };
 		164C29A41ECF47D80026562A /* SearchDirectoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchDirectoryTests.swift; sourceTree = "<group>"; };
 		164C29A61ED2D7B00026562A /* SearchResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
@@ -1975,6 +1979,7 @@
 				BF491CD01F03D7CF0055EE44 /* PermissionsDownloadRequestStrategy.swift */,
 				F9ABE84B1EFD568B00D83214 /* TeamDownloadRequestStrategy.swift */,
 				A913C02123A7EDFA0048CE74 /* TeamRolesDownloadRequestStrategy.swift */,
+				1645ECFB2449CE75007A82D6 /* TeamMembersDownloadRequestStrategy.swift */,
 				F9ABE84D1EFD568B00D83214 /* TeamRequestFactory.swift */,
 				16D9E8B922BCD39200FA463F /* LegalHoldRequestStrategy.swift */,
 				F9F631411DE3524100416938 /* TypingStrategy.swift */,
@@ -2005,6 +2010,7 @@
 			children = (
 				BF491CD41F03E0FC0055EE44 /* PermissionsDownloadRequestStrategyTests.swift */,
 				169BC10E22BD17FF0003159B /* LegalHoldRequestStrategyTests.swift */,
+				1645ED1A244DE345007A82D6 /* TeamMembersDownloadRequestStrategy.swift */,
 				F9ABE8531EFD56BF00D83214 /* TeamDownloadRequestStrategyTests.swift */,
 				F9ABE8541EFD56BF00D83214 /* TeamDownloadRequestStrategy+EventsTests.swift */,
 				A913C02323A7F1C00048CE74 /* TeamRolesDownloadRequestStrategyTests.swift */,
@@ -3131,6 +3137,7 @@
 				EE9CDE9227DA05D100C4DAC8 /* APIVersionResolverTests.swift in Sources */,
 				636826F82953465F00D904C2 /* ZMUserSessionTests+AccessToken.swift in Sources */,
 				0601900B2678750D0043F8F8 /* DeepLinkURLActionProcessorTests.swift in Sources */,
+				1645ED1B244DE345007A82D6 /* TeamMembersDownloadRequestStrategy.swift in Sources */,
 				549552541D645683004F21F6 /* AddressBookTests.swift in Sources */,
 				161C886623FD248A00CB0B8E /* RecordingMockTransportSession.swift in Sources */,
 				63D5654D28B50CEB00BDFB49 /* ZMUserSessionTests+CryptoStack.swift in Sources */,
@@ -3420,6 +3427,7 @@
 				BFE7FCBF2101E50700D1165F /* CompanyLoginVerificationToken.swift in Sources */,
 				5498162E1A432BC800A7CE2E /* ZMLastUpdateEventIDTranscoder.m in Sources */,
 				F9B171F61C0EF21100E6EEC6 /* ClientUpdateStatus.swift in Sources */,
+				1645ECFC2449CE75007A82D6 /* TeamMembersDownloadRequestStrategy.swift in Sources */,
 				7AA7112F286DB6F50098F670 /* OptionalString+NonEmptyValue.swift in Sources */,
 				EEC7AB0C2A08F3DF005614BE /* OperationStateProvider.swift in Sources */,
 				549816351A432BC800A7CE2E /* ZMLoginTranscoder.m in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4552" title="WPB-4552" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4552</a>  [iOS] Stop maintaining a local list of all team members
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This reverts commit 05247251d3b37d4376e7f9395cb0cd56feeafc3f.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

PR https://github.com/wireapp/wire-ios/pull/703 broke searching for users

### Causes (Optional)

A feature branch is needed, where subsequent PRs (and JRIA tickets) restore the functionality.

### Solutions

Revert commit.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
