### PR TITLE
fix: participant role optionality of conversation [WPB-6003]

### DIFF
--- a/wire-ios-data-model/Source/Model/ConversationRole/ParticipantRole.swift
+++ b/wire-ios-data-model/Source/Model/ConversationRole/ParticipantRole.swift
@@ -23,7 +23,7 @@ let ZMParticipantRoleRoleValueKey           = #keyPath(ParticipantRole.role)
 @objcMembers
 final public class ParticipantRole: ZMManagedObject {
 
-    @NSManaged public var conversation: ZMConversation
+    @NSManaged public var conversation: ZMConversation?
     @NSManaged public var user: ZMUser?
     @NSManaged public var role: Role?
 

--- a/wire-ios-data-model/Source/Model/User/ZMUser.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.swift
@@ -59,7 +59,7 @@ extension ZMUser: UserType {
     }
 
     public var activeConversations: Set<ZMConversation> {
-        return Set(self.participantRoles.map(\.conversation))
+        return Set(self.participantRoles.compactMap(\.conversation))
     }
 
     public var isVerified: Bool {
@@ -352,7 +352,7 @@ extension ZMUser {
     /// Remove user from all group conversations he is a participant of
     fileprivate func removeFromAllConversations(at timestamp: Date) {
         let allGroupConversations: [ZMConversation] = participantRoles.compactMap {
-            guard $0.conversation.conversationType == .group else {
+            guard $0.conversation?.conversationType == .group else {
                 return nil
             }
             return $0.conversation
@@ -374,7 +374,7 @@ extension ZMUser {
 
     @objc
     public var conversations: Set<ZMConversation> {
-        Set(participantRoles.map(\.conversation))
+        Set(participantRoles.compactMap(\.conversation))
     }
 }
 

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -888,7 +888,7 @@ extension UserClient {
         let conversations: Set<ZMConversation> = clients.map(\.user).reduce(into: []) {
             guard let user = $1 else { return }
             guard user.isSelfUser else {
-                return $0.formUnion(user.participantRoles.map(\.conversation))
+                return $0.formUnion(user.participantRoles.compactMap(\.conversation))
             }
             let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
             fetchRequest.predicate = ZMConversation.predicateForConversationsIncludingArchived()

--- a/wire-ios-data-model/Source/Notifications/SideEffectSources.swift
+++ b/wire-ios-data-model/Source/Notifications/SideEffectSources.swift
@@ -81,7 +81,7 @@ extension ZMManagedObject {
 extension ZMUser: SideEffectSource {
 
     var allConversations: [ZMConversation] {
-        var conversations = self.participantRoles.map(\.conversation)
+        var conversations = self.participantRoles.compactMap(\.conversation)
         if let connectedConversation = connection?.conversation {
             conversations.append(connectedConversation)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6003" title="WPB-6003" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6003</a>  iOS : V-3.111.5 - Crashing after update- Especially when using reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Revert the optionality of the property changed with #804

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- We don't know

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
