### PR TITLE
feat: fix remove device action WPB-5523

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
@@ -82,7 +82,6 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
 
     @MainActor
     func removeDevice() async -> Bool {
-        isProcessing?(true)
         return await withCheckedContinuation {[weak self] continuation in
             guard let self = self else {
                 return

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
@@ -44,7 +44,6 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
     }
 
     private var saveFileManager: SaveFileActions
-    private var continuation: CheckedContinuation<Bool, Never>?
 
     init(
         userClient: UserClient,
@@ -86,7 +85,9 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
             guard let self = self else {
                 return
             }
-            self.continuation = continuation
+            // (Continuation)[https://developer.apple.com/documentation/swift/checkedcontinuation]
+            // Using the same continuation twice results in a crash.
+            var optionalContinuation: CheckedContinuation<Bool, Never>? = continuation
             clientRemovalObserver = ClientRemovalObserver(
                 userClientToDelete: userClient,
                 delegate: self,
@@ -94,9 +95,9 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
                 completion: {
                     error in
                     defer {
-                        self.continuation = nil
+                        optionalContinuation = nil
                     }
-                    self.continuation?.resume(returning: error == nil)
+                    optionalContinuation?.resume(returning: error == nil)
                     if let error = error {
                         WireLogger.e2ei.error(error.localizedDescription)
                     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
@@ -91,7 +91,7 @@ final class DeviceInfoViewModel: ObservableObject {
     var isCopyEnabled: Bool {
         return Settings.isClipboardEnabled
     }
-    @Published var shouldDissmissView: Bool = false
+    @Published var isRemoved: Bool = false
     @Published var isProteusVerificationEnabled: Bool = false
     @Published var isActionInProgress: Bool = false
     @Published var proteusKeyFingerprint: String = ""
@@ -151,7 +151,7 @@ final class DeviceInfoViewModel: ObservableObject {
     @MainActor
     func removeDevice() async {
         let isRemoved = await actionsHandler.removeDevice()
-        shouldDissmissView = isRemoved
+        self.isRemoved = isRemoved
     }
 
     func resetSession() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
@@ -91,7 +91,7 @@ final class DeviceInfoViewModel: ObservableObject {
     var isCopyEnabled: Bool {
         return Settings.isClipboardEnabled
     }
-    @Published var isRemoved: Bool = false
+    @Published var shouldDissmissView: Bool = false
     @Published var isProteusVerificationEnabled: Bool = false
     @Published var isActionInProgress: Bool = false
     @Published var proteusKeyFingerprint: String = ""
@@ -148,15 +148,10 @@ final class DeviceInfoViewModel: ObservableObject {
         }
     }
 
+    @MainActor
     func removeDevice() async {
-        DispatchQueue.main.async {
-            self.isActionInProgress = true
-        }
         let isRemoved = await actionsHandler.removeDevice()
-        DispatchQueue.main.async {
-            self.isRemoved = isRemoved
-            self.isActionInProgress = false
-        }
+        shouldDissmissView = isRemoved
     }
 
     func resetSession() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
@@ -123,8 +123,8 @@ struct DeviceDetailsView: View {
         .onDisappear {
             dismissedView?()
         }
-        .onReceive(viewModel.$shouldDissmissView) { shouldDismiss in
-            if shouldDismiss {
+        .onReceive(viewModel.$isRemoved) { isRemoved in
+            if isRemoved {
                 dismiss()
             }
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/DeviceDetailsView.swift
@@ -123,6 +123,11 @@ struct DeviceDetailsView: View {
         .onDisappear {
             dismissedView?()
         }
+        .onReceive(viewModel.$shouldDissmissView) { shouldDismiss in
+            if shouldDismiss {
+                dismiss()
+            }
+        }
         .sheet(isPresented: $isCertificateViewPresented) {
             if let certificate = viewModel.e2eIdentityCertificate {
                 E2EIdentityCertificateDetailsView(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5523" title="WPB-5523" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5523</a>  [iOS] 5.3.24 Show E2EI certificate info - Business logic & initial integration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Remove device should be called on main thread to function as expected.

### Causes (Optional)

Calling from a background thread produces unknown behavious

### Solutions

Using MainActor, all the calls are made on Main thread


Needs releases with:

- [ ] GitHub link to other pull request

### Testing


#### How to Test

**Steps**
1. Go to Settings
2. Tap on Devices
3. Tap on any of Active devices
4. Tap on Remove Device
**Expectation ** 
The device should be removed from active devices and should navigate to devices screen


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
