### PR TITLE
fix: joining MLS conversation after login

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -820,7 +820,12 @@ public final class MLSService: MLSServiceInterface {
             return
         }
 
-        let pendingGroups = await context.perform { self.fetchPendingGroups(in: context) }
+        let pendingGroups = try await context.perform {
+            try ZMConversation.fetchConversationsWithMLSGroupStatus(
+                mlsGroupStatus: .pendingJoin,
+                in: context
+            ).compactMap(\.mlsGroupID)
+        }
 
         logger.info("joining \(pendingGroups.count) group(s)")
 
@@ -835,15 +840,6 @@ public final class MLSService: MLSServiceInterface {
                 }
             }
         }
-    }
-
-    private func fetchPendingGroups(in context: NSManagedObjectContext) -> [MLSGroupID] {
-        logger.info("fetching list of groups pending join")
-
-        return ZMConversation.fetchConversationsWithMLSGroupStatus(
-            mlsGroupStatus: .pendingJoin,
-            in: context
-        ).compactMap(\.mlsGroupID)
     }
 
     // MARK: - Out-of-sync conversations

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -840,12 +840,10 @@ public final class MLSService: MLSServiceInterface {
     private func fetchPendingGroups(in context: NSManagedObjectContext) -> [MLSGroupID] {
         logger.info("fetching list of groups pending join")
 
-        let pendingConversations = ZMConversation.fetchConversationsWithMLSGroupStatus(
+        return ZMConversation.fetchConversationsWithMLSGroupStatus(
             mlsGroupStatus: .pendingJoin,
             in: context
-        )
-
-        return pendingConversations.compactMap(\.mlsGroupID)
+        ).compactMap(\.mlsGroupID)
     }
 
     // MARK: - Out-of-sync conversations

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -159,6 +159,24 @@ public extension ZMConversation {
         return context.executeFetchRequestOrAssert(request) as? [ZMConversation] ?? []
     }
 
+    static func fetchConversationsWithMLSGroupStatus(
+        mlsGroupStatus: MLSGroupStatus,
+        in context: NSManagedObjectContext
+    ) -> [ZMConversation] {
+        let request = Self.fetchRequest()
+
+        let matchingGroupStatus = NSPredicate(
+            format: "%K == \(mlsGroupStatus.rawValue)",
+            argumentArray: [Self.mlsStatusKey]
+        )
+
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            matchingGroupStatus, .isMLSConversation
+        ])
+
+        return context.executeFetchRequestOrAssert(request) as? [ZMConversation] ?? []
+    }
+
     static func fetchSelfMLSConversation(
         in context: NSManagedObjectContext
     ) -> ZMConversation? {

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -162,9 +162,9 @@ public extension ZMConversation {
     static func fetchConversationsWithMLSGroupStatus(
         mlsGroupStatus: MLSGroupStatus,
         in context: NSManagedObjectContext
-    ) -> [ZMConversation] {
-        let request = Self.fetchRequest()
+    ) throws -> [ZMConversation] {
 
+        let request = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
         let matchingGroupStatus = NSPredicate(
             format: "%K == \(mlsGroupStatus.rawValue)",
             argumentArray: [Self.mlsStatusKey]
@@ -174,7 +174,7 @@ public extension ZMConversation {
             matchingGroupStatus, .isMLSConversation
         ])
 
-        return context.executeFetchRequestOrAssert(request) as? [ZMConversation] ?? []
+        return try context.fetch(request)
     }
 
     static func fetchSelfMLSConversation(

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -3061,21 +3061,6 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock(clientIds, groupID)
     }
 
-    // MARK: - registerPendingJoin
-
-    public var registerPendingJoin_Invocations: [MLSGroupID] = []
-    public var registerPendingJoin_MockMethod: ((MLSGroupID) -> Void)?
-
-    public func registerPendingJoin(_ group: MLSGroupID) {
-        registerPendingJoin_Invocations.append(group)
-
-        guard let mock = registerPendingJoin_MockMethod else {
-            fatalError("no mock for `registerPendingJoin`")
-        }
-
-        mock(group)
-    }
-
     // MARK: - performPendingJoins
 
     public var performPendingJoins_Invocations: [Void] = []

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1009,9 +1009,6 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         // TODO: Mock properly
         let mockUpdateEvents = [ZMUpdateEvent]()
 
-        // register the group to be joined
-        sut.registerPendingJoin(groupID)
-
         // expectation
         let expectation = XCTestExpectation(description: "Send Message")
 
@@ -1090,9 +1087,6 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             return conversation
         }
 
-        // register the group to be joined
-        sut.registerPendingJoin(groupID)
-
         // set up expectations
         let expectation = XCTestExpectation(description: "Send Message")
         expectation.isInverted = !shouldRetry
@@ -1150,9 +1144,6 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation.domain = "domain.com"
             conversation.mlsStatus = .ready
         }
-
-        // register the group to be joined
-        sut.registerPendingJoin(groupID)
 
         // expectation
         let expectation = XCTestExpectation(description: "Send Message")

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1003,6 +1003,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation.domain = domain
             conversation.mlsGroupID = groupID
             conversation.mlsStatus = .pendingJoin
+            conversation.messageProtocol = .mls
             return conversation
         }
 
@@ -1084,6 +1085,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation.domain = domain
             conversation.mlsGroupID = groupID
             conversation.mlsStatus = .pendingJoin
+            conversation.messageProtocol = .mls
             return conversation
         }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+MLS.swift
@@ -56,8 +56,8 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
         }
     }
 
-    func testThatItFetchesConversationWithMLSGroupStatus() {
-        syncMOC.performGroupedBlockAndWait { [self] in
+    func testThatItFetchesConversationWithMLSGroupStatus() throws {
+        try syncMOC.performAndWait { [self] in
             // Given
             BackendInfo.isFederationEnabled = false
             let groupID = MLSGroupID([1, 2, 3])
@@ -67,8 +67,8 @@ final class ZMConversationTests_MLS: ZMConversationTestsBase {
             readyConversation?.mlsStatus = .ready
 
             // When
-            let pendingConversations = ZMConversation.fetchConversationsWithMLSGroupStatus(mlsGroupStatus: .pendingJoin, in: syncMOC)
-            let readyConversations = ZMConversation.fetchConversationsWithMLSGroupStatus(mlsGroupStatus: .ready, in: syncMOC)
+            let pendingConversations = try ZMConversation.fetchConversationsWithMLSGroupStatus(mlsGroupStatus: .pendingJoin, in: syncMOC)
+            let readyConversations = try ZMConversation.fetchConversationsWithMLSGroupStatus(mlsGroupStatus: .ready, in: syncMOC)
 
             // Then
             XCTAssertEqual(pendingConversations, [pendingConversation])

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/IdentifierObjectSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/IdentifierObjectSync.swift
@@ -107,14 +107,16 @@ public class IdentifierObjectSync<Transcoder: IdentifierObjectSyncTranscoder>: N
             case .permanentError, .success:
                 self.downloading.subtract(scheduled)
                 self.transcoder?.didReceive(response: response, for: scheduled) {
-                    if case .permanentError = response.result {
-                        self.delegate?.didFailToSyncAllObjects()
-                    }
+                    self.managedObjectContext.perform {
+                        if case .permanentError = response.result {
+                            self.delegate?.didFailToSyncAllObjects()
+                        }
 
-                    if !self.isSyncing {
-                        self.delegate?.didFinishSyncingAllObjects()
+                        if !self.isSyncing {
+                            self.delegate?.didFinishSyncingAllObjects()
+                        }
+                        self.managedObjectContext.enqueueDelayedSave()
                     }
-                    self.managedObjectContext.enqueueDelayedSave()
                 }
             default:
                 self.downloading.subtract(scheduled)

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -687,15 +687,6 @@ final class ConversationEventPayloadProcessor {
             groupID: payload.mlsGroupID,
             context: context
         )
-
-        if source == .slowSync {
-            await context.perform {
-                mlsEventProcessor.joinMLSGroupWhenReady(
-                    forConversation: conversation,
-                    context: context
-                )
-            }
-        }
     }
 
     func fetchCreator(

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
@@ -34,8 +34,6 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
         mockMLSService = .init()
         mockRemoveLocalConversation = MockLocalConversationRemovalUseCase()
         mockMLSEventProcessor = .init()
-
-        mockMLSEventProcessor.joinMLSGroupWhenReadyForConversationContext_MockMethod = { _, _ in }
         mockMLSEventProcessor.updateConversationIfNeededConversationGroupIDContext_MockMethod = { _, _, _ in }
 
         MLSEventProcessor.setMock(mockMLSEventProcessor)
@@ -912,52 +910,6 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
             let updateConversationCalls = mockMLSEventProcessor.updateConversationIfNeededConversationGroupIDContext_Invocations
             XCTAssertEqual(updateConversationCalls.count, 1)
             XCTAssertEqual(updateConversationCalls.first?.conversation, groupConversation)
-        }
-    }
-
-    func testUpdateOrCreateConversation_Group_MLS_AsksToJoinGroupWhenReady_DuringSlowSync() async {
-        // given
-        let qualifiedID = await syncMOC.perform {
-            self.groupConversation.qualifiedID!
-        }
-        let payload = Payload.Conversation(qualifiedID: qualifiedID,
-                                           type: BackendConversationType.group.rawValue,
-                                           messageProtocol: "mls")
-
-        // when
-        await sut.updateOrCreateConversation(
-            from: payload,
-            source: .slowSync,
-            in: syncMOC
-        )
-
-        // then
-        await syncMOC.perform { [self] in
-            let joinMLSGroupWhenReadyCalls = mockMLSEventProcessor.joinMLSGroupWhenReadyForConversationContext_Invocations
-            XCTAssertEqual(joinMLSGroupWhenReadyCalls.count, 1)
-            XCTAssertEqual(joinMLSGroupWhenReadyCalls.first?.conversation, groupConversation)
-        }
-    }
-
-    func testUpdateOrCreateConversation_Group_MLS_DoesntAskToJoinGroupWhenReady_DuringQuickSync() async {
-        // given
-        let qualifiedID = await syncMOC.perform {
-            self.groupConversation.qualifiedID!
-        }
-        let payload = Payload.Conversation(qualifiedID: qualifiedID,
-                                           type: BackendConversationType.group.rawValue,
-                                           messageProtocol: "mls")
-
-        // when
-        await sut.updateOrCreateConversation(
-            from: payload,
-            source: .eventStream,
-            in: syncMOC
-        )
-
-        // then
-        await syncMOC.perform { [self] in
-            XCTAssertEqual(mockMLSEventProcessor.joinMLSGroupWhenReadyForConversationContext_Invocations.count, 0)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -23,7 +23,6 @@ protocol MLSEventProcessing {
 
     func updateConversationIfNeeded(conversation: ZMConversation, groupID: String?, context: NSManagedObjectContext) async
     func process(welcomeMessage: String, in context: NSManagedObjectContext) async
-    func joinMLSGroupWhenReady(forConversation conversation: ZMConversation, context: NSManagedObjectContext)
     func wipeMLSGroup(forConversation conversation: ZMConversation, context: NSManagedObjectContext) async
 
 }
@@ -70,32 +69,6 @@ final class MLSEventProcessor: MLSEventProcessing {
                 "MLS event processor updated previous mlsStatus (\(String(describing: previousStatus))) with new value (\(String(describing: conversation.mlsStatus))) for conversation (\(String(describing: conversation.qualifiedID)))"
             )
         }
-    }
-
-    // MARK: - Joining new conversations
-
-    /// - Note: must be executed on syncContext
-    func joinMLSGroupWhenReady(forConversation conversation: ZMConversation, context: NSManagedObjectContext) {
-        Logging.mls.info("MLS event processor is adding group to join")
-
-        guard conversation.messageProtocol == .mls else {
-            return logWarn(aborting: .joiningGroup, withReason: .notMLSConversation)
-        }
-
-        guard let groupID = conversation.mlsGroupID else {
-            return logWarn(aborting: .joiningGroup, withReason: .missingGroupID)
-        }
-
-        guard let mlsService = context.mlsService else {
-            return logWarn(aborting: .joiningGroup, withReason: .missingMLSService)
-        }
-
-        guard let status = conversation.mlsStatus, status.isPendingJoin else {
-            return logWarn(aborting: .joiningGroup, withReason: .other(reason: "MLS status is not .pendingJoin"))
-        }
-
-        mlsService.registerPendingJoin(groupID)
-        Logging.mls.info("MLS event processor added group (\(groupID.safeForLoggingDescription)) to be joined")
     }
 
     // MARK: - Process welcome message

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
@@ -33,7 +33,6 @@ class MLSEventProcessorTests: MessagingTestBase {
         sut = MLSEventProcessor()
         syncMOC.performGroupedBlockAndWait {
             self.mlsServiceMock = .init()
-            self.mlsServiceMock.registerPendingJoin_MockMethod = { _ in }
             self.mlsServiceMock.wipeGroup_MockMethod = { _ in }
             self.syncMOC.mlsService = self.mlsServiceMock
             self.conversation = ZMConversation.insertNewObject(in: self.syncMOC)
@@ -110,31 +109,6 @@ class MLSEventProcessorTests: MessagingTestBase {
         )
     }
 
-    // MARK: - Joining new conversations
-
-    func test_itAddsPendingGroupToGroupsPendingJoin() {
-        syncMOC.performAndWait {
-            // Given
-            self.conversation.mlsStatus = .pendingJoin
-
-            // When
-            self.sut.joinMLSGroupWhenReady(
-                forConversation: self.conversation,
-                context: self.syncMOC
-            )
-
-            // Then
-            XCTAssertEqual(self.mlsServiceMock.registerPendingJoin_Invocations.count, 1)
-            XCTAssertEqual(self.mlsServiceMock.registerPendingJoin_Invocations.first, self.conversation.mlsGroupID)
-        }
-    }
-
-    func test_itDoesntAddNotPendingGroupsToGroupsPendingJoin() {
-        test_thatGroupIsNotAddedToGroupsPendingJoin(forStatus: .ready)
-        test_thatGroupIsNotAddedToGroupsPendingJoin(forStatus: .pendingLeave)
-        test_thatGroupIsNotAddedToGroupsPendingJoin(forStatus: .outOfSync)
-    }
-
     // MARK: - Wiping group
 
     func test_itWipesGroup() async {
@@ -174,22 +148,6 @@ class MLSEventProcessorTests: MessagingTestBase {
     }
 
     // MARK: - Helpers
-
-    func test_thatGroupIsNotAddedToGroupsPendingJoin(forStatus status: MLSGroupStatus) {
-        syncMOC.performAndWait {
-            // Given
-            self.conversation.mlsStatus = status
-
-            // When
-            self.sut.joinMLSGroupWhenReady(
-                forConversation: self.conversation,
-                context: self.syncMOC
-            )
-
-            // Then
-            XCTAssertTrue(self.mlsServiceMock.registerPendingJoin_Invocations.isEmpty)
-        }
-    }
 
     func assert_mlsStatus(
         originalValue: MLSGroupStatus,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -496,23 +496,23 @@ class ConversationByIDTranscoder: IdentifierObjectSyncTranscoder {
     }
 
     func didReceive(response: ZMTransportResponse, for identifiers: Set<UUID>, completionHandler: @escaping () -> Void) {
-        defer { completionHandler() }
 
         guard response.result != .permanentError else {
             if response.httpStatus == 404 {
-                Task {
+                WaitingGroupTask(context: context) { [self] in
                     await deleteConversations(identifiers)
+                    await context.perform { completionHandler() }
                 }
                 return
             }
 
             if response.httpStatus == 403 {
                 removeSelfUser(identifiers)
-                return
+                return completionHandler()
             }
 
             markConversationsAsFetched(identifiers)
-            return
+            return completionHandler()
         }
 
         guard
@@ -521,14 +521,15 @@ class ConversationByIDTranscoder: IdentifierObjectSyncTranscoder {
             let payload = Payload.Conversation(rawData, apiVersion: apiVersion, decoder: decoder)
         else {
             Logging.network.warn("Can't process response, aborting.")
-            return
+            return completionHandler()
         }
 
-        Task {
+        WaitingGroupTask(context: context) { [self] in
             await processor.updateOrCreateConversation(
                 from: payload,
                 in: context
             )
+            await context.perform { completionHandler() }
         }
     }
 
@@ -611,23 +612,23 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
     }
 
     func didReceive(response: ZMTransportResponse, for identifiers: Set<QualifiedID>, completionHandler: @escaping () -> Void) {
-        defer { completionHandler() }
 
         guard response.result != .permanentError else {
             markConversationsAsFetched(identifiers)
 
             if response.httpStatus == 404 {
-                Task {
+                WaitingGroupTask(context: context) { [self] in
                     await deleteConversations(identifiers)
+                    await context.perform { completionHandler() }
                 }
                 return
             }
 
             if response.httpStatus == 403 {
                 removeSelfUser(identifiers)
-                return
+                return completionHandler()
             }
-            return
+            return completionHandler()
         }
 
         guard
@@ -639,14 +640,16 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
                 decoder: decoder
             )
         else {
-            return Logging.network.warn("Can't process response, aborting.")
+            Logging.network.warn("Can't process response, aborting.")
+            return completionHandler()
         }
 
-        Task {
+        WaitingGroupTask(context: context) { [self] in
             await processor.updateOrCreateConversation(
                 from: payload,
                 in: context
             )
+            await context.perform { completionHandler() }
         }
     }
 
@@ -719,17 +722,16 @@ class ConversationByIDListTranscoder: IdentifierObjectSyncTranscoder {
     }
 
     func didReceive(response: ZMTransportResponse, for identifiers: Set<UUID>, completionHandler: @escaping () -> Void) {
-        defer { completionHandler() }
         guard
             let apiVersion = APIVersion(rawValue: response.apiVersion),
             let rawData = response.rawData,
             let payload = Payload.ConversationList(rawData, apiVersion: apiVersion, decoder: decoder)
         else {
             Logging.network.warn("Can't process response, aborting.")
-            return
+            return completionHandler()
         }
 
-        Task {
+        WaitingGroupTask(context: context) { [self] in
             await processor.updateOrCreateConversations(
                 from: payload,
                 in: context
@@ -739,6 +741,7 @@ class ConversationByIDListTranscoder: IdentifierObjectSyncTranscoder {
                 let missingIdentifiers = identifiers.subtracting(payload.conversations.compactMap(\.id))
                 self.queryStatusForMissingConversations(missingIdentifiers)
             }
+            await context.perform { completionHandler() }
         }
     }
 
@@ -782,7 +785,6 @@ class ConversationByQualifiedIDListTranscoder: IdentifierObjectSyncTranscoder {
     }
 
     func didReceive(response: ZMTransportResponse, for identifiers: Set<QualifiedID>, completionHandler: @escaping () -> Void) {
-        defer { completionHandler() }
 
         guard
             let apiVersion = APIVersion(rawValue: response.apiVersion),
@@ -790,10 +792,10 @@ class ConversationByQualifiedIDListTranscoder: IdentifierObjectSyncTranscoder {
             let payload = Payload.QualifiedConversationList(rawData, apiVersion: apiVersion, decoder: decoder)
         else {
             Logging.network.warn("Can't process response, aborting.")
-            return
+            return completionHandler()
         }
 
-        Task {
+        WaitingGroupTask(context: context) { [self] in
             await processor.updateOrCreateConverations(
                 from: payload,
                 in: context
@@ -803,6 +805,7 @@ class ConversationByQualifiedIDListTranscoder: IdentifierObjectSyncTranscoder {
                 self.queryStatusForMissingConversations(payload.notFound)
                 self.queryStatusForFailedConversations(payload.failed)
             }
+            await context.perform { completionHandler() }
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -501,7 +501,7 @@ class ConversationByIDTranscoder: IdentifierObjectSyncTranscoder {
             if response.httpStatus == 404 {
                 WaitingGroupTask(context: context) { [self] in
                     await deleteConversations(identifiers)
-                    await context.perform { completionHandler() }
+                    completionHandler()
                 }
                 return
             }
@@ -529,7 +529,7 @@ class ConversationByIDTranscoder: IdentifierObjectSyncTranscoder {
                 from: payload,
                 in: context
             )
-            await context.perform { completionHandler() }
+            completionHandler()
         }
     }
 
@@ -619,7 +619,7 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
             if response.httpStatus == 404 {
                 WaitingGroupTask(context: context) { [self] in
                     await deleteConversations(identifiers)
-                    await context.perform { completionHandler() }
+                    completionHandler()
                 }
                 return
             }
@@ -649,7 +649,7 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
                 from: payload,
                 in: context
             )
-            await context.perform { completionHandler() }
+            completionHandler()
         }
     }
 
@@ -741,7 +741,7 @@ class ConversationByIDListTranscoder: IdentifierObjectSyncTranscoder {
                 let missingIdentifiers = identifiers.subtracting(payload.conversations.compactMap(\.id))
                 self.queryStatusForMissingConversations(missingIdentifiers)
             }
-            await context.perform { completionHandler() }
+            completionHandler()
         }
     }
 
@@ -805,7 +805,7 @@ class ConversationByQualifiedIDListTranscoder: IdentifierObjectSyncTranscoder {
                 self.queryStatusForMissingConversations(payload.notFound)
                 self.queryStatusForFailedConversations(payload.failed)
             }
-            await context.perform { completionHandler() }
+            completionHandler()
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/MLSRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/MLSRequestStrategy.swift
@@ -49,6 +49,8 @@ public final class MLSRequestStrategy: AbstractRequestStrategy {
             withManagedObjectContext: managedObjectContext,
             applicationStatus: applicationStatus
         )
+
+        configuration = [.allowsRequestsDuringSlowSync, .allowsRequestsWhileOnline]
     }
 
     // MARK: - Requests

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -253,9 +253,9 @@ final class UserClientByUserClientIDTranscoder: IdentifierObjectSyncTranscoder {
         }
 
         if response.result == .permanentError {
-            WaitingGroupTask(context: managedObjectContext) { [self] in
+            WaitingGroupTask(context: managedObjectContext) {
                 await client.deleteClientAndEndSession()
-                await managedObjectContext.perform { completionHandler() }
+                completionHandler()
             }
         } else if let rawData = response.rawData,
                   let payload = Payload.UserClient(rawData, decoder: decoder) {
@@ -371,7 +371,7 @@ final class UserClientByQualifiedUserIDTranscoder: IdentifierObjectSyncTranscode
         case .v1, .v2, .v3, .v4, .v5:
             WaitingGroupTask(context: managedObjectContext) { [self] in
                 await commonResponseHandling(response: response, for: identifiers)
-                await managedObjectContext.perform { completionHandler() }
+                completionHandler()
             }
         }
     }
@@ -480,7 +480,7 @@ final class UserClientByUserIDTranscoder: IdentifierObjectSyncTranscoder {
                 for: user,
                 selfClient: selfClient
             )
-            await managedObjectContext.perform { completionHandler() }
+            completionHandler()
         }
     }
 }

--- a/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/sourcery/generated/AutoMockable.generated.swift
@@ -187,21 +187,6 @@ class MockMLSEventProcessing: MLSEventProcessing {
         await mock(welcomeMessage, context)
     }
 
-    // MARK: - joinMLSGroupWhenReady
-
-    var joinMLSGroupWhenReadyForConversationContext_Invocations: [(conversation: ZMConversation, context: NSManagedObjectContext)] = []
-    var joinMLSGroupWhenReadyForConversationContext_MockMethod: ((ZMConversation, NSManagedObjectContext) -> Void)?
-
-    func joinMLSGroupWhenReady(forConversation conversation: ZMConversation, context: NSManagedObjectContext) {
-        joinMLSGroupWhenReadyForConversationContext_Invocations.append((conversation: conversation, context: context))
-
-        guard let mock = joinMLSGroupWhenReadyForConversationContext_MockMethod else {
-            fatalError("no mock for `joinMLSGroupWhenReadyForConversationContext`")
-        }
-
-        mock(conversation, context)
-    }
-
     // MARK: - wipeMLSGroup
 
     var wipeMLSGroupForConversationContext_Invocations: [(conversation: ZMConversation, context: NSManagedObjectContext)] = []


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Already MLS conversations aren't always joined via external commit after login.

### Causes

1. The slow sync ends without having processed MLS conversation payload since that's done inside a Task
2. The conversation we should join is tracked in memory inside the MLSService, this is unreliable.

### Solutions

1. Wait for the Tasks to complete
2. Fetch conversation we need to join using a fetch request.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
