### PR TITLE
fix: Crash in AddParticipantsViewControllerSnapshotTests

### DIFF
--- a/wire-ios/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
@@ -70,7 +70,6 @@ final class AddParticipantsViewControllerSnapshotTests: BaseSnapshotTestCase {
     }
 
     func testForAddParticipantsButtonIsShown() {
-
         let conversation = MockGroupDetailsConversation()
         sut = AddParticipantsViewController(context: .add(conversation), userSession: userSession)
         let user = MockUserType.createUser(name: "Bill")

--- a/wire-ios/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
@@ -49,7 +49,8 @@ final class AddParticipantsViewControllerSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSelfUser = .createDefaultSelfUser()
+        SelfUser.setupMockSelfUser(inTeam: UUID())
+        mockSelfUser = SelfUser.provider?.providedSelfUser as? MockUserType
         userSession = UserSessionMock(mockUser: mockSelfUser)
     }
 
@@ -69,6 +70,7 @@ final class AddParticipantsViewControllerSnapshotTests: BaseSnapshotTestCase {
     }
 
     func testForAddParticipantsButtonIsShown() {
+
         let conversation = MockGroupDetailsConversation()
         sut = AddParticipantsViewController(context: .add(conversation), userSession: userSession)
         let user = MockUserType.createUser(name: "Bill")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Running AddParticipantsViewControllerSnapshotTests would crash. 👇 

<img width="1049" alt="Screenshot 2023-12-13 at 09 29 05" src="https://github.com/wireapp/wire-ios/assets/10944108/798977d3-19e7-4ea8-914f-0b2c19168777">

With this PR I fixed the crash by setting providedSelfUser through the SelfUser.provider.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
