### PR TITLE
fix: [MLS] proteus to mls migration - tests threading violations [WPB-5040]

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1729,7 +1729,7 @@ public final class MLSService: MLSServiceInterface {
 
                 } catch SendMLSMessageAction.Failure.mlsStaleMessage {
 
-                    logger.error("failed to migrate conversation \(conversation): stale message")
+                    logger.error("failed to migrate conversation \(qualifiedID): stale message")
 
                     // rollback: destroy/wipe group
                     try await wipeGroup(mlsGroupID)
@@ -1737,7 +1737,7 @@ public final class MLSService: MLSServiceInterface {
                 }
 
             } catch {
-                logger.error("failed to migrate conversation \(conversation): \(String(describing: error))")
+                logger.error("failed to migrate conversation \(qualifiedID): \(String(describing: error))")
                 continue
             }
         }

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1344,7 +1344,7 @@ class MockMLSActionsProviderProtocol: MLSActionsProviderProtocol {
             fatalError("no mock for `syncUsersQualifiedIDsContext`")
         }
 
-        try await mock(qualifiedIDs, context)            
+        try await mock(qualifiedIDs, context)
     }
 
 }

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -21,7 +21,7 @@ import XCTest
 @testable import WireDataModel
 @testable import WireDataModelSupport
 
-class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
+final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
 
     // MARK: - Properties
 
@@ -48,7 +48,9 @@ class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
             actionsProvider: mockActionsProvider
         )
 
-        syncMOC.mlsService = mockMLSService
+        syncMOC.performAndWait {
+            syncMOC.mlsService = mockMLSService
+        }
 
         // Set default mocks
         mockActionsProvider.syncUsersQualifiedIDsContext_MockMethod = { _, _ in }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5040" title="WPB-5040" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5040</a>  [iOS] Process protocol change event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes tests that had threading violations.

### Testing

Run unit tests.

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
