### PR TITLE
feat: turn MLS encryption and decryption service async - WPB-5941

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -30,7 +30,7 @@ public protocol MLSDecryptionServiceInterface {
         message: String,
         for groupID: MLSGroupID,
         subconversationType: SubgroupType?
-    ) throws -> MLSDecryptResult?
+    ) async throws -> MLSDecryptResult?
 
 }
 
@@ -94,7 +94,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
         message: String,
         for groupID: MLSGroupID,
         subconversationType: SubgroupType?
-    ) throws -> MLSDecryptResult? {
+    ) async throws -> MLSDecryptResult? {
         WireLogger.mls.debug("decrypting message for group (\(groupID.safeForLoggingDescription)) and subconversation type (\(String(describing: subconversationType)))")
 
         guard let messageBytes = message.base64DecodedBytes else {
@@ -105,6 +105,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
 
         if
             let type = subconversationType,
+            // TODO: [F] does subconverationGroupIDRepository needs to be an actor?
             let subconversationGroupID = subconverationGroupIDRepository.fetchSubconversationGroupID(
                 forType: type,
                 parentGroupID: groupID

--- a/wire-ios-data-model/Source/MLS/MLSEncryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSEncryptionService.swift
@@ -25,7 +25,7 @@ public protocol MLSEncryptionServiceInterface {
     func encrypt(
         message: [Byte],
         for groupID: MLSGroupID
-    ) throws -> [Byte]
+    ) async throws -> [Byte]
 
 }
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1241,8 +1241,8 @@ public final class MLSService: MLSServiceInterface {
     public func encrypt(
         message: [Byte],
         for groupID: MLSGroupID
-    ) throws -> [Byte] {
-        return try encryptionService.encrypt(
+    ) async throws -> [Byte] {
+        return try await encryptionService.encrypt(
             message: message,
             for: groupID
         )
@@ -1254,11 +1254,11 @@ public final class MLSService: MLSServiceInterface {
         message: String,
         for groupID: MLSGroupID,
         subconversationType: SubgroupType?
-    ) throws -> MLSDecryptResult? {
+    ) async throws -> MLSDecryptResult? {
         typealias DecryptionError = MLSDecryptionService.MLSMessageDecryptionError
 
         do {
-            return try decryptionService.decrypt(
+            return try await decryptionService.decrypt(
                 message: message,
                 for: groupID,
                 subconversationType: subconversationType

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -97,7 +97,7 @@ public protocol MLSServiceDelegate: AnyObject {
 
     func mlsServiceDidCommitPendingProposal(for groupID: MLSGroupID)
     func mlsServiceDidUpdateKeyMaterialForAllGroups()
-    func MLSServiceDidFinishInitialization()
+    func mlsServiceDidFinishInitialization()
 
 }
 
@@ -230,7 +230,7 @@ public final class MLSService: MLSServiceInterface {
         // FIXME: [jacob] fetch on demand when creating group
         Task {
             await fetchBackendPublicKeys()
-            delegate?.MLSServiceDidFinishInitialization()
+            delegate?.mlsServiceDidFinishInitialization()
         }
     }
 

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1305,10 +1305,10 @@ public class MockMLSDecryptionServiceInterface: MLSDecryptionServiceInterface {
 
     public var decryptMessageForSubconversationType_Invocations: [(message: String, groupID: MLSGroupID, subconversationType: SubgroupType?)] = []
     public var decryptMessageForSubconversationType_MockError: Error?
-    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) throws -> MLSDecryptResult?)?
+    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) async throws -> MLSDecryptResult?)?
     public var decryptMessageForSubconversationType_MockValue: MLSDecryptResult??
 
-    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) throws -> MLSDecryptResult? {
+    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) async throws -> MLSDecryptResult? {
         decryptMessageForSubconversationType_Invocations.append((message: message, groupID: groupID, subconversationType: subconversationType))
 
         if let error = decryptMessageForSubconversationType_MockError {
@@ -1316,7 +1316,7 @@ public class MockMLSDecryptionServiceInterface: MLSDecryptionServiceInterface {
         }
 
         if let mock = decryptMessageForSubconversationType_MockMethod {
-            return try mock(message, groupID, subconversationType)
+            return try await mock(message, groupID, subconversationType)
         } else if let mock = decryptMessageForSubconversationType_MockValue {
             return mock
         } else {
@@ -1337,10 +1337,10 @@ public class MockMLSEncryptionServiceInterface: MLSEncryptionServiceInterface {
 
     public var encryptMessageFor_Invocations: [(message: [Byte], groupID: MLSGroupID)] = []
     public var encryptMessageFor_MockError: Error?
-    public var encryptMessageFor_MockMethod: (([Byte], MLSGroupID) throws -> [Byte])?
+    public var encryptMessageFor_MockMethod: (([Byte], MLSGroupID) async throws -> [Byte])?
     public var encryptMessageFor_MockValue: [Byte]?
 
-    public func encrypt(message: [Byte], for groupID: MLSGroupID) throws -> [Byte] {
+    public func encrypt(message: [Byte], for groupID: MLSGroupID) async throws -> [Byte] {
         encryptMessageFor_Invocations.append((message: message, groupID: groupID))
 
         if let error = encryptMessageFor_MockError {
@@ -1348,7 +1348,7 @@ public class MockMLSEncryptionServiceInterface: MLSEncryptionServiceInterface {
         }
 
         if let mock = encryptMessageFor_MockMethod {
-            return try mock(message, groupID)
+            return try await mock(message, groupID)
         } else if let mock = encryptMessageFor_MockValue {
             return mock
         } else {
@@ -1835,10 +1835,10 @@ public class MockMLSServiceInterface: MLSServiceInterface {
 
     public var decryptMessageForSubconversationType_Invocations: [(message: String, groupID: MLSGroupID, subconversationType: SubgroupType?)] = []
     public var decryptMessageForSubconversationType_MockError: Error?
-    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) throws -> MLSDecryptResult?)?
+    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) async throws -> MLSDecryptResult?)?
     public var decryptMessageForSubconversationType_MockValue: MLSDecryptResult??
 
-    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) throws -> MLSDecryptResult? {
+    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) async throws -> MLSDecryptResult? {
         decryptMessageForSubconversationType_Invocations.append((message: message, groupID: groupID, subconversationType: subconversationType))
 
         if let error = decryptMessageForSubconversationType_MockError {
@@ -1846,7 +1846,7 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         }
 
         if let mock = decryptMessageForSubconversationType_MockMethod {
-            return try mock(message, groupID, subconversationType)
+            return try await mock(message, groupID, subconversationType)
         } else if let mock = decryptMessageForSubconversationType_MockValue {
             return mock
         } else {
@@ -1858,10 +1858,10 @@ public class MockMLSServiceInterface: MLSServiceInterface {
 
     public var encryptMessageFor_Invocations: [(message: [Byte], groupID: MLSGroupID)] = []
     public var encryptMessageFor_MockError: Error?
-    public var encryptMessageFor_MockMethod: (([Byte], MLSGroupID) throws -> [Byte])?
+    public var encryptMessageFor_MockMethod: (([Byte], MLSGroupID) async throws -> [Byte])?
     public var encryptMessageFor_MockValue: [Byte]?
 
-    public func encrypt(message: [Byte], for groupID: MLSGroupID) throws -> [Byte] {
+    public func encrypt(message: [Byte], for groupID: MLSGroupID) async throws -> [Byte] {
         encryptMessageFor_Invocations.append((message: message, groupID: groupID))
 
         if let error = encryptMessageFor_MockError {
@@ -1869,7 +1869,7 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         }
 
         if let mock = encryptMessageFor_MockMethod {
-            return try mock(message, groupID)
+            return try await mock(message, groupID)
         } else if let mock = encryptMessageFor_MockValue {
             return mock
         } else {

--- a/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
@@ -20,6 +20,7 @@ import Foundation
 import XCTest
 import Combine
 import WireCoreCrypto
+import WireTesting
 
 @testable import WireDataModel
 @testable import WireDataModelSupport
@@ -60,221 +61,210 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
 
     typealias DecryptionError = MLSDecryptionService.MLSMessageDecryptionError
 
-    func test_Decrypt_ThrowsFailedToConvertMessageToBytes() {
-        syncMOC.performAndWait {
-            // Given
-            let groupID = MLSGroupID.random()
-            let invalidBase64String = "%"
+    func test_Decrypt_ThrowsFailedToConvertMessageToBytes() async {
+        // Given
+        let groupID = MLSGroupID.random()
+        let invalidBase64String = "%"
 
-            // Then
-            assertItThrows(error: DecryptionError.failedToConvertMessageToBytes) {
-                // When
-                try _ = sut.decrypt(
-                    message: invalidBase64String,
-                    for: groupID,
-                    subconversationType: nil
-                )
-            }
-        }
-    }
-
-    func test_Decrypt_ThrowsFailedToDecryptMessage() {
-        syncMOC.performAndWait {
-            // Given
-            let groupID = MLSGroupID.random()
-            let message = Data.random().base64EncodedString()
-            self.mockCoreCrypto.mockDecryptMessage = { _, _ in
-                throw CryptoError.ConversationNotFound(message: "conversation not found")
-            }
-
-            // Then
-            assertItThrows(error: DecryptionError.failedToDecryptMessage) {
-                // When
-                try _ = sut.decrypt(
-                    message: message,
-                    for: groupID,
-                    subconversationType: nil
-                )
-            }
-        }
-    }
-
-    func test_Decrypt_ReturnsNil_WhenCoreCryptoReturnsNil() {
-        syncMOC.performAndWait {
-            // Given
-            let groupID = MLSGroupID.random()
-            let messageBytes = Data.random().bytes
-            self.mockCoreCrypto.mockDecryptMessage = { _, _ in
-                DecryptedMessage(
-                    message: nil,
-                    proposals: [],
-                    isActive: false,
-                    commitDelay: nil,
-                    senderClientId: nil,
-                    hasEpochChanged: false,
-                    identity: nil
-                )
-            }
-
+        // Then
+        await assertItThrows(error: DecryptionError.failedToConvertMessageToBytes) {
             // When
-            var result: MLSDecryptResult?
-            do {
-                result = try sut.decrypt(
-                    message: messageBytes.data.base64EncodedString(),
-                    for: groupID,
-                    subconversationType: nil
-                )
-            } catch {
-                XCTFail("Unexpected error: \(String(describing: error))")
-            }
-
-            // Then
-            XCTAssertNil(result)
-        }
-    }
-
-    func test_Decrypt_IsSuccessful() {
-        syncMOC.performAndWait {
-            // Given
-            let groupID = MLSGroupID.random()
-            let messageBytes = Data.random().bytes
-            let sender = MLSClientID(
-                userID: UUID.create().transportString(),
-                clientID: "client",
-                domain: "example.com"
+            try _ = await sut.decrypt(
+                message: invalidBase64String,
+                for: groupID,
+                subconversationType: nil
             )
-
-            var mockDecryptMessageCount = 0
-            self.mockCoreCrypto.mockDecryptMessage = {
-                mockDecryptMessageCount += 1
-
-                XCTAssertEqual($0, groupID.bytes)
-                XCTAssertEqual($1, messageBytes)
-
-                return DecryptedMessage(
-                    message: messageBytes,
-                    proposals: [],
-                    isActive: false,
-                    commitDelay: nil,
-                    senderClientId: sender.rawValue.data(using: .utf8)!.bytes,
-                    hasEpochChanged: false,
-                    identity: nil
-                )
-            }
-
-            // When
-            var result: MLSDecryptResult?
-            do {
-                result = try sut.decrypt(
-                    message: messageBytes.data.base64EncodedString(),
-                    for: groupID,
-                    subconversationType: nil
-                )
-            } catch {
-                XCTFail("Unexpected error: \(String(describing: error))")
-            }
-
-            // Then
-            XCTAssertEqual(mockDecryptMessageCount, 1)
-            XCTAssertEqual(result, MLSDecryptResult.message(messageBytes.data, sender.clientID))
         }
     }
 
-    func test_Decrypt_ForSubconversation_IsSuccessful() {
-        syncMOC.performAndWait {
-            // Given
-            let parentGroupID = MLSGroupID.random()
-            let subconversationGroupID = MLSGroupID.random()
-            let messageBytes = Data.random().bytes
-            let sender = MLSClientID.random()
-
-            mockSubconversationGroupIDRepository.fetchSubconversationGroupIDForTypeParentGroupID_MockValue = subconversationGroupID
-
-            var mockDecryptMessageCount = 0
-            self.mockCoreCrypto.mockDecryptMessage = {
-                mockDecryptMessageCount += 1
-
-                XCTAssertEqual($0, subconversationGroupID.bytes)
-                XCTAssertEqual($1, messageBytes)
-
-                return DecryptedMessage(
-                    message: messageBytes,
-                    proposals: [],
-                    isActive: false,
-                    commitDelay: nil,
-                    senderClientId: sender.rawValue.data(using: .utf8)!.bytes,
-                    hasEpochChanged: false,
-                    identity: nil
-                )
-            }
-
-            // When
-            var result: MLSDecryptResult?
-            do {
-                result = try sut.decrypt(
-                    message: messageBytes.data.base64EncodedString(),
-                    for: parentGroupID,
-                    subconversationType: .conference
-                )
-            } catch {
-                XCTFail("Unexpected error: \(String(describing: error))")
-            }
-
-            // Then
-            XCTAssertEqual(mockDecryptMessageCount, 1)
-            XCTAssertEqual(result, MLSDecryptResult.message(messageBytes.data, sender.clientID))
-
-            XCTAssertEqual(mockSubconversationGroupIDRepository.fetchSubconversationGroupIDForTypeParentGroupID_Invocations.count, 1)
+    func test_Decrypt_ThrowsFailedToDecryptMessage() async {
+        // Given
+        let groupID = MLSGroupID.random()
+        let message = Data.random().base64EncodedString()
+        self.mockCoreCrypto.mockDecryptMessage = { _, _ in
+            throw CryptoError.ConversationNotFound(message: "conversation not found")
         }
-    }
 
-    func test_Decrypt_ReportsEpochChanged() {
-        syncMOC.performAndWait {
-            // Given
-            let groupID = MLSGroupID.random()
-            let messageBytes = Data.random().bytes
-            let hasEpochChanged = true
-            let sender = MLSClientID(
-                userID: UUID.create().transportString(),
-                clientID: "client",
-                domain: "example.com"
+        // Then
+        await assertItThrows(error: DecryptionError.failedToDecryptMessage) {
+            // When
+            try _ = await sut.decrypt(
+                message: message,
+                for: groupID,
+                subconversationType: nil
             )
-
-            var receivedGroupIDs = [MLSGroupID]()
-            let didReceiveGroupIDs = expectation(description: "didReceiveGroupIDs")
-            let cancellable = sut.onEpochChanged().collect(1).sink {
-                receivedGroupIDs = $0
-                didReceiveGroupIDs.fulfill()
-            }
-
-            mockCoreCrypto.mockDecryptMessage = { _, _ in
-                return DecryptedMessage(
-                    message: messageBytes,
-                    proposals: [],
-                    isActive: false,
-                    commitDelay: nil,
-                    senderClientId: sender.rawValue.data(using: .utf8)!.bytes,
-                    hasEpochChanged: hasEpochChanged,
-                    identity: nil
-                )
-            }
-
-            // When
-            do {
-                _ = try sut.decrypt(
-                    message: messageBytes.data.base64EncodedString(),
-                    for: groupID,
-                    subconversationType: nil
-                )
-            } catch {
-                XCTFail("Unexpected error: \(String(describing: error))")
-            }
-
-            // Then
-            XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
-            cancellable.cancel()
-            XCTAssertEqual(receivedGroupIDs, [groupID])
         }
+    }
+
+    func test_Decrypt_ReturnsNil_WhenCoreCryptoReturnsNil() async {
+
+        // Given
+        let groupID = MLSGroupID.random()
+        let messageBytes = Data.random().bytes
+        self.mockCoreCrypto.mockDecryptMessage = { _, _ in
+            DecryptedMessage(
+                message: nil,
+                proposals: [],
+                isActive: false,
+                commitDelay: nil,
+                senderClientId: nil,
+                hasEpochChanged: false,
+                identity: nil
+            )
+        }
+
+        // When
+        var result: MLSDecryptResult?
+        do {
+            result = try await sut.decrypt(
+                message: messageBytes.data.base64EncodedString(),
+                for: groupID,
+                subconversationType: nil
+            )
+        } catch {
+            XCTFail("Unexpected error: \(String(describing: error))")
+        }
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_Decrypt_IsSuccessful() async {
+        // Given
+        let groupID = MLSGroupID.random()
+        let messageBytes = Data.random().bytes
+        let sender = MLSClientID(
+            userID: UUID.create().transportString(),
+            clientID: "client",
+            domain: "example.com"
+        )
+
+        var mockDecryptMessageCount = 0
+        self.mockCoreCrypto.mockDecryptMessage = {
+            mockDecryptMessageCount += 1
+
+            XCTAssertEqual($0, groupID.bytes)
+            XCTAssertEqual($1, messageBytes)
+
+            return DecryptedMessage(
+                message: messageBytes,
+                proposals: [],
+                isActive: false,
+                commitDelay: nil,
+                senderClientId: sender.rawValue.data(using: .utf8)!.bytes,
+                hasEpochChanged: false,
+                identity: nil
+            )
+        }
+
+        // When
+        var result: MLSDecryptResult?
+        do {
+            result = try await sut.decrypt(
+                message: messageBytes.data.base64EncodedString(),
+                for: groupID,
+                subconversationType: nil
+            )
+        } catch {
+            XCTFail("Unexpected error: \(String(describing: error))")
+        }
+
+        // Then
+        XCTAssertEqual(mockDecryptMessageCount, 1)
+        XCTAssertEqual(result, MLSDecryptResult.message(messageBytes.data, sender.clientID))
+    }
+
+    func test_Decrypt_ForSubconversation_IsSuccessful() async {
+        // Given
+        let parentGroupID = MLSGroupID.random()
+        let subconversationGroupID = MLSGroupID.random()
+        let messageBytes = Data.random().bytes
+        let sender = MLSClientID.random()
+
+        mockSubconversationGroupIDRepository.fetchSubconversationGroupIDForTypeParentGroupID_MockValue = subconversationGroupID
+
+        var mockDecryptMessageCount = 0
+        self.mockCoreCrypto.mockDecryptMessage = {
+            mockDecryptMessageCount += 1
+
+            XCTAssertEqual($0, subconversationGroupID.bytes)
+            XCTAssertEqual($1, messageBytes)
+
+            return DecryptedMessage(
+                message: messageBytes,
+                proposals: [],
+                isActive: false,
+                commitDelay: nil,
+                senderClientId: sender.rawValue.data(using: .utf8)!.bytes,
+                hasEpochChanged: false,
+                identity: nil
+            )
+        }
+
+        // When
+        var result: MLSDecryptResult?
+        do {
+            result = try await sut.decrypt(
+                message: messageBytes.data.base64EncodedString(),
+                for: parentGroupID,
+                subconversationType: .conference
+            )
+        } catch {
+            XCTFail("Unexpected error: \(String(describing: error))")
+        }
+
+        // Then
+        XCTAssertEqual(mockDecryptMessageCount, 1)
+        XCTAssertEqual(result, MLSDecryptResult.message(messageBytes.data, sender.clientID))
+
+        XCTAssertEqual(mockSubconversationGroupIDRepository.fetchSubconversationGroupIDForTypeParentGroupID_Invocations.count, 1)
+    }
+
+    func test_Decrypt_ReportsEpochChanged() async {
+        // Given
+        let groupID = MLSGroupID.random()
+        let messageBytes = Data.random().bytes
+        let hasEpochChanged = true
+        let sender = MLSClientID(
+            userID: UUID.create().transportString(),
+            clientID: "client",
+            domain: "example.com"
+        )
+
+        var receivedGroupIDs = [MLSGroupID]()
+        let didReceiveGroupIDs = expectation(description: "didReceiveGroupIDs")
+        let cancellable = sut.onEpochChanged().collect(1).sink {
+            receivedGroupIDs = $0
+            didReceiveGroupIDs.fulfill()
+        }
+
+        mockCoreCrypto.mockDecryptMessage = { _, _ in
+            return DecryptedMessage(
+                message: messageBytes,
+                proposals: [],
+                isActive: false,
+                commitDelay: nil,
+                senderClientId: sender.rawValue.data(using: .utf8)!.bytes,
+                hasEpochChanged: hasEpochChanged,
+                identity: nil
+            )
+        }
+
+        // When
+        do {
+            _ = try await sut.decrypt(
+                message: messageBytes.data.base64EncodedString(),
+                for: groupID,
+                subconversationType: nil
+            )
+        } catch {
+            XCTFail("Unexpected error: \(String(describing: error))")
+        }
+
+        // Then
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+        cancellable.cancel()
+        XCTAssertEqual(receivedGroupIDs, [groupID])
     }
 
 }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -304,7 +304,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     // MARK: - Message Encryption
 
-    func test_Encrypt_UsesEncyptionService() throws {
+    func test_Encrypt_UsesEncyptionService() async throws {
         // Given
         let message = "foo"
         let groupID = MLSGroupID.random()
@@ -315,10 +315,10 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockDecryptionService.decryptMessageForSubconversationType_MockValue = mockResult
 
         // wait for `MLSService.init`'s async operations
-        wait(for: [didFinishInitializationExpectation], timeout: 1)
+        await fulfillment(of: [didFinishInitializationExpectation], timeout: 1)
 
         // When
-        let result = try sut.decrypt(
+        let result = try await sut.decrypt(
             message: message,
             for: groupID,
             subconversationType: subconversationType
@@ -335,7 +335,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     // MARK: - Message Decryption
 
-    func test_Decrypt_UsesDecyptionService() throws {
+    func test_Decrypt_UsesDecyptionService() async throws {
         // Given
         let message = "foo"
         let groupID = MLSGroupID.random()
@@ -345,10 +345,10 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockDecryptionService.decryptMessageForSubconversationType_MockValue = mockResult
 
         // wait for `MLSService.init`'s async operations
-        wait(for: [didFinishInitializationExpectation], timeout: 1)
+        await fulfillment(of: [didFinishInitializationExpectation], timeout: 1)
 
         // When
-        let result = try sut.decrypt(
+        let result = try await sut.decrypt(
             message: message,
             for: groupID,
             subconversationType: subconversationType
@@ -363,7 +363,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertEqual(result, mockResult)
     }
 
-    func test_Decrypt_RepairsConversationOnWrongEpochError() throws {
+    func test_Decrypt_RepairsConversationOnWrongEpochError() async throws {
         // Given
         let conversation = createConversation(outOfSync: true).conversation
         let groupID = try XCTUnwrap(conversation.mlsGroupID)
@@ -383,17 +383,17 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         )
 
         // wait for `MLSService.init`'s async operations
-        wait(for: [didFinishInitializationExpectation], timeout: 1)
+        await fulfillment(of: [didFinishInitializationExpectation], timeout: 1)
 
         // When
-        _ = try? sut.decrypt(
+        _ = try? await sut.decrypt(
             message: message,
             for: groupID,
             subconversationType: nil
         )
 
         // Then
-        wait(for: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 0.5)
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
     }
 

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -162,7 +162,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         keyMaterialUpdatedExpectation?.fulfill()
     }
 
-    func MLSServiceDidFinishInitialization() {
+    func mlsServiceDidFinishInitialization() {
         didFinishInitializationExpectation.fulfill()
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5941" title="WPB-5941" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5941</a>  [iOS] turn MLSEncryptionService and MLSDecryptionService async
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

This updates the methods of both  MLS encryption and decryption service because of the upcoming CC update.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution
