### PR TITLE
feat: turn onConferenceInfoChange async WBP-5722

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -60,12 +60,12 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     func generateConferenceInfo(
         parentGroupID: MLSGroupID,
         subconversationGroupID: MLSGroupID
-    ) throws -> MLSConferenceInfo
+    ) async throws -> MLSConferenceInfo
 
     func onConferenceInfoChange(
         parentGroupID: MLSGroupID,
         subConversationGroupID: MLSGroupID
-    ) -> AnyPublisher<MLSConferenceInfo, Never>
+    ) -> AsyncStream<MLSConferenceInfo>
 
     func leaveSubconversationIfNeeded(
         parentQualifiedID: QualifiedID,
@@ -280,7 +280,7 @@ public final class MLSService: MLSServiceInterface {
     public func generateConferenceInfo(
         parentGroupID: MLSGroupID,
         subconversationGroupID: MLSGroupID
-    ) throws -> MLSConferenceInfo {
+    ) async throws -> MLSConferenceInfo {
         do {
             logger.info("generating conference info")
 
@@ -343,15 +343,21 @@ public final class MLSService: MLSServiceInterface {
     public func onConferenceInfoChange(
         parentGroupID: MLSGroupID,
         subConversationGroupID: MLSGroupID
-    ) -> AnyPublisher<MLSConferenceInfo, Never> {
-        return onEpochChanged().filter {
-            $0.isOne(of: parentGroupID, subConversationGroupID)
-        }.compactMap { [weak self] _ in
-            try? self?.generateConferenceInfo(
-                parentGroupID: parentGroupID,
-                subconversationGroupID: subConversationGroupID
-            )
-        }.eraseToAnyPublisher()
+    ) -> AsyncStream<MLSConferenceInfo> {
+        var sequence = onEpochChanged()
+            .buffer(size: 1000, prefetch: .keepFull, whenFull: .dropOldest)
+            .filter({ $0.isOne(of: parentGroupID, subConversationGroupID) })
+            .values
+            .compactMap({ [weak self] _ in
+                try? await self?.generateConferenceInfo(
+                    parentGroupID: parentGroupID,
+                    subconversationGroupID: subConversationGroupID
+                )
+            }).makeAsyncIterator()
+
+        return AsyncStream {
+            await sequence.next()
+        }
     }
 
     // MARK: - Update key material

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -144,6 +144,8 @@ public final class MLSService: MLSServiceInterface {
 
     private static let backendMessageHoldTimeInDays: UInt = 28
 
+    private static let epochChangeBufferSize: Int = 1000
+
     weak var delegate: MLSServiceDelegate?
 
     // MARK: - Life cycle
@@ -345,7 +347,7 @@ public final class MLSService: MLSServiceInterface {
         subConversationGroupID: MLSGroupID
     ) -> AsyncStream<MLSConferenceInfo> {
         var sequence = onEpochChanged()
-            .buffer(size: 1000, prefetch: .keepFull, whenFull: .dropOldest)
+            .buffer(size: Self.epochChangeBufferSize, prefetch: .keepFull, whenFull: .dropOldest)
             .filter({ $0.isOne(of: parentGroupID, subConversationGroupID) })
             .values
             .compactMap({ [weak self] _ in

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1562,10 +1562,10 @@ public class MockMLSServiceInterface: MLSServiceInterface {
 
     public var generateConferenceInfoParentGroupIDSubconversationGroupID_Invocations: [(parentGroupID: MLSGroupID, subconversationGroupID: MLSGroupID)] = []
     public var generateConferenceInfoParentGroupIDSubconversationGroupID_MockError: Error?
-    public var generateConferenceInfoParentGroupIDSubconversationGroupID_MockMethod: ((MLSGroupID, MLSGroupID) throws -> MLSConferenceInfo)?
+    public var generateConferenceInfoParentGroupIDSubconversationGroupID_MockMethod: ((MLSGroupID, MLSGroupID) async throws -> MLSConferenceInfo)?
     public var generateConferenceInfoParentGroupIDSubconversationGroupID_MockValue: MLSConferenceInfo?
 
-    public func generateConferenceInfo(parentGroupID: MLSGroupID, subconversationGroupID: MLSGroupID) throws -> MLSConferenceInfo {
+    public func generateConferenceInfo(parentGroupID: MLSGroupID, subconversationGroupID: MLSGroupID) async throws -> MLSConferenceInfo {
         generateConferenceInfoParentGroupIDSubconversationGroupID_Invocations.append((parentGroupID: parentGroupID, subconversationGroupID: subconversationGroupID))
 
         if let error = generateConferenceInfoParentGroupIDSubconversationGroupID_MockError {
@@ -1573,7 +1573,7 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         }
 
         if let mock = generateConferenceInfoParentGroupIDSubconversationGroupID_MockMethod {
-            return try mock(parentGroupID, subconversationGroupID)
+            return try await mock(parentGroupID, subconversationGroupID)
         } else if let mock = generateConferenceInfoParentGroupIDSubconversationGroupID_MockValue {
             return mock
         } else {
@@ -1584,10 +1584,10 @@ public class MockMLSServiceInterface: MLSServiceInterface {
     // MARK: - onConferenceInfoChange
 
     public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_Invocations: [(parentGroupID: MLSGroupID, subConversationGroupID: MLSGroupID)] = []
-    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod: ((MLSGroupID, MLSGroupID) -> AnyPublisher<MLSConferenceInfo, Never>)?
-    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockValue: AnyPublisher<MLSConferenceInfo, Never>?
+    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod: ((MLSGroupID, MLSGroupID) -> AsyncStream<MLSConferenceInfo>)?
+    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockValue: AsyncStream<MLSConferenceInfo>?
 
-    public func onConferenceInfoChange(parentGroupID: MLSGroupID, subConversationGroupID: MLSGroupID) -> AnyPublisher<MLSConferenceInfo, Never> {
+    public func onConferenceInfoChange(parentGroupID: MLSGroupID, subConversationGroupID: MLSGroupID) -> AsyncStream<MLSConferenceInfo> {
         onConferenceInfoChangeParentGroupIDSubConversationGroupID_Invocations.append((parentGroupID: parentGroupID, subConversationGroupID: subConversationGroupID))
 
         if let mock = onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod {

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1584,10 +1584,10 @@ public class MockMLSServiceInterface: MLSServiceInterface {
     // MARK: - onConferenceInfoChange
 
     public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_Invocations: [(parentGroupID: MLSGroupID, subConversationGroupID: MLSGroupID)] = []
-    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod: ((MLSGroupID, MLSGroupID) -> AsyncStream<MLSConferenceInfo>)?
-    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockValue: AsyncStream<MLSConferenceInfo>?
+    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod: ((MLSGroupID, MLSGroupID) -> AsyncThrowingStream<MLSConferenceInfo, Error>)?
+    public var onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockValue: AsyncThrowingStream<MLSConferenceInfo, Error>?
 
-    public func onConferenceInfoChange(parentGroupID: MLSGroupID, subConversationGroupID: MLSGroupID) -> AsyncStream<MLSConferenceInfo> {
+    public func onConferenceInfoChange(parentGroupID: MLSGroupID, subConversationGroupID: MLSGroupID) -> AsyncThrowingStream<MLSConferenceInfo, Error> {
         onConferenceInfoChangeParentGroupIDSubConversationGroupID_Invocations.append((parentGroupID: parentGroupID, subConversationGroupID: subConversationGroupID))
 
         if let mock = onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod {

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -2457,7 +2457,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         }
 
         // Then
-        let receivedConferenceInfo = await conferenceInfoChanges.first(where: { _ in true })
+        let receivedConferenceInfo = try await conferenceInfoChanges.first(where: { _ in true })
         let expectedConferenceInfo = MLSConferenceInfo(
             epoch: epoch,
             keyData: key,

--- a/wire-ios-sync-engine/Source/Calling/CallSnapshot.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallSnapshot.swift
@@ -41,8 +41,8 @@ struct CallSnapshot {
     let activeSpeakers: [AVSActiveSpeakersChange.ActiveSpeaker]
     let videoGridPresentationMode: VideoGridPresentationMode
     var conversationObserverToken: NSObjectProtocol?
-    var onConferenceInfoChangedToken: AnyCancellable?
     var mlsConferenceStaleParticipantsRemover: MLSConferenceStaleParticipantsRemover?
+    var updateConferenceInfoTask: Task<Void, Error>?
 
     var isDegradedCall: Bool {
         return degradedUser != nil
@@ -70,8 +70,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: videoGridPresentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 
@@ -97,8 +97,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: videoGridPresentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 
@@ -124,8 +124,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: videoGridPresentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 
@@ -151,8 +151,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: videoGridPresentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 
@@ -182,8 +182,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: videoGridPresentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 
@@ -209,8 +209,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: videoGridPresentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 
@@ -236,8 +236,8 @@ struct CallSnapshot {
             activeSpeakers: activeSpeakers,
             videoGridPresentationMode: presentationMode,
             conversationObserverToken: conversationObserverToken,
-            onConferenceInfoChangedToken: onConferenceInfoChangedToken,
-            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover
+            mlsConferenceStaleParticipantsRemover: mlsConferenceStaleParticipantsRemover,
+            updateConferenceInfoTask: updateConferenceInfoTask
         )
     }
 }

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -668,11 +668,15 @@ extension WireCallCenterV3 {
                             subConversationGroupID: subgroupID
                         )
 
-                        for await conferenceInfo in onConferenceInfoChange {
-                            self.avsWrapper.setMLSConferenceInfo(
-                                conversationId: conversationID,
-                                info: conferenceInfo
-                            )
+                        do {
+                            for try await conferenceInfo in onConferenceInfoChange {
+                                self.avsWrapper.setMLSConferenceInfo(
+                                    conversationId: conversationID,
+                                    info: conferenceInfo
+                                )
+                            }
+                        } catch {
+                            WireLogger.calling.error("Error updating conference info: \(error)")
                         }
                     }
 

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -652,22 +652,28 @@ extension WireCallCenterV3 {
                         parentID: parentGroupID
                     )
 
-                    let initialConferenceInfo = try mlsService.generateConferenceInfo(
-                        parentGroupID: parentGroupID,
-                        subconversationGroupID: subgroupID
-                    )
-
-                    let onConferenceInfoChanged = mlsService.onConferenceInfoChange(
-                        parentGroupID: parentGroupID,
-                        subConversationGroupID: subgroupID
-                    ).prepend(initialConferenceInfo)
-
-                    let token = onConferenceInfoChanged.sink { [weak self] newConferenceInfo in
-                        Self.logger.debug("passing MLS conference info to AVS")
-                        self?.avsWrapper.setMLSConferenceInfo(
-                            conversationId: conversationID,
-                            info: newConferenceInfo
+                    let updateConferenceInfoTask = Task {
+                        let initialConferenceInfo = try await mlsService.generateConferenceInfo(
+                            parentGroupID: parentGroupID,
+                            subconversationGroupID: subgroupID
                         )
+
+                        self.avsWrapper.setMLSConferenceInfo(
+                            conversationId: conversationID,
+                            info: initialConferenceInfo
+                        )
+
+                        let onConferenceInfoChange = mlsService.onConferenceInfoChange(
+                            parentGroupID: parentGroupID,
+                            subConversationGroupID: subgroupID
+                        )
+
+                        for await conferenceInfo in onConferenceInfoChange {
+                            self.avsWrapper.setMLSConferenceInfo(
+                                conversationId: conversationID,
+                                info: conferenceInfo
+                            )
+                        }
                     }
 
                     let staleParticipantsRemover = MLSConferenceStaleParticipantsRemover(
@@ -682,7 +688,7 @@ extension WireCallCenterV3 {
                     if var snapshot = self.callSnapshots[conversationID] {
                         snapshot.qualifiedID = parentQualifiedID
                         snapshot.groupIDs = (parentGroupID, subgroupID)
-                        snapshot.onConferenceInfoChangedToken = token
+                        snapshot.updateConferenceInfoTask = updateConferenceInfoTask
                         snapshot.mlsConferenceStaleParticipantsRemover = staleParticipantsRemover
                         self.callSnapshots[conversationID] = snapshot
                     }
@@ -721,7 +727,9 @@ extension WireCallCenterV3 {
         }
 
         if let mlsParentIDs = mlsParentIDS(for: conversationId) {
-            cancelPendingStaleParticipantsRemovals(callSnapshot: callSnapshots[conversationId])
+            let snapshot = callSnapshots[conversationId]
+            snapshot?.updateConferenceInfoTask?.cancel()
+            cancelPendingStaleParticipantsRemovals(callSnapshot: snapshot)
             leaveSubconversation(
                 parentQualifiedID: mlsParentIDs.0,
                 parentGroupID: mlsParentIDs.1

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -869,7 +869,7 @@ class WireCallCenterV3Tests: MessagingTest {
         let conferenceInfoChangeSubject = PassthroughSubject<MLSConferenceInfo, Never>()
         mlsService.onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod = { _, _ in
             var iterator = conferenceInfoChangeSubject.values.makeAsyncIterator()
-            return AsyncStream {
+            return AsyncThrowingStream {
                 await iterator.next()
             }
         }

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -868,7 +868,10 @@ class WireCallCenterV3Tests: MessagingTest {
         // So we can inform of new conference infos
         let conferenceInfoChangeSubject = PassthroughSubject<MLSConferenceInfo, Never>()
         mlsService.onConferenceInfoChangeParentGroupIDSubConversationGroupID_MockMethod = { _, _ in
-            return conferenceInfoChangeSubject.eraseToAnyPublisher()
+            var iterator = conferenceInfoChangeSubject.values.makeAsyncIterator()
+            return AsyncStream {
+                await iterator.next()
+            }
         }
 
         try checkThatItPostsNotification(
@@ -879,6 +882,8 @@ class WireCallCenterV3Tests: MessagingTest {
             // when
             try block()
         }
+
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
 
         let didSetConferenceInfo2 = expectation(description: "didSetConferenceInfo2")
         mockAVSWrapper.mockSetMLSConferenceInfo = {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Turn `generateConferenceInfo` async and `onConferenceInfoChange ` into an async sequence. This in preparation for upgrading CC which will force this change.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
