### PR TITLE
fix: conflicting testplan configuration

### DIFF
--- a/wire-ios-sync-engine/Tests/TestsPlans/IntegrationTests.xctestplan
+++ b/wire-ios-sync-engine/Tests/TestsPlans/IntegrationTests.xctestplan
@@ -49,9 +49,6 @@
         "value" : "MockTransportRequests"
       }
     ],
-    "mallocStackLoggingOptions" : {
-      "loggingType" : "liveAllocations"
-    },
     "targetForVariableExpansion" : {
       "containerPath" : "container:WireSyncEngine.xcodeproj",
       "identifier" : "549815921A43232400A7CE2E",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Unsets "Malloc Stack Logging" in WireSyncEngine IntegrationTests.xctestplan, since Xcode marks it as conflicting configuration.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
