### PR TITLE
feat: Handle out order messages WBP-5829

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -32,7 +32,7 @@ public protocol MLSActionExecutorProtocol {
 
 }
 
-actor MLSActionExecutor: MLSActionExecutorProtocol {
+public actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Types
 
@@ -61,7 +61,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Life cycle
 
-    init(
+    public init(
         coreCryptoProvider: CoreCryptoProviderProtocol,
         commitSender: CommitSending
     ) {
@@ -104,7 +104,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Actions
 
-    func addMembers(_ invitees: [KeyPackage], to groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+    public func addMembers(_ invitees: [KeyPackage], to groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("adding members to group (\(groupID.safeForLoggingDescription))...")
@@ -119,7 +119,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
         }
     }
 
-    func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+    public func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("removing clients from group (\(groupID.safeForLoggingDescription))...")
@@ -134,7 +134,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
         }
     }
 
-    func updateKeyMaterial(for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+    public func updateKeyMaterial(for groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("updating key material for group (\(groupID.safeForLoggingDescription))...")
@@ -149,7 +149,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
         }
     }
 
-    func commitPendingProposals(in groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
+    public func commitPendingProposals(in groupID: MLSGroupID) async throws -> [ZMUpdateEvent] {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("committing pending proposals for group (\(groupID.safeForLoggingDescription))...")
@@ -166,7 +166,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
         }
     }
 
-    func joinGroup(_ groupID: MLSGroupID, groupInfo: Data) async throws -> [ZMUpdateEvent] {
+    public func joinGroup(_ groupID: MLSGroupID, groupInfo: Data) async throws -> [ZMUpdateEvent] {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("joining group (\(groupID.safeForLoggingDescription)) via external commit")
@@ -183,7 +183,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Decryption
 
-    func decryptMessage(_ message: Data, in groupID: MLSGroupID) async throws -> DecryptedMessage {
+    public func decryptMessage(_ message: Data, in groupID: MLSGroupID) async throws -> DecryptedMessage {
         try await performNonReentrant(groupID: groupID) {
             try await coreCrypto.perform {
                 try await $0.decryptMessage(conversationId: groupID.data, payload: message)
@@ -259,7 +259,7 @@ actor MLSActionExecutor: MLSActionExecutorProtocol {
     // MARK: - Epoch publisher
 
     nonisolated
-    func onEpochChanged() -> AnyPublisher<MLSGroupID, Never> {
+    public func onEpochChanged() -> AnyPublisher<MLSGroupID, Never> {
         commitSender.onEpochChanged()
     }
 }

--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -76,7 +76,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     /// That is only one operation is allowed execute concurrently, if multiple operations for the same group is scheduled
     /// they will be queued and executed in sequence.
     ///
-    /// This used for operations where ordering is important. For example when sending a commit to add client to a group, this a two-step operation:
+    /// This is used for operations where ordering is important. For example when sending a commit to add client to a group, this is a two-step operations:
     ///
     /// 1. Create pending commit and send to distribution server
     /// 2. Merge pending commit when accepted by distribution server

--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -160,7 +160,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
 
         if let message = messageBundle.message {
             guard let clientId = messageBundle.senderClientId else {
-                // We are guranteed to have a senderClientId with messages
+                // We are guaranteed to have a senderClientId with messages
                 throw MLSMessageDecryptionError.failedToDecodeSenderClientID
             }
 
@@ -180,7 +180,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
 
         if let message = messageBundle.message {
             guard let clientId = messageBundle.senderClientId else {
-                // We are guranteed to have a senderClientId with messages
+                // We are guaranteed to have a senderClientId with messages
                 throw MLSMessageDecryptionError.failedToDecodeSenderClientID
             }
 

--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -157,7 +157,7 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
             // Received already sent or received message, can safely be ignored.
             case CryptoError.DuplicateMessage: return []
 
-            // Received self commit, any unmerged group has know when merged by CoreCrypto.
+            // Received self commit, any pending self commit has now been merged
             case CryptoError.SelfCommitIgnored: return []
 
             // Message arrive in an unmerged group, it has been buffered and will be consumed later.

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -217,7 +217,7 @@ public final class MLSService: MLSServiceInterface {
         self.encryptionService = encryptionService ?? MLSEncryptionService(coreCryptoProvider: coreCryptoProvider)
         self.decryptionService = decryptionService ?? MLSDecryptionService(
             context: context,
-            coreCryptoProvider: coreCryptoProvider,
+            mlsActionExecutor: self.mlsActionExecutor,
             subconversationGroupIDRepository: subconversationGroupIDRepository
         )
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1248,7 +1248,7 @@ public final class MLSService: MLSServiceInterface {
         message: String,
         for groupID: MLSGroupID,
         subconversationType: SubgroupType?
-    ) async throws -> MLSDecryptResult? {
+    ) async throws -> [MLSDecryptResult] {
         typealias DecryptionError = MLSDecryptionService.MLSMessageDecryptionError
 
         do {

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -2830,10 +2830,10 @@ public class MockMLSDecryptionServiceInterface: MLSDecryptionServiceInterface {
 
     public var decryptMessageForSubconversationType_Invocations: [(message: String, groupID: MLSGroupID, subconversationType: SubgroupType?)] = []
     public var decryptMessageForSubconversationType_MockError: Error?
-    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) async throws -> MLSDecryptResult?)?
-    public var decryptMessageForSubconversationType_MockValue: MLSDecryptResult??
+    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) async throws -> [MLSDecryptResult])?
+    public var decryptMessageForSubconversationType_MockValue: [MLSDecryptResult]?
 
-    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) async throws -> MLSDecryptResult? {
+    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) async throws -> [MLSDecryptResult] {
         decryptMessageForSubconversationType_Invocations.append((message: message, groupID: groupID, subconversationType: subconversationType))
 
         if let error = decryptMessageForSubconversationType_MockError {
@@ -3350,10 +3350,10 @@ public class MockMLSServiceInterface: MLSServiceInterface {
 
     public var decryptMessageForSubconversationType_Invocations: [(message: String, groupID: MLSGroupID, subconversationType: SubgroupType?)] = []
     public var decryptMessageForSubconversationType_MockError: Error?
-    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) async throws -> MLSDecryptResult?)?
-    public var decryptMessageForSubconversationType_MockValue: MLSDecryptResult??
+    public var decryptMessageForSubconversationType_MockMethod: ((String, MLSGroupID, SubgroupType?) async throws -> [MLSDecryptResult])?
+    public var decryptMessageForSubconversationType_MockValue: [MLSDecryptResult]?
 
-    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) async throws -> MLSDecryptResult? {
+    public func decrypt(message: String, for groupID: MLSGroupID, subconversationType: SubgroupType?) async throws -> [MLSDecryptResult] {
         decryptMessageForSubconversationType_Invocations.append((message: message, groupID: groupID, subconversationType: subconversationType))
 
         if let error = decryptMessageForSubconversationType_MockError {

--- a/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
@@ -133,7 +133,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
             )
         }
 
-        // the decrypt message operaiton should wait for update key material to finish
+        // the decrypt message operation should wait for update key material to finish
         await fulfillment(of: [sendCommitExpectation])
         try await Task.sleep(nanoseconds: 1_000_000_000)
         XCTAssertEqual(mockCoreCrypto.decryptMessageConversationIdPayload_Invocations.count, 0)

--- a/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
@@ -28,31 +28,26 @@ import WireTesting
 final class MLSDecryptionServiceTests: ZMConversationTestsBase {
 
     var sut: MLSDecryptionService!
-    var mockCoreCrypto: MockCoreCryptoProtocol!
-    var mockSafeCoreCrypto: MockSafeCoreCrypto!
-    var mockCoreCryptoProvider: MockCoreCryptoProviderProtocol!
+    var mockMLSActionExecutor: MockMLSActionExecutor!
     var mockSubconversationGroupIDRepository: MockSubconversationGroupIDRepositoryInterface!
 
     // MARK: - Setup
 
     override func setUp() {
         super.setUp()
-        mockCoreCrypto = MockCoreCryptoProtocol()
-        mockSafeCoreCrypto = MockSafeCoreCrypto(coreCrypto: mockCoreCrypto)
-        mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
-        mockCoreCryptoProvider.coreCryptoRequireMLS_MockValue = mockSafeCoreCrypto
+        mockMLSActionExecutor = MockMLSActionExecutor()
         mockSubconversationGroupIDRepository = MockSubconversationGroupIDRepositoryInterface()
 
         sut = MLSDecryptionService(
             context: syncMOC,
-            coreCryptoProvider: mockCoreCryptoProvider,
+            mlsActionExecutor: mockMLSActionExecutor,
             subconversationGroupIDRepository: mockSubconversationGroupIDRepository
         )
     }
 
     override func tearDown() {
         sut = nil
-        mockCoreCrypto = nil
+        mockMLSActionExecutor = nil
         mockSubconversationGroupIDRepository = nil
         super.tearDown()
     }
@@ -81,7 +76,10 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         // Given
         let groupID = MLSGroupID.random()
         let message = Data.random().base64EncodedString()
-        self.mockCoreCrypto.decryptMessageConversationIdPayload_MockError = CryptoError.ConversationNotFound(message: "conversation not found")
+
+        self.mockMLSActionExecutor.mockDecryptMessage = { _, _ in
+            throw CryptoError.ConversationNotFound(message: "conversation not found")
+        }
 
         // Then
         await assertItThrows(error: DecryptionError.failedToDecryptMessage) {
@@ -99,7 +97,7 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         // Given
         let groupID = MLSGroupID.random()
         let messageBytes = Data.random().bytes
-        self.mockCoreCrypto.decryptMessageConversationIdPayload_MockValue =
+        self.mockMLSActionExecutor.mockDecryptMessage = { _, _ in
             DecryptedMessage(
                 message: nil,
                 proposals: [],
@@ -110,6 +108,7 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
                 identity: nil,
                 bufferedMessages: nil
             )
+        }
 
         // When
         var result: MLSDecryptResult?
@@ -138,11 +137,11 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         )
 
         var mockDecryptMessageCount = 0
-        self.mockCoreCrypto.decryptMessageConversationIdPayload_MockMethod = {
+        self.mockMLSActionExecutor.mockDecryptMessage = {
             mockDecryptMessageCount += 1
 
-            XCTAssertEqual($0, groupID.data)
-            XCTAssertEqual($1, messageData)
+            XCTAssertEqual($0, messageData)
+            XCTAssertEqual($1, groupID)
 
             return DecryptedMessage(
                 message: messageData,
@@ -183,11 +182,11 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         mockSubconversationGroupIDRepository.fetchSubconversationGroupIDForTypeParentGroupID_MockValue = subconversationGroupID
 
         var mockDecryptMessageCount = 0
-        self.mockCoreCrypto.decryptMessageConversationIdPayload_MockMethod = {
+        self.mockMLSActionExecutor.mockDecryptMessage = {
             mockDecryptMessageCount += 1
 
-            XCTAssertEqual($0, subconversationGroupID.data)
-            XCTAssertEqual($1, messageData)
+            XCTAssertEqual($0, messageData)
+            XCTAssertEqual($1, subconversationGroupID)
 
             return DecryptedMessage(
                 message: messageData,
@@ -238,7 +237,7 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
             didReceiveGroupIDs.fulfill()
         }
 
-        mockCoreCrypto.decryptMessageConversationIdPayload_MockMethod = { _, _ in
+        self.mockMLSActionExecutor.mockDecryptMessage = { _, _ in
             return DecryptedMessage(
                 message: messageData,
                 proposals: [],

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -252,13 +252,12 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         let message = "foo"
         let groupID = MLSGroupID.random()
         let subconversationType = SubgroupType.conference
-
         let mockResult = MLSDecryptResult.message(.random(), .random(length: 3))
 
-        mockDecryptionService.decryptMessageForSubconversationType_MockValue = mockResult
+        mockDecryptionService.decryptMessageForSubconversationType_MockValue = [mockResult]
 
         // When
-        let result = try await sut.decrypt(
+        let results = try await sut.decrypt(
             message: message,
             for: groupID,
             subconversationType: subconversationType
@@ -270,7 +269,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertEqual(invocation?.message, message)
         XCTAssertEqual(invocation?.groupID, groupID)
         XCTAssertEqual(invocation?.subconversationType, subconversationType)
-        XCTAssertEqual(result, mockResult)
+        XCTAssertEqual(results.first, mockResult)
     }
 
     // MARK: - Message Decryption
@@ -282,10 +281,10 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         let subconversationType = SubgroupType.conference
 
         let mockResult = MLSDecryptResult.message(.random(), .random(length: 3))
-        mockDecryptionService.decryptMessageForSubconversationType_MockValue = mockResult
+        mockDecryptionService.decryptMessageForSubconversationType_MockValue = [mockResult]
 
         // When
-        let result = try await sut.decrypt(
+        let results = try await sut.decrypt(
             message: message,
             for: groupID,
             subconversationType: subconversationType
@@ -297,7 +296,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertEqual(invocation?.message, message)
         XCTAssertEqual(invocation?.groupID, groupID)
         XCTAssertEqual(invocation?.subconversationType, subconversationType)
-        XCTAssertEqual(result, mockResult)
+        XCTAssertEqual(results.first, mockResult)
     }
 
     func test_Decrypt_RepairsConversationOnWrongEpochError() async throws {

--- a/wire-ios-data-model/Tests/MLS/MockMLSActionExecutor.swift
+++ b/wire-ios-data-model/Tests/MLS/MockMLSActionExecutor.swift
@@ -135,6 +135,28 @@ final class MockMLSActionExecutor: MLSActionExecutorProtocol {
         return try await mock(groupID, groupInfo)
     }
 
+    // MARK: - Decrypt
+
+    typealias DecryptMessage = ((Data, MLSGroupID) async throws -> DecryptedMessage)
+    private var mockDecryptMessage_: DecryptMessage?
+    var mockDecryptMessage: DecryptMessage? {
+        get { serialQueue.sync { mockDecryptMessage_ } }
+        set { serialQueue.sync { mockDecryptMessage_ = newValue } }
+    }
+    private var mockDecryptMessageCount_ = 0
+    var mockDecryptMessageCount: Int {
+        get { serialQueue.sync { mockDecryptMessageCount_ } }
+        set { serialQueue.sync { mockDecryptMessageCount_ = newValue } }
+    }
+    func decryptMessage(_ message: Data, in groupID: WireDataModel.MLSGroupID) async throws -> WireCoreCrypto.DecryptedMessage {
+        guard let mock = mockDecryptMessage else {
+            fatalError("no mock for `decryptMessage`")
+        }
+
+        mockDecryptMessageCount += 1
+        return try await mock(message, groupID)
+    }
+
     // MARK: - On epoch changed
 
     typealias OnEpochChangedMock = () -> AnyPublisher<MLSGroupID, Never>

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -236,6 +236,14 @@ public class NotificationSession {
             cryptoboxMigrationManager: cryptoboxMigrationManager,
             allowCreation: false
         )
+        let commitSender = CommitSender(
+            coreCryptoProvider: coreCryptoProvider,
+            notificationContext: coreDataStack.syncContext.notificationContext
+        )
+        let mlsActionExecutor = MLSActionExecutor(
+            coreCryptoProvider: coreCryptoProvider,
+            commitSender: commitSender
+        )
 
         let saveNotificationPersistence = ContextDidSaveNotificationPersistence(accountContainer: accountContainer)
 
@@ -251,7 +259,7 @@ public class NotificationSession {
             cryptoboxMigrationManager: cryptoboxMigrationManager,
             earService: EARService(accountID: accountIdentifier, sharedUserDefaults: sharedUserDefaults),
             proteusService: ProteusService(coreCryptoProvider: coreCryptoProvider),
-            mlsDecryptionService: MLSDecryptionService(context: coreDataStack.syncContext, coreCryptoProvider: coreCryptoProvider)
+            mlsDecryptionService: MLSDecryptionService(context: coreDataStack.syncContext, mlsActionExecutor: mlsActionExecutor)
         )
     }
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -23,7 +23,7 @@ extension EventDecoder {
     func decryptMlsMessage(
         from updateEvent: ZMUpdateEvent,
         context: NSManagedObjectContext
-    ) async -> ZMUpdateEvent? {
+    ) async -> [ZMUpdateEvent] {
         Logging.mls.info("decrypting mls message")
 
         guard let decryptionService = await context.perform({ context.mlsDecryptionService }) else {
@@ -33,7 +33,7 @@ extension EventDecoder {
 
         guard let payload = updateEvent.eventPayload(type: Payload.UpdateConversationMLSMessageAdd.self) else {
             WireLogger.mls.error("failed to decrypt mls message: invalid update event payload")
-            return nil
+            return []
         }
 
         var conversation: ZMConversation?
@@ -55,48 +55,50 @@ extension EventDecoder {
 
         guard let groupID else {
             WireLogger.mls.error("failed to decrypt mls message: missing MLS group ID")
-            return nil
+            return []
         }
 
         do {
-            guard
-                let result = try await decryptionService.decrypt(
-                    message: payload.data,
-                    for: groupID,
-                    subconversationType: payload.subconversationType
-                )
-            else {
+            let results = try await decryptionService.decrypt(
+                message: payload.data,
+                for: groupID,
+                subconversationType: payload.subconversationType
+            )
+
+            if results.isEmpty {
                 WireLogger.mls.info("successfully decrypted mls message but no result was returned")
-                return nil
+                return []
             }
 
-            switch result {
-            case .message(let decryptedData, let senderClientID):
-                return updateEvent.decryptedMLSEvent(decryptedData: decryptedData, senderClientID: senderClientID)
+            return await results.asyncCompactMap { result in
+                switch result {
+                case .message(let decryptedData, let senderClientID):
+                    return updateEvent.decryptedMLSEvent(decryptedData: decryptedData, senderClientID: senderClientID)
 
-            case .proposal(let commitDelay):
-                let scheduledDate = (updateEvent.timestamp ?? Date()) + TimeInterval(commitDelay)
-                var mlsService: MLSServiceInterface?
-                await context.perform {
-                    conversation?.commitPendingProposalDate = scheduledDate
-                    mlsService = context.mlsService
-                }
-
-                if let mlsService, updateEvent.source == .webSocket {
-                    do {
-                        try await mlsService.commitPendingProposals()
-                    } catch {
-                        WireLogger.mls.error("failed to commit pending proposals: \(String(describing: error))")
+                case .proposal(let commitDelay):
+                    let scheduledDate = (updateEvent.timestamp ?? Date()) + TimeInterval(commitDelay)
+                    var mlsService: MLSServiceInterface?
+                    await context.perform {
+                        conversation?.commitPendingProposalDate = scheduledDate
+                        mlsService = context.mlsService
                     }
 
-                }
+                    if let mlsService, updateEvent.source == .webSocket {
+                        do {
+                            try await mlsService.commitPendingProposals()
+                        } catch {
+                            WireLogger.mls.error("failed to commit pending proposals: \(String(describing: error))")
+                        }
 
-                return nil
+                    }
+
+                    return nil
+                }
             }
 
         } catch {
             Logging.mls.warn("failed to decrypt mls message: \(String(describing: error))")
-            return nil
+            return []
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -77,10 +77,9 @@ extension EventDecoder {
 
                 case .proposal(let commitDelay):
                     let scheduledDate = (updateEvent.timestamp ?? Date()) + TimeInterval(commitDelay)
-                    var mlsService: MLSServiceInterface?
-                    await context.perform {
+                    let mlsService = await context.perform {
                         conversation?.commitPendingProposalDate = scheduledDate
-                        mlsService = context.mlsService
+                        return context.mlsService
                     }
 
                     if let mlsService, updateEvent.source == .webSocket {

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -163,22 +163,23 @@ extension EventDecoder {
     ) async -> [ZMUpdateEvent] {
         var decryptedEvents = [ZMUpdateEvent]()
 
-        decryptedEvents = await events.asyncCompactMap { event -> ZMUpdateEvent? in
+        decryptedEvents = Array(await events.asyncMap { event -> [ZMUpdateEvent] in
             switch event.type {
             case .conversationOtrMessageAdd, .conversationOtrAssetAdd:
-                return await self.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
+                let proteusEvent = await self.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
                     try await proteusService.decrypt(
                         data: encryptedData,
                         forSession: sessionID
                     )
                 }
+                return proteusEvent.map { [$0] } ?? []
             case .conversationMLSMessageAdd:
                 return await self.decryptMlsMessage(from: event, context: self.syncMOC)
 
             default:
-                return event
+                return [event]
             }
-        }
+        }.joined())
 
         // This call has to be synchronous to ensure that we close the
         // encryption context only if we stored all events in the database.
@@ -200,23 +201,24 @@ extension EventDecoder {
         await keyStore.encryptionContext.performAsync { [weak self] sessionsDirectory in
             guard let self else { return }
 
-            decryptedEvents = await events.asyncCompactMap { event -> ZMUpdateEvent? in
+            decryptedEvents = Array(await events.asyncMap { event -> [ZMUpdateEvent] in
                 switch event.type {
                 case .conversationOtrMessageAdd, .conversationOtrAssetAdd:
-                    return await self.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
+                    let proteusEvent = await self.decryptProteusEventAndAddClient(event, in: self.syncMOC) { sessionID, encryptedData in
                         try sessionsDirectory.decryptData(
                             encryptedData,
                             for: sessionID.mapToEncryptionSessionID()
                         )
                     }
+                    return proteusEvent.map { [$0] } ?? []
 
                 case .conversationMLSMessageAdd:
                     return await self.decryptMlsMessage(from: event, context: self.syncMOC)
 
                 default:
-                    return event
+                    return [event]
                 }
-            }
+            }.joined())
 
             // This call has to be synchronous to ensure that we close the
             // encryption context only if we stored all events in the database.

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -489,7 +489,7 @@ extension EventDecoderTest {
         let messageData = randomData
         let senderClientID = "clientID"
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
-                .message(messageData, senderClientID)
+                [.message(messageData, senderClientID)]
         }
         let event: ZMUpdateEvent = await syncMOC.perform { [self] in
             self.mlsMessageAddEvent(
@@ -498,9 +498,10 @@ extension EventDecoderTest {
             )
         }
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
+        let decryptedEvent = decryptedEvents.first
         let payloadData = decryptedEvent?.payload["data"] as? [String: Any]
         let decryptedData = payloadData?["text"] as? String
         let senderID = payloadData?["sender"] as? String
@@ -524,14 +525,14 @@ extension EventDecoderTest {
         var expectedCommitDate = try XCTUnwrap(event.timestamp)
         expectedCommitDate += TimeInterval(commitDelay)
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
-                .proposal(commitDelay)
+                [.proposal(commitDelay)]
         }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
 
         await syncMOC.perform {
             guard let conversation = ZMConversation.fetch(with: mlsGroupID, in: self.syncMOC) else {
@@ -554,14 +555,14 @@ extension EventDecoderTest {
         }
         event.source = .webSocket
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
-                .proposal(commitDelay)
+                [.proposal(commitDelay)]
         }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
         XCTAssertTrue(wait(withTimeout: 3.0) { [self] in
             !mockMLSService.commitPendingProposals_Invocations.isEmpty
         })
@@ -581,32 +582,32 @@ extension EventDecoderTest {
         }
         event.source = .download
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
-                .proposal(commitDelay)
+                [.proposal(commitDelay)]
         }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
         spinMainQueue(withTimeout: 1)
         XCTAssertTrue(mockMLSService.commitPendingProposals_Invocations.isEmpty)
     }
 
-    func test_DecryptMLSMessage_ReturnsNil_WhenPayloadIsInvalid() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenPayloadIsInvalid() async {
         // Given
         let invalidDataPayload = ["invalidKey": ""]
         let event = await syncMOC.perform { self.mlsMessageAddEvent(data: invalidDataPayload) }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
 
     }
 
-    func test_DecryptMLSMessage_ReturnsNil_WhenGroupIDIsMissing() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenGroupIDIsMissing() async {
         // Given
         let event = await syncMOC.perform { [self] in
             mlsMessageAddEvent(
@@ -615,16 +616,16 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
     }
 
-    func test_DecryptMLSMessage_ReturnsNil_WhenDecryptedDataIsNil() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenDecryptedDataIsNil() async {
         // Given
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
-                .none
+            []
         }
 
         let event = await syncMOC.perform { [self] in
@@ -635,13 +636,13 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
     }
 
-    func test_DecryptMLSMessage_ReturnsNil_WhenmlsServiceThrows() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenmlsServiceThrows() async {
         // Given
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
             throw MLSDecryptionService.MLSMessageDecryptionError.failedToDecryptMessage
@@ -655,10 +656,10 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvent = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
-        XCTAssertNil(decryptedEvent)
+        XCTAssertTrue(decryptedEvents.isEmpty)
     }
 
     var randomData: Data {

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -368,6 +368,14 @@ public class SharingSession {
             cryptoboxMigrationManager: cryptoboxMigrationManager,
             allowCreation: false
         )
+        let commitSender = CommitSender(
+            coreCryptoProvider: coreCryptoProvider,
+            notificationContext: coreDataStack.syncContext.notificationContext
+        )
+        let mlsActionExecutor = MLSActionExecutor(
+            coreCryptoProvider: coreCryptoProvider,
+            commitSender: commitSender
+        )
         let earService = EARService(
             accountID: accountIdentifier,
             databaseContexts: [
@@ -377,7 +385,7 @@ public class SharingSession {
             sharedUserDefaults: sharedUserDefaults
         )
         let proteusService = ProteusService(coreCryptoProvider: coreCryptoProvider)
-        let mlsDecryptionService = MLSDecryptionService(context: coreDataStack.syncContext, coreCryptoProvider: coreCryptoProvider)
+        let mlsDecryptionService = MLSDecryptionService(context: coreDataStack.syncContext, mlsActionExecutor: mlsActionExecutor)
 
         try self.init(
             accountIdentifier: accountIdentifier,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

#### Handle new errors which can be thrown when decrypting a message

CoreCrypto returns some new errors which we should ignore:

- `BufferedFutureMessage`:   Message arrive in future epoch, it has been buffered and will be consumed later.
- `DuplicateMessage`: Received an already sent or received message
- `SelfCommitIgnored`: Received self commit, any unmerged group has know when merged by CoreCrypto. This allows us to recover from when we manage to successfully sent a commit to the distribution server, but the server response never reaches us which leaves the group with the unmerged pending commit.
- `UnmergedPendingGroup`: Message arrive in an unmerged group, this will never happens since we don't allow decrypting messages while sending a commit.

#### Handle buffered message when decrypting a commit

If we receive message and commits in the wrong order CoreCrypto will buffer the message until the commit is received, at which point CoreCrypto will decrypt the buffered messages and return them.

This means a call to `decryptMessage` can now returns a list of messages instead of only a single message.
  
#### Handle buffered messages when merging a pending commit

We avoid this scenario by not allowing decrypting message while we are in process of sending a commit, see `performNonReentrant ` in the `MLSActionExecutor`.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
