### PR TITLE
refactor: extract commit sending into separate actor WPB-2091

### DIFF
--- a/wire-ios-data-model/Source/MLS/CommitError.swift
+++ b/wire-ios-data-model/Source/MLS/CommitError.swift
@@ -21,12 +21,12 @@ import Foundation
 enum CommitError: Error, Equatable {
 
     case failedToGenerateCommit
-    case failedToSendCommit(recovery: Recovery)
+    case failedToSendCommit(recovery: RecoveryStrategy)
     case failedToMergeCommit
     case failedToClearCommit
     case noPendingProposals
 
-    enum Recovery: Equatable {
+    enum RecoveryStrategy: Equatable {
 
         /// Perform a quick sync, then commit pending proposals.
         ///
@@ -60,7 +60,7 @@ enum CommitError: Error, Equatable {
     }
 }
 
-extension CommitError.Recovery {
+extension CommitError.RecoveryStrategy {
 
     /// Whether the pending commit should be discarded.
 

--- a/wire-ios-data-model/Source/MLS/CommitError.swift
+++ b/wire-ios-data-model/Source/MLS/CommitError.swift
@@ -1,0 +1,76 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum CommitError: Error, Equatable {
+
+    case failedToGenerateCommit
+    case failedToSendCommit(recovery: Recovery)
+    case failedToMergeCommit
+    case failedToClearCommit
+    case noPendingProposals
+
+    enum Recovery: Equatable {
+
+        /// Perform a quick sync, then commit pending proposals.
+        ///
+        /// Core Crypto can automatically recover if it processes all
+        /// incoming handshake messages. It will migrate any pending
+        /// commits/proposals, which can then be committed as pending
+        /// proposals.
+
+        case commitPendingProposalsAfterQuickSync
+
+        /// Perform a quick sync, then retry the action in its entirety.
+        ///
+        /// Core Crypto can not automatically recover by itself. It needs
+        /// to process incoming handshake messages then generate a new commit.
+
+        case retryAfterQuickSync
+
+        /// Repair (re-join) the group and retry the action
+        ///
+        /// We may have missed a few commits so we will rejoin the group
+        /// and try again.
+
+        case retryAfterRepairingGroup
+
+        /// Abort the action and inform the user.
+        ///
+        /// There is no way to automatically recover from the error.
+
+        case giveUp
+
+    }
+}
+
+extension CommitError.Recovery {
+
+    /// Whether the pending commit should be discarded.
+
+    var shouldDiscardCommit: Bool {
+        switch self {
+        case .commitPendingProposalsAfterQuickSync:
+            return false
+
+        case .retryAfterQuickSync, .giveUp, .retryAfterRepairingGroup:
+            return true
+        }
+    }
+}

--- a/wire-ios-data-model/Source/MLS/CommitSender.swift
+++ b/wire-ios-data-model/Source/MLS/CommitSender.swift
@@ -1,0 +1,242 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Combine
+import WireCoreCrypto
+
+// sourcery: AutoMockable
+public protocol CommitSending {
+
+    func sendCommitBundle(
+        _ bundle: CommitBundle,
+        for groupID: MLSGroupID
+    ) async throws -> [ZMUpdateEvent]
+
+    func sendExternalCommitBundle(
+        _ bundle: CommitBundle,
+        for groupID: MLSGroupID
+    ) async throws -> [ZMUpdateEvent]
+
+    func onEpochChanged() -> AnyPublisher<MLSGroupID, Never>
+
+}
+
+public actor CommitSender: CommitSending {
+
+    // MARK: - Properties
+
+    private let coreCryptoProvider: CoreCryptoProviderProtocol
+    private let notificationContext: NotificationContext
+    private let actionsProvider: MLSActionsProviderProtocol
+    private let onEpochChangedSubject = PassthroughSubject<MLSGroupID, Never>()
+
+    private var coreCrypto: SafeCoreCryptoProtocol {
+        get throws {
+            try coreCryptoProvider.coreCrypto(requireMLS: true)
+        }
+    }
+
+    // MARK: - Life cycle
+
+    public init(
+        coreCryptoProvider: CoreCryptoProviderProtocol,
+        notificationContext: NotificationContext
+    ) {
+        self.init(
+            coreCryptoProvider: coreCryptoProvider,
+            notificationContext: notificationContext,
+            actionsProvider: nil
+        )
+    }
+
+    init(
+        coreCryptoProvider: CoreCryptoProviderProtocol,
+        notificationContext: NotificationContext,
+        actionsProvider: MLSActionsProviderProtocol? = nil
+    ) {
+        self.coreCryptoProvider = coreCryptoProvider
+        self.notificationContext = notificationContext
+        self.actionsProvider = actionsProvider ?? MLSActionsProvider()
+    }
+
+    // MARK: - Public interface
+
+    public func sendCommitBundle(
+        _ bundle: CommitBundle,
+        for groupID: MLSGroupID
+    ) async throws -> [ZMUpdateEvent] {
+
+        do {
+            WireLogger.mls.info("sending commit bundle for group (\(groupID.safeForLoggingDescription))")
+            let events = try await sendCommitBundle(bundle)
+
+            WireLogger.mls.info("merging commit for group (\(groupID.safeForLoggingDescription))")
+            try await mergeCommit(in: groupID)
+
+            return events
+
+        } catch let error as SendCommitBundleAction.Failure {
+            WireLogger.mls.warn("failed to send commit bundle: \(String(describing: error))")
+
+            let recoveryStrategy = CommitError.Recovery(from: error)
+
+            if recoveryStrategy.shouldDiscardCommit {
+                try await discardPendingCommit(in: groupID)
+            }
+
+            throw CommitError.failedToSendCommit(recovery: recoveryStrategy)
+        }
+    }
+
+    public func sendExternalCommitBundle(
+        _ bundle: CommitBundle,
+        for groupID: MLSGroupID
+    ) async throws -> [ZMUpdateEvent] {
+
+        do {
+            WireLogger.mls.info("sending external commit bundle for group (\(groupID.safeForLoggingDescription))")
+            let events = try await sendCommitBundle(bundle)
+
+            WireLogger.mls.info("merging pending group for (\(groupID.safeForLoggingDescription))")
+            try await mergePendingGroup(in: groupID)
+
+            return events
+
+        } catch let error as SendCommitBundleAction.Failure {
+            WireLogger.mls.warn("failed to send external commit bundle: \(String(describing: error))")
+
+            let recoveryStrategy = ExternalCommitError.Recovery(from: error)
+
+            if recoveryStrategy.shouldClearPendingGroup {
+                try await clearPendingGroup(in: groupID)
+            }
+
+            throw ExternalCommitError.failedToSendCommit(recovery: recoveryStrategy)
+        }
+    }
+
+    nonisolated
+    public func onEpochChanged() -> AnyPublisher<MLSGroupID, Never> {
+        return onEpochChangedSubject.eraseToAnyPublisher()
+    }
+
+    // MARK: - Helpers
+
+    private func sendCommitBundle(_ bundle: CommitBundle) async throws -> [ZMUpdateEvent] {
+        return try await actionsProvider.sendCommitBundle(
+            bundle.transportData(),
+            in: notificationContext
+        )
+    }
+
+    // MARK: - Post sending
+
+    private func mergeCommit(in groupID: MLSGroupID) async throws {
+        do {
+            WireLogger.mls.info("merging commit for group (\(groupID.safeForLoggingDescription))")
+            try await coreCrypto.perform {
+                try $0.commitAccepted(conversationId: groupID.bytes)
+            }
+            onEpochChangedSubject.send(groupID)
+        } catch {
+            WireLogger.mls.error("failed to merge commit for group (\(groupID.safeForLoggingDescription))")
+            throw CommitError.failedToMergeCommit
+        }
+    }
+
+    private func discardPendingCommit(in groupID: MLSGroupID) async throws {
+        do {
+            WireLogger.mls.info("discarding pending commit for group (\(groupID.safeForLoggingDescription))")
+            try await coreCrypto.perform {
+                try $0.clearPendingCommit(conversationId: groupID.bytes)
+            }
+        } catch {
+            WireLogger.mls.error("failed to discard pending commit for group (\(groupID.safeForLoggingDescription))")
+            throw CommitError.failedToClearCommit
+        }
+    }
+
+    private func mergePendingGroup(in groupID: MLSGroupID) async throws {
+        do {
+            WireLogger.mls.info("merging pending group (\(groupID.safeForLoggingDescription))")
+            try await coreCrypto.perform {
+                try $0.mergePendingGroupFromExternalCommit(
+                    conversationId: groupID.bytes
+                )
+            }
+        } catch {
+            WireLogger.mls.error("failed to merge pending group (\(groupID.safeForLoggingDescription))")
+            throw ExternalCommitError.failedToMergePendingGroup
+        }
+    }
+
+    private func clearPendingGroup(in groupID: MLSGroupID) async throws {
+        do {
+            WireLogger.mls.info("clearing pending group (\(groupID.safeForLoggingDescription))")
+            try await coreCrypto.perform {
+                try $0.clearPendingGroupFromExternalCommit(conversationId: groupID.bytes)
+            }
+        } catch {
+            WireLogger.mls.error("failed to clear pending group (\(groupID.safeForLoggingDescription))")
+            throw ExternalCommitError.failedToClearPendingGroup
+        }
+    }
+}
+
+private extension CommitError.Recovery {
+
+    init(from error: SendCommitBundleAction.Failure) {
+        switch error {
+        case .mlsClientMismatch:
+            self = .retryAfterQuickSync
+        case .mlsCommitMissingReferences:
+            self = .commitPendingProposalsAfterQuickSync
+        case .mlsStaleMessage:
+            self = .retryAfterRepairingGroup
+        default:
+            self = .giveUp
+        }
+    }
+
+}
+
+private extension ExternalCommitError.Recovery {
+
+    init(from error: SendCommitBundleAction.Failure) {
+        switch error {
+        case .mlsStaleMessage:
+            self = .retry
+        default:
+            self = .giveUp
+        }
+
+    }
+}
+
+extension CommitBundle {
+
+    func transportData() -> Data {
+        var data = Data()
+        data.append(Data(commit))
+        data.append(Data(welcome ?? []))
+        data.append(Data(groupInfo.payload))
+        return data
+    }
+
+}

--- a/wire-ios-data-model/Source/MLS/CommitSender.swift
+++ b/wire-ios-data-model/Source/MLS/CommitSender.swift
@@ -94,7 +94,7 @@ public actor CommitSender: CommitSending {
         } catch let error as SendCommitBundleAction.Failure {
             WireLogger.mls.warn("failed to send commit bundle: \(String(describing: error))")
 
-            let recoveryStrategy = CommitError.Recovery(from: error)
+            let recoveryStrategy = CommitError.RecoveryStrategy(from: error)
 
             if recoveryStrategy.shouldDiscardCommit {
                 try await discardPendingCommit(in: groupID)
@@ -121,7 +121,7 @@ public actor CommitSender: CommitSending {
         } catch let error as SendCommitBundleAction.Failure {
             WireLogger.mls.warn("failed to send external commit bundle: \(String(describing: error))")
 
-            let recoveryStrategy = ExternalCommitError.Recovery(from: error)
+            let recoveryStrategy = ExternalCommitError.RecoveryStrategy(from: error)
 
             if recoveryStrategy.shouldClearPendingGroup {
                 try await clearPendingGroup(in: groupID)
@@ -199,7 +199,7 @@ public actor CommitSender: CommitSending {
     }
 }
 
-private extension CommitError.Recovery {
+private extension CommitError.RecoveryStrategy {
 
     init(from error: SendCommitBundleAction.Failure) {
         switch error {
@@ -216,7 +216,7 @@ private extension CommitError.Recovery {
 
 }
 
-private extension ExternalCommitError.Recovery {
+private extension ExternalCommitError.RecoveryStrategy {
 
     init(from error: SendCommitBundleAction.Failure) {
         switch error {

--- a/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
+++ b/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
@@ -1,0 +1,52 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum ExternalCommitError: Error, Equatable {
+
+    case failedToSendCommit(recovery: Recovery)
+    case failedToMergePendingGroup
+    case failedToClearPendingGroup
+
+    enum Recovery {
+
+        /// Retry the action from the beginning
+        case retry
+
+        /// Abort the action and log the error
+        case giveUp
+
+    }
+}
+
+extension ExternalCommitError.Recovery {
+
+    /// Whether the pending group should be cleared
+
+    var shouldClearPendingGroup: Bool {
+        switch self {
+        case .retry:
+            return false
+
+        case .giveUp:
+            return true
+        }
+    }
+
+}

--- a/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
+++ b/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
@@ -20,11 +20,11 @@ import Foundation
 
 enum ExternalCommitError: Error, Equatable {
 
-    case failedToSendCommit(recovery: Recovery)
+    case failedToSendCommit(recovery: RecoveryStrategy)
     case failedToMergePendingGroup
     case failedToClearPendingGroup
 
-    enum Recovery {
+    enum RecoveryStrategy {
 
         /// Retry the action from the beginning
         case retry
@@ -35,7 +35,7 @@ enum ExternalCommitError: Error, Equatable {
     }
 }
 
-extension ExternalCommitError.Recovery {
+extension ExternalCommitError.RecoveryStrategy {
 
     /// Whether the pending group should be cleared
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -205,8 +205,10 @@ public final class MLSService: MLSServiceInterface {
         self.coreCryptoProvider = coreCryptoProvider
         self.mlsActionExecutor = mlsActionExecutor ?? MLSActionExecutor(
             coreCryptoProvider: coreCryptoProvider,
-            context: context,
-            actionsProvider: actionsProvider
+            commitSender: CommitSender(
+                coreCryptoProvider: coreCryptoProvider,
+                notificationContext: context.notificationContext
+            )
         )
         self.conversationEventProcessor = conversationEventProcessor
         self.staleKeyMaterialDetector = staleKeyMaterialDetector
@@ -1378,7 +1380,7 @@ public final class MLSService: MLSServiceInterface {
             await conversationEventProcessor.processConversationEvents(events)
             clearPendingProposalCommitDate(for: groupID)
             delegate?.mlsServiceDidCommitPendingProposal(for: groupID)
-        } catch MLSActionExecutor.Error.noPendingProposals {
+        } catch CommitError.noPendingProposals {
             logger.info("no proposals to commit in group (\(groupID.safeForLoggingDescription))...")
             clearPendingProposalCommitDate(for: groupID)
         } catch {
@@ -1404,41 +1406,40 @@ public final class MLSService: MLSServiceInterface {
         for groupID: MLSGroupID,
         operation: @escaping () async throws -> Void
     ) async throws {
-        typealias Error = MLSActionExecutor.Error
 
         do {
             try await operation()
 
-        } catch Error.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync) {
+        } catch CommitError.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync) {
             logger.warn("failed to send commit, syncing then committing pending proposals...")
             await syncStatus.performQuickSync()
             logger.info("sync finished, committing pending proposals...")
             try await commitPendingProposals(in: groupID)
 
-        } catch Error.failedToSendCommit(recovery: .retryAfterQuickSync) {
+        } catch CommitError.failedToSendCommit(recovery: .retryAfterQuickSync) {
             logger.warn("failed to send commit, syncing then retrying operation...")
             await syncStatus.performQuickSync()
             logger.info("sync finished, retying operation...")
             try await retryOnCommitFailure(for: groupID, operation: operation)
 
-        } catch Error.failedToSendCommit(recovery: .retryAfterRepairingGroup) {
+        } catch CommitError.failedToSendCommit(recovery: .retryAfterRepairingGroup) {
             logger.warn("failed to send commit, repairing group then retrying operation...")
             await fetchAndRepairGroup(with: groupID)
             logger.info("repair finished, retrying operation...")
             try await operation()
 
-        } catch Error.failedToSendCommit(recovery: .giveUp) {
+        } catch CommitError.failedToSendCommit(recovery: .giveUp) {
             logger.warn("failed to send commit, giving up...")
             // TODO: [John] inform user
-            throw Error.failedToSendCommit(recovery: .giveUp)
+            throw CommitError.failedToSendCommit(recovery: .giveUp)
 
-        } catch Error.failedToSendExternalCommit(recovery: .retry) {
+        } catch ExternalCommitError.failedToSendCommit(recovery: .retry) {
             logger.warn("failed to send external commit, retrying operation...")
             try await retryOnCommitFailure(for: groupID, operation: operation)
 
-        } catch Error.failedToSendExternalCommit(recovery: .giveUp) {
+        } catch ExternalCommitError.failedToSendCommit(recovery: .giveUp) {
             logger.warn("failed to send external commit, giving up...")
-            throw MLSActionExecutor.Error.failedToSendExternalCommit(recovery: .giveUp)
+            throw ExternalCommitError.failedToSendCommit(recovery: .giveUp)
 
         }
     }

--- a/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
@@ -22,6 +22,7 @@ import WireCoreCrypto
 // MARK: - Protocols
 
 public protocol SafeCoreCryptoProtocol {
+    func perform<T>(_ block: (CoreCryptoProtocol) async throws -> T) async rethrows -> T
     func perform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T
     func unsafePerform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T
     func mlsInit(clientID: String) throws
@@ -31,6 +32,7 @@ public protocol SafeCoreCryptoProtocol {
 let defaultCipherSuite = CiphersuiteName.mls128Dhkemx25519Aes128gcmSha256Ed25519
 
 public class SafeCoreCrypto: SafeCoreCryptoProtocol {
+    
     public enum CoreCryptoSetupFailure: Error, Equatable {
         case failedToGetClientIDBytes
     }
@@ -112,6 +114,11 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
         }
 
         return result
+    }
+
+    // TODO: Remove when async core crypto is supported
+    public func perform<T>(_ block: (WireCoreCrypto.CoreCryptoProtocol) async throws -> T) async rethrows -> T {
+        try await block(coreCrypto)
     }
 
     public func unsafePerform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T {

--- a/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
@@ -32,7 +32,7 @@ public protocol SafeCoreCryptoProtocol {
 let defaultCipherSuite = CiphersuiteName.mls128Dhkemx25519Aes128gcmSha256Ed25519
 
 public class SafeCoreCrypto: SafeCoreCryptoProtocol {
-    
+
     public enum CoreCryptoSetupFailure: Error, Equatable {
         case failedToGetClientIDBytes
     }

--- a/wire-ios-data-model/Support/Sourcery/config.yml
+++ b/wire-ios-data-model/Support/Sourcery/config.yml
@@ -6,4 +6,4 @@ output:
   ./generated
 args:
   autoMockableTestableImports: ["WireDataModel"]
-  autoMockableImports: ["LocalAuthentication", "Combine"]
+  autoMockableImports: ["LocalAuthentication", "Combine", "WireCoreCrypto"]

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -33,6 +33,7 @@ import AppKit
 
 import LocalAuthentication
 import Combine
+import WireCoreCrypto
 
 @testable import WireDataModel
 
@@ -55,6 +56,79 @@ import Combine
 
 
 
+
+public class MockCommitSending: CommitSending {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - sendCommitBundle
+
+    public var sendCommitBundleFor_Invocations: [(bundle: CommitBundle, groupID: MLSGroupID)] = []
+    public var sendCommitBundleFor_MockError: Error?
+    public var sendCommitBundleFor_MockMethod: ((CommitBundle, MLSGroupID) async throws -> [ZMUpdateEvent])?
+    public var sendCommitBundleFor_MockValue: [ZMUpdateEvent]?
+
+    public func sendCommitBundle(_ bundle: CommitBundle, for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        sendCommitBundleFor_Invocations.append((bundle: bundle, groupID: groupID))
+
+        if let error = sendCommitBundleFor_MockError {
+            throw error
+        }
+
+        if let mock = sendCommitBundleFor_MockMethod {
+            return try await mock(bundle, groupID)
+        } else if let mock = sendCommitBundleFor_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `sendCommitBundleFor`")
+        }
+    }
+
+    // MARK: - sendExternalCommitBundle
+
+    public var sendExternalCommitBundleFor_Invocations: [(bundle: CommitBundle, groupID: MLSGroupID)] = []
+    public var sendExternalCommitBundleFor_MockError: Error?
+    public var sendExternalCommitBundleFor_MockMethod: ((CommitBundle, MLSGroupID) async throws -> [ZMUpdateEvent])?
+    public var sendExternalCommitBundleFor_MockValue: [ZMUpdateEvent]?
+
+    public func sendExternalCommitBundle(_ bundle: CommitBundle, for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+        sendExternalCommitBundleFor_Invocations.append((bundle: bundle, groupID: groupID))
+
+        if let error = sendExternalCommitBundleFor_MockError {
+            throw error
+        }
+
+        if let mock = sendExternalCommitBundleFor_MockMethod {
+            return try await mock(bundle, groupID)
+        } else if let mock = sendExternalCommitBundleFor_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `sendExternalCommitBundleFor`")
+        }
+    }
+
+    // MARK: - onEpochChanged
+
+    public var onEpochChanged_Invocations: [Void] = []
+    public var onEpochChanged_MockMethod: (() -> AnyPublisher<MLSGroupID, Never>)?
+    public var onEpochChanged_MockValue: AnyPublisher<MLSGroupID, Never>?
+
+    public func onEpochChanged() -> AnyPublisher<MLSGroupID, Never> {
+        onEpochChanged_Invocations.append(())
+
+        if let mock = onEpochChanged_MockMethod {
+            return mock()
+        } else if let mock = onEpochChanged_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `onEpochChanged`")
+        }
+    }
+
+}
 
 public class MockConversationEventProcessorProtocol: ConversationEventProcessorProtocol {
 

--- a/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
@@ -1,0 +1,253 @@
+//
+// Wire
+// Copyright (C) 2023 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+import WireCoreCrypto
+@testable import WireDataModel
+@testable import WireDataModelSupport
+
+class CommitSenderTests: ZMBaseManagedObjectTest {
+
+    // MARK: - Properties
+
+    private var sut: CommitSender!
+    private var mockActionsProvider: MockMLSActionsProviderProtocol!
+    private var mockCoreCrypto: MockCoreCrypto!
+    private var mockCoreCryptoProvider: MockCoreCryptoProviderProtocol!
+    private var mockClearPendingCommitInvocations: [[Byte]]!
+    private var mockClearPendingGroupInvocations: [[Byte]]!
+
+    private lazy var groupID: MLSGroupID = .random()
+    private lazy var commitBundle = CommitBundle(
+        welcome: nil,
+        commit: .random(),
+        groupInfo: .init(
+            encryptionType: .plaintext,
+            ratchetTreeType: .full,
+            payload: .random()
+        )
+    )
+
+    // MARK: - Life cycle
+
+    override func setUp() {
+        super.setUp()
+
+        mockCoreCrypto = MockCoreCrypto()
+        mockActionsProvider = MockMLSActionsProviderProtocol()
+        mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
+        mockCoreCryptoProvider.coreCryptoRequireMLS_MockValue = MockSafeCoreCrypto(coreCrypto: mockCoreCrypto)
+
+        sut = CommitSender(
+            coreCryptoProvider: mockCoreCryptoProvider,
+            notificationContext: syncMOC.notificationContext,
+            actionsProvider: mockActionsProvider
+        )
+
+        mockClearPendingCommitInvocations = []
+        mockCoreCrypto.mockClearPendingCommit = { [self] groupID in
+            mockClearPendingCommitInvocations.append(groupID)
+        }
+
+        mockClearPendingGroupInvocations = []
+        mockCoreCrypto.mockClearPendingGroupFromExternalCommit = { [self] groupID in
+            mockClearPendingGroupInvocations.append(groupID)
+        }
+    }
+
+    override func tearDown() {
+        mockCoreCrypto = nil
+        mockCoreCryptoProvider = nil
+        mockActionsProvider = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Send Commit
+
+    func test_SendCommitBundle_Success() async throws {
+        // Given
+        let event = ZMUpdateEvent()
+
+        // Mock action provider
+        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+            return [event]
+        }
+
+        // Mock core crypto
+        var commitAcceptedInvocations = [[Byte]]()
+        mockCoreCrypto.mockCommitAccepted = { groupID in
+            commitAcceptedInvocations.append(groupID)
+        }
+
+        // When
+        let receivedEvents = try await sut.sendCommitBundle(commitBundle, for: groupID)
+
+        // Then
+        // Send commit bundle was called on the action provider
+        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
+        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, commitBundle.transportData())
+
+        // Commit accepted was called
+        XCTAssertEqual(commitAcceptedInvocations.count, 1)
+        XCTAssertEqual(commitAcceptedInvocations.first, groupID.bytes)
+
+        // Events were received
+        XCTAssertEqual(receivedEvents, [event])
+    }
+
+    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_RetryAfterQuickSync() async {
+        await assertSendCommitBundleThrows(
+            withRecovery: .retryAfterQuickSync,
+            for: .mlsClientMismatch,
+            shouldClearPendingCommit: true
+        )
+    }
+
+    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_CommitPendingProposalsAfterQuickSync() async {
+        await assertSendCommitBundleThrows(
+            withRecovery: .commitPendingProposalsAfterQuickSync,
+            for: .mlsCommitMissingReferences,
+            shouldClearPendingCommit: false
+        )
+    }
+
+    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_RetryAfterRepairingGroup() async {
+        await assertSendCommitBundleThrows(
+            withRecovery: .retryAfterRepairingGroup,
+            for: .mlsStaleMessage,
+            shouldClearPendingCommit: true
+        )
+    }
+
+    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_GiveUp() async {
+        await assertSendCommitBundleThrows(
+            withRecovery: .giveUp,
+            for: .unknown(status: 400, label: "", message: ""),
+            shouldClearPendingCommit: true
+        )
+    }
+
+    private func assertSendCommitBundleThrows(
+        withRecovery recovery: CommitError.Recovery,
+        for error: SendCommitBundleAction.Failure,
+        shouldClearPendingCommit: Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        // Given
+        // Mock action provider throwing an error
+        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+            throw error
+        }
+
+        // Then
+        await assertItThrows(error: CommitError.failedToSendCommit(recovery: recovery)) {
+            // When
+            _ = try await sut.sendCommitBundle(commitBundle, for: groupID)
+        }
+
+        if shouldClearPendingCommit {
+            // It clears pending commit
+            XCTAssertEqual(mockClearPendingCommitInvocations.count, 1)
+            XCTAssertEqual(mockClearPendingCommitInvocations.first, groupID.bytes)
+        } else {
+            // It doesn't clear pending commit
+            XCTAssertEqual(mockClearPendingCommitInvocations.count, 0)
+        }
+    }
+
+    // MARK: - Send External Commit
+
+    func test_SendExternalCommitBundle_Success() async throws {
+        // Given
+        let event = ZMUpdateEvent()
+
+        // Mock action provider
+        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+            return [event]
+        }
+
+        // Mock core crypto
+        var mergePendingGroupInvocations = [[Byte]]()
+        mockCoreCrypto.mockMergePendingGroupFromExternalCommit = { groupID in
+            mergePendingGroupInvocations.append(groupID)
+        }
+
+        // When
+        let receivedEvents = try await sut.sendExternalCommitBundle(commitBundle, for: groupID)
+
+        // Then
+        // Send commit bundle was called on the action provider
+        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
+        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, commitBundle.transportData())
+
+        // Commit accepted was called
+        XCTAssertEqual(mergePendingGroupInvocations.count, 1)
+        XCTAssertEqual(mergePendingGroupInvocations.first, groupID.bytes)
+
+        // Events were received
+        XCTAssertEqual(receivedEvents, [event])
+    }
+
+    func test_SendExternalCommitBundle_ThrowsWithRecoveryStrategy_Retry() async {
+        await assertSendExternalCommitBundleThrows(
+            withRecovery: .retry,
+            for: .mlsStaleMessage,
+            shouldClearPendingGroup: false
+        )
+    }
+
+    func test_SendExternalCommitBundle_ThrowsWithRecoveryStrategy_GiveUp() async {
+        await assertSendExternalCommitBundleThrows(
+            withRecovery: .giveUp,
+            for: .unknown(status: 400, label: "", message: ""),
+            shouldClearPendingGroup: true
+        )
+    }
+
+    private func assertSendExternalCommitBundleThrows(
+        withRecovery recovery: ExternalCommitError.Recovery,
+        for error: SendCommitBundleAction.Failure,
+        shouldClearPendingGroup: Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        // Given
+        // Mock action provider throwing an error
+        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+            throw error
+        }
+
+        // Then
+        await assertItThrows(error: ExternalCommitError.failedToSendCommit(recovery: recovery)) {
+            // When
+            _ = try await sut.sendExternalCommitBundle(commitBundle, for: groupID)
+        }
+
+        if shouldClearPendingGroup {
+            // It clears pending commit
+            XCTAssertEqual(mockClearPendingGroupInvocations.count, 1)
+            XCTAssertEqual(mockClearPendingGroupInvocations.first, groupID.bytes)
+        } else {
+            // It doesn't clear pending commit
+            XCTAssertEqual(mockClearPendingGroupInvocations.count, 0)
+        }
+    }
+}

--- a/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
@@ -145,7 +145,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
     }
 
     private func assertSendCommitBundleThrows(
-        withRecovery recovery: CommitError.Recovery,
+        withRecovery recovery: CommitError.RecoveryStrategy,
         for error: SendCommitBundleAction.Failure,
         shouldClearPendingCommit: Bool,
         file: StaticString = #file,
@@ -223,7 +223,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
     }
 
     private func assertSendExternalCommitBundleThrows(
-        withRecovery recovery: ExternalCommitError.Recovery,
+        withRecovery recovery: ExternalCommitError.RecoveryStrategy,
         for error: SendCommitBundleAction.Failure,
         shouldClearPendingGroup: Bool,
         file: StaticString = #file,
@@ -243,11 +243,11 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
 
         if shouldClearPendingGroup {
             // It clears pending commit
-            XCTAssertEqual(mockClearPendingGroupInvocations.count, 1)
-            XCTAssertEqual(mockClearPendingGroupInvocations.first, groupID.bytes)
+            XCTAssertEqual(mockClearPendingGroupInvocations.count, 1, file: file, line: line)
+            XCTAssertEqual(mockClearPendingGroupInvocations.first, groupID.bytes, file: file, line: line)
         } else {
             // It doesn't clear pending commit
-            XCTAssertEqual(mockClearPendingGroupInvocations.count, 0)
+            XCTAssertEqual(mockClearPendingGroupInvocations.count, 0, file: file, line: line)
         }
     }
 

--- a/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
@@ -28,28 +28,29 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
 
     var mockCoreCrypto: MockCoreCrypto!
     var mockSafeCoreCrypto: MockSafeCoreCrypto!
-    var mockActionsProvider: MockMLSActionsProviderProtocol!
     var mockCoreCryptoProvider: MockCoreCryptoProviderProtocol!
+    var mockCommitSender: MockCommitSending!
     var sut: MLSActionExecutor!
 
     override func setUp() {
         super.setUp()
         mockCoreCrypto = MockCoreCrypto()
         mockSafeCoreCrypto = MockSafeCoreCrypto(coreCrypto: mockCoreCrypto)
-        mockActionsProvider = MockMLSActionsProviderProtocol()
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
         mockCoreCryptoProvider.coreCryptoRequireMLS_MockValue = mockSafeCoreCrypto
+        mockCommitSender = MockCommitSending()
 
         sut = MLSActionExecutor(
             coreCryptoProvider: mockCoreCryptoProvider,
-            context: uiMOC,
-            actionsProvider: mockActionsProvider
+            commitSender: mockCommitSender
         )
     }
 
     override func tearDown() {
         mockCoreCrypto = nil
-        mockActionsProvider = nil
+        mockSafeCoreCrypto = nil
+        mockCoreCryptoProvider = nil
+        mockCommitSender = nil
         sut = nil
         super.tearDown()
     }
@@ -101,14 +102,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         }
 
         // Mock send commit bundle.
-        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+        mockCommitSender.sendCommitBundleFor_MockMethod = { _, _ in
             return [mockUpdateEvent]
-        }
-
-        // Mock merge commit.
-        var mockCommitAcceptedArguments = [[Byte]]()
-        mockCoreCrypto.mockCommitAccepted = {
-            mockCommitAcceptedArguments.append($0)
         }
 
         // When
@@ -126,12 +121,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
             groupInfo: mockGroupInfo
         )
 
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, expectedCommitBundle.transportData())
-
-        // Then the commit was merged.
-        XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
-        XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.count, 1)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.first?.bundle, expectedCommitBundle)
 
         // Then the update event was returned.
         XCTAssertEqual(updateEvents, [mockUpdateEvent])
@@ -171,14 +162,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         }
 
         // Mock send commit bundle.
-        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+        mockCommitSender.sendCommitBundleFor_MockMethod = { _, _ in
             return [mockUpdateEvent]
-        }
-
-        // Mock merge commit.
-        var mockCommitAcceptedArguments = [[Byte]]()
-        mockCoreCrypto.mockCommitAccepted = {
-            mockCommitAcceptedArguments.append($0)
         }
 
         // When
@@ -190,12 +175,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(mockRemoveClientsArguments.first?.1, clientIds)
 
         // Then the commit bundle was sent.
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, mockCommitBundle.transportData())
-
-        // Then the commit was merged.
-        XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
-        XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.count, 1)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.first?.bundle, mockCommitBundle)
 
         // Then the update event was returned.
         XCTAssertEqual(updateEvents, [mockUpdateEvent])
@@ -226,14 +207,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         }
 
         // Mock send commit bundle.
-        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+        mockCommitSender.sendCommitBundleFor_MockMethod = { _, _ in
             return []
-        }
-
-        // Mock merge commit.
-        var mockCommitAcceptedArguments = [[Byte]]()
-        mockCoreCrypto.mockCommitAccepted = {
-            mockCommitAcceptedArguments.append($0)
         }
 
         // When
@@ -244,12 +219,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(mockUpdateKeyMaterialArguments.first, groupID.bytes)
 
         // Then the commit bundle was sent.
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, mockCommitBundle.transportData())
-
-        // Then the commit was merged.
-        XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
-        XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.count, 1)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.first?.bundle, mockCommitBundle)
 
         // Then no update events were returned.
         XCTAssertEqual(updateEvents, [ZMUpdateEvent]())
@@ -287,15 +258,10 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         }
 
         // Mock send commit bundle.
-        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+        mockCommitSender.sendCommitBundleFor_MockMethod = { _, _ in
             return [mockUpdateEvent]
         }
 
-        // Mock merge commit.
-        var mockCommitAcceptedArguments = [[Byte]]()
-        mockCoreCrypto.mockCommitAccepted = {
-            mockCommitAcceptedArguments.append($0)
-        }
 
         // When
         let updateEvents = try await sut.commitPendingProposals(in: groupID)
@@ -305,12 +271,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(mockCommitPendingProposals.first, groupID.bytes)
 
         // Then the commit bundle was sent.
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, mockCommitBundle.transportData())
-
-        // Then the commit was merged.
-        XCTAssertEqual(mockCommitAcceptedArguments.count, 1)
-        XCTAssertEqual(mockCommitAcceptedArguments.first, groupID.bytes)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.count, 1)
+        XCTAssertEqual(mockCommitSender.sendCommitBundleFor_Invocations.first?.bundle, mockCommitBundle)
 
         // Then the update event was returned.
         XCTAssertEqual(updateEvents, [mockUpdateEvent])
@@ -349,14 +311,8 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         }
 
         // Mock send commit bundle
-        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in
+        mockCommitSender.sendExternalCommitBundleFor_MockMethod = { _, _ in
             return mockUpdateEvents
-        }
-
-        // Mock merge pending group
-        var mockMergePendingGroupArguments = [[Byte]]()
-        mockCoreCrypto.mockMergePendingGroupFromExternalCommit = { conversationId in
-            mockMergePendingGroupArguments.append(conversationId)
         }
 
         // When
@@ -367,96 +323,11 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(mockJoinByExternalCommitArguments.first, mockGroupInfo.bytes)
 
         // Then commit bundle was sent
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.count, 1)
-        XCTAssertEqual(mockActionsProvider.sendCommitBundleIn_Invocations.first?.bundle, mockCommitBundle.transportData())
-
-        // Then pending group is merged
-        XCTAssertEqual(mockMergePendingGroupArguments.count, 1)
-        XCTAssertEqual(mockMergePendingGroupArguments.first, groupID.bytes)
+        XCTAssertEqual(mockCommitSender.sendExternalCommitBundleFor_Invocations.count, 1)
+        XCTAssertEqual(mockCommitSender.sendExternalCommitBundleFor_Invocations.first?.bundle, mockCommitBundle)
 
         // Then the update event was returned
         XCTAssertEqual(updateEvents, mockUpdateEvents)
-    }
-
-    func test_JoinGroup_ThrowsErrorWithRetryRecoveryStrategy() async throws {
-        // When
-        try await test_JoinGroupThrowsErrorWithRecoveryStrategy(
-            sendCommitBundleError: SendCommitBundleAction.Failure.mlsStaleMessage
-        ) { recovery, clearPendingGroupArguments in
-            // Then
-            XCTAssertEqual(recovery, .retry)
-            XCTAssertEqual(clearPendingGroupArguments.count, 0)
-        }
-    }
-
-    func test_JoinGroup_ThrowsErrorWithGiveUpRecoveryStrategy() async throws {
-        // Given
-        let groupID = MLSGroupID.random()
-        let error = SendCommitBundleAction.Failure.unknown(
-            status: 999,
-            label: "unknown",
-            message: "unknown"
-        )
-
-        // When
-        try await test_JoinGroupThrowsErrorWithRecoveryStrategy(
-            groupID: groupID,
-            sendCommitBundleError: error
-        ) { recovery, clearPendingGroupArguments in
-            // Then
-            XCTAssertEqual(recovery, .giveUp)
-            XCTAssertEqual(clearPendingGroupArguments.count, 1)
-            XCTAssertEqual(clearPendingGroupArguments.first, groupID.bytes)
-        }
-    }
-
-    private typealias AssertRecoveryBlock = (
-        _ recovery: MLSActionExecutor.ExternalCommitErrorRecovery,
-        _ clearPendingGroupArguments: [[Byte]]
-    ) -> Void
-
-    private func test_JoinGroupThrowsErrorWithRecoveryStrategy(
-        groupID: MLSGroupID = .random(),
-        sendCommitBundleError: Error,
-        assertRecovery: AssertRecoveryBlock
-    ) async throws {
-        // Given
-        let mockCommit = Data.random().bytes
-        let mockGroupInfoBundle = GroupInfoBundle(
-            encryptionType: .plaintext,
-            ratchetTreeType: .full,
-            payload: []
-        )
-
-        // Mock join by external commit
-        var mockJoinByExternalCommitArguments = [[Byte]]()
-        mockCoreCrypto.mockJoinByExternalCommit = { groupState, _, _ in
-            mockJoinByExternalCommitArguments.append(groupState)
-            return .init(
-                conversationId: groupID.bytes,
-                commit: mockCommit,
-                groupInfo: mockGroupInfoBundle
-            )
-        }
-
-        // Mock send commit bundle
-        mockActionsProvider.sendCommitBundleIn_MockError = sendCommitBundleError
-
-        // Mock clear pending group
-        var mockClearPendingGroupArguments = [[Byte]]()
-        mockCoreCrypto.mockClearPendingGroupFromExternalCommit = {
-            mockClearPendingGroupArguments.append($0)
-        }
-
-        // When / Then
-        do {
-            _ = try await sut.joinGroup(groupID, groupInfo: Data())
-            XCTFail("expected an error")
-        } catch MLSActionExecutor.Error.failedToSendExternalCommit(recovery: let recovery) {
-            assertRecovery(recovery, mockClearPendingGroupArguments)
-        } catch {
-            XCTFail("wrong error")
-        }
     }
 
     // MARK: - Epoch change
@@ -486,7 +357,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
 
         // When we make a commit
         mockCoreCrypto.mockUpdateKeyingMaterial = { _ in return mockCommitBundle }
-        mockActionsProvider.sendCommitBundleIn_MockMethod = { _, _ in return [] }
+        mockCommitSender.sendCommitBundleFor_MockMethod = { _, _ in return [] }
         mockCoreCrypto.mockCommitAccepted = { _ in }
         _ = try await sut.updateKeyMaterial(for: groupID)
 

--- a/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
@@ -262,7 +262,6 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
             return [mockUpdateEvent]
         }
 
-
         // When
         let updateEvents = try await sut.commitPendingProposals(in: groupID)
 
@@ -328,43 +327,6 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
 
         // Then the update event was returned
         XCTAssertEqual(updateEvents, mockUpdateEvents)
-    }
-
-    // MARK: - Epoch change
-
-    func test_OnEpochChanged() async throws {
-        // Given
-        let groupID = MLSGroupID.random()
-
-        var receivedGroupIDs = [MLSGroupID]()
-        let didReceiveGroupIDs = expectation(description: "didReceiveGroupIDs")
-        let cancellable = sut.onEpochChanged().collect(1).sink {
-            receivedGroupIDs = $0
-            didReceiveGroupIDs.fulfill()
-        }
-
-        let mockCommit = Data.random().bytes
-        let mockGroupInfo = GroupInfoBundle(
-            encryptionType: .plaintext,
-            ratchetTreeType: .full,
-            payload: .random()
-        )
-        let mockCommitBundle = CommitBundle(
-            welcome: nil,
-            commit: mockCommit,
-            groupInfo: mockGroupInfo
-        )
-
-        // When we make a commit
-        mockCoreCrypto.mockUpdateKeyingMaterial = { _ in return mockCommitBundle }
-        mockCommitSender.sendCommitBundleFor_MockMethod = { _, _ in return [] }
-        mockCoreCrypto.mockCommitAccepted = { _ in }
-        _ = try await sut.updateKeyMaterial(for: groupID)
-
-        // Then
-        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
-        cancellable.cancel()
-        XCTAssertEqual(receivedGroupIDs, [groupID])
     }
 
 }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -475,7 +475,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock claiming a key package.
@@ -582,7 +582,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // wait for `MLSService.init`'s async operations
@@ -603,7 +603,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock failure for claiming key packages.
@@ -628,7 +628,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock key package.
@@ -639,14 +639,14 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         }
 
         mockMLSActionExecutor.mockAddMembers = { _, _ in
-            throw MLSActionExecutor.Error.failedToGenerateCommit
+            throw CommitError.failedToGenerateCommit
         }
 
         // wait for `MLSService.init`'s async operations
         await fulfillment(of: [didFinishInitializationExpectation], timeout: 1)
 
         // when / then
-        await assertItThrows(error: MLSActionExecutor.Error.failedToGenerateCommit) {
+        await assertItThrows(error: CommitError.failedToGenerateCommit) {
             try await sut.addMembersToConversation(with: mlsUser, for: mlsGroupID)
         }
     }
@@ -663,7 +663,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock removing clients from the group.
@@ -758,7 +758,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // wait for `MLSService.init`'s async operations
@@ -780,19 +780,19 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock executor error.
         mockMLSActionExecutor.mockRemoveClients = { _, _ in
-            throw MLSActionExecutor.Error.failedToGenerateCommit
+            throw CommitError.failedToGenerateCommit
         }
 
         // wait for `MLSService.init`'s async operations
         await fulfillment(of: [didFinishInitializationExpectation], timeout: 1)
 
         // When / Then
-        await assertItThrows(error: MLSActionExecutor.Error.failedToGenerateCommit) {
+        await assertItThrows(error: CommitError.failedToGenerateCommit) {
             try await sut.removeMembersFromConversation(with: [mlsClientID], for: mlsGroupID)
         }
     }
@@ -817,7 +817,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // wait for `MLSService.init`'s async operations
@@ -1151,7 +1151,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         test_PerformPendingJoinsRecovery(.giveUp)
     }
 
-    private func test_PerformPendingJoinsRecovery(_ recovery: MLSActionExecutor.ExternalCommitErrorRecovery) {
+    private func test_PerformPendingJoinsRecovery(_ recovery: ExternalCommitError.Recovery) {
         // Given
         let shouldRetry = recovery == .retry
         let groupID = MLSGroupID.random()
@@ -1180,7 +1180,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             joinGroupCount += 1
 
             if joinGroupCount == 1 {
-                throw MLSActionExecutor.Error.failedToSendExternalCommit(recovery: recovery)
+                throw ExternalCommitError.failedToSendCommit(recovery: recovery)
             }
 
             return []
@@ -1690,7 +1690,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock stale groups.
@@ -1761,7 +1761,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock one failure to update key material, then a success.
@@ -1770,7 +1770,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockUpdateKeyMaterialCount += 1 }
             switch mockUpdateKeyMaterialCount {
             case 0:
-                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
             default:
                 return []
             }
@@ -1804,7 +1804,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock three failures to update key material, then a success.
@@ -1813,7 +1813,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockUpdateKeyMaterialCount += 1 }
             switch mockUpdateKeyMaterialCount {
             case 0..<3:
-                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
             default:
                 return []
             }
@@ -1851,7 +1851,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockCommitPendingProposalsCount += 1 }
             switch mockCommitPendingProposalsCount {
             case 0..<2:
-                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
             default:
                 return []
             }
@@ -1863,7 +1863,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockUpdateKeyMaterialCount += 1 }
             switch mockUpdateKeyMaterialCount {
             case 0..<3:
-                throw MLSActionExecutor.Error.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
             default:
                 return []
             }
@@ -1906,7 +1906,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockCommitPendingProposalsCount += 1 }
             switch mockCommitPendingProposalsCount {
             case 0:
-                throw MLSActionExecutor.Error.noPendingProposals
+                throw CommitError.noPendingProposals
             default:
                 return []
             }
@@ -1917,7 +1917,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         var mockUpdateKeyMaterialCount = 0
         mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
             defer { mockUpdateKeyMaterialCount += 1 }
-            throw MLSActionExecutor.Error.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync)
+            throw CommitError.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync)
         }
 
         // Mock quick sync.
@@ -1951,14 +1951,14 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Mock no pending proposals.
         mockMLSActionExecutor.mockCommitPendingProposals = { _ in
-            throw MLSActionExecutor.Error.noPendingProposals
+            throw CommitError.noPendingProposals
         }
 
         // Mock failures to update key material, no successes.
         var mockUpdateKeyMaterialCount = 0
         mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
             defer { mockUpdateKeyMaterialCount += 1 }
-            throw MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp)
+            throw CommitError.failedToSendCommit(recovery: .giveUp)
         }
 
         // Mock quick sync.
@@ -1971,7 +1971,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         await fulfillment(of: [didFinishInitializationExpectation], timeout: 1)
 
         // Then
-        await assertItThrows(error: MLSActionExecutor.Error.failedToSendCommit(recovery: .giveUp)) {
+        await assertItThrows(error: CommitError.failedToSendCommit(recovery: .giveUp)) {
             // When
             try await sut.updateKeyMaterial(for: groupID)
         }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1151,7 +1151,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         test_PerformPendingJoinsRecovery(.giveUp)
     }
 
-    private func test_PerformPendingJoinsRecovery(_ recovery: ExternalCommitError.Recovery) {
+    private func test_PerformPendingJoinsRecovery(_ recovery: ExternalCommitError.RecoveryStrategy) {
         // Given
         let shouldRetry = recovery == .retry
         let groupID = MLSGroupID.random()

--- a/wire-ios-data-model/Tests/MLS/MockSafeCoreCrypto.swift
+++ b/wire-ios-data-model/Tests/MLS/MockSafeCoreCrypto.swift
@@ -40,6 +40,11 @@ class MockSafeCoreCrypto: SafeCoreCryptoProtocol {
         return try block(coreCrypto)
     }
 
+    // TODO: Update after update of CC 1.0
+    func perform<T>(_ block: (WireCoreCrypto.CoreCryptoProtocol) async throws -> T) async rethrows -> T {
+        return try await block(coreCrypto)
+    }
+
     var mockMlsInit: ((String) throws -> Void)?
 
     func mlsInit(clientID: String) throws {

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -288,6 +288,11 @@
 		6391A7FA2A6FD6FC00832665 /* MappingModel_2.106-2.107.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 6391A7F92A6FD6FC00832665 /* MappingModel_2.106-2.107.xcmappingmodel */; };
 		6391A7FD2A6FD7D100832665 /* DatabaseMigrationTests+UserClientUniqueness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6391A7FB2A6FD7C900832665 /* DatabaseMigrationTests+UserClientUniqueness.swift */; };
 		6391A7FF2A6FDB9100832665 /* store2-107-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 6391A7FE2A6FDB9100832665 /* store2-107-0.wiredatabase */; };
+		639971AE2B2732E6009DD5CF /* CommitSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971AD2B2732E6009DD5CF /* CommitSender.swift */; };
+		639971B02B27346B009DD5CF /* CommitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971AF2B27346B009DD5CF /* CommitError.swift */; };
+		639971B22B2734C0009DD5CF /* ExternalCommitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971B12B2734C0009DD5CF /* ExternalCommitError.swift */; };
+		639971BF2B28BB63009DD5CF /* config.yml in Resources */ = {isa = PBXBuildFile; fileRef = 639971BE2B28BB63009DD5CF /* config.yml */; };
+		639971C22B28C5FF009DD5CF /* CommitSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971C02B28C5FA009DD5CF /* CommitSenderTests.swift */; };
 		63AFE2D6244F49A90003F619 /* GenericMessage+MessageCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFE2D5244F49A90003F619 /* GenericMessage+MessageCapable.swift */; };
 		63B1335429A503D100009D84 /* ProteusServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1333729A503D000009D84 /* ProteusServiceInterface.swift */; };
 		63B1335529A503D100009D84 /* ProteusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1333829A503D000009D84 /* ProteusService.swift */; };
@@ -1097,6 +1102,11 @@
 		6391A7F92A6FD6FC00832665 /* MappingModel_2.106-2.107.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "MappingModel_2.106-2.107.xcmappingmodel"; sourceTree = "<group>"; };
 		6391A7FB2A6FD7C900832665 /* DatabaseMigrationTests+UserClientUniqueness.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DatabaseMigrationTests+UserClientUniqueness.swift"; sourceTree = "<group>"; };
 		6391A7FE2A6FDB9100832665 /* store2-107-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-107-0.wiredatabase"; sourceTree = "<group>"; };
+		639971AD2B2732E6009DD5CF /* CommitSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitSender.swift; sourceTree = "<group>"; };
+		639971AF2B27346B009DD5CF /* CommitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitError.swift; sourceTree = "<group>"; };
+		639971B12B2734C0009DD5CF /* ExternalCommitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalCommitError.swift; sourceTree = "<group>"; };
+		639971BE2B28BB63009DD5CF /* config.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = config.yml; sourceTree = "<group>"; };
+		639971C02B28C5FA009DD5CF /* CommitSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitSenderTests.swift; sourceTree = "<group>"; };
 		63AFE2D5244F49A90003F619 /* GenericMessage+MessageCapable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+MessageCapable.swift"; sourceTree = "<group>"; };
 		63B1333729A503D000009D84 /* ProteusServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProteusServiceInterface.swift; sourceTree = "<group>"; };
 		63B1333829A503D000009D84 /* ProteusService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProteusService.swift; sourceTree = "<group>"; };
@@ -1885,6 +1895,7 @@
 		594EB2FE2B1E31D30022A5CD /* Sourcery */ = {
 			isa = PBXGroup;
 			children = (
+				639971BE2B28BB63009DD5CF /* config.yml */,
 				594EB2FF2B1E31D30022A5CD /* generated */,
 			);
 			path = Sourcery;
@@ -2008,6 +2019,9 @@
 				63BEF5862A2636BC00F482E8 /* MLSConferenceInfo.swift */,
 				63F0781129F6C59D0031E19D /* MLSSubgroup.swift */,
 				16BBA1FF2AFD130F00CDF38A /* CoreCryptoProvider.swift */,
+				639971AD2B2732E6009DD5CF /* CommitSender.swift */,
+				639971B12B2734C0009DD5CF /* ExternalCommitError.swift */,
+				639971AF2B27346B009DD5CF /* CommitError.swift */,
 			);
 			name = MLS;
 			path = Source/MLS;
@@ -2225,6 +2239,7 @@
 				63FACD55291BC598003AB25D /* MLSClientIDTests.swift */,
 				EED6C7152A31AD1200CB8B60 /* MLSUserIDTests.swift */,
 				EE74E4DF2A37B3BF00B63E6E /* SubconversationGroupIDRepositoryTests.swift */,
+				639971C02B28C5FA009DD5CF /* CommitSenderTests.swift */,
 			);
 			path = MLS;
 			sourceTree = "<group>";
@@ -3443,6 +3458,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				639971BF2B28BB63009DD5CF /* config.yml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3600,6 +3616,7 @@
 				EED6C7142A30B94100CB8B60 /* MLSUserID.swift in Sources */,
 				EE28991E26B4422800E7BAF0 /* Feature.ConferenceCalling.swift in Sources */,
 				63B1336A29A503D100009D84 /* ClaimMLSKeyPackageAction.swift in Sources */,
+				639971AE2B2732E6009DD5CF /* CommitSender.swift in Sources */,
 				6308F8A62A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift in Sources */,
 				63B1335929A503D100009D84 /* MLSGroupID.swift in Sources */,
 				F963E9831D9C0DC400098AD3 /* ZMMessageDestructionTimer.swift in Sources */,
@@ -3799,6 +3816,7 @@
 				EF1F850422FD71BB0020F6DC /* ZMOTRMessage+VerifySender.swift in Sources */,
 				165DC523214A614100090B7B /* ZMConversation+Message.swift in Sources */,
 				F9A706811CAEE01D00C2F5FE /* ZMMessage.m in Sources */,
+				639971B02B27346B009DD5CF /* CommitError.swift in Sources */,
 				631A0578240420380062B387 /* UserClient+SafeLogging.swift in Sources */,
 				165DC52121491D8700090B7B /* ZMClientMessage+TextMessageData.swift in Sources */,
 				EEE95CD52A432FA100E136CB /* LeaveSubconversationAction.swift in Sources */,
@@ -3829,6 +3847,7 @@
 				F16378511E5C805100898F84 /* ZMConversationSecurityLevel.swift in Sources */,
 				5E9EA4E22243E0D300D401B2 /* ConversationMessage+Attachments.swift in Sources */,
 				EE5F54CC259B22C400F11F3C /* Account+Keychain.swift in Sources */,
+				639971B22B2734C0009DD5CF /* ExternalCommitError.swift in Sources */,
 				F93C4C7D1E24E1B1007E9CEE /* NotificationDispatcher.swift in Sources */,
 				06D48735241F930A00881B08 /* GenericMessage+Obfuscation.swift in Sources */,
 				0686649F256FB0CA001C8747 /* AppLockController.swift in Sources */,
@@ -4126,6 +4145,7 @@
 				EEC794F82A385359008E1A3B /* MLSDecryptionServiceTests.swift in Sources */,
 				EE46B92828A511630063B38D /* ZMClientMessageTests+MLSEncryptedPayloadGenerator.swift in Sources */,
 				4058AAA82AAB65530013DE71 /* ReactionsSortingTests.swift in Sources */,
+				639971C22B28C5FF009DD5CF /* CommitSenderTests.swift in Sources */,
 				F9A7083C1CAEEB7500C2F5FE /* MockModelObjectContextFactory.m in Sources */,
 				F9331C5C1CB3BF9F00139ECC /* UserClientKeyStoreTests.swift in Sources */,
 				87C1C261207F812F0083BF6B /* InvalidGenericMessageDataRemovalTests.swift in Sources */,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -291,7 +291,6 @@
 		639971AE2B2732E6009DD5CF /* CommitSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971AD2B2732E6009DD5CF /* CommitSender.swift */; };
 		639971B02B27346B009DD5CF /* CommitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971AF2B27346B009DD5CF /* CommitError.swift */; };
 		639971B22B2734C0009DD5CF /* ExternalCommitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971B12B2734C0009DD5CF /* ExternalCommitError.swift */; };
-		639971BF2B28BB63009DD5CF /* config.yml in Resources */ = {isa = PBXBuildFile; fileRef = 639971BE2B28BB63009DD5CF /* config.yml */; };
 		639971C22B28C5FF009DD5CF /* CommitSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639971C02B28C5FA009DD5CF /* CommitSenderTests.swift */; };
 		63AFE2D6244F49A90003F619 /* GenericMessage+MessageCapable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AFE2D5244F49A90003F619 /* GenericMessage+MessageCapable.swift */; };
 		63B1335429A503D100009D84 /* ProteusServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B1333729A503D000009D84 /* ProteusServiceInterface.swift */; };
@@ -1105,7 +1104,6 @@
 		639971AD2B2732E6009DD5CF /* CommitSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitSender.swift; sourceTree = "<group>"; };
 		639971AF2B27346B009DD5CF /* CommitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitError.swift; sourceTree = "<group>"; };
 		639971B12B2734C0009DD5CF /* ExternalCommitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalCommitError.swift; sourceTree = "<group>"; };
-		639971BE2B28BB63009DD5CF /* config.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = config.yml; sourceTree = "<group>"; };
 		639971C02B28C5FA009DD5CF /* CommitSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitSenderTests.swift; sourceTree = "<group>"; };
 		63AFE2D5244F49A90003F619 /* GenericMessage+MessageCapable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+MessageCapable.swift"; sourceTree = "<group>"; };
 		63B1333729A503D000009D84 /* ProteusServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProteusServiceInterface.swift; sourceTree = "<group>"; };
@@ -1895,7 +1893,6 @@
 		594EB2FE2B1E31D30022A5CD /* Sourcery */ = {
 			isa = PBXGroup;
 			children = (
-				639971BE2B28BB63009DD5CF /* config.yml */,
 				594EB2FF2B1E31D30022A5CD /* generated */,
 			);
 			path = Sourcery;
@@ -3458,7 +3455,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				639971BF2B28BB63009DD5CF /* config.yml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2091" title="WPB-2091" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-2091</a>  [iOS] put Certificate in KeyPackages and LeafNodes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->



----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR contains a refactoring of the logic for sending commit bundles

### Changes

- Introduced `CommitSender` to send commit bundles
- Created `CommitError` and `ExternalCommitError` to represent errors and recovery strategies
- Added an async method to `SafeCoreCrypto` in preparation for core crypto becoming async
- Updated `MLSActionsExecutor` to use `CommitSender`
- Updated `MLSService` to use new error types

### Testing

- Updated `MLSServiceTests`
- Updated `MLSActionsExecutorTests`
- Added tests for `CommitSender`

