### PR TITLE
feat: handle federation errors when adding users to an MLS conversation WPB-2228

### DIFF
--- a/wire-ios-data-model/Source/MLS/Actions/SendMLSMessageAction.swift
+++ b/wire-ios-data-model/Source/MLS/Actions/SendMLSMessageAction.swift
@@ -54,10 +54,14 @@ public final class SendMLSMessageAction: EntityAction {
         // 409
         case mlsStaleMessage
         case mlsClientMismatch
+        case unreachableDomains(Set<String>)
 
         // 422
         case mlsUnsupportedProposal
         case mlsUnsupportedMessage
+
+        // 503
+        case nonFederatingDomains(Set<String>)
 
         case unknown(status: Int, label: String, message: String)
 
@@ -123,6 +127,9 @@ public final class SendMLSMessageAction: EntityAction {
             case .mlsClientMismatch:
                 return "A proposal of type Add or Remove does not apply to the full list of clients for a user"
 
+            case .nonFederatingDomains(let domains):
+                return "Some domains are note fully connected: \(domains)"
+
             case .mlsUnsupportedProposal:
                 return "Unsupported proposal type"
 
@@ -131,6 +138,9 @@ public final class SendMLSMessageAction: EntityAction {
 
             case let .unknown(status, label, message):
                 return "Unknown error (response status: \(status), label: \(label), message: \(message))"
+
+            case .unreachableDomains(let domains):
+                return "Some domains were unrechable: \(domains)"
             }
         }
     }

--- a/wire-ios-data-model/Source/MLS/CommitError.swift
+++ b/wire-ios-data-model/Source/MLS/CommitError.swift
@@ -21,7 +21,7 @@ import Foundation
 enum CommitError: Error, Equatable {
 
     case failedToGenerateCommit
-    case failedToSendCommit(recovery: RecoveryStrategy)
+    case failedToSendCommit(recovery: RecoveryStrategy, cause: SendCommitBundleAction.Failure)
     case failedToMergeCommit
     case failedToClearCommit
     case noPendingProposals

--- a/wire-ios-data-model/Source/MLS/CommitSender.swift
+++ b/wire-ios-data-model/Source/MLS/CommitSender.swift
@@ -100,7 +100,7 @@ public actor CommitSender: CommitSending {
                 try await discardPendingCommit(in: groupID)
             }
 
-            throw CommitError.failedToSendCommit(recovery: recoveryStrategy)
+            throw CommitError.failedToSendCommit(recovery: recoveryStrategy, cause: error)
         }
     }
 
@@ -127,7 +127,7 @@ public actor CommitSender: CommitSending {
                 try await clearPendingGroup(in: groupID)
             }
 
-            throw ExternalCommitError.failedToSendCommit(recovery: recoveryStrategy)
+            throw ExternalCommitError.failedToSendCommit(recovery: recoveryStrategy, cause: error)
         }
     }
 

--- a/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
+++ b/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
@@ -20,7 +20,7 @@ import Foundation
 
 enum ExternalCommitError: Error, Equatable {
 
-    case failedToSendCommit(recovery: RecoveryStrategy)
+    case failedToSendCommit(recovery: RecoveryStrategy, cause: SendCommitBundleAction.Failure)
     case failedToMergePendingGroup
     case failedToClearPendingGroup
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1400,36 +1400,36 @@ public final class MLSService: MLSServiceInterface {
         do {
             try await operation()
 
-        } catch CommitError.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync) {
+        } catch CommitError.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync, _) {
             logger.warn("failed to send commit, syncing then committing pending proposals...")
             await syncStatus.performQuickSync()
             logger.info("sync finished, committing pending proposals...")
             try await commitPendingProposals(in: groupID)
 
-        } catch CommitError.failedToSendCommit(recovery: .retryAfterQuickSync) {
+        } catch CommitError.failedToSendCommit(recovery: .retryAfterQuickSync, _) {
             logger.warn("failed to send commit, syncing then retrying operation...")
             await syncStatus.performQuickSync()
             logger.info("sync finished, retying operation...")
             try await retryOnCommitFailure(for: groupID, operation: operation)
 
-        } catch CommitError.failedToSendCommit(recovery: .retryAfterRepairingGroup) {
+        } catch CommitError.failedToSendCommit(recovery: .retryAfterRepairingGroup, _) {
             logger.warn("failed to send commit, repairing group then retrying operation...")
             await fetchAndRepairGroup(with: groupID)
             logger.info("repair finished, retrying operation...")
             try await operation()
 
-        } catch CommitError.failedToSendCommit(recovery: .giveUp) {
+        } catch CommitError.failedToSendCommit(recovery: .giveUp, cause: let error) {
             logger.warn("failed to send commit, giving up...")
             // TODO: [John] inform user
-            throw CommitError.failedToSendCommit(recovery: .giveUp)
+            throw error
 
-        } catch ExternalCommitError.failedToSendCommit(recovery: .retry) {
+        } catch ExternalCommitError.failedToSendCommit(recovery: .retry, _) {
             logger.warn("failed to send external commit, retrying operation...")
             try await retryOnCommitFailure(for: groupID, operation: operation)
 
-        } catch ExternalCommitError.failedToSendCommit(recovery: .giveUp) {
+        } catch ExternalCommitError.failedToSendCommit(recovery: .giveUp, cause: let error) {
             logger.warn("failed to send external commit, giving up...")
-            throw ExternalCommitError.failedToSendCommit(recovery: .giveUp)
+            throw error
 
         }
     }

--- a/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
@@ -159,7 +159,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         }
 
         // Then
-        await assertItThrows(error: CommitError.failedToSendCommit(recovery: recovery)) {
+        await assertItThrows(error: CommitError.failedToSendCommit(recovery: recovery, cause: error)) {
             // When
             _ = try await sut.sendCommitBundle(commitBundle, for: groupID)
         }
@@ -238,7 +238,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         }
 
         // Then
-        await assertItThrows(error: ExternalCommitError.failedToSendCommit(recovery: recovery)) {
+        await assertItThrows(error: ExternalCommitError.failedToSendCommit(recovery: recovery, cause: error)) {
             // When
             _ = try await sut.sendExternalCommitBundle(commitBundle, for: groupID)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandler.swift
@@ -131,11 +131,39 @@ class SendCommitBundleActionHandler: ActionHandler<SendCommitBundleAction> {
         case (409, "mls-client-mismatch"):
             action.fail(with: .mlsClientMismatch)
 
+        case (409, _):
+            guard
+                let payload = FederationErrorResponse(response),
+                let nonFederatingDomains = payload.non_federating_backends
+            else {
+                let errorInfo = response.errorInfo
+                return action.fail(with: .unknown(
+                    status: response.httpStatus,
+                    label: errorInfo.label,
+                    message: errorInfo.message
+                ))
+            }
+            action.fail(with: .nonFederatingDomains(Set(nonFederatingDomains)))
+
         case (422, "mls-unsupported-proposal"):
             action.fail(with: .mlsUnsupportedProposal)
 
         case (422, "mls-unsupported-message"):
             action.fail(with: .mlsUnsupportedMessage)
+
+        case (533, _):
+            guard
+                let payload = FederationErrorResponse(response),
+                let unreachableBackends = payload.unreachable_backends
+            else {
+                let errorInfo = response.errorInfo
+                return action.fail(with: .unknown(
+                    status: response.httpStatus,
+                    label: errorInfo.label,
+                    message: errorInfo.message
+                ))
+            }
+            action.fail(with: .unreachableDomains(Set(unreachableBackends)))
 
         default:
             let errorInfo = response.errorInfo
@@ -145,5 +173,14 @@ class SendCommitBundleActionHandler: ActionHandler<SendCommitBundleAction> {
                 message: errorInfo.message
             ))
         }
+    }
+
+    // MARK: - Error response
+
+    struct FederationErrorResponse: Codable {
+
+        var unreachable_backends: [String]?
+        var non_federating_backends: [String]?
+
     }
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
@@ -58,6 +58,7 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
     }
 
     // MARK: - Response handling
+
     func test_itHandlesSuccess() throws {
         // Given
         let payload: [AnyHashable: Any] = [
@@ -113,5 +114,23 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
             .failure(status: 422, error: .mlsUnsupportedMessage, label: "mls-unsupported-message"),
             .failure(status: 999, error: .unknown(status: 999, label: "foo", message: "?"), label: "foo")
         ])
+    }
+
+    func test_itHandlesUnreachableBackendsFailure() {
+        let domains = ["example.com"]
+        let payload = ["unreachable_backends": domains]
+        test_itHandlesFailure(
+            status: 533,
+            payload: payload as ZMTransportData,
+            expectedError: SendCommitBundleAction.Failure.unreachableDomains(Set(domains)))
+    }
+
+    func test_itHandlesNonFederatingBackendsFailure() {
+        let domains = ["example.com"]
+        let payload = ["non_federating_backends": domains]
+        test_itHandlesFailure(
+            status: 409,
+            payload: payload as ZMTransportData,
+            expectedError: SendCommitBundleAction.Failure.nonFederatingDomains(Set(domains)))
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2228" title="WPB-2228" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-2228</a>  [iOS] Implement MLS client protocol for adding users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When adding federated users (or creating a new group) to a conversation, the backends of those users might not be reachable or might not be properly configured to allow the users to be added. If this happens a client should remove exclude these users and insert a system informing the user about the users who couldn't be added.

This logic was already implemented for proteus conversations, this PR enables this logic to also be applied to MLS conversations by parsing and bubbling up federation errors during the MLS add participant action.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
