### PR TITLE
fix: use Swift.Result for conversation created callback [WPB-4544]

### DIFF
--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/UserType+Helpers.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/UserType+Helpers.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
 import Foundation
 import WireSyncEngine
 
-typealias ConversationCreatedBlock = (ZMConversation?) -> Void
+typealias ConversationCreatedBlock = (Swift.Result<ZMConversation, Error>) -> Void
 
 extension UserType {
 
@@ -50,10 +50,11 @@ extension UserType {
         conversationService.createTeamOneToOneConversation(user: user) { result in
             switch result {
             case .success(let conversation):
-                completion(conversation)
+                completion(.success(conversation))
 
             case .failure(let error):
                 WireLogger.conversation.error("failed to create one to one conversation: \(String(describing: error))")
+                completion(.failure(error))
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -22,8 +23,8 @@ import WireSyncEngine
 
 extension ConversationListViewController.ViewModel: StartUIDelegate {
     func startUI(_ startUI: StartUIViewController, didSelect user: UserType) {
-        oneToOneConversationWithUser(user, callback: { conversation in
-            guard let conversation = conversation else { return }
+        oneToOneConversationWithUser(user, callback: { result in
+            guard case .success(let conversation) = result else { return }
 
             ZClientViewController.shared?.select(conversation: conversation, focusOnView: true, animated: true)
         })
@@ -48,7 +49,7 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
 
         viewController?.setState(.conversationList, animated: true) {
             if let conversation = user.oneToOneConversation {
-                onConversationCreated(conversation)
+                onConversationCreated(.success(conversation))
             } else {
                 user.createTeamOneToOneConversation(in: userSession.viewContext) { conversation in
                     onConversationCreated(conversation)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -23,11 +23,11 @@ import WireSyncEngine
 
 extension ConversationListViewController.ViewModel: StartUIDelegate {
     func startUI(_ startUI: StartUIViewController, didSelect user: UserType) {
-        oneToOneConversationWithUser(user, callback: { result in
+        oneToOneConversationWithUser(user) { result in
             guard case .success(let conversation) = result else { return }
 
             ZClientViewController.shared?.select(conversation: conversation, focusOnView: true, animated: true)
-        })
+        }
     }
 
     func startUI(_ startUI: StartUIViewController, didSelect conversation: ZMConversation) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewControllerViewModel.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2019 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -134,8 +134,8 @@ final class ProfileViewControllerViewModel: NSObject {
         if let conversation = user.oneToOneConversation {
             transition(to: conversation)
         } else {
-            user.createTeamOneToOneConversation(in: userSession.viewContext) { conversation in
-                guard let conversation = conversation else { return }
+            user.createTeamOneToOneConversation(in: userSession.viewContext) { result in
+                guard case .success(let conversation) = result else { return }
 
                 self.transition(to: conversation)
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4544" title="WPB-4544" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4544</a>  [iOS] Stop processing team events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Minor change taken out from a larger PR:
Support returning an error through a callback.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
