### PR TITLE
feat: fix business logic for reset -session WPB-5523

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -320,15 +320,10 @@ public class UserClient: ZMManagedObject, UserClientType {
     /// Can be called several times without issues
 
     public func resetSession() {
-        resetSession(completion: nil)
-    }
-
-    public func resetSession(completion: ((Bool) -> Void)? = nil) {
         guard
             let uiMOC = managedObjectContext?.zm_userInterface,
             let syncMOC = uiMOC.zm_sync
         else {
-            completion?(false)
             return
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
@@ -99,12 +99,8 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
         }
     }
 
-    func resetSession() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            userClient.resetSession { value in
-                continuation.resume(returning: value)
-            }
-        }
+    func resetSession() {
+        userClient.resetSession()
     }
 
     @MainActor

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
@@ -31,7 +31,7 @@ protocol DeviceDetailsViewActions {
     func fetchCertificate() async -> E2eIdentityCertificate?
     func fetchMLSThumbprint() async -> String?
     func removeDevice() async -> Bool
-    func resetSession() async -> Bool
+    func resetSession()
     func updateVerified(_ value: Bool) async -> Bool
     func copyToClipboard(_ value: String)
     func downloadE2EIdentityCertificate(certificate: E2eIdentityCertificate)
@@ -92,7 +92,6 @@ final class DeviceInfoViewModel: ObservableObject {
         return Settings.isClipboardEnabled
     }
     @Published var isRemoved: Bool = false
-    @Published var isReset: Bool = false
     @Published var isProteusVerificationEnabled: Bool = false
     @Published var isActionInProgress: Bool = false
     @Published var proteusKeyFingerprint: String = ""
@@ -160,15 +159,8 @@ final class DeviceInfoViewModel: ObservableObject {
         }
     }
 
-    func resetSession() async {
-        DispatchQueue.main.async {
-            self.isActionInProgress = true
-        }
-        let isReset =  await actionsHandler.resetSession()
-        DispatchQueue.main.async {
-            self.isReset = isReset
-            self.isActionInProgress = false
-        }
+    func resetSession() {
+        actionsHandler.resetSession()
     }
 
     func updateVerifiedStatus(_ value: Bool) async {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/DeviceDetailsBottomView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/DeviceDetailsBottomView.swift
@@ -32,9 +32,7 @@ struct DeviceDetailsBottomView: View {
     var resetSessionView: some View {
         HStack {
             SwiftUI.Button {
-                Task {
-                    await viewModel.resetSession()
-                }
+                viewModel.resetSession()
             } label: {
                 Text(L10n.Localizable.Profile.Devices.Detail.ResetSession.title)
                     .padding(.all, ViewConstants.Padding.standard)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5523" title="WPB-5523" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5523</a>  [iOS] 5.3.24 Show E2EI certificate info - Business logic & initial integration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Asynchronous calling of this function does not work as expected

### Causes
Coredata calls from the upderlying API expect it to be called on main thread

### Solutions

Running this on main thread solves the issue. Also removed completion handlers as the original implementation did not have that support

Needs releases with:

- [ ] GitHub link to other pull request

### Testing


#### How to Test

**Steps**
1. Go to Settings
2. Tap on Devices
3. Tap on any of the active devices.
4. Tap on Reset Session button.

**Expectation**
The app should not crash

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
