### PR TITLE
fix: accessing core data model on the right queue for several WireSyncEngine tests

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/E2EE/APSSignalingKeyStoreTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/APSSignalingKeyStoreTests.swift
@@ -30,31 +30,35 @@ class APSSignalingKeyStoreTests: MessagingTest {
     }
 
     func testThatItCreatesKeyStoreFromUserClientWithKeys() {
-        // given
-        let keySize = Int(APSSignalingKeysStore.defaultKeyLengthBytes)
-        let client = self.createSelfClient()
-        let keys = APSSignalingKeysStore.createKeys()
-        client.apsVerificationKey = keys.verificationKey
-        client.apsDecryptionKey = keys.decryptionKey
+        syncMOC.performAndWait {
+            // given
+            let keySize = Int(APSSignalingKeysStore.defaultKeyLengthBytes)
+            let client = self.createSelfClient()
+            let keys = APSSignalingKeysStore.createKeys()
+            client.apsVerificationKey = keys.verificationKey
+            client.apsDecryptionKey = keys.decryptionKey
 
-        // when
-        let keyStore = APSSignalingKeysStore(userClient: client)
+            // when
+            let keyStore = APSSignalingKeysStore(userClient: client)
 
-        // then
-        XCTAssertNotNil(keyStore)
-        XCTAssertEqual(keyStore?.verificationKey.count, keySize)
-        XCTAssertEqual(keyStore?.decryptionKey.count, keySize)
+            // then
+            XCTAssertNotNil(keyStore)
+            XCTAssertEqual(keyStore?.verificationKey.count, keySize)
+            XCTAssertEqual(keyStore?.decryptionKey.count, keySize)
+        }
     }
 
     func testThatItReturnsNilKeyStoreFromUserClientWithoutKeys() {
-        // given
-        let client = self.createSelfClient()
+        syncMOC.performAndWait {
+            // given
+            let client = self.createSelfClient()
 
-        // when
-        let keyStore = APSSignalingKeysStore(userClient: client)
+            // when
+            let keyStore = APSSignalingKeysStore(userClient: client)
 
-        // then
-        XCTAssertNil(keyStore)
+            // then
+            XCTAssertNil(keyStore)
+        }
     }
 
     func testThatItRandomizesTheKeys() {

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+OTR.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+OTR.swift
@@ -713,7 +713,7 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
 
         let expectation = XCTestExpectation(description: "It should call the observer")
 
-        var token: Any? = NotificationInContext.addObserver(
+        let token = NotificationInContext.addObserver(
             name: ZMConversation.failedToDecryptMessageNotificationName,
             context: try XCTUnwrap(userSession?.managedObjectContext.notificationContext),
             object: nil,
@@ -723,7 +723,10 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
                 let cause = note.userInfo["cause"] as? Int
 
                 // THEN
-                XCTAssertEqual(conversation?.remoteIdentifier, object?.remoteIdentifier)
+                XCTAssertEqual(
+                    conversation?.managedObjectContext?.performAndWait { conversation?.remoteIdentifier },
+                    object?.managedObjectContext?.performAndWait { object?.remoteIdentifier }
+                )
                 XCTAssertNotNil(cause)
 
                 if let cause = cause {
@@ -749,8 +752,7 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
 
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
-        // clean up
-        token = nil
+        withExtendedLifetime(token) {}
     }
 
     enum AssetMediumTestUseCase {

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/APIMigrationManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/APIMigrationManagerTests.swift
@@ -39,10 +39,10 @@ class APIMigrationManagerTests: MessagingTest {
 
     // MARK: - Verifying if migration is needed
 
-    func test_itReturnsTrue_WhenMigrationIsNeeded() {
+    func test_itReturnsTrue_WhenMigrationIsNeeded() async {
         // Given
-        let session1 = setupSession(with: "clientID1")
-        let session2 = setupSession(with: "clientID2")
+        let session1 = await setupSession(with: "clientID1")
+        let session2 = await setupSession(with: "clientID2")
 
         let migrationV1 = APIMigrationMock(version: .v1)
         let migrationV2 = APIMigrationMock(version: .v2)
@@ -60,13 +60,13 @@ class APIMigrationManagerTests: MessagingTest {
         // When / Then
         XCTAssertTrue(sut.isMigration(to: .v3, neededForSessions: [session1, session2]))
 
-        tearDownSessions([session1, session2])
+        await tearDownSessions([session1, session2])
     }
 
-    func test_itReturnsFalse_WhenMigrationIsNotNeeded() {
+    func test_itReturnsFalse_WhenMigrationIsNotNeeded() async {
         // Given
-        let session1 = setupSession(with: "clientID1")
-        let session2 = setupSession(with: "clientID2")
+        let session1 = await setupSession(with: "clientID1")
+        let session2 = await setupSession(with: "clientID2")
 
         let migrationV1 = APIMigrationMock(version: .v1)
         let migrationV2 = APIMigrationMock(version: .v2)
@@ -82,7 +82,7 @@ class APIMigrationManagerTests: MessagingTest {
         // When / Then
         XCTAssertFalse(sut.isMigration(to: .v3, neededForSessions: [session1, session2]))
 
-        tearDownSessions([session1, session2])
+        await tearDownSessions([session1, session2])
     }
 
     // MARK: - Migrating sessions
@@ -90,7 +90,7 @@ class APIMigrationManagerTests: MessagingTest {
     func test_itPerformsMigrationsForVersionsHigherThanLastUsed() async {
         // Given
         let clientID = "123abcd"
-        let userSession = setupSession(with: clientID)
+        let userSession = await setupSession(with: clientID)
 
         let migrationV1 = APIMigrationMock(version: .v1)
         let migrationV2 = APIMigrationMock(version: .v2)
@@ -112,15 +112,15 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(migrationV2.performCalls.count, 0)
         XCTAssertEqual(migrationV3.performCalls.count, 1)
 
-        tearDownSession(userSession)
+        await tearDownSession(userSession)
     }
 
     func test_itPerformsMigrationsForMultipleSessions() async {
         // Given
         let clientID1 = "client1"
         let clientID2 = "client2"
-        let userSession1 = setupSession(with: clientID1)
-        let userSession2 = setupSession(with: clientID2)
+        let userSession1 = await setupSession(with: clientID1)
+        let userSession2 = await setupSession(with: clientID2)
 
         let migration = APIMigrationMock(version: .v3)
         let sut = APIMigrationManager(migrations: [migration])
@@ -141,14 +141,14 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(migration.performCalls[1].session, userSession2)
         XCTAssertEqual(migration.performCalls[1].clientID, clientID2)
 
-        tearDownSessions([userSession1, userSession2])
+        await tearDownSessions([userSession1, userSession2])
     }
 
     // MARK: - Persisting last used API version
 
     func test_itPersistsLastUsedAPIVersion_AfterMigrations() async {
         // Given
-        let userSession = stubUserSession()
+        let userSession = await stubUserSession()
         let clientID = "1234abcd"
 
         setupClient(clientID, in: userSession)
@@ -162,17 +162,17 @@ class APIMigrationManagerTests: MessagingTest {
         // Then
         XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID), .v3)
 
-        tearDownSession(userSession)
+        await tearDownSession(userSession)
     }
 
-    func test_itPersistsLastUsedAPIVersion_ForMultipleSessions() {
+    func test_itPersistsLastUsedAPIVersion_ForMultipleSessions() async {
         // Given
         let sut = APIMigrationManager(migrations: [])
 
         let clientID1 = "client1"
         let clientID2 = "client2"
-        let userSession1 = setupSession(with: clientID1)
-        let userSession2 = setupSession(with: clientID2)
+        let userSession1 = await setupSession(with: clientID1)
+        let userSession2 = await setupSession(with: clientID2)
 
         sut.persistLastUsedAPIVersion(for: userSession1, apiVersion: .v1)
         sut.persistLastUsedAPIVersion(for: userSession2, apiVersion: .v1)
@@ -191,21 +191,24 @@ class APIMigrationManagerTests: MessagingTest {
         XCTAssertEqual(sut.lastUsedAPIVersion(for: clientID2), APIVersion.v3)
 
         // clean up
-        tearDownSessions([userSession1, userSession2])
+        await tearDownSessions([userSession1, userSession2])
     }
 
     // MARK: - Helpers
 
+    @MainActor
     private func setupSession(with clientID: String) -> ZMUserSession {
         let session = stubUserSession()
         setupClient(clientID, in: session)
         return session
     }
 
+    @MainActor
     private func tearDownSessions(_ sessions: [ZMUserSession]) {
         sessions.forEach(tearDownSession(_:))
     }
 
+    @MainActor
     private func tearDownSession(_ session: ZMUserSession) {
         if let clientID = session.selfUserClient?.remoteIdentifier {
             APIMigrationManager.removeDefaults(for: clientID)
@@ -228,6 +231,7 @@ class APIMigrationManagerTests: MessagingTest {
         }
     }
 
+    @MainActor
     private func stubUserSession() -> ZMUserSession {
         let mockStrategyDirectory = MockStrategyDirectory()
         let mockUpdateEventProcessor = MockUpdateEventProcessor()

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -1,6 +1,6 @@
-////
+//
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2023 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -177,9 +177,10 @@ class ZMHotFixTests_Integration: MessagingTest {
     }
 
     func testThatItMarksClientsNeedsToUpdateCapabilities_381_0_0() {
-        let selfClient = self.createSelfClient(self.syncMOC)
+        var selfClient: UserClient!
         syncMOC.performGroupedBlock {
             // GIVEN
+            selfClient = self.createSelfClient(self.syncMOC)
             self.syncMOC.setPersistentStoreMetadata("380.0.0", key: "lastSavedVersion")
             self.syncMOC.setPersistentStoreMetadata(NSNumber(value: true), key: "HasHistory")
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -243,29 +243,33 @@ class ZMHotFixTests_Integration: MessagingTest {
 
     func testThatItUpdatesAccessRolesForConversations_432_1_0() {
         var g1: ZMConversation!
-        // GIVEN
-        self.syncMOC.setPersistentStoreMetadata("432.0.1", key: "lastSavedVersion")
-        self.syncMOC.setPersistentStoreMetadata(NSNumber(value: true), key: "HasHistory")
+        syncMOC.performAndWait {
+            // GIVEN
+            self.syncMOC.setPersistentStoreMetadata("432.0.1", key: "lastSavedVersion")
+            self.syncMOC.setPersistentStoreMetadata(NSNumber(value: true), key: "HasHistory")
 
-        g1 = ZMConversation.insertNewObject(in: self.syncMOC)
-        g1.conversationType = .group
-        g1.team = nil
-        g1.updateAccessStatus(accessModes: ConversationAccessMode.teamOnly.stringValue,
-                              accessRoles: [ConversationAccessRoleV2.teamMember.rawValue])
+            g1 = ZMConversation.insertNewObject(in: self.syncMOC)
+            g1.conversationType = .group
+            g1.team = nil
+            g1.updateAccessStatus(accessModes: ConversationAccessMode.teamOnly.stringValue,
+                                  accessRoles: [ConversationAccessRoleV2.teamMember.rawValue])
 
-        self.syncMOC.saveOrRollback()
-        XCTAssertEqual(g1.accessRoles, [ConversationAccessRoleV2.teamMember])
-        XCTAssertEqual(g1.accessMode, ConversationAccessMode.teamOnly)
-        XCTAssertNil(g1.team)
+            self.syncMOC.saveOrRollback()
+            XCTAssertEqual(g1.accessRoles, [ConversationAccessRoleV2.teamMember])
+            XCTAssertEqual(g1.accessMode, ConversationAccessMode.teamOnly)
+            XCTAssertNil(g1.team)
+        }
 
         // WHEN
         let sut = ZMHotFix(syncMOC: self.syncMOC)
         self.performIgnoringZMLogError {
-            sut!.applyPatches(forCurrentVersion: "432.1.0")
+            self.syncMOC.performAndWait {
+                sut!.applyPatches(forCurrentVersion: "432.1.0")
+            }
         }
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = expectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: UpdateAccessRolesAction.notificationName,
                                                       context: self.syncMOC.notificationContext,
                                                       using: { note in

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ApplicationStatusDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ApplicationStatusDirectoryTests.swift
@@ -30,14 +30,16 @@ class ApplicationStatusDirectoryTests: MessagingTest {
         let cookieStorage = ZMPersistentCookieStorage()
         let mockApplication = ApplicationMock()
 
-        sut = ApplicationStatusDirectory(
-            withManagedObjectContext: syncMOC,
-            cookieStorage: cookieStorage,
-            requestCancellation: self,
-            application: mockApplication,
-            syncStateDelegate: self,
-            lastEventIDRepository: lastEventIDRepository
-        )
+        syncMOC.performAndWait {
+            sut = ApplicationStatusDirectory(
+                withManagedObjectContext: syncMOC,
+                cookieStorage: cookieStorage,
+                requestCancellation: self,
+                application: mockApplication,
+                syncStateDelegate: self,
+                lastEventIDRepository: lastEventIDRepository
+            )
+        }
     }
 
     override func tearDown() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

I looked into a flaky test and discovered that Core Data instances were not accessed on the right queue.
Even if it does not resolve the flakiness I consider it a good idea to fix them.

### Solutions

Adopt measures so that race conditions are prevented.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
