### PR TITLE
fix: unit test which asserts string formatted time

### DIFF
--- a/wire-ios/Wire-iOS Tests/DateFormatterTests.swift
+++ b/wire-ios/Wire-iOS Tests/DateFormatterTests.swift
@@ -128,19 +128,22 @@ final class DateFormatterTests: XCTestCase {
     func testWr_formattedDateForTwoHourBefore() {
         // GIVEN
         let twoHourBefore = Calendar.current.date(byAdding: .hour, value: -2, to: Date())!
-        var hour = Calendar.current.component(.hour, from: twoHourBefore)
-
-        // to fit US 12hr format
-        if hour == 0 {
-            hour = 12
-        }
+        let hour = Calendar.current.component(.hour, from: twoHourBefore)
+        let minute = Calendar.current.component(.minute, from: twoHourBefore)
+        let dateFormatter = DateFormatter()
 
         // WHEN
         let dateString = twoHourBefore.formattedDate
 
         // THEN
-        // If two hours before is yesterday, dateString looks like "Yesterday, 11:17 PM"
-        XCTAssertTrue(dateString.contains(String(hour)), "hour is \(hour), dateString is \(dateString)")
+        dateFormatter.dateFormat = "h:mm\u{202f}a"
+        let expected12HoursString = dateFormatter.string(from: twoHourBefore)
+        dateFormatter.dateFormat = "H:mm"
+        let expected24HoursString = dateFormatter.string(from: twoHourBefore)
+        XCTAssert(
+            dateString.contains(expected24HoursString) || dateString.contains(expected12HoursString),
+            "dateString '\(dateString)' neither contains '\(expected12HoursString)' nor '\(expected24HoursString)'"
+        )
     }
 
     func testWr_formattedDateForNow() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A unit test asserting a formatted time string didn't work with each hour value. This PR fixes it.
### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
