### PR TITLE
fix: flaky MLSServiceTests WPB-5481

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -932,7 +932,7 @@ public final class MLSService: MLSServiceInterface {
 
         logger.info("repaired out of sync conversation! (\(groupID.safeForLoggingDescription))")
 
-        appendGapSystemMessage(
+        await appendGapSystemMessage(
             in: conversation,
             context: context
         )
@@ -943,8 +943,8 @@ public final class MLSService: MLSServiceInterface {
     private func appendGapSystemMessage(
         in conversation: ZMConversation,
         context: NSManagedObjectContext
-    ) {
-        context.perform {
+    ) async {
+        await context.perform {
             conversation.appendNewPotentialGapSystemMessage(
                 users: conversation.localParticipants,
                 timestamp: Date()

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -259,10 +259,11 @@ extension ZMConversation {
 
     /// Creates a system message that inform that there are pontential lost messages, and that some users were added to the conversation
     @objc public func appendNewPotentialGapSystemMessage(users: Set<ZMUser>?, timestamp: Date) {
+        guard let context = managedObjectContext else { return }
 
         let previousLastMessage = lastMessage
         let systemMessage = self.appendSystemMessage(type: .potentialGap,
-                                                     sender: ZMUser.selfUser(in: self.managedObjectContext!),
+                                                     sender: ZMUser.selfUser(in: context),
                                                      users: users,
                                                      clients: nil,
                                                      timestamp: timestamp)
@@ -275,7 +276,7 @@ extension ZMConversation {
             // users property of the new one to use old users and calculate the added / removed users
             // from the time the previous one was added
             systemMessage.users = previousLastMessage.users
-            self.managedObjectContext?.delete(previousLastMessage)
+            context.delete(previousLastMessage)
         }
     }
 

--- a/wire-ios-data-model/Tests/TestPlans/AllTests.xctestplan
+++ b/wire-ios-data-model/Tests/TestPlans/AllTests.xctestplan
@@ -13,9 +13,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "MLSServiceTests"
-      ],
       "target" : {
         "containerPath" : "container:WireDataModel.xcodeproj",
         "identifier" : "F9C9A5051CAD5DF10039E10C",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5481" title="WPB-5481" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-5481</a>  [iOS] DataModel: Flaky MLSServiceTests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Flaky tests in `MLSServiceTests`

### Causes 

1. In `MLSService` we have a method `appendGapSystemMessage` that inserts a system message in a conversation. It uses a method that force unwraps the context.
2. In the tests the context is deallocated in `tearDown`
3. The tests are async but `appendGapSystemMessage` isn't. So the tests complete and `tearDown` is called before we append the system message

Result: we force unwrap a `nil` value

### Solutions

Remove force unwrapping + make  `appendGapSystemMessage` async

