### PR TITLE
fix: [MLS] proteus to mls migration - tests request strategy [WPB-5040]

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
@@ -47,6 +47,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
 
         mockConversationService = MockConversationServiceInterface()
 
+        mockConversationService.syncConversationQualifiedID_MockMethod = { _ in }
         mockConversationService.syncConversationQualifiedIDCompletion_MockMethod = { _, completion in
             completion()
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/MLSConversationParticipantsServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/MLSConversationParticipantsServiceTests.swift
@@ -39,6 +39,8 @@ class MLSConversationParticipantsServiceTests: MessagingTestBase {
 
         mockClientIDsProvider = MockMLSClientIDsProviding()
         mockMLSService = MockMLSServiceInterface()
+        mockMLSService.addMembersToConversationWithFor_MockMethod = { _, _ in }
+        mockMLSService.removeMembersFromConversationWithFor_MockMethod = { _, _ in }
 
         syncMOC.performAndWait { [self] in
             conversation = ZMConversation.insertNewObject(in: syncMOC)

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/UpdateConversationProtocolActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/UpdateConversationProtocolActionHandlerTests.swift
@@ -29,6 +29,7 @@ final class UpdateConversationProtocolActionHandlerTests: ActionHandlerTestBase<
         uuidString = "b906579d-60dd-4510-a3ca-14b2ec225f4a"
         let qualifiedID = QualifiedID(uuid: .init(uuidString: uuidString)!, domain: "example.com")
         action = UpdateConversationProtocolAction(qualifiedID: qualifiedID, messageProtocol: .mls)
+        handler = UpdateConversationProtocolActionHandler(context: syncMOC)
     }
 
     override func tearDown() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5040" title="WPB-5040" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5040</a>  [iOS] Process protocol change event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes more tests in wire request strategy.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Run unit tests.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
