### PR TITLE
fix: proteus provider access

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+ProteusProvider.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+ProteusProvider.swift
@@ -18,19 +18,10 @@
 
 import Foundation
 
-extension NSManagedObjectContext {
+public extension NSManagedObjectContext {
 
-    private static let proteusProviderUserInfoKey = "ProteusProvidingUserInfoKey"
-
-    public var proteusProvider: ProteusProviding {
-        get {
-            precondition(zm_isSyncContext, "ProteusProviding should only be accessed on the sync context")
-            return userInfo[Self.proteusProviderUserInfoKey] as! ProteusProviding
-        }
-
-        set {
-            precondition(zm_isSyncContext, "ProteusProviding should only be accessed on the sync context")
-            userInfo[Self.proteusProviderUserInfoKey] = newValue
-        }
+    var proteusProvider: ProteusProviding {
+        precondition(zm_isSyncContext, "ProteusProvider should only be accessed on the sync context")
+        return ProteusProvider(context: self)
     }
 }

--- a/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+ProteusProvider.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+ProteusProvider.swift
@@ -18,10 +18,19 @@
 
 import Foundation
 
-public extension NSManagedObjectContext {
+extension NSManagedObjectContext {
 
-    var proteusProvider: ProteusProviding {
-        precondition(zm_isSyncContext, "ProteusProvider should only be accessed on the sync context")
-        return ProteusProvider(context: self)
+    private static let proteusProviderUserInfoKey = "ProteusProvidingUserInfoKey"
+
+    public var proteusProvider: ProteusProviding {
+        get {
+            precondition(zm_isSyncContext, "ProteusProviding should only be accessed on the sync context")
+            return userInfo[Self.proteusProviderUserInfoKey] as! ProteusProviding
+        }
+
+        set {
+            precondition(zm_isSyncContext, "ProteusProviding should only be accessed on the sync context")
+            userInfo[Self.proteusProviderUserInfoKey] = newValue
+        }
     }
 }

--- a/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
@@ -74,10 +74,14 @@ public class ProteusProvider: ProteusProviding {
 
           return try proteusServiceBlock(proteusService)
 
-        } else {
+        } else if !proteusViaCoreCrypto {
 
             // remove comment once implementation of proteus via core crypto is done
             return try keyStoreBlock(keyStore)
+        } else {
+
+            WireLogger.coreCrypto.error("can't access any proteus cryptography service")
+            fatal("can't access any proteus cryptography service")
         }
     }
 
@@ -90,10 +94,14 @@ public class ProteusProvider: ProteusProviding {
 
             return try await proteusServiceBlock(proteusService)
 
-        } else {
+        } else if !proteusViaCoreCrypto {
 
             // remove comment once implementation of proteus via core crypto is done
             return try await keyStoreBlock(keyStore)
+        } else {
+
+            WireLogger.coreCrypto.error("can't access any proteus cryptography service")
+            fatal("can't access any proteus cryptography service")
         }
     }
 

--- a/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
@@ -46,6 +46,15 @@ public class ProteusProvider: ProteusProviding {
     private let keyStore: UserClientKeysStore
     private let proteusViaCoreCrypto: Bool
 
+    convenience init(
+        context: NSManagedObjectContext,
+        proteusViaCoreCrypto: Bool = DeveloperFlag.proteusViaCoreCrypto.isOn
+    ) {
+        self.init(proteusService: context.proteusService,
+                  keyStore: context.zm_cryptKeyStore,
+                  proteusViaCoreCrypto: proteusViaCoreCrypto)
+    }
+
     public init(
         proteusService: ProteusServiceInterface?,
         keyStore: UserClientKeysStore,

--- a/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusProvider.swift
@@ -46,16 +46,11 @@ public class ProteusProvider: ProteusProviding {
     private let keyStore: UserClientKeysStore
     private let proteusViaCoreCrypto: Bool
 
-    public convenience init(
-        context: NSManagedObjectContext,
+    public init(
+        proteusService: ProteusServiceInterface?,
+        keyStore: UserClientKeysStore,
         proteusViaCoreCrypto: Bool = DeveloperFlag.proteusViaCoreCrypto.isOn
     ) {
-        self.init(proteusService: context.proteusService,
-                  keyStore: context.zm_cryptKeyStore,
-                  proteusViaCoreCrypto: proteusViaCoreCrypto)
-    }
-
-    internal init(proteusService: ProteusServiceInterface?, keyStore: UserClientKeysStore, proteusViaCoreCrypto: Bool) {
         self.proteusService = proteusService
         self.keyStore = keyStore
         self.proteusViaCoreCrypto = proteusViaCoreCrypto

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -63,7 +63,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             useLegacyPushNotifications: useLegacyPushNotifications,
             lastEventIDRepository: lastEventIDRepository,
             transportSession: transportSession,
-            proteusProvider: ProteusProviding,
+            proteusProvider: proteusProvider,
             mlsService: mlsService
         )
 

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -48,7 +48,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         useLegacyPushNotifications: Bool,
         lastEventIDRepository: LastEventIDRepositoryInterface,
         transportSession: TransportSessionType,
-        proteusProvider: ProteusProvider,
+        proteusProvider: ProteusProviding,
         mlsService: MLSServiceInterface
     ) {
 
@@ -63,7 +63,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             useLegacyPushNotifications: useLegacyPushNotifications,
             lastEventIDRepository: lastEventIDRepository,
             transportSession: transportSession,
-            proteusProvider: proteusProvider,
+            proteusProvider: ProteusProviding,
             mlsService: mlsService
         )
 
@@ -99,7 +99,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         useLegacyPushNotifications: Bool,
         lastEventIDRepository: LastEventIDRepositoryInterface,
         transportSession: TransportSessionType,
-        proteusProvider: ProteusProvider,
+        proteusProvider: ProteusProviding,
         mlsService: MLSServiceInterface
     ) -> [Any] {
         let syncMOC = contextProvider.syncContext
@@ -123,7 +123,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             quickSyncObserver: quickSyncObserver,
             context: syncMOC)
         let strategies: [Any] = [
-            // TODO: [John] use flag here
+
             UserClientRequestStrategy(
                 clientRegistrationStatus: applicationStatusDirectory.clientRegistrationStatus,
                 clientUpdateStatus: applicationStatusDirectory.clientUpdateStatus,

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -47,7 +47,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         localNotificationDispatcher: LocalNotificationDispatcher,
         useLegacyPushNotifications: Bool,
         lastEventIDRepository: LastEventIDRepositoryInterface,
-        transportSession: TransportSessionType
+        transportSession: TransportSessionType,
+        proteusProvider: ProteusProvider
     ) {
 
         self.strategies = Self.buildStrategies(
@@ -60,7 +61,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             localNotificationDispatcher: localNotificationDispatcher,
             useLegacyPushNotifications: useLegacyPushNotifications,
             lastEventIDRepository: lastEventIDRepository,
-            transportSession: transportSession
+            transportSession: transportSession,
+            proteusProvider: proteusProvider
         )
 
         self.requestStrategies = strategies.compactMap({ $0 as? RequestStrategy})
@@ -94,7 +96,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         localNotificationDispatcher: LocalNotificationDispatcher,
         useLegacyPushNotifications: Bool,
         lastEventIDRepository: LastEventIDRepositoryInterface,
-        transportSession: TransportSessionType
+        transportSession: TransportSessionType,
+        proteusProvider: ProteusProvider
     ) -> [Any] {
         let syncMOC = contextProvider.syncContext
 
@@ -122,7 +125,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 clientRegistrationStatus: applicationStatusDirectory.clientRegistrationStatus,
                 clientUpdateStatus: applicationStatusDirectory.clientUpdateStatus,
                 context: syncMOC,
-                proteusProvider: ProteusProvider(context: syncMOC)
+                proteusProvider: proteusProvider
             ),
             MissingClientsRequestStrategy(
                 withManagedObjectContext: syncMOC,

--- a/wire-ios-sync-engine/Source/Use cases/GetUserClientFingerprintUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/GetUserClientFingerprintUseCase.swift
@@ -34,7 +34,7 @@ public class GetUserClientFingerprintUseCase: GetUserClientFingerprintUseCasePro
 
     convenience init(syncContext: NSManagedObjectContext,
                      transportSession: TransportSessionType,
-                     proteusProvider: ProteusProvider) {
+                     proteusProvider: ProteusProviding) {
         let httpClient = HttpClientImpl(
             transportSession: transportSession,
             queue: syncContext)

--- a/wire-ios-sync-engine/Source/Use cases/GetUserClientFingerprintUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/GetUserClientFingerprintUseCase.swift
@@ -33,7 +33,8 @@ public class GetUserClientFingerprintUseCase: GetUserClientFingerprintUseCasePro
     // MARK: - Initialization
 
     convenience init(syncContext: NSManagedObjectContext,
-                     transportSession: TransportSessionType) {
+                     transportSession: TransportSessionType,
+                     proteusProvider: ProteusProvider) {
         let httpClient = HttpClientImpl(
             transportSession: transportSession,
             queue: syncContext)
@@ -41,7 +42,6 @@ public class GetUserClientFingerprintUseCase: GetUserClientFingerprintUseCasePro
         let sessionEstablisher = SessionEstablisher(
             context: syncContext,
             apiProvider: apiProvider)
-        let proteusProvider = ProteusProvider(context: syncContext)
 
         self.init(proteusProvider: proteusProvider, sessionEstablisher: sessionEstablisher, managedObjectContext: syncContext)
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -253,7 +253,6 @@ public class ZMUserSession: NSObject {
     /// - Note: this is safe if coredataStack and proteus are ready
     public lazy var getUserClientFingerprint: GetUserClientFingerprintUseCaseProtocol = {
         GetUserClientFingerprintUseCase(syncContext: coreDataStack.syncContext,
-
                                         transportSession: transportSession,
                                         proteusProvider: proteusProvider)
     }()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -100,7 +100,7 @@ public class ZMUserSession: NSObject {
     var coreCryptoProvider: CoreCryptoProvider
     lazy var proteusService: ProteusServiceInterface = ProteusService(coreCryptoProvider: coreCryptoProvider)
     var mlsService: MLSServiceInterface
-    var proteusProvider: ProteusProvider!
+    var proteusProvider: ProteusProviding!
 
     public var syncStatus: SyncStatusProtocol {
         return applicationStatusDirectory.syncStatus
@@ -279,7 +279,6 @@ public class ZMUserSession: NSObject {
         cryptoboxMigrationManager: CryptoboxMigrationManagerInterface,
         sharedUserDefaults: UserDefaults
     ) {
-        // why is this set here
         coreDataStack.syncContext.performGroupedBlockAndWait {
             coreDataStack.syncContext.analytics = analytics
             coreDataStack.syncContext.zm_userInterface = coreDataStack.viewContext

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -98,13 +98,7 @@ public class ZMUserSession: NSObject {
 
     var cryptoboxMigrationManager: CryptoboxMigrationManagerInterface
     var coreCryptoProvider: CoreCryptoProvider
-    lazy var proteusService: ProteusServiceInterface? = {
-        if DeveloperFlag.proteusViaCoreCrypto.isOn {
-            return  ProteusService(coreCryptoProvider: coreCryptoProvider)
-        } else {
-            return nil
-        }
-    }()
+    lazy var proteusService: ProteusServiceInterface = ProteusService(coreCryptoProvider: coreCryptoProvider)
     var mlsService: MLSServiceInterface
     var proteusProvider: ProteusProvider!
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -376,6 +376,8 @@ public class ZMUserSession: NSObject {
 
             // FIXME: [jacob] inject instead of storing on context WPB-5827
             self.syncManagedObjectContext.proteusService = self.proteusService
+
+            self.syncManagedObjectContext.proteusProvider = proteusProvider
             self.syncManagedObjectContext.mlsService = self.mlsService
 
             applicationStatusDirectory.clientRegistrationStatus.prepareForClientRegistration()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -376,8 +376,6 @@ public class ZMUserSession: NSObject {
 
             // FIXME: [jacob] inject instead of storing on context WPB-5827
             self.syncManagedObjectContext.proteusService = self.proteusService
-
-            self.syncManagedObjectContext.proteusProvider = proteusProvider
             self.syncManagedObjectContext.mlsService = self.mlsService
 
             applicationStatusDirectory.clientRegistrationStatus.prepareForClientRegistration()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

access to proteusProvider is done on main queue when it should be accessed on syncContext queue.

### Causes (Optional)

ProteusProvider properties are initialized on mainQueue.

### Solutions

Create instance of proteusProvider within ZMUserSession on syncContext. This is a first step towards removing the property from NSManagedContext.
Restricting creating ProteusProvider from context to DataModel.

### Notes (Optional)

ProteusService is still optional though enableProteusByCoreCrypto might be soon the default.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
