### PR TITLE
refactor: use legacy ZMTExpectation only explicitly

### DIFF
--- a/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
@@ -232,7 +232,7 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         )
 
         var receivedGroupIDs = [MLSGroupID]()
-        let didReceiveGroupIDs = expectation(description: "didReceiveGroupIDs")
+        let didReceiveGroupIDs = customExpectation(description: "didReceiveGroupIDs")
         let cancellable = sut.onEpochChanged().collect(1).sink {
             receivedGroupIDs = $0
             didReceiveGroupIDs.fulfill()

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1461,8 +1461,8 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         let unsufficientKeyPackagesAmount = sut.targetUnclaimedKeyPackageCount / 3
 
         // expectation
-        let countUnclaimedKeyPackages = self.expectation(description: "Count unclaimed key packages")
-        let uploadKeyPackages = self.expectation(description: "Upload key packages")
+        let countUnclaimedKeyPackages = self.customExpectation(description: "Count unclaimed key packages")
+        let uploadKeyPackages = self.customExpectation(description: "Upload key packages")
 
         // mock that we queried kp count recently
         userDefaultsTestSuite.set(Date(), forKey: MLSService.Keys.keyPackageQueriedTime.rawValue)
@@ -1626,7 +1626,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         }
 
         // Expectations
-        keyMaterialUpdatedExpectation = expectation(description: "did update key material")
+        keyMaterialUpdatedExpectation = customExpectation(description: "did update key material")
 
         // When
         await sut.updateKeyMaterialForAllStaleGroupsIfNeeded()
@@ -2289,7 +2289,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Colect ids for groups with changed epochs
         var receivedGroupIDs = [MLSGroupID]()
-        let didReceiveGroupIDs = expectation(description: "didReceiveGroupIDs")
+        let didReceiveGroupIDs = customExpectation(description: "didReceiveGroupIDs")
         let cancellable = sut.onEpochChanged().collect(3).sink {
             receivedGroupIDs = $0
             didReceiveGroupIDs.fulfill()
@@ -2394,8 +2394,8 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Given a group.
         let groupID = MLSGroupID.random()
-        let expectation1 = self.expectation(description: "CreateConversation should be called")
-        let expectation2 = self.expectation(description: "UpdateKeyMaterial should be called")
+        let expectation1 = self.customExpectation(description: "CreateConversation should be called")
+        let expectation2 = self.customExpectation(description: "UpdateKeyMaterial should be called")
 
         mockCoreCrypto.createConversationConversationIdCreatorCredentialTypeConfig_MockMethod = { _, _, _ in
             expectation1.fulfill()
@@ -2426,8 +2426,8 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         BackendInfo.domain = "example.com"
 
         // Given a group.
-        let expectation1 = self.expectation(description: "CreateConversation should be called")
-        let expectation2 = self.expectation(description: "AddMembers should be called")
+        let expectation1 = self.customExpectation(description: "CreateConversation should be called")
+        let expectation2 = self.customExpectation(description: "AddMembers should be called")
         mockCoreCrypto.createConversationConversationIdCreatorCredentialTypeConfig_MockMethod = { _, _, _ in
             expectation1.fulfill()
         }
@@ -2493,7 +2493,7 @@ class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation.domain = "example.com"
         }
 
-        let expectation1 = self.expectation(description: "CreateConversation should be called")
+        let expectation1 = self.customExpectation(description: "CreateConversation should be called")
 
         mockMLSActionExecutor.mockJoinGroup = { _, _ in
             return [ZMUpdateEvent()]

--- a/wire-ios-data-model/Tests/Proteus/CryptoboxMigrationManagerTests.swift
+++ b/wire-ios-data-model/Tests/Proteus/CryptoboxMigrationManagerTests.swift
@@ -107,7 +107,7 @@ class CryptoboxMigrationManagerTests: ZMBaseManagedObjectTest {
 
     func test_itPerformsMigrations() async throws {
         // Given
-        let migrated = expectation(description: "Cryptobox was migrated")
+        let migrated = customExpectation(description: "Cryptobox was migrated")
         mockFileManager.fileExistsAtPath_MockValue = true
         proteusViaCoreCryptoFlag.isOn = true
         mockSafeCoreCrypto.coreCrypto.proteusCryptoboxMigratePath_MockMethod = { _ in

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -67,7 +67,7 @@ class DatabaseBaseTest: ZMTBaseTest {
                                   inMemoryStore: false,
                                   dispatchGroup: dispatchGroup)
 
-        let exp = self.expectation(description: "should wait for loadStores to finish")
+        let exp = self.customExpectation(description: "should wait for loadStores to finish")
         stack.setup(onStartMigration: {
             // do nothing
         }, onFailure: { error in

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/ManagedObjectContextChangeObserverTests.swift
@@ -22,7 +22,7 @@ class ManagedObjectContextChangeObserverTests: ZMBaseManagedObjectTest {
 
     func testThatItCallsTheCallbackWhenObjectsAreInserted() {
         // given
-        let changeExpectation = expectation(description: "The callback should be called")
+        let changeExpectation = customExpectation(description: "The callback should be called")
         let sut = ManagedObjectContextChangeObserver(context: uiMOC) {
             changeExpectation.fulfill()
         }
@@ -42,7 +42,7 @@ class ManagedObjectContextChangeObserverTests: ZMBaseManagedObjectTest {
         let message = ZMMessage(nonce: UUID(), managedObjectContext: uiMOC)
         XCTAssert(uiMOC.saveOrRollback())
 
-        let changeExpectation = expectation(description: "The callback should be called")
+        let changeExpectation = customExpectation(description: "The callback should be called")
         let sut = ManagedObjectContextChangeObserver(context: uiMOC) {
             changeExpectation.fulfill()
         }
@@ -62,7 +62,7 @@ class ManagedObjectContextChangeObserverTests: ZMBaseManagedObjectTest {
         let message = ZMMessage(nonce: UUID(), managedObjectContext: uiMOC)
         XCTAssert(uiMOC.saveOrRollback())
 
-        let changeExpectation = expectation(description: "The callback should be called")
+        let changeExpectation = customExpectation(description: "The callback should be called")
         let sut = ManagedObjectContextChangeObserver(context: uiMOC) {
             changeExpectation.fulfill()
         }

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/ManagedObjectContextTests.m
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/ManagedObjectContextTests.m
@@ -267,7 +267,7 @@
     NSError *error;
     XCTAssert([sut save:&error], @"Failed to save: %@", error);
     NSMutableArray *events = [NSMutableArray array];
-    XCTestExpectation *expectation = [self expectationWithDescription: @"Did save"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Did save"];
     id token = [[NSNotificationCenter defaultCenter] addObserverForName:NSManagedObjectContextDidSaveNotification object:sut queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
         NOT_USED(note);
         [events addObject:@"save"];
@@ -311,7 +311,7 @@
     NSError *error;
     XCTAssert([sut save:&error], @"Failed to save: %@", error);
     NSMutableArray *events = [NSMutableArray array];
-    XCTestExpectation *expectation = [self expectationWithDescription :@"Did save"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Did save"];
     id token = [[NSNotificationCenter defaultCenter] addObserverForName:NSManagedObjectContextDidSaveNotification object:sut queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
         NOT_USED(note);
         [events addObject:@"save"];
@@ -357,7 +357,7 @@
     NSError *error;
     XCTAssert([sut save:&error], @"Failed to save: %@", error);
     
-    XCTestExpectation *expectation = [self expectationWithDescription :@"Did save"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Did save"];
     id token = [[NSNotificationCenter defaultCenter] addObserverForName:NSManagedObjectContextDidSaveNotification object:sut queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
         NOT_USED(note);
         [expectation fulfill];

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/ManagedObjectContextTests.m
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/ManagedObjectContextTests.m
@@ -388,7 +388,7 @@
 - (void)testThatItDoesNotSaveWhenThereAreNoUserInfoChanges {
     
     // GIVEN
-    [self expectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
+    [self customExpectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
     
     // WHEN
     [self.uiMOC saveOrRollback];
@@ -400,7 +400,7 @@
 - (void)testThatItSaveWhenThereAreUserInfoChanges {
     
     // GIVEN
-    [self expectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
+    [self customExpectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
     self.uiMOC.zm_hasUserInfoChanges = YES;
     
     // WHEN
@@ -413,7 +413,7 @@
 - (void)testThatItResetsUserInfoChangesAfterASave {
     
     // GIVEN
-    [self expectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
+    [self customExpectationForNotification:NSManagedObjectContextDidSaveNotification object:nil handler:nil];
     self.uiMOC.zm_hasUserInfoChanges = YES;
     
     // WHEN

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/NSManagedObjectContextDebuggingTests.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/NSManagedObjectContextDebuggingTests.swift
@@ -24,7 +24,7 @@ class NSManagedObjectContextDebuggingTests: ZMBaseManagedObjectTest {
 
         // GIVEN
         self.makeChangeThatWillCauseRollback()
-        let expectation = self.expectation(description: "callback invoked")
+        let expectation = self.customExpectation(description: "callback invoked")
         self.uiMOC.errorOnSaveCallback = { (moc, error) in
             XCTAssertEqual(moc, self.uiMOC)
             XCTAssertNotNil(error)

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -822,7 +822,7 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
             context: syncMOC.notificationContext
         )
 
-        let expectation = expectation(description: "System message is added")
+        let expectation = customExpectation(description: "System message is added")
 
         // WHEN
         conversation.addParticipants([user1, user2]) { _ in
@@ -913,7 +913,7 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
             context: syncMOC.notificationContext
         )
 
-        let isDone = expectation(description: "isDone")
+        let isDone = customExpectation(description: "isDone")
 
         // WHEN
         conversation.addParticipants([applesUser, bananasUser, carrotsUser]) { _ in

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
@@ -320,7 +320,7 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
             let selfClient = self.createSelfClient(onMOC: self.syncMOC)
 
             // expect
-            let expectation = self.expectation(description: "Notified")
+            let expectation = self.customExpectation(description: "Notified")
             token = NotificationInContext.addObserver(
                 name: ZMConversation.isVerifiedNotificationName,
                 context: self.uiMOC.notificationContext) {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
@@ -297,7 +297,7 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
 
         // expect
-        expectation(forNotification: ZMConversation.lastReadDidChangeNotificationName, object: nil) { (_) -> Bool in
+        customExpectation(forNotification: ZMConversation.lastReadDidChangeNotificationName, object: nil) { (_) -> Bool in
             return true
         }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -1089,7 +1089,7 @@
     ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
 
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"isReadOnly" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"isReadOnly" expectedValue:nil];
     
     // when
     [conversation removeParticipantAndUpdateConversationStateWithUser:selfUser initiatingUser:selfUser];
@@ -1106,7 +1106,7 @@
     [conversation addParticipantAndUpdateConversationStateWithUser:[ZMUser selfUserInContext:self.uiMOC] role:nil];
     
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"isReadOnly" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"isReadOnly" expectedValue:nil];
     
     // when
     conversation.conversationType = ZMConversationTypeGroup;
@@ -1228,7 +1228,7 @@
     XCTAssertTrue(conversation.isPendingConnectionConversation);
     
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"isPendingConnectionConversation" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"isPendingConnectionConversation" expectedValue:nil];
     
     // when
     connection.status = ZMConnectionStatusAccepted;
@@ -1251,7 +1251,7 @@
     XCTAssertTrue(conversation.isPendingConnectionConversation);
 
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"isPendingConnectionConversation" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"isPendingConnectionConversation" expectedValue:nil];
     
     // when
     ZMConnection *connection2 = [ZMConnection insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -1947,7 +1947,7 @@
     XCTAssertTrue(conversation.hasDraftMessage);
     
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"hasDraftMessage" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"hasDraftMessage" expectedValue:nil];
     
     // when
     conversation.draftMessage = nil;
@@ -1979,7 +1979,7 @@
     XCTAssertEqualObjects(conversation.firstUnreadMessage, message2);
 
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"firstUnreadMessage" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"firstUnreadMessage" expectedValue:nil];
 
     // when
     conversation.lastReadServerTimeStamp = message2.serverTimestamp;
@@ -2007,7 +2007,7 @@
     XCTAssertNil(conversation.firstUnreadMessage);
 
     // expect
-    [self keyValueObservingExpectationForObject:conversation keyPath:@"firstUnreadMessage" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:conversation keyPath:@"firstUnreadMessage" expectedValue:nil];
 
     // when
     [conversation.mutableMessages addObject:message2];

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMAssetClientMessageTests.swift
@@ -500,7 +500,7 @@ extension ZMAssetClientMessageTests {
             sut.transferState = .uploaded
             XCTAssertTrue(self.syncMOC.saveOrRollback())
 
-            let expectation = self.expectation(description: "Notification fired")
+            let expectation = self.customExpectation(description: "Notification fired")
             let token = NotificationInContext.addObserver(
                 name: ZMAssetClientMessage.didCancelFileDownloadNotificationName,
                 context: self.uiMOC.notificationContext,
@@ -881,7 +881,7 @@ extension ZMAssetClientMessageTests {
         uiMOC.saveOrRollback()
 
         // expect
-        let expectation = self.expectation(description: "Image arrived")
+        let expectation = self.customExpectation(description: "Image arrived")
 
         // when
         message.imageMessageData?.fetchImageData(with: DispatchQueue.global(qos: .background), completionHandler: { (imageData) in
@@ -945,7 +945,7 @@ extension ZMAssetClientMessageTests {
         message.managedObjectContext?.saveOrRollback()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMAssetClientMessage.imageDownloadNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       object: message.objectID,
@@ -1305,7 +1305,7 @@ extension ZMAssetClientMessageTests {
         XCTAssertTrue(sut.hasDownloadedPreview)
         XCTAssertEqual(sut.version, 3)
 
-        let expectation = self.expectation(description: "preview data was retreived")
+        let expectation = self.customExpectation(description: "preview data was retreived")
         sut.fileMessageData?.fetchImagePreviewData(queue: .global(qos: .background), completionHandler: { (previewDataResult) in
             XCTAssertEqual(previewDataResult, previewData)
             expectation.fulfill()
@@ -1344,7 +1344,7 @@ extension ZMAssetClientMessageTests {
         uiMOC.saveOrRollback()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMAssetClientMessage.imageDownloadNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       object: sut.objectID,
@@ -1374,7 +1374,7 @@ extension ZMAssetClientMessageTests {
         uiMOC.saveOrRollback()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMAssetClientMessage.assetDownloadNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       object: sut.objectID,

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+TextMessage.swift
@@ -208,7 +208,7 @@ class ZMClientMessageTests_TextMessage: BaseZMMessageTests {
         try! uiMOC.obtainPermanentIDs(for: [clientMessage])
 
         // when
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token: Any? = NotificationInContext.addObserver(name: ZMClientMessage.linkPreviewImageDownloadNotification,
                                           context: self.uiMOC.notificationContext,
                                           object: clientMessage.objectID) { _ in

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTests.m
@@ -618,7 +618,7 @@ NSUInteger const ZMClientMessageByteSizeExternalThreshold = 128000;
     [self.uiMOC saveOrRollback];
     
     // expect
-    XCTestExpectation *imageDataArrived = [self expectationWithDescription:@"image data arrived"];
+    XCTestExpectation *imageDataArrived = [self customExpectationWithDescription:@"image data arrived"];
     
     // when
     [message fetchImageDataWithQueue:dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0) completionHandler:^(NSData *imageDataResult) {

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTimerTests.swift
@@ -53,7 +53,7 @@ class ZMMessageTimerTests: BaseZMMessageTests {
     func testThatItRemovesTheInternalTimerAfterTimerFired() {
         // given
         let message = createClientTextMessage(withText: "hello")
-        let expectation = self.expectation(description: "timer fired")
+        let expectation = self.customExpectation(description: "timer fired")
         sut.timerCompletionBlock = { _, _ in expectation.fulfill() }
 
         // when

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
@@ -71,7 +71,7 @@ class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
 
         // expect
-        let expectation = self.expectation(description: "notified")
+        let expectation = self.customExpectation(description: "notified")
         self.token = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
@@ -103,7 +103,7 @@ class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
 
         // expect
-        let expectation = self.expectation(description: "notified")
+        let expectation = self.customExpectation(description: "notified")
         self.token = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
@@ -138,7 +138,7 @@ class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
 
         // expect
-        let expectation = self.expectation(description: "notified")
+        let expectation = self.customExpectation(description: "notified")
         self.token = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
@@ -169,7 +169,7 @@ class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
 
         // expect
-        let expectation = self.expectation(description: "notified")
+        let expectation = self.customExpectation(description: "notified")
         self.token = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
@@ -257,7 +257,7 @@ class SearchUserObserverCenterTests: ModelObjectsTests {
         sut.addSearchUser(searchUser)
 
         // expect
-        let expectation = self.expectation(description: "notified")
+        let expectation = self.customExpectation(description: "notified")
         let token: Any? = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,
@@ -284,7 +284,7 @@ class SearchUserObserverCenterTests: ModelObjectsTests {
         sut.addSearchUser(searchUser)
 
         // expect
-        let expectation = self.expectation(description: "notified")
+        let expectation = self.customExpectation(description: "notified")
         let token = NotificationInContext.addObserver(
             name: .SearchUserChange,
             context: self.uiMOC.notificationContext,

--- a/wire-ios-data-model/Tests/Source/Model/User/UserImageLocalCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/UserImageLocalCacheTests.swift
@@ -63,8 +63,8 @@ class UserImageLocalCacheTests: BaseZMMessageTests {
         sut = UserImageLocalCache(location: nil)
 
         // then
-        let previewImageArrived = expectation(description: "Preview image arrived")
-        let completeImageArrived = expectation(description: "Complete image arrived")
+        let previewImageArrived = customExpectation(description: "Preview image arrived")
+        let completeImageArrived = customExpectation(description: "Complete image arrived")
         sut.userImage(testUser, size: .preview, queue: .global()) { (smallDataResult) in
             XCTAssertEqual(smallDataResult, smallData)
             previewImageArrived.fulfill()

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+Connections.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+Connections.swift
@@ -29,7 +29,7 @@ class ZMSearchUserTests_Connections: ModelObjectsTests {
                                       remoteIdentifier: UUID())
 
         // expect
-        expectation(forNotification: ConnectToUserAction.notificationName, object: nil)
+        customExpectation(forNotification: ConnectToUserAction.notificationName, object: nil)
 
         // when
         searchUser.connect { (_) in }

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+ProfileImages.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+ProfileImages.swift
@@ -143,7 +143,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
         searchUser.updateImageData(for: .preview, imageData: imageData)
 
         // then
-        let imageDataArrived = expectation(description: "completion handler called")
+        let imageDataArrived = customExpectation(description: "completion handler called")
         searchUser.imageData(for: .preview, queue: .global()) { (imageDataResult) in
             XCTAssertEqual(imageData, imageDataResult)
             imageDataArrived.fulfill()
@@ -160,7 +160,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
         searchUser.updateImageData(for: .complete, imageData: imageData)
 
         // then
-        let imageDataArrived = expectation(description: "completion handler called")
+        let imageDataArrived = customExpectation(description: "completion handler called")
         searchUser.imageData(for: .complete, queue: .global()) { (imageDataResult) in
             XCTAssertEqual(imageData, imageDataResult)
             imageDataArrived.fulfill()

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -273,7 +273,7 @@ extension ZMUserTests_Swift {
 extension ZMUserTests_Swift {
 
     func testThatItPostsPreviewRequestNotifications() {
-        let noteExpectation = expectation(description: "PreviewAssetFetchNotification should be fired")
+        let noteExpectation = customExpectation(description: "PreviewAssetFetchNotification should be fired")
         var userObjectId: NSManagedObjectID?
 
         let token = ManagedObjectObserverToken(name: .userDidRequestPreviewAsset,
@@ -296,7 +296,7 @@ extension ZMUserTests_Swift {
     }
 
     func testThatItPostsCompleteRequestNotifications() {
-        let noteExpectation = expectation(description: "CompleteAssetFetchNotification should be fired")
+        let noteExpectation = customExpectation(description: "CompleteAssetFetchNotification should be fired")
         var userObjectId: NSManagedObjectID?
 
         let token = ManagedObjectObserverToken(name: .userDidRequestCompleteAsset,

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -1024,7 +1024,7 @@ extension ZMUserTests_Swift {
         let user = createUser(in: uiMOC)
 
         // expect
-        expectation(forNotification: ConnectToUserAction.notificationName, object: nil)
+        customExpectation(forNotification: ConnectToUserAction.notificationName, object: nil)
 
         // when
         user.connect { (_) in }
@@ -1039,7 +1039,7 @@ extension ZMUserTests_Swift {
         user.connection = ZMConnection.insertNewObject(in: uiMOC)
 
         // expect
-        expectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
+        customExpectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
             guard let action = note.userInfo?[UpdateConnectionAction.userInfoKey] as? UpdateConnectionAction else {
                 return false
             }
@@ -1060,7 +1060,7 @@ extension ZMUserTests_Swift {
         user.connection = ZMConnection.insertNewObject(in: uiMOC)
 
         // expect
-        expectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
+        customExpectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
             guard let action = note.userInfo?[UpdateConnectionAction.userInfoKey] as? UpdateConnectionAction else {
                 return false
             }
@@ -1081,7 +1081,7 @@ extension ZMUserTests_Swift {
         user.connection = ZMConnection.insertNewObject(in: uiMOC)
 
         // expect
-        expectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
+        customExpectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
             guard let action = note.userInfo?[UpdateConnectionAction.userInfoKey] as? UpdateConnectionAction else {
                 return false
             }
@@ -1102,7 +1102,7 @@ extension ZMUserTests_Swift {
         user.connection = ZMConnection.insertNewObject(in: uiMOC)
 
         // expect
-        expectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
+        customExpectation(forNotification: UpdateConnectionAction.notificationName, object: nil) { (note) -> Bool in
             guard let action = note.userInfo?[UpdateConnectionAction.userInfoKey] as? UpdateConnectionAction else {
                 return false
             }

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -674,8 +674,8 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     }];
     
     // expect
-    XCTestExpectation *previewDataArrived = [self expectationWithDescription:@"preview image data arrived"];
-    XCTestExpectation *completeDataArrived = [self expectationWithDescription:@"complete image data arrived"];
+    XCTestExpectation *previewDataArrived = [self customExpectationWithDescription:@"preview image data arrived"];
+    XCTestExpectation *completeDataArrived = [self customExpectationWithDescription:@"complete image data arrived"];
     
     // when
     [user imageDataFor:ProfileImageSizePreview queue:dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0) completion:^(NSData *imageDataResult) {

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -2043,7 +2043,7 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     XCTAssertFalse(user1.isBlocked);
     // expect
 
-    [self keyValueObservingExpectationForObject:user1 keyPath:@"isBlocked" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:user1 keyPath:@"isBlocked" expectedValue:nil];
     
     // when
     connection.status = ZMConnectionStatusBlocked;
@@ -2065,7 +2065,7 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
 
     // expect
 
-    [self keyValueObservingExpectationForObject:user1 keyPath:@"blockStateReason" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:user1 keyPath:@"blockStateReason" expectedValue:nil];
 
     // when
     connection.status = ZMConnectionStatusBlockedMissingLegalholdConsent;
@@ -2087,7 +2087,7 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     XCTAssertFalse(user1.isIgnored);
     // expect
     
-    [self keyValueObservingExpectationForObject:user1 keyPath:@"isIgnored" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:user1 keyPath:@"isIgnored" expectedValue:nil];
     
     // when
     connection.status = ZMConnectionStatusIgnored;
@@ -2108,7 +2108,7 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     XCTAssertTrue(user1.isPendingApprovalBySelfUser);
     // expect
     
-    [self keyValueObservingExpectationForObject:user1 keyPath:@"isPendingApprovalBySelfUser" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:user1 keyPath:@"isPendingApprovalBySelfUser" expectedValue:nil];
     
     // when
     connection.status = ZMConnectionStatusAccepted;
@@ -2129,7 +2129,7 @@ static NSString * const domainValidCharactersLowercased = @"abcdefghijklmnopqrst
     XCTAssertTrue(user.isPendingApprovalByOtherUser);
     // expect
     
-    [self keyValueObservingExpectationForObject:user keyPath:@"isPendingApprovalByOtherUser" expectedValue:nil];
+    [self customKeyValueObservingExpectationForObject:user keyPath:@"isPendingApprovalByOtherUser" expectedValue:nil];
     
     // when
     connection.status = ZMConnectionStatusAccepted;

--- a/wire-ios-data-model/Tests/Source/Model/ZMConnectionTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/ZMConnectionTests.m
@@ -219,7 +219,7 @@
     
     
     // expect
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Notified"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Notified"];
     id token = [NotificationInContext addObserverWithName:ZMConnection.invalidateTopConversationCacheNotificationName
                                        context:self.uiMOC.notificationContext
                                         object:nil

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionRequestsTests.m
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionRequestsTests.m
@@ -284,7 +284,7 @@
     // WHEN
     NSString *path = [NSString stringWithFormat:@"/conversations/ids"];
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Got a response"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Got a response"];
     
     ZMTransportSession *mockedTransportSession = self.sut.mockedTransportSession;
     

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.m
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.m
@@ -219,7 +219,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 
 - (ZMTransportResponse *)responseForImageData:(NSData *)imageData contentDisposition:(NSDictionary *)contentDisposition path:(NSString *)path apiVersion:(APIVersion)apiVersion;
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Got an image response"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Got an image response"];
     
     __block ZMTransportResponse *response;
     ZMTransportRequestGenerator postGenerator = ^ZMTransportRequest*(void) {
@@ -247,7 +247,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 
 - (ZMTransportResponse *)responseForFileData:(NSData *)fileData path:(NSString *)path metadata:(NSData *)metadata contentType:(NSString *)contentType apiVersion:(APIVersion)apiVersion;
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Got a file upload response"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Got a file upload response"];
     __block ZMTransportResponse *response;
     
     ZMTransportRequestGenerator generator = ^ZMTransportRequest *{
@@ -292,7 +292,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 
 - (ZMTransportResponse *)responseForImageData:(NSData *)imageData metaData:(NSData *)metaData imageMediaType:(NSString *)imageMediaType path:(NSString *)path apiVersion:(APIVersion)apiVersion;
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Got an image response"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Got an image response"];
     
     __block ZMTransportResponse *response;
     ZMTransportRequestGenerator postGenerator = ^ZMTransportRequest*(void) {
@@ -314,7 +314,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 
 - (ZMTransportResponse *)responseForPayload:(id<ZMTransportData>)payload path:(NSString *)path method:(ZMTransportRequestMethod)method apiVersion:(APIVersion)apiVersion
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Got a response"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Got a response"];
     
     ZMTransportSession *mockedTransportSession = self.sut.mockedTransportSession;
     
@@ -337,7 +337,7 @@ static char* const ZMLogTag ZM_UNUSED = "MockTransportTests";
 
 - (ZMTransportResponse *)responseForProtobufData:(NSData *)data path:(NSString *)path method:(ZMTransportRequestMethod)method apiVersion:(APIVersion)apiVersion
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Got a response"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Got a response"];
     
     ZMTransportSession *mockedTransportSession = self.sut.mockedTransportSession;
     

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.swift
@@ -21,7 +21,7 @@ import Foundation
 extension MockTransportSessionTests {
 
     func response(forAssetData assetData: Data, contentType: String, path: String, apiVersion: APIVersion) -> ZMTransportResponse? {
-        let expectation = self.expectation(description: "Got an asset response")
+        let expectation = self.customExpectation(description: "Got an asset response")
 
         var response: ZMTransportResponse?
         let result = sut.mockedTransportSession().attemptToEnqueueSyncRequest {

--- a/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatusTests.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatusTests.swift
@@ -175,7 +175,7 @@ class PushNotificationStatusTests: MessagingTestBase {
     func testThatCompletionHandlerIsCalledAfterAllEventsHaveBeenFetched() {
         // given
         let eventId = UUID.timeBasedUUID() as UUID
-        let expectation = self.expectation(description: "completion handler was called")
+        let expectation = self.customExpectation(description: "completion handler was called")
 
         // expect
         syncMOC.performGroupedBlockAndWait {
@@ -197,7 +197,7 @@ class PushNotificationStatusTests: MessagingTestBase {
     func testThatCompletionHandlerIsCalledEvenIfNoEventsWereDownloaded() {
         // given
         let eventId = UUID.timeBasedUUID() as UUID
-        let expectation = self.expectation(description: "completion handler was called")
+        let expectation = self.customExpectation(description: "completion handler was called")
 
         // expect
         syncMOC.performGroupedBlockAndWait {
@@ -220,7 +220,7 @@ class PushNotificationStatusTests: MessagingTestBase {
         // given
         let eventId = UUID.timeBasedUUID() as UUID
         lastEventIDRepository.storeLastEventID(eventId)
-        let expectation = self.expectation(description: "completion handler was called")
+        let expectation = self.customExpectation(description: "completion handler was called")
         syncMOC.performGroupedBlockAndWait {
             // when
             self.sut.fetch(eventId: eventId) {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategyTests.swift
@@ -254,7 +254,7 @@ final class AssetClientMessageRequestStrategyTests: MessagingTestBase {
         var token: Any?
         self.syncMOC.performGroupedBlockAndWait {
             self.createMessage(uploaded: true, assetId: true)
-            let expectation = self.expectation(description: "Notification fired")
+            let expectation = self.customExpectation(description: "Notification fired")
             token = NotificationInContext.addObserver(name: ZMConversation.failedToSendMessageNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       object: nil) {_ in

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3DownloadRequestStrategyTests.swift
@@ -504,7 +504,7 @@ extension AssetV3DownloadRequestStrategyTests {
 
         // EXPECT
         var token: Any?
-        let expectation = self.expectation(description: "Notification fired")
+        let expectation = self.customExpectation(description: "Notification fired")
         token = NotificationInContext.addObserver(name: .NonCoreDataChangeInManagedObject,
                                                   context: self.uiMOC.notificationContext,
                                                   object: nil) { note in

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
@@ -154,7 +154,7 @@ extension ClientMessageRequestStrategyTests {
             // WHEN
             self.sut.contextChangeTrackers.forEach { $0.objectsDidChange(Set([confirmationMessage])) }
 
-            let expectation = self.expectation(description: "Notification fired")
+            let expectation = self.customExpectation(description: "Notification fired")
             token = NotificationInContext.addObserver(name: ZMConversation.failedToSendMessageNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       object: nil) {_ in

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandlerTests.swift
@@ -119,7 +119,7 @@ class ConnectToUserActionHandlerTests: MessagingTestBase {
                                                transportSessionError: nil,
                                                apiVersion: APIVersion.v0.rawValue)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -141,7 +141,7 @@ class ConnectToUserActionHandlerTests: MessagingTestBase {
             let domain = self.owningDomain
             var action = ConnectToUserAction(userID: userID, domain: domain)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure = result {
                     expectation.fulfill()
@@ -170,7 +170,7 @@ class ConnectToUserActionHandlerTests: MessagingTestBase {
             let domain = self.owningDomain
             var action = ConnectToUserAction(userID: userID, domain: domain)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure(let error) = result {
                     if expectedError == error {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandlerTests.swift
@@ -124,7 +124,7 @@ class UpdateConnectionActionHandlerTests: MessagingTestBase {
                                                transportSessionError: nil,
                                                apiVersion: APIVersion.v0.rawValue)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -145,7 +145,7 @@ class UpdateConnectionActionHandlerTests: MessagingTestBase {
             var action = UpdateConnectionAction(connection: self.oneToOneConversation.connection!,
                                                 newStatus: .blocked)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure = result {
                     expectation.fulfill()
@@ -172,7 +172,7 @@ class UpdateConnectionActionHandlerTests: MessagingTestBase {
             // given
             var action = UpdateConnectionAction(connection: self.oneToOneConversation.connection!, newStatus: .accepted)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure(let error) = result {
                     if expectedError == error {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
@@ -168,7 +168,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
             )
         }
 
-        let waitForHandler = self.expectation(description: "wait for Handler to be called")
+        let waitForHandler = self.customExpectation(description: "wait for Handler to be called")
 
         action.resultHandler = { _ in
             waitForHandler.fulfill()
@@ -225,7 +225,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
             // given
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             action = AddParticipantAction(users: [user], conversation: conversation)
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -269,7 +269,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
             // given
             var action = AddParticipantAction(users: [user], conversation: conversation)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -293,7 +293,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
             // given
             var action = AddParticipantAction(users: [user], conversation: conversation)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure = result {
                     expectation.fulfill()
@@ -332,7 +332,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
                 conversation: conversation
             )
 
-            let isDone = self.expectation(description: "isDone")
+            let isDone = self.customExpectation(description: "isDone")
 
             action.onResult {
                 switch $0 {
@@ -376,7 +376,7 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
                 conversation: conversation
             )
 
-            let isDone = self.expectation(description: "isDone")
+            let isDone = self.customExpectation(description: "isDone")
 
             action.onResult {
                 switch $0 {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
@@ -381,7 +381,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
             )
             handler = sut
 
-            let isDone = self.expectation(description: "isDone")
+            let isDone = self.customExpectation(description: "isDone")
 
             action.onResult {
                 switch $0 {
@@ -436,7 +436,7 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
             )
             handler = sut
 
-            let isDone = self.expectation(description: "isDone")
+            let isDone = self.customExpectation(description: "isDone")
 
             action.onResult {
                 switch $0 {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandlerTests.swift
@@ -135,7 +135,7 @@ class RemoveParticipantActionHandlerTests: MessagingTestBase {
                                                transportSessionError: nil,
                                                apiVersion: APIVersion.v0.rawValue)
 
-            let waitForHandler = self.expectation(description: "wait for Handler to be called")
+            let waitForHandler = self.customExpectation(description: "wait for Handler to be called")
             action.resultHandler = { _ in
                 waitForHandler.fulfill()
             }
@@ -238,7 +238,7 @@ class RemoveParticipantActionHandlerTests: MessagingTestBase {
             conversation.addParticipantAndUpdateConversationState(user: self.user, role: nil)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             var action = RemoveParticipantAction(user: user, conversation: conversation)
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -268,7 +268,7 @@ class RemoveParticipantActionHandlerTests: MessagingTestBase {
             // given
             var action = RemoveParticipantAction(user: user, conversation: conversation)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -292,7 +292,7 @@ class RemoveParticipantActionHandlerTests: MessagingTestBase {
             // given
             var action = RemoveParticipantAction(user: user, conversation: conversation)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure = result {
                     expectation.fulfill()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandlerTests.swift
@@ -86,7 +86,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
         let sut = SyncConversationActionHandler(context: uiMOC)
         let id = QualifiedID(uuid: .create(), domain: "example.com")
 
-        let didFail = expectation(description: "did fail")
+        let didFail = customExpectation(description: "did fail")
         let action = SyncConversationAction(qualifiedID: id) { result in
             // Then
             guard case .failure(.invalidResponsePayload) = result else {
@@ -114,7 +114,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
         let sut = SyncConversationActionHandler(context: uiMOC)
         let id = QualifiedID(uuid: .create(), domain: "example.com")
 
-        let didFail = expectation(description: "did fail")
+        let didFail = customExpectation(description: "did fail")
         let action = SyncConversationAction(qualifiedID: id) { result in
             // Then
             guard case .failure(.conversationNotFound) = result else {
@@ -146,7 +146,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
         let sut = SyncConversationActionHandler(context: syncMOC)
         let id = QualifiedID(uuid: .create(), domain: "example.com")
 
-        let didSucceed = self.expectation(description: "did succeed")
+        let didSucceed = self.customExpectation(description: "did succeed")
         let action = SyncConversationAction(qualifiedID: id) { result in
             // Then
             guard case .success = result else {
@@ -192,7 +192,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
         let sut = SyncConversationActionHandler(context: uiMOC)
         let id = QualifiedID(uuid: .create(), domain: "example.com")
 
-        let didFail = expectation(description: "did fail")
+        let didFail = customExpectation(description: "did fail")
         let action = SyncConversationAction(qualifiedID: id) { result in
             // Then
             guard case .failure(.invalidBody) = result else {
@@ -224,7 +224,7 @@ final class SyncConversationActionHandlerTests: MessagingTestBase {
         let sut = SyncConversationActionHandler(context: uiMOC)
         let id = QualifiedID(uuid: .create(), domain: "example.com")
 
-        let didFail = expectation(description: "did fail")
+        let didFail = customExpectation(description: "did fail")
         let action = SyncConversationAction(qualifiedID: id) { result in
             // Then
             guard case .failure(.unknownError(code: 999, label: "foo", message: "bar")) = result else {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateAccessRolesActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateAccessRolesActionHandlerTests.swift
@@ -119,7 +119,7 @@ final class UpdateAccessRolesActionHandlerTests: MessagingTestBase {
             let action = UpdateAccessRolesAction(conversation: self.conversation,
                                                  accessMode: accessMode,
                                                  accessRoles: accessRoles)
-            let expectation = self.expectation(description: "wait for handler to be called")
+            let expectation = self.customExpectation(description: "wait for handler to be called")
             action.resultHandler = { _ in
                 expectation.fulfill()
             }
@@ -159,7 +159,7 @@ final class UpdateAccessRolesActionHandlerTests: MessagingTestBase {
             var action = UpdateAccessRolesAction(conversation: self.conversation,
                                                  accessMode: accessMode,
                                                  accessRoles: accessRoles)
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .success = result {
                     expectation.fulfill()
@@ -193,7 +193,7 @@ final class UpdateAccessRolesActionHandlerTests: MessagingTestBase {
                                                  accessMode: accessMode,
                                                  accessRoles: accessRoles)
 
-            let expectation = self.expectation(description: "Result Handler was called")
+            let expectation = self.customExpectation(description: "Result Handler was called")
             action.onResult { (result) in
                 if case .failure = result {
                     expectation.fulfill()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
@@ -51,7 +51,7 @@ final class ConversationServiceTests: MessagingTestBase {
             in: uiMOC
         )
 
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         // Mock
         let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
@@ -105,7 +105,7 @@ final class ConversationServiceTests: MessagingTestBase {
             in: uiMOC
         )
 
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         // Mock
         let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
@@ -159,7 +159,7 @@ final class ConversationServiceTests: MessagingTestBase {
             in: uiMOC
         )
 
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         // Mock
         let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
@@ -199,7 +199,7 @@ final class ConversationServiceTests: MessagingTestBase {
         selfUser.membership?.permissions.remove(.member)
         XCTAssertFalse(selfUser.canCreateConversation(type: .group))
 
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         // When
         sut.createGroupConversation(
@@ -229,7 +229,7 @@ final class ConversationServiceTests: MessagingTestBase {
     func test_CreateGroupConversation_ConversationNotFoundFailure() throws {
         // Given
         let randomObjectID = otherUser.objectID
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
             result: .success(randomObjectID),
@@ -264,7 +264,7 @@ final class ConversationServiceTests: MessagingTestBase {
 
     func test_CreateGroupConversation_NetworkErrorFailure() throws {
         // Given
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
             result: .failure(.operationDenied),
@@ -299,7 +299,7 @@ final class ConversationServiceTests: MessagingTestBase {
 
     func test_CreateGroupConversation_UnreachableDomainsFailure() throws {
         // GIVEN
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
         let unreachableDomain = "foma.wire.link"
         user2.domain = unreachableDomain
 
@@ -352,7 +352,7 @@ final class ConversationServiceTests: MessagingTestBase {
 
     func test_CreateGroupConversation_NonFederatingDomainsFailure() throws {
         // GIVEN
-        let didFinish = expectation(description: "didFinish")
+        let didFinish = customExpectation(description: "didFinish")
 
         let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
             result: .failure(.nonFederatingDomains(["example.com"])),
@@ -390,7 +390,7 @@ final class ConversationServiceTests: MessagingTestBase {
     func test_SyncConversation() throws {
         // Given
         let qualifiedID = QualifiedID.randomID()
-        let didSync = expectation(description: "didSync")
+        let didSync = customExpectation(description: "didSync")
 
         // Mock
         let mockActionHandler = MockActionHandler<SyncConversationAction>(

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
@@ -65,7 +65,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
             var action = GetFeatureConfigsAction()
 
             // Expectation
-            let gotResult = self.expectation(description: "gotResult")
+            let gotResult = self.customExpectation(description: "gotResult")
 
             action.onResult { result in
                 switch result {
@@ -143,7 +143,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
             var action = GetFeatureConfigsAction()
 
             // Expectation
-            let gotResult = self.expectation(description: "gotResult")
+            let gotResult = self.customExpectation(description: "gotResult")
 
             action.onResult { result in
                 switch result {
@@ -219,7 +219,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
         var action = GetFeatureConfigsAction()
 
         // Expectation
-        let gotResult = expectation(description: "gotResult")
+        let gotResult = customExpectation(description: "gotResult")
 
         action.onResult { result in
             switch result {
@@ -244,7 +244,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
         var action = GetFeatureConfigsAction()
 
         // Expectation
-        let gotResult = expectation(description: "gotResult")
+        let gotResult = customExpectation(description: "gotResult")
 
         action.onResult { result in
             switch result {
@@ -269,7 +269,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
         var action = GetFeatureConfigsAction()
 
         // Expectation
-        let gotResult = expectation(description: "gotResult")
+        let gotResult = customExpectation(description: "gotResult")
 
         action.onResult { result in
             switch result {
@@ -294,7 +294,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
         var action = GetFeatureConfigsAction()
 
         // Expectation
-        let gotResult = expectation(description: "gotResult")
+        let gotResult = customExpectation(description: "gotResult")
 
         action.onResult { result in
             switch result {
@@ -319,7 +319,7 @@ class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
         var action = GetFeatureConfigsAction()
 
         // Expectation
-        let gotResult = expectation(description: "gotResult")
+        let gotResult = customExpectation(description: "gotResult")
 
         action.onResult { result in
             switch result {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/GetPushTokensActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/GetPushTokensActionHandlerTests.swift
@@ -68,7 +68,7 @@ class GetPushTokensActionHandlerTests: MessagingTestBase {
         var action = GetPushTokensAction(clientID: "clientA")
 
         // Expectation
-        let didSucceed = expectation(description: "didSucceed")
+        let didSucceed = customExpectation(description: "didSucceed")
         var receivedTokens = [PushToken]()
 
         action.onResult { result in
@@ -105,7 +105,7 @@ class GetPushTokensActionHandlerTests: MessagingTestBase {
         var action = GetPushTokensAction(clientID: "clientID")
 
         // Expectation
-        let didFail = expectation(description: "didFail")
+        let didFail = customExpectation(description: "didFail")
 
         action.onResult { result in
             guard case .failure(.malformedResponse) = result else { return }
@@ -125,7 +125,7 @@ class GetPushTokensActionHandlerTests: MessagingTestBase {
         var action = GetPushTokensAction(clientID: "clientID")
 
         // Expectation
-        let didFail = expectation(description: "didFail")
+        let didFail = customExpectation(description: "didFail")
 
         action.onResult { result in
             guard case .failure(.unknown(status: 999)) = result else { return }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RegisterPushTokenActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RegisterPushTokenActionHandlerTests.swift
@@ -72,7 +72,7 @@ class RegisterPushTokenActionHandlerTests: MessagingTestBase {
         var action = RegisterPushTokenAction(token: pushToken, clientID: "clientID")
 
         // Expectation
-        let didSucceed = expectation(description: "didSucceed")
+        let didSucceed = customExpectation(description: "didSucceed")
 
         action.onResult { result in
             guard case .success = result else { return }
@@ -92,7 +92,7 @@ class RegisterPushTokenActionHandlerTests: MessagingTestBase {
         var action = RegisterPushTokenAction(token: pushToken, clientID: "clientID")
 
         // Expectation
-        let didFail = expectation(description: "didFail")
+        let didFail = customExpectation(description: "didFail")
 
         action.onResult { result in
             guard case .failure(.appDoesNotExist) = result else { return }
@@ -112,7 +112,7 @@ class RegisterPushTokenActionHandlerTests: MessagingTestBase {
         var action = RegisterPushTokenAction(token: pushToken, clientID: "clientID")
 
         // Expectation
-        let didFail = expectation(description: "didFail")
+        let didFail = customExpectation(description: "didFail")
 
         action.onResult { result in
             guard case .failure(.unknown(999)) = result else { return }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RemovePushTokenActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Push Token/Actions/RemovePushTokenActionHandlerTests.swift
@@ -57,7 +57,7 @@ class RemovePushTokenActionHandlerTests: MessagingTestBase {
         var action = RemovePushTokenAction(deviceToken: deviceToken)
 
         // Expectation
-        let didSucceed = expectation(description: "didSucceed")
+        let didSucceed = customExpectation(description: "didSucceed")
 
         action.onResult { result in
             guard case .success = result else { return }
@@ -77,7 +77,7 @@ class RemovePushTokenActionHandlerTests: MessagingTestBase {
         var action = RemovePushTokenAction(deviceToken: deviceToken)
 
         // Expectation
-        let didSucceed = expectation(description: "didSucceed")
+        let didSucceed = customExpectation(description: "didSucceed")
 
         action.onResult { result in
             guard case .success = result else { return }
@@ -97,7 +97,7 @@ class RemovePushTokenActionHandlerTests: MessagingTestBase {
         var action = RemovePushTokenAction(deviceToken: deviceToken)
 
         // Expectation
-        let didFail = expectation(description: "didFail")
+        let didFail = customExpectation(description: "didFail")
 
         action.onResult { result in
             guard case .failure(.tokenDoesNotExist) = result else { return }
@@ -117,7 +117,7 @@ class RemovePushTokenActionHandlerTests: MessagingTestBase {
         var action = RemovePushTokenAction(deviceToken: deviceToken)
 
         // Expectation
-        let didFail = expectation(description: "didFail")
+        let didFail = customExpectation(description: "didFail")
 
         action.onResult { result in
             guard case .failure(.unknown(999)) = result else { return }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -477,9 +477,11 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
             let event = self.userDeleteEvent(userID: ZMUser.selfUser(in: self.syncMOC).remoteIdentifier)
 
             // expect
-            self.expectation(forNotification: AccountDeletedNotification.notificationName,
-                             object: nil,
-                             handler: nil)
+            self.customExpectation(
+                forNotification: AccountDeletedNotification.notificationName,
+                object: nil,
+                handler: nil
+            )
 
             // when
             self.sut.processEvents([event], liveEvents: true, prefetchResult: nil)

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -314,7 +314,7 @@ extension EventDecoderTest {
     func testThatItProcessesEventsWithDifferentUUIDWhenThroughPushEventsFirst() async {
 
         // given
-        let pushProcessed = self.expectation(description: "Push event processed")
+        let pushProcessed = self.customExpectation(description: "Push event processed")
 
         let pushEvent = await syncMOC.perform {
             self.pushNotificationEvent()
@@ -334,7 +334,7 @@ extension EventDecoderTest {
         XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
 
         // and when
-        let streamProcessed = self.expectation(description: "Stream event processed")
+        let streamProcessed = self.customExpectation(description: "Stream event processed")
         _ = await sut.decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { (events) in
             XCTAssertTrue(events.contains(streamEvent))
@@ -348,7 +348,7 @@ extension EventDecoderTest {
     func testThatItDoesNotProcessesEventsWithSameUUIDWhenThroughPushEventsFirst() async {
 
         // given
-        let pushProcessed = self.expectation(description: "Push event processed")
+        let pushProcessed = self.customExpectation(description: "Push event processed")
         let uuid = UUID.create()
 
         let pushEvent = await syncMOC.perform {
@@ -369,7 +369,7 @@ extension EventDecoderTest {
         XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
 
         // and when
-        let streamProcessed = self.expectation(description: "Stream event not processed")
+        let streamProcessed = self.customExpectation(description: "Stream event not processed")
 
         _ = await sut.decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { (events) in
@@ -384,7 +384,7 @@ extension EventDecoderTest {
     func testThatItProcessesEventsWithSameUUIDWhenThroughPushEventsFirstAndDiscarding() async {
 
         // given
-        let pushProcessed = self.expectation(description: "Push event processed")
+        let pushProcessed = self.customExpectation(description: "Push event processed")
         let uuid = UUID.create()
 
         let pushEvent = await syncMOC.perform {
@@ -406,7 +406,7 @@ extension EventDecoderTest {
         XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
 
         // and when
-        let streamProcessed = self.expectation(description: "Stream event processed")
+        let streamProcessed = self.customExpectation(description: "Stream event processed")
 
         _ = await self.sut.decryptAndStoreEvents([streamEvent])
         await self.sut.processStoredEvents { (events) in

--- a/wire-ios-request-strategy/Tests/Helpers/ActionHandlerTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/ActionHandlerTestBase.swift
@@ -287,7 +287,7 @@ extension ActionHandlerTestBase {
         action: inout Action,
         toPassValidation validateResult: @escaping ValidationBlock
     ) {
-        let expectation = self.expectation(description: "didPassValidation")
+        let expectation = self.customExpectation(description: "didPassValidation")
 
         action.onResult { result in
             guard validateResult(result) else { return }

--- a/wire-ios-share-engine/WireShareEngineTests/RequestGeneratorStoreTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/RequestGeneratorStoreTests.swift
@@ -96,7 +96,7 @@ final class RequestGeneratorStoreTests: ZMTBaseTest {
 
     func testThatItCallsTheGivenGenerator() {
 
-        let expectation = self.expectation(description: "calledGenerator")
+        let expectation = self.customExpectation(description: "calledGenerator")
         let generator = DummyGenerator(requestBlock: {
             expectation.fulfill()
             return nil

--- a/wire-ios-sync-engine/Tests/Source/Calling/CallStateObserverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/CallStateObserverTests.swift
@@ -249,7 +249,7 @@ class CallStateObserverTests: DatabaseTest, CallNotificationStyleProvider {
         uiMOC.zm_callCenter = mockCallCenter
 
         // expect
-        expectation(forNotification: CallStateObserver.CallInProgressNotification, object: nil) { (_) -> Bool in
+        customExpectation(forNotification: CallStateObserver.CallInProgressNotification, object: nil) { (_) -> Bool in
             return true
         }
 
@@ -266,7 +266,7 @@ class CallStateObserverTests: DatabaseTest, CallNotificationStyleProvider {
         uiMOC.zm_callCenter  = mockCallCenter
 
         // expect
-        expectation(forNotification: CallStateObserver.CallInProgressNotification, object: nil) { (_) -> Bool in
+        customExpectation(forNotification: CallStateObserver.CallInProgressNotification, object: nil) { (_) -> Bool in
             return true
         }
 
@@ -285,7 +285,7 @@ class CallStateObserverTests: DatabaseTest, CallNotificationStyleProvider {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // expect
-        expectation(forNotification: CallStateObserver.CallInProgressNotification, object: nil) { (note) -> Bool in
+        customExpectation(forNotification: CallStateObserver.CallInProgressNotification, object: nil) { (note) -> Bool in
             if let open = note.userInfo?[CallStateObserver.CallInProgressKey] as? Bool, open == false {
                 return true
             } else {

--- a/wire-ios-sync-engine/Tests/Source/Calling/FlowManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/FlowManagerTests.swift
@@ -23,7 +23,7 @@ import avs
 class FlowManagerTests: MessagingTest {
     func testThatItSendsNotificationWhenFlowManagerIsCreated() {
         // GIVEN
-        let expectation = self.expectation(description: "Notification is sent")
+        let expectation = self.customExpectation(description: "Notification is sent")
         let notificationObserver = NotificationCenter.default.addObserver(forName: FlowManager.AVSFlowManagerCreatedNotification, object: nil, queue: nil) { _ in
             expectation.fulfill()
         }

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -129,7 +129,7 @@ class WireCallCenterV3Tests: MessagingTest {
 
     func checkThatItPostsNotification(expectedCallState: CallState, expectedCallerId: AVSIdentifier, expectedConversationId: AVSIdentifier, line: UInt = #line, file: StaticString = #file, actionBlock: () throws -> Void) rethrows {
         // expect
-        expectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, expectedConversationId, "conversationIds are not the same", file: file, line: line)
             XCTAssertEqual(note.callerId, expectedCallerId, "callerIds are not the same", file: file, line: line)
@@ -198,7 +198,7 @@ class WireCallCenterV3Tests: MessagingTest {
         let timestamp = Date()
 
         // expect
-        expectation(forNotification: WireCallCenterMissedCallNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: WireCallCenterMissedCallNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterMissedCallNotification.userInfoKey] as? WireCallCenterMissedCallNotification else { return false }
             XCTAssertEqual(note.conversationId, conversationId)
             XCTAssertEqual(note.callerId, userId)
@@ -402,7 +402,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // expect
-        expectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.groupConversationID)
             XCTAssertEqual(note.callerId, self.otherUserID)
@@ -431,7 +431,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // expect
-        expectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallStateNotification.userInfoKey] as? WireCallCenterCallStateNotification else { return false }
             XCTAssertEqual(note.conversationId, self.oneOnOneConversationID)
             XCTAssertEqual(note.callerId, self.otherUserID)
@@ -907,7 +907,7 @@ class WireCallCenterV3Tests: MessagingTest {
         conferenceCalling.status = .disabled
 
         // expect
-        expectation(forNotification: WireCallCenterConferenceCallingUnavailableNotification.notificationName, object: nil)
+        customExpectation(forNotification: WireCallCenterConferenceCallingUnavailableNotification.notificationName, object: nil)
 
         // when
         assertItThrows(error: WireCallCenterV3.Failure.missingConferencingPermission) {
@@ -959,7 +959,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssertNil(sut.establishedDate)
 
         // expect
-        expectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { _ in
+        customExpectation(forNotification: WireCallCenterCallStateNotification.notificationName, object: nil) { _ in
             XCTAssertNotNil(self.sut.establishedDate)
             return true
         }
@@ -1082,7 +1082,7 @@ class WireCallCenterV3Tests: MessagingTest {
         // expect
         let calledCompletionHandler = customExpectation(description: "processCallEvent completion handler called")
 
-        expectation(forNotification: WireCallCenterCallErrorNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: WireCallCenterCallErrorNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallErrorNotification.userInfoKey] as? WireCallCenterCallErrorNotification else { return false }
             XCTAssertEqual(note.error, self.mockAVSWrapper.callError)
             XCTAssertEqual(note.conversationId, self.oneOnOneConversationID)
@@ -1746,7 +1746,7 @@ extension WireCallCenterV3Tests {
         let change = activeSpeakersChange(for: conversationId, clients: [client])
 
         // EXPECT
-        expectation(forNotification: WireCallCenterActiveSpeakersNotification.notificationName, object: nil) { _ in
+        customExpectation(forNotification: WireCallCenterActiveSpeakersNotification.notificationName, object: nil) { _ in
             return true
         }
 

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -479,7 +479,7 @@ class WireCallCenterV3Tests: MessagingTest {
             syncMOC.mlsService = mlsService
         }
 
-        let didLeaveSubconversation = expectation(description: "didLeaveSubconversation")
+        let didLeaveSubconversation = customExpectation(description: "didLeaveSubconversation")
         mlsService.leaveSubconversationParentQualifiedIDParentGroupIDSubconversationType_MockMethod = { parentID, parentGroupID, subconversationType in
             XCTAssertEqual(parentID, self.groupConversation.qualifiedID)
             XCTAssertEqual(parentGroupID, self.groupConversation.mlsGroupID)
@@ -509,7 +509,7 @@ class WireCallCenterV3Tests: MessagingTest {
             syncMOC.mlsService = mlsService
         }
 
-        let didLeaveSubconversationIfNeeded = expectation(description: "didLeaveSubconversationIfNeeded")
+        let didLeaveSubconversationIfNeeded = customExpectation(description: "didLeaveSubconversationIfNeeded")
         mlsService.leaveSubconversationIfNeededParentQualifiedIDParentGroupIDSubconversationTypeSelfClientID_MockMethod = {
             XCTAssertEqual($0, self.groupConversation.qualifiedID)
             XCTAssertEqual($1, self.groupConversation.mlsGroupID)
@@ -550,7 +550,7 @@ class WireCallCenterV3Tests: MessagingTest {
             syncMOC.mlsService = mlsService
         }
 
-        let didLeaveSubconversationIfNeeded = expectation(description: "didLeaveSubconversationIfNeeded")
+        let didLeaveSubconversationIfNeeded = customExpectation(description: "didLeaveSubconversationIfNeeded")
         mlsService.leaveSubconversationIfNeededParentQualifiedIDParentGroupIDSubconversationTypeSelfClientID_MockMethod = {
             XCTAssertEqual($0, self.groupConversation.qualifiedID)
             XCTAssertEqual($1, self.groupConversation.mlsGroupID)
@@ -586,7 +586,7 @@ class WireCallCenterV3Tests: MessagingTest {
             syncMOC.mlsService = mlsService
         }
 
-        let didLeaveSubconversationIfNeeded = expectation(description: "didLeaveSubconversationIfNeeded")
+        let didLeaveSubconversationIfNeeded = customExpectation(description: "didLeaveSubconversationIfNeeded")
         mlsService.leaveSubconversationIfNeededParentQualifiedIDParentGroupIDSubconversationTypeSelfClientID_MockMethod = {
             XCTAssertEqual($0, self.groupConversation.qualifiedID)
             XCTAssertEqual($1, self.groupConversation.mlsGroupID)
@@ -838,7 +838,7 @@ class WireCallCenterV3Tests: MessagingTest {
 
         let mlsService = MockMLSServiceInterface()
 
-        let didJoinSubgroup = expectation(description: "didJoinSubgroup")
+        let didJoinSubgroup = customExpectation(description: "didJoinSubgroup")
         mlsService.createOrJoinSubgroupParentQualifiedIDParentID_MockMethod = {
             defer { didJoinSubgroup.fulfill() }
             XCTAssertEqual($0, self.groupConversation.qualifiedID)
@@ -846,7 +846,7 @@ class WireCallCenterV3Tests: MessagingTest {
             return subconversationGroupID
         }
 
-        let didGenerateConferenceInfo1 = expectation(description: "didGenerateConferenceInfo1")
+        let didGenerateConferenceInfo1 = customExpectation(description: "didGenerateConferenceInfo1")
         mlsService.generateConferenceInfoParentGroupIDSubconversationGroupID_MockMethod = {
             XCTAssertEqual($0, parentGroupID)
             XCTAssertEqual($1, subconversationGroupID)
@@ -854,7 +854,7 @@ class WireCallCenterV3Tests: MessagingTest {
             return conferenceInfo1
         }
 
-        let didSetConferenceInfo1 = expectation(description: "didSetConferenceInfo1")
+        let didSetConferenceInfo1 = customExpectation(description: "didSetConferenceInfo1")
         mockAVSWrapper.mockSetMLSConferenceInfo = {
             XCTAssertEqual($0, self.groupConversation.avsIdentifier)
             XCTAssertEqual($1, conferenceInfo1)
@@ -886,7 +886,7 @@ class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        let didSetConferenceInfo2 = expectation(description: "didSetConferenceInfo2")
+        let didSetConferenceInfo2 = customExpectation(description: "didSetConferenceInfo2")
         mockAVSWrapper.mockSetMLSConferenceInfo = {
             XCTAssertEqual($0, self.groupConversation.avsIdentifier)
             XCTAssertEqual($1, conferenceInfo2)
@@ -1014,7 +1014,7 @@ class WireCallCenterV3Tests: MessagingTest {
         sut.setCallReady(version: 3)
 
         // expect
-        let calledCompletionHandler = expectation(description: "processCallEvent completion handler called")
+        let calledCompletionHandler = customExpectation(description: "processCallEvent completion handler called")
 
         // when
         syncMOC.performAndWait {
@@ -1036,7 +1036,7 @@ class WireCallCenterV3Tests: MessagingTest {
         sut.setCallReady(version: 3)
 
         // expect
-        let calledCompletionHandler = expectation(description: "processCallEvent completion handler called")
+        let calledCompletionHandler = customExpectation(description: "processCallEvent completion handler called")
 
         // when
         sut.processCallEvent(callEvent, completionHandler: {
@@ -1055,7 +1055,7 @@ class WireCallCenterV3Tests: MessagingTest {
         let callEvent = CallEvent(data: data, currentTimestamp: Date(), serverTimestamp: Date(), conversationId: oneOnOneConversationID, userId: userId, clientId: clientId)
 
         // expect
-        let calledCompletionHandler = expectation(description: "processCallEvent completion handler called")
+        let calledCompletionHandler = customExpectation(description: "processCallEvent completion handler called")
 
         // when
         sut.processCallEvent(callEvent, completionHandler: {
@@ -1080,7 +1080,7 @@ class WireCallCenterV3Tests: MessagingTest {
         sut.setCallReady(version: 3)
 
         // expect
-        let calledCompletionHandler = expectation(description: "processCallEvent completion handler called")
+        let calledCompletionHandler = customExpectation(description: "processCallEvent completion handler called")
 
         expectation(forNotification: WireCallCenterCallErrorNotification.notificationName, object: nil) { wrappedNote in
             guard let note = wrappedNote.userInfo?[WireCallCenterCallErrorNotification.userInfoKey] as? WireCallCenterCallErrorNotification else { return false }
@@ -1111,7 +1111,7 @@ class WireCallCenterV3Tests: MessagingTest {
         sut.setCallReady(version: 3)
 
         // expect
-        let calledCompletionHandler = expectation(description: "processCallEvent completion handler called")
+        let calledCompletionHandler = customExpectation(description: "processCallEvent completion handler called")
 
         // when
         sut.processCallEvent(callEvent, completionHandler: {
@@ -1872,7 +1872,7 @@ extension WireCallCenterV3Tests {
         let mlsService = MockMLSServiceInterface()
         uiMOC.zm_sync.mlsService = mlsService
 
-        let didGenereateNewEpoch = expectation(description: "didGenerateNewEpoch")
+        let didGenereateNewEpoch = customExpectation(description: "didGenerateNewEpoch")
         mlsService.generateNewEpochGroupID_MockMethod = {
             XCTAssertEqual($0, subconversationGroupID)
             didGenereateNewEpoch.fulfill()
@@ -1928,7 +1928,7 @@ extension WireCallCenterV3Tests {
             AVSClient(userId: otherUserID, clientId: "client2")
         ]
 
-        let didReceiveClientList = expectation(description: "didReceiveClientList")
+        let didReceiveClientList = customExpectation(description: "didReceiveClientList")
         sut.clientsRequestCompletionsByConversationId[groupConversationID] = { _ in
             didReceiveClientList.fulfill()
         }

--- a/wire-ios-sync-engine/Tests/Source/Data Model/Conversation+DeletionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/Conversation+DeletionTests.swift
@@ -59,7 +59,7 @@ class Conversation_DeletionTests: DatabaseTest {
         let conversation = ZMConversation.insertGroupConversation(moc: uiMOC, participants: [])!
         conversation.remoteIdentifier = UUID()
         conversation.conversationType = .group
-        let invalidOperationfailure = expectation(description: "Invalid Operation")
+        let invalidOperationfailure = customExpectation(description: "Invalid Operation")
 
         // WHEN
         conversation.delete(in: coreDataStack!, transportSession: mockTransportSession) { (result) in
@@ -79,7 +79,7 @@ class Conversation_DeletionTests: DatabaseTest {
         let conversation = ZMConversation.insertGroupConversation(moc: uiMOC, participants: [])!
         conversation.conversationType = .group
         conversation.teamRemoteIdentifier = UUID()
-        let invalidOperationfailure = expectation(description: "Invalid Operation")
+        let invalidOperationfailure = customExpectation(description: "Invalid Operation")
 
         // WHEN
         conversation.delete(in: coreDataStack!, transportSession: mockTransportSession) { (result) in

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ServiceUserTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ServiceUserTests.swift
@@ -289,7 +289,7 @@ final class ServiceUserTests: IntegrationTest {
 
     func testThatItAddsServiceToExistingConversation() throws {
         // given
-        let jobIsDone = expectation(description: "service is added")
+        let jobIsDone = customExpectation(description: "service is added")
         let service = self.createService()
         let conversation = self.conversation(for: self.groupConversation)!
 
@@ -308,7 +308,7 @@ final class ServiceUserTests: IntegrationTest {
 
     func testThatItCreatesConversationAndAddsUser() {
         // given
-        let jobIsDone = expectation(description: "service is added")
+        let jobIsDone = customExpectation(description: "service is added")
         let service = self.createService()
 
         // when

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ZMConversation+TypingUsersTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ZMConversation+TypingUsersTests.swift
@@ -27,7 +27,7 @@ class ZMConversation_TypingUsersTests: MessagingTest {
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
 
         // Then
-        let expectation = self.expectation(description: "Notification")
+        let expectation = self.customExpectation(description: "Notification")
         let assertion: (NotificationInContext) -> Void = { notification in
             XCTAssertEqual(notification.object as? ZMConversation, conversation)
             XCTAssertEqual(notification.userInfo["isTyping"] as? Bool, true)

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -102,7 +102,7 @@ final class ZMUserConsentTests: DatabaseTest {
             return ZMTransportResponse(payload: ["results": [["type": 2, "value": 1]]] as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
         }
 
-        let fetchedData = expectation(description: "fetched data")
+        let fetchedData = customExpectation(description: "fetched data")
 
         // when
         selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
@@ -128,7 +128,7 @@ final class ZMUserConsentTests: DatabaseTest {
             return ZMTransportResponse(payload: ["label": "invalid-op"] as ZMTransportData, httpStatus: 403, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
         }
 
-        let receivedError = expectation(description: "received error")
+        let receivedError = customExpectation(description: "received error")
         // when
 
         selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
@@ -154,7 +154,7 @@ final class ZMUserConsentTests: DatabaseTest {
             return ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
         }
 
-        let successExpectation = expectation(description: "set is successful")
+        let successExpectation = customExpectation(description: "set is successful")
 
         // when
         selfUser.setConsent(to: true, for: .marketing, on: mockTransportSession) { result in
@@ -179,7 +179,7 @@ final class ZMUserConsentTests: DatabaseTest {
             return ZMTransportResponse(payload: ["label": "invalid-op"] as ZMTransportData, httpStatus: 403, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
         }
 
-        let receivedError = expectation(description: "received error")
+        let receivedError = customExpectation(description: "received error")
 
         // when
         selfUser.setConsent(to: true, for: .marketing, on: mockTransportSession) { result in

--- a/wire-ios-sync-engine/Tests/Source/Integration/APNSTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/APNSTests.m
@@ -59,7 +59,7 @@
     [self.application setBackground];
     
     // when
-    XCTestExpectation *fetchingExpectation = [self expectationWithDescription:@"fetching notification"];
+    XCTestExpectation *fetchingExpectation = [self customExpectationWithDescription:@"fetching notification"];
 
     NSUUID *lastNotificationId = [self.lastEventIDRepository fetchLastEventID];
 
@@ -113,7 +113,7 @@
     [self.application setBackground];
     
     // when
-    XCTestExpectation *fetchingExpectation = [self expectationWithDescription:@"fetching notification"];
+    XCTestExpectation *fetchingExpectation = [self customExpectationWithDescription:@"fetching notification"];
     
     __block NSUInteger requestCount = 0;
 

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Deletion.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Deletion.swift
@@ -27,7 +27,7 @@ class ConversationTests_Deletion: ConversationTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // WHEN
-        let conversationIsDeleted = expectation(description: "Team conversation is deleted")
+        let conversationIsDeleted = customExpectation(description: "Team conversation is deleted")
         let teamConversation = conversation(for: groupConversationWithWholeTeam)!
         teamConversation.delete(in: userSession!, completion: { (result) in
             if case .success = result {
@@ -57,7 +57,7 @@ class ConversationTests_Deletion: ConversationTestsBase {
         }
 
         // WHEN
-        let conversationDeletionFailed = expectation(description: "Team conversation deletion failed")
+        let conversationDeletionFailed = customExpectation(description: "Team conversation deletion failed")
         let teamConversation = conversation(for: groupConversationWithWholeTeam)!
         teamConversation.delete(in: userSession!, completion: { (result) in
             if case .failure = result {

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Guests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Guests.swift
@@ -136,7 +136,7 @@ class ConversationTests_Guests: IntegrationTest {
             self.mockTransportSession?.resetReceivedRequests()
 
             // WHEN
-            let didFail  = self.expectation(description: "did fail")
+            let didFail  = self.customExpectation(description: "did fail")
             conversation.canGenerateGuestLink(in: self.userSession!) { result in
                 // THEN
                 switch result {

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+MessageEditing.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+MessageEditing.m
@@ -119,7 +119,7 @@
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Send proteus message"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Send proteus message"];
     NSUUID *originalNonce = message.nonce;
     [self.mockTransportSession resetReceivedRequests];
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request){

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+ReceiptMode.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+ReceiptMode.swift
@@ -94,7 +94,7 @@ class ConversationTests_ReceiptMode: IntegrationTest {
         XCTAssert(login())
         let sut = conversation(for: selfToUser1Conversation)!
         XCTAssertFalse(sut.hasReadReceiptsEnabled)
-        let expectation = self.expectation(description: "Invalid Operation")
+        let expectation = self.customExpectation(description: "Invalid Operation")
 
         // when
         sut.setEnableReadReceipts(true, in: userSession!) { (result) in

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTestsBase.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTestsBase.m
@@ -282,7 +282,7 @@
     __block NSArray *messsagesNonces;
     
     // expect
-    XCTestExpectation *exp = [self expectationWithDescription:@"All messages received"];
+    XCTestExpectation *exp = [self customExpectationWithDescription:@"All messages received"];
     observer.notificationCallback = (ObserverCallback) ^(ConversationChangeInfo * __unused note) {
         BOOL hasAllMessages = [self conversation:conversation hasMessagesWithNonces:messsagesNonces];
         if (hasAllMessages) {

--- a/wire-ios-sync-engine/Tests/Source/Integration/GiphyTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/GiphyTests.m
@@ -36,7 +36,7 @@
     // given
     XCTAssertTrue([self login]);
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"callback called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"callback called"];
     NSArray *expectedPayload = @[@"bar"];
     NSString *path = @"/foo/bar/baz";
 

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
@@ -28,7 +28,7 @@ extension IntegrationTest {
         // TODO: do test assertion on apiVersion and move currentApiVersion on caller
         self.overrideAPIVersion(.v2)
 
-        let searchCompleted = expectation(description: "Search result arrived")
+        let searchCompleted = customExpectation(description: "Search result arrived")
         let request = SearchRequest(query: searchQuery, searchOptions: [.directory])
         let task = sharedSearchDirectory?.perform(request)
         var searchResult: SearchResult?
@@ -50,7 +50,7 @@ extension IntegrationTest {
         XCTAssertNotNil(searchUser)
         XCTAssertEqual(searchUser?.name, name)
 
-        let didConnect = expectation(description: "did connect to user")
+        let didConnect = customExpectation(description: "did connect to user")
         searchUser?.connect { _ in
             didConnect.fulfill()
         }
@@ -63,7 +63,7 @@ extension IntegrationTest {
         // this only work for v2 and above
         // TODO: do test assertion on apiVersion and move currentApiVersion on caller
         setCurrentAPIVersion(.v2)
-        let searchCompleted = expectation(description: "Search result arrived")
+        let searchCompleted = customExpectation(description: "Search result arrived")
         let request = SearchRequest(query: searchQuery, searchOptions: [.directory])
         let task = sharedSearchDirectory?.perform(request)
         var searchResult: SearchResult?
@@ -87,7 +87,7 @@ extension IntegrationTest {
     public func searchForConnectedUser(withName name: String, searchQuery: String) -> ZMUser? {
         createSharedSearchDirectory()
 
-        let searchCompleted = expectation(description: "Search result arrived")
+        let searchCompleted = customExpectation(description: "Search result arrived")
         let request = SearchRequest(query: searchQuery, searchOptions: [.contacts])
         let task = sharedSearchDirectory?.perform(request)
         var searchResult: SearchResult?

--- a/wire-ios-sync-engine/Tests/Source/Integration/LoginFlowTests+PushToken.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/LoginFlowTests+PushToken.swift
@@ -38,7 +38,7 @@ class LoginFlowTests_PushToken: IntegrationTest {
         XCTAssertTrue(self.login())
 
         let pushService = try XCTUnwrap(sessionManager?.pushTokenService)
-        let registrationComplete = expectation(description: "registrtation complete")
+        let registrationComplete = customExpectation(description: "registrtation complete")
         pushService.onRegistrationComplete = { registrationComplete.fulfill() }
 
         // when

--- a/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SendAndReceiveMessagesTests.m
@@ -258,7 +258,7 @@
     
     //we block first request from finishing and check that no other requests are comming in
     __block ZMTransportRequest *firstRequest;
-    XCTestExpectation *firstRequestRecievedExpectation = [self expectationWithDescription:@"Recieved request to add first message"];
+    XCTestExpectation *firstRequestRecievedExpectation = [self customExpectationWithDescription:@"Recieved request to add first message"];
 
     ZM_WEAK(self);
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(ZMTransportRequest *request) {
@@ -312,7 +312,7 @@
     
     //we block first request from finishing and check that no other requests are comming in
     __block NSInteger recievedRequests = 0;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Recieved requests for both messages"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Recieved requests for both messages"];
     self.mockTransportSession.responseGeneratorBlock = ^ZMTransportResponse *(__unused ZMTransportRequest *request) {
         //we should not recieve another request untill we finish this one
         if ([request.path.lastPathComponent containsString:@"messages"]) {

--- a/wire-ios-sync-engine/Tests/Source/Integration/SlowSyncTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/SlowSyncTests.m
@@ -244,7 +244,7 @@
     [self.mockTransportSession resetReceivedRequests];
     
     // when
-    XCTestExpectation *expectation = [self expectationWithDescription:@"fetchCompleted"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"fetchCompleted"];
     [self.userSession application:self.application performFetchWithCompletionHandler:^(UIBackgroundFetchResult result) {
         NOT_USED(result);
         ZMTransportRequest *request = self.mockTransportSession.receivedRequests.lastObject;

--- a/wire-ios-sync-engine/Tests/Source/Integration/UserProfileTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/UserProfileTests.m
@@ -128,7 +128,7 @@
     [(id<ZMUserObserver>)[userObserver expect] userDidChange:OCMOCK_ANY]; // <- DONE: when receiving this, I know that the phone number was set
     
     // expect
-    XCTestExpectation *phoneNumberVerificationCodeExpectation = [self expectationWithDescription:@"phoneNumberVerificationCodeExpectation"];
+    XCTestExpectation *phoneNumberVerificationCodeExpectation = [self customExpectationWithDescription:@"phoneNumberVerificationCodeExpectation"];
     [[[editableUserObserver expect] andDo:^(NSInvocation *inv) {
         NOT_USED(inv);
         [phoneNumberVerificationCodeExpectation fulfill];

--- a/wire-ios-sync-engine/Tests/Source/Integration/ZMUserSessionLegalHoldTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ZMUserSessionLegalHoldTests.swift
@@ -57,7 +57,7 @@ class ZMUserSessionLegalHoldTests: IntegrationTest {
         }
 
         // WHEN: I accept the legal hold request
-        let completionExpectation = expectation(description: "The request completes.")
+        let completionExpectation = customExpectation(description: "The request completes.")
 
         userSession?.accept(legalHoldRequest: legalHoldRequest, password: IntegrationTest.SelfUserPassword) { error in
             XCTAssertNil(error)
@@ -102,7 +102,7 @@ class ZMUserSessionLegalHoldTests: IntegrationTest {
         }
 
         // WHEN: I accept the legal hold request with the wrong password
-        let completionExpectation = expectation(description: "The request completes.")
+        let completionExpectation = customExpectation(description: "The request completes.")
 
         userSession?.accept(legalHoldRequest: legalHoldRequest, password: "I tRieD 3 tImeS!") { error in
             XCTAssertEqual(error, .invalidPassword)

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/APIVersionResolverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/APIVersionResolverTests.swift
@@ -87,7 +87,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         transportSession.isAPIVersionEndpointAvailable = false
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -118,7 +118,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         XCTAssertNil(BackendInfo.apiVersion)
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -146,7 +146,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         XCTAssertNil(BackendInfo.apiVersion)
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -179,7 +179,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         XCTAssertNil(BackendInfo.apiVersion)
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -210,7 +210,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         XCTAssertNil(BackendInfo.apiVersion)
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -241,7 +241,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         XCTAssertNil(BackendInfo.apiVersion)
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -268,7 +268,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         )
 
         // When
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -297,7 +297,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         )
 
         // When version is resolved
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -327,7 +327,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         )
 
         // When version is resolved
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -360,7 +360,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         )
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
@@ -389,7 +389,7 @@ class APIVersionResolverTests: ZMTBaseTest {
         )
 
         // When version is resolved.
-        let done = expectation(description: "done")
+        let done = customExpectation(description: "done")
         sut.resolveAPIVersion(completion: { _ in done.fulfill() })
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManager+PushTokenTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManager+PushTokenTests.swift
@@ -62,10 +62,10 @@ class SessionManagerPushTokenTests: IntegrationTest {
             .createVOIPToken(from: .secureRandomData(length: 8))
         ]
 
-        let registrationDone = expectation(description: "registration done")
+        let registrationDone = customExpectation(description: "registration done")
         pushService.onRegistrationComplete = { registrationDone.fulfill() }
 
-        let unregistrationDone = expectation(description: "unregistration done")
+        let unregistrationDone = customExpectation(description: "unregistration done")
         pushService.onUnregistrationComplete = { unregistrationDone.fulfill() }
 
         // When
@@ -107,10 +107,10 @@ class SessionManagerPushTokenTests: IntegrationTest {
             .createVOIPToken(from: .secureRandomData(length: 8))
         ]
 
-        let registrationDone = expectation(description: "registration done")
+        let registrationDone = customExpectation(description: "registration done")
         pushService.onRegistrationComplete = { registrationDone.fulfill() }
 
-        let unregistrationDone = expectation(description: "unregistration done")
+        let unregistrationDone = customExpectation(description: "unregistration done")
         pushService.onUnregistrationComplete = { unregistrationDone.fulfill() }
 
         // When
@@ -150,10 +150,10 @@ class SessionManagerPushTokenTests: IntegrationTest {
             pushService.localToken!
         ]
 
-        let registrationDone = expectation(description: "registration done")
+        let registrationDone = customExpectation(description: "registration done")
         pushService.onRegistrationComplete = { registrationDone.fulfill() }
 
-        let unregistrationDone = expectation(description: "unregistration done")
+        let unregistrationDone = customExpectation(description: "unregistration done")
         pushService.onUnregistrationComplete = { unregistrationDone.fulfill() }
 
         // When

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerAVSTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerAVSTests.swift
@@ -55,7 +55,7 @@ class SessionManagerAVSTests: ZMTBaseTest {
         let logMessage = "123"
 
         // expect
-        expectation(forNotification: NSNotification.Name("AVSLogMessageNotification"), object: nil) { (note) -> Bool in
+        customExpectation(forNotification: NSNotification.Name("AVSLogMessageNotification"), object: nil) { (note) -> Bool in
             let message = note.userInfo?["message"] as? String
             return message == logMessage
         }

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+Proxy.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+Proxy.swift
@@ -85,7 +85,7 @@ final class SessionManagerTests_Proxy: IntegrationTest {
         XCTAssertFalse(unauthenticatedSessionFactory.readyForRequests)
 
         // EXPECT
-        expectation(forNotification: NSNotification.Name(rawValue: ZMTransportSessionReachabilityIsEnabled), object: nil) { (_) -> Bool in
+        customExpectation(forNotification: NSNotification.Name(rawValue: ZMTransportSessionReachabilityIsEnabled), object: nil) { (_) -> Bool in
             return true
         }
 

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -153,7 +153,7 @@ final class SessionManagerTests: IntegrationTest {
 
         guard let application = application else { return XCTFail() }
 
-        let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
+        let sessionManagerExpectation = self.customExpectation(description: "Session manager and session is loaded")
 
         let observer = SessionManagerObserverMock()
         var createToken: Any?
@@ -245,7 +245,7 @@ final class SessionManagerTests: IntegrationTest {
 
         guard let application = application else { return XCTFail() }
 
-        let sessionManagerExpectation = self.expectation(description: "Session manager and sessions are loaded")
+        let sessionManagerExpectation = self.customExpectation(description: "Session manager and sessions are loaded")
         let observer = SessionManagerObserverMock()
 
         var destroyToken: Any?
@@ -361,7 +361,7 @@ final class SessionManagerTests: IntegrationTest {
         XCTAssertEqual(sut?.accountManager.accounts.count, 1)
 
         // THEN
-        let logoutExpectation = expectation(description: "Authentication after reboot")
+        let logoutExpectation = customExpectation(description: "Authentication after reboot")
 
         delegate.onLogout = { error in
             XCTAssertNil(self.sut?.activeUserSession)
@@ -827,7 +827,7 @@ class SessionManagerTests_AuthenticationFailure_With_DeleteAccountOnAuthentictio
         XCTAssertNotNil(sessionManager?.activeUserSession)
 
         // load additional account as a background session
-        let sessionLoaded = expectation(description: "Background session loaded")
+        let sessionLoaded = customExpectation(description: "Background session loaded")
         sessionManager?.withSession(for: additionalAccount, perform: {_ in
             sessionLoaded.fulfill()
         })
@@ -1050,7 +1050,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         manager.addOrUpdate(account2)
         // WHEN
         weak var sessionForAccount1Reference: ZMUserSession?
-        let session1LoadedExpectation = self.expectation(description: "Session for account 1 loaded")
+        let session1LoadedExpectation = self.customExpectation(description: "Session for account 1 loaded")
         self.sessionManager!.withSession(for: account1, perform: { sessionForAccount1 in
             // THEN
             session1LoadedExpectation.fulfill()
@@ -1059,7 +1059,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         })
         // WHEN
         weak var sessionForAccount2Reference: ZMUserSession?
-        let session2LoadedExpectation = self.expectation(description: "Session for account 2 loaded")
+        let session2LoadedExpectation = self.customExpectation(description: "Session for account 2 loaded")
         self.sessionManager!.withSession(for: account1, perform: { sessionForAccount2 in
             // THEN
             session2LoadedExpectation.fulfill()
@@ -1082,7 +1082,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         let account = self.createAccount()
 
         // WHEN
-        let sessionLoadedExpectation = self.expectation(description: "Session loaded")
+        let sessionLoadedExpectation = self.customExpectation(description: "Session loaded")
         self.sessionManager!.withSession(for: account, perform: { session in
             XCTAssertNotNil(session.managedObjectContext)
             sessionLoadedExpectation.fulfill()
@@ -1107,7 +1107,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
 
         guard let application = application else { return XCTFail() }
 
-        let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
+        let sessionManagerExpectation = self.customExpectation(description: "Session manager and session is loaded")
 
         // WHEN
         let testSessionManager = SessionManager(
@@ -1166,7 +1166,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
 
         guard let application = application else { return XCTFail() }
 
-        let sessionManagerExpectation = self.expectation(description: "Session manager and session is loaded")
+        let sessionManagerExpectation = self.customExpectation(description: "Session manager and session is loaded")
 
         // WHEN
         let testSessionManager = SessionManager(
@@ -1255,7 +1255,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         ]
 
         // WHEN
-        let pushCompleted = self.expectation(description: "Push completed")
+        let pushCompleted = self.customExpectation(description: "Push completed")
         sessionManager?.processIncomingRealVoIPPush(payload: payload, completion: {
             DispatchQueue.main.async {
                 // THEN
@@ -1284,9 +1284,9 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         ]
 
         // WHEN
-        let pushCompleted1 = self.expectation(description: "Push completed 1")
+        let pushCompleted1 = self.customExpectation(description: "Push completed 1")
         var userSession1: ZMUserSession!
-        let pushCompleted2 = self.expectation(description: "Push completed 2")
+        let pushCompleted2 = self.customExpectation(description: "Push completed 2")
         var userSession2: ZMUserSession!
         sessionManager?.processIncomingRealVoIPPush(payload: payload, completion: {
             pushCompleted1.fulfill()
@@ -1315,7 +1315,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
 
         var session: ZMUserSession! = nil
 
-        let sessionLoadExpectation = self.expectation(description: "Session loaded")
+        let sessionLoadExpectation = self.customExpectation(description: "Session loaded")
         self.sessionManager?.withSession(for: account, perform: { createdSession in
             session = createdSession
             sessionLoadExpectation.fulfill()
@@ -1343,7 +1343,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
     func testThatItConfiguresNotificationSettingsWhenAccountIsActivated() {
         // GIVEN
         _ = self.setupSession()
-        let expectation = self.expectation(description: "Session loaded")
+        let expectation = self.customExpectation(description: "Session loaded")
         sessionManager?.notificationCenter = notificationCenter!
 
         guard
@@ -1421,7 +1421,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         XCTAssertNil(self.sessionManager!.activeUserSession)
 
         // WHEN
-        let completionExpectation = self.expectation(description: "Completed action")
+        let completionExpectation = self.customExpectation(description: "Completed action")
         self.sessionManager?.handleNotification(with: userInfo) { userSession in
             userSession.handleNotificationResponse(actionIdentifier: "",
                                                    categoryIdentifier: category,
@@ -1458,7 +1458,7 @@ final class SessionManagerTests_MultiUserSession: IntegrationTest {
         XCTAssertTrue(responder.notificationPermissionRequests.isEmpty)
 
         // WHEN
-        let completionExpectation = self.expectation(description: "Completed action")
+        let completionExpectation = self.customExpectation(description: "Completed action")
         self.sessionManager?.handleNotification(with: userInfo) { userSession in
             userSession.handleInAppNotification(with: userInfo, categoryIdentifier: category) { _ in
                 completionExpectation.fulfill()
@@ -1562,7 +1562,7 @@ final class SessionManagerTests_AppLock: IntegrationTest {
         XCTAssertEqual(sessionManager!.activeUserSession, session1)
 
         // When
-        let switchedAccount = expectation(description: "switched account")
+        let switchedAccount = customExpectation(description: "switched account")
         sessionManager?.select(account2, completion: { _ in
             switchedAccount.fulfill()
         }, tearDownCompletion: nil)
@@ -1625,7 +1625,7 @@ extension SessionManagerTests {
 
         var conversations: [ZMConversation] = []
 
-        let conversation1CreatedExpectation = self.expectation(description: "Conversation 1 created")
+        let conversation1CreatedExpectation = self.customExpectation(description: "Conversation 1 created")
 
         self.sessionManager?.withSession(for: account1, perform: { createdSession in
             createdSession.managedObjectContext.createSelfUserAndSelfConversation()
@@ -1637,7 +1637,7 @@ extension SessionManagerTests {
             conversation1CreatedExpectation.fulfill()
         })
 
-        let conversation2CreatedExpectation = self.expectation(description: "Conversation 2 created")
+        let conversation2CreatedExpectation = self.customExpectation(description: "Conversation 2 created")
 
         self.sessionManager?.withSession(for: account2, perform: { createdSession in
             createdSession.managedObjectContext.createSelfUserAndSelfConversation()
@@ -1654,7 +1654,7 @@ extension SessionManagerTests {
         XCTAssertEqual(conversations.filter { $0.firstUnreadMessage != nil }.count, 2)
 
         // when
-        let doneExpectation = self.expectation(description: "Conversations are marked as read")
+        let doneExpectation = self.customExpectation(description: "Conversations are marked as read")
 
         self.sessionManager?.markAllConversationsAsRead(completion: {
             doneExpectation.fulfill()

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -81,7 +81,7 @@ class CallingRequestStrategyTests: MessagingTest {
 
         // given
         let expectedCallConfig = "{\"config\":true}"
-        let receivedCallConfigExpectation = expectation(description: "Received CallConfig")
+        let receivedCallConfigExpectation = customExpectation(description: "Received CallConfig")
 
         sut.requestCallConfig { (callConfig, httpStatusCode) in
             if callConfig == expectedCallConfig, httpStatusCode == 200 {
@@ -132,7 +132,7 @@ class CallingRequestStrategyTests: MessagingTest {
     func testThatItDoesNotForwardUnsuccessfulResponses() {
         // given
         let expectedCallConfig = "{\"config\":true}"
-        let receivedCallConfigExpectation = expectation(description: "Received CallConfig")
+        let receivedCallConfigExpectation = customExpectation(description: "Received CallConfig")
 
         sut.requestCallConfig { (callConfig, httpStatusCode) in
             if callConfig == expectedCallConfig, httpStatusCode == 200 {
@@ -200,7 +200,7 @@ class CallingRequestStrategyTests: MessagingTest {
             """
 
             // Expectation
-            let receivedClientList = expectation(description: "Received client list")
+            let receivedClientList = customExpectation(description: "Received client list")
 
             let avsClient1 = try XCTUnwrap(AVSClient(userClient: client1))
             let avsClient2 = try XCTUnwrap(AVSClient(userClient: client2))
@@ -287,7 +287,7 @@ class CallingRequestStrategyTests: MessagingTest {
             """
 
             // Expectation
-            let receivedClientList = expectation(description: "Received client list")
+            let receivedClientList = customExpectation(description: "Received client list")
 
             let avsClient1 = try XCTUnwrap(AVSClient(userClient: client1))
             let avsClient2 = try XCTUnwrap(AVSClient(userClient: client2))
@@ -360,7 +360,7 @@ class CallingRequestStrategyTests: MessagingTest {
             syncMOC.saveOrRollback()
 
             // Expectations
-            let receivedClientList = expectation(description: "Received client list")
+            let receivedClientList = customExpectation(description: "Received client list")
 
             let avsClient1 = try XCTUnwrap(AVSClient(userClient: client1))
             let avsClient2 = try XCTUnwrap(AVSClient(userClient: client2))
@@ -710,7 +710,7 @@ class CallingRequestStrategyTests: MessagingTest {
         let avsClient1 = AVSClient(userId: user1AVSIdentifier, clientId: client1RemoteIdentifier)
         let targets = [avsClient1]
 
-        let expectation = self.expectation(description: "reject message is sent to MLS self conversation")
+        let expectation = self.customExpectation(description: "reject message is sent to MLS self conversation")
         // When we schedule the message
         syncMOC.performGroupedBlock {
             self.sut.send(

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ProxiedRequestStrategyTests.swift
@@ -125,7 +125,7 @@ class ProxiedRequestStrategyTests: MessagingTest {
         )!
 
         let response = ZMTransportResponse(httpurlResponse: HTTPResponse, data: data, error: error, apiVersion: APIVersion.v0.rawValue)
-        let expectation = self.expectation(description: "Callback invoked")
+        let expectation = self.customExpectation(description: "Callback invoked")
 
         requestsStatus.add(request: ProxyRequest(type: .giphy, path: "/foo/bar1", method: .get, callback: { responseData, responseURLResponse, responseError in
             XCTAssertEqual(data, responseData)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -113,7 +113,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
             "data": NSNull()
         ]
 
-        expectation(forNotification: AccountDeletedNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: AccountDeletedNotification.notificationName, object: nil) { wrappedNote in
             guard
                 (wrappedNote.userInfo?[AccountDeletedNotification.userInfoKey] as? AccountDeletedNotification) != nil
             else {
@@ -152,7 +152,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
             "data": NSNull()
         ]
 
-        expectation(forNotification: AccountDeletedNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: AccountDeletedNotification.notificationName, object: nil) { wrappedNote in
             guard
                 (wrappedNote.userInfo?[AccountDeletedNotification.userInfoKey] as? AccountDeletedNotification) != nil
             else {
@@ -308,7 +308,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
         }
 
         // expect
-        expectation(forNotification: AccountDeletedNotification.notificationName, object: nil) { wrappedNote in
+        customExpectation(forNotification: AccountDeletedNotification.notificationName, object: nil) { wrappedNote in
             guard
                 (wrappedNote.userInfo?[AccountDeletedNotification.userInfoKey] as? AccountDeletedNotification) != nil
             else {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TypingStrategyTests.swift
@@ -544,7 +544,7 @@ extension TypingStrategyTests {
         let conversation = insertUIConversation()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMConversation.clearTypingNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       using: { note in
@@ -670,7 +670,7 @@ extension TypingStrategyTests {
         let conversation = insertUIConversation()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMConversation.typingChangeNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       using: { _ in
@@ -696,7 +696,7 @@ extension TypingStrategyTests {
         let conversation = insertUIConversation()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMConversation.typingNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       using: { _ in
@@ -723,7 +723,7 @@ extension TypingStrategyTests {
         let conversation = insertUIConversation()
 
         // expect
-        let expectation = self.expectation(description: "Notified")
+        let expectation = self.customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: ZMConversation.clearTypingNotificationName,
                                                       context: self.uiMOC.notificationContext,
                                                       using: { _ in

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -269,7 +269,7 @@ class ZMHotFixTests_Integration: MessagingTest {
         }
 
         // expect
-        let expectation = expectation(description: "Notified")
+        let expectation = customExpectation(description: "Notified")
         let token = NotificationInContext.addObserver(name: UpdateAccessRolesAction.notificationName,
                                                       context: self.syncMOC.notificationContext,
                                                       using: { note in

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.m
@@ -562,7 +562,7 @@
     NSDictionary *pushPayload = [self noticePushPayloadWithUUID:notificationID];
     
     // expect
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Called completion handler"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Called completion handler"];
     [self.sut fetchEventsFromPushChannelPayload:pushPayload completionHandler:^{
         [expectation fulfill];
     }];
@@ -585,7 +585,7 @@
     
     // expect
     __block BOOL completionHandlerHasBeenCalled = NO;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Called completion handler"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Called completion handler"];
     [self.sut fetchEventsFromPushChannelPayload:pushPayload completionHandler:^{
         [expectation fulfill];
         completionHandlerHasBeenCalled = YES;

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMOperationLoopTests.swift
@@ -48,7 +48,7 @@ extension ZMOperationLoopTests {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
 
         // expect
-        expectation(
+        customExpectation(
             forNotification: .NSManagedObjectContextDidSave,
             object: nil,
             handler: nil)
@@ -76,7 +76,7 @@ extension ZMOperationLoopTests {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
 
         // expect
-        expectation(
+        customExpectation(
             forNotification: .NSManagedObjectContextDidSave,
             object: nil,
             handler: nil)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -204,7 +204,7 @@
     __block ZMUser *syncUser;
     
     // expect
-    [self expectationForNotification:NSManagedObjectContextObjectsDidChangeNotification object:self.uiMOC handler:nil];
+    [self customExpectationForNotification:NSManagedObjectContextObjectsDidChangeNotification object:self.uiMOC handler:nil];
     
     // when
     [self.syncMOC performGroupedBlockThenWaitForReasonableTimeout:^{
@@ -221,7 +221,7 @@
     NSString *name = @"very-unique-name_ps9ijsdnmf";
 
     // and expect
-    [self expectationForNotification:NSManagedObjectContextObjectsDidChangeNotification object:self.uiMOC handler:^BOOL(NSNotification *notification ZM_UNUSED) {
+    [self customExpectationForNotification:NSManagedObjectContextObjectsDidChangeNotification object:self.uiMOC handler:^BOOL(NSNotification *notification ZM_UNUSED) {
         return uiUser.name != nil;
     }];
     
@@ -402,7 +402,7 @@
 - (void)testThatItNotifiesTheOperationLoopOfNewOperationWhenEnteringBackground
 {
     // expect
-    [self expectationForNotification:@"RequestAvailableNotification" object:nil handler:nil];
+    [self customExpectationForNotification:@"RequestAvailableNotification" object:nil handler:nil];
 
     // when
     [self goToBackground];
@@ -414,7 +414,7 @@
 - (void)testThatItNotifiesTheOperationLoopOfNewOperationWhenEnteringForeground
 {
     // expect
-    [self expectationForNotification:@"RequestAvailableNotification" object:nil handler:nil];
+    [self customExpectationForNotification:@"RequestAvailableNotification" object:nil handler:nil];
     
     // when
     [self goToForeground];

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMSyncStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMSyncStrategyTests.swift
@@ -49,7 +49,7 @@ extension ZMSyncStrategyTests {
 
     func testThatItNotifiesTheOperationLoopOfNewOperation_WhenContextIsSaved() {
         // expect
-        expectation(forNotification: NSNotification.Name("RequestAvailableNotification"), object: nil, handler: nil)
+        customExpectation(forNotification: NSNotification.Name("RequestAvailableNotification"), object: nil, handler: nil)
 
         // when
         _ = ZMClientMessage(nonce: NSUUID.create(), managedObjectContext: uiMOC)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/AssetDeletionStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/AssetDeletionStatusTests.swift
@@ -105,7 +105,7 @@ class AssetDeletionStatusTests: MessagingTest {
         let identifier = UUID.create().transportString()
 
         // Expect
-        let requestExpectation = expectation(description: "notification should be posted")
+        let requestExpectation = customExpectation(description: "notification should be posted")
         let observer = MockRequestAvailableObserver(requestAvailable: requestExpectation.fulfill)
 
         // When

--- a/wire-ios-sync-engine/Tests/Source/UserSession/CallEventStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/CallEventStatusTests.swift
@@ -41,7 +41,7 @@ class CallEventStatusTests: ZMTBaseTest {
     func testThatWaitForCallEventCompleteImmediatelyIfNoCallEventsAreScheduled() {
 
         // expect
-        let processingDidComplete = expectation(description: "processingDidComplete")
+        let processingDidComplete = customExpectation(description: "processingDidComplete")
 
         // when
         let hasUnprocessedCallEvents = sut.waitForCallEventProcessingToComplete {
@@ -58,7 +58,7 @@ class CallEventStatusTests: ZMTBaseTest {
         sut.scheduledCallEventForProcessing()
 
         // expect
-        let processingDidComplete = expectation(description: "processingDidComplete")
+        let processingDidComplete = customExpectation(description: "processingDidComplete")
         let hasUnprocessedCallEvents = sut.waitForCallEventProcessingToComplete {
             processingDidComplete.fulfill()
         }
@@ -76,7 +76,7 @@ class CallEventStatusTests: ZMTBaseTest {
         sut.finishedProcessingCallEvent()
 
         // expect
-        let processingDidComplete = expectation(description: "processingDidComplete")
+        let processingDidComplete = customExpectation(description: "processingDidComplete")
         let hasUnprocessedCallEvents = sut.waitForCallEventProcessingToComplete {
             processingDidComplete.fulfill()
         }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/OperationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/OperationStatusTests.swift
@@ -65,7 +65,7 @@ class OperationStatusTests: MessagingTest {
 
         // given
         sut.isInBackground = true
-        let handlerCalled = expectation(description: "background task handler called")
+        let handlerCalled = customExpectation(description: "background task handler called")
 
         // when
         sut.startBackgroundTask { (_) in
@@ -87,7 +87,7 @@ class OperationStatusTests: MessagingTest {
 
         // given
         sut.isInBackground = true
-        let handlerCalled = expectation(description: "background fetch handler called")
+        let handlerCalled = customExpectation(description: "background fetch handler called")
 
         // when
         sut.startBackgroundFetch(withCompletionHandler: { (_) in
@@ -108,8 +108,8 @@ class OperationStatusTests: MessagingTest {
 
     func testThatStartingMultipleBackgroundTasksFail() {
 
-        let successHandler = expectation(description: "background task handler called with success result")
-        let failureHandler = expectation(description: "background task handler called with failure result")
+        let successHandler = customExpectation(description: "background task handler called with success result")
+        let failureHandler = customExpectation(description: "background task handler called with failure result")
 
         // given
         sut.startBackgroundTask(withCompletionHandler: { (result) in
@@ -132,8 +132,8 @@ class OperationStatusTests: MessagingTest {
 
     func testThatStartingMultipleBackgroundFetchesFail() {
 
-        let successHandler = expectation(description: "background fetch handler called with success result")
-        let failureHandler = expectation(description: "background fetch handler called with failure result")
+        let successHandler = customExpectation(description: "background fetch handler called with success result")
+        let failureHandler = customExpectation(description: "background fetch handler called with failure result")
 
         // given
         sut.startBackgroundFetch(withCompletionHandler: { (result) in
@@ -155,7 +155,7 @@ class OperationStatusTests: MessagingTest {
     }
 
     func testBackgroundTaskFailAfterTimeout() {
-        let failureHandler = expectation(description: "background task handler called with failure result")
+        let failureHandler = customExpectation(description: "background task handler called with failure result")
 
         // given
         sut.startBackgroundTask(timeout: 1.0) { (result) in
@@ -172,7 +172,7 @@ class OperationStatusTests: MessagingTest {
     }
 
     func testBackgroundFetchFailAfterTimeout() {
-        let failureHandler = expectation(description: "background fetch handler called with failure result")
+        let failureHandler = customExpectation(description: "background fetch handler called with failure result")
 
         // given
         sut.startBackgroundFetch(timeout: 1.0) { (result) in

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -80,7 +80,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatItFindsASingleUnconnectedUserByHandle() {
 
         // given
-        let remoteResultArrived = expectation(description: "received remote result")
+        let remoteResultArrived = customExpectation(description: "received remote result")
 
         mockTransportSession.performRemoteChanges { (remoteChanges) in
             let mockUser = remoteChanges.insertUser(withName: "Dale Cooper")
@@ -123,7 +123,7 @@ class SearchTaskTests: DatabaseTest {
             self.syncMOC.saveOrRollback()
         }
 
-        let remoteResultArrived = expectation(description: "received remote result")
+        let remoteResultArrived = customExpectation(description: "received remote result")
         let request = SearchRequest(query: "einstein", searchOptions: [.directory])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -143,7 +143,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatItFindsASingleUser() {
 
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user = createConnectedUser(withName: "userA")
 
         let request = SearchRequest(query: "userA", searchOptions: [.contacts])
@@ -162,7 +162,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItDoesFindUsersContainingButNotBeginningWithSearchString() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user = createConnectedUser(withName: "userA")
         let normaliedName = user.normalizedName
 
@@ -182,7 +182,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFindsUsersBeginningWithSearchString() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user = createConnectedUser(withName: "userA")
 
         let request = SearchRequest(query: "user", searchOptions: [.contacts])
@@ -201,7 +201,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItUsesAllQueryComponentsToFindAUser() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user1 = createConnectedUser(withName: "Some Body")
         _ = createConnectedUser(withName: "Some")
         _ = createConnectedUser(withName: "Any Body")
@@ -222,7 +222,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFindsSeveralUsers() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user1 = createConnectedUser(withName: "Grant")
         let user2 = createConnectedUser(withName: "Greg")
         _ = createConnectedUser(withName: "Bob")
@@ -243,7 +243,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatUserSearchIsCaseInsensitive() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user1 = createConnectedUser(withName: "Somebody")
 
         let request = SearchRequest(query: "someBodY", searchOptions: [.contacts])
@@ -262,7 +262,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatUserSearchIsInsensitiveToDiacritics() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user1 = createConnectedUser(withName: "Sömëbodÿ")
 
         let request = SearchRequest(query: "Sømebôdy", searchOptions: [.contacts])
@@ -281,7 +281,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatUserSearchOnlyReturnsConnectedUsers() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user1 = createConnectedUser(withName: "Somebody Blocked")
         user1.connection?.status = .blocked
         let user2 = createConnectedUser(withName: "Somebody Pending")
@@ -304,7 +304,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItDoesNotReturnTheSelfUser() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let selfUser = ZMUser.selfUser(in: uiMOC)
         selfUser.name = "Some self user"
         let user = createConnectedUser(withName: "Somebody")
@@ -327,7 +327,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCanSearchForTeamMembersLocally() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let user = ZMUser.insertNewObject(in: uiMOC)
         let member = Member.insertNewObject(in: uiMOC)
@@ -355,7 +355,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCanExcludeNonActiveTeamMembersLocally() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let userA = ZMUser.insertNewObject(in: uiMOC)
         let userB = ZMUser.insertNewObject(in: uiMOC)
@@ -394,7 +394,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItIncludesNonActiveTeamMembersLocally_WhenSelfUserWasCreatedByThem() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let userA = ZMUser.insertNewObject(in: uiMOC)
         let memberA = Member.insertNewObject(in: uiMOC) // non-active team-member
@@ -428,7 +428,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCanExcludeNonActivePartnersLocally() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let userA = ZMUser.insertNewObject(in: uiMOC)
         let userB = ZMUser.insertNewObject(in: uiMOC)
@@ -476,7 +476,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItIncludesNonActivePartnersLocally_WhenSearchingWithExactHandle() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let userA = ZMUser.insertNewObject(in: uiMOC)
         let memberA = Member.insertNewObject(in: uiMOC) // non-active partner
@@ -506,7 +506,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItIncludesNonActivePartnersLocally_WhenSelfUserCreatedPartner() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let userA = ZMUser.insertNewObject(in: uiMOC)
         let memberA = Member.insertNewObject(in: uiMOC) // non-active partner
@@ -539,7 +539,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFindsASingleConversation() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation = createGroupConversation(withName: "Somebody")
 
         let request = SearchRequest(query: "Somebody", searchOptions: [.conversations])
@@ -558,7 +558,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItDoesFindConversationsUsingPartialNames() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation = createGroupConversation(withName: "Somebody")
 
         let request = SearchRequest(query: "mebo", searchOptions: [.conversations])
@@ -577,7 +577,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFindsSeveralConversations() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation1 = createGroupConversation(withName: "Candy Apple Records")
         let conversation2 = createGroupConversation(withName: "Landspeed Records")
         _ = createGroupConversation(withName: "New Day Rising")
@@ -598,7 +598,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatConversationSearchIsCaseInsensitive() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation = createGroupConversation(withName: "SoMEBody")
 
         let request = SearchRequest(query: "someBodY", searchOptions: [.conversations])
@@ -617,7 +617,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatConversationSearchIsInsensitiveToDiacritics() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation = createGroupConversation(withName: "Sömëbodÿ")
 
         let request = SearchRequest(query: "Sømebôdy", searchOptions: [.conversations])
@@ -636,7 +636,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItOnlyFindsGroupConversations() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let groupConversation = createGroupConversation(withName: "Group Conversation")
         let oneOnOneConversation = createGroupConversation(withName: "OneOnOne Conversation")
         oneOnOneConversation.conversationType = .oneOnOne
@@ -661,7 +661,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFindsConversationsThatDoNotHaveAUserDefinedName() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
         conversation.conversationType = .group
 
@@ -690,7 +690,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFindsConversationsThatContainsSearchTermOnlyInParticipantName() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation = createGroupConversation(withName: "Summertime")
         let user = createConnectedUser(withName: "Rëï")
         conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
@@ -713,7 +713,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItOrdersConversationsByUserDefinedName() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let conversation1 = createGroupConversation(withName: "FooA")
         let conversation2 = createGroupConversation(withName: "FooC")
         let conversation3 = createGroupConversation(withName: "FooB")
@@ -734,7 +734,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItOrdersConversationsByUserDefinedNameFirstAndByParticipantNameSecond() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let user1 = createConnectedUser(withName: "Bla")
         let user2 = createConnectedUser(withName: "FooB")
 
@@ -764,7 +764,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItFiltersConversationWhenTheQueryStartsWithAtSymbol() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         _ = createGroupConversation(withName: "New Day Rising")
         _ = createGroupConversation(withName: "Landspeed Records")
 
@@ -784,7 +784,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItReturnsAllConversationsWhenPassingTeamParameter() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let team = Team.insertNewObject(in: uiMOC)
         let conversationInTeam = createGroupConversation(withName: "Beach Club")
         let conversationNotInTeam = createGroupConversation(withName: "Beach Club")
@@ -885,7 +885,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatItCallsCompletionHandlerForDirectorySearch() {
         // given
         setCurrentAPIVersion(.v2)
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let request = SearchRequest(query: "User", searchOptions: [.directory])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -955,7 +955,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatItCallsCompletionHandlerForTeamMemberDirectorySearch() {
         // given
         setCurrentAPIVersion(.v2)
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let request = SearchRequest(query: "User", searchOptions: [.directory, .teamMembers])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -1012,7 +1012,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCallsCompletionHandlerForServicesSearch() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         let request = SearchRequest(query: "Service", searchOptions: [.services])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
@@ -1071,7 +1071,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatItCallsCompletionHandlerForUserLookup() {
         // given
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
 
         var userId: UUID!
         mockTransportSession.performRemoteChanges { (remoteChanges) in
@@ -1127,7 +1127,7 @@ class SearchTaskTests: DatabaseTest {
         // given
         setCurrentAPIVersion(.v3)
         let federatedDomain = "example.com"
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
 
         mockTransportSession.federatedDomains = [federatedDomain]
         mockTransportSession.performRemoteChanges { (remoteChanges) in
@@ -1156,7 +1156,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatItCallsCompletionHandlerForFederatedUserSearch_WhenUserDoesntExist() {
         // given
         setCurrentAPIVersion(.v3)
-        let resultArrived = expectation(description: "received result")
+        let resultArrived = customExpectation(description: "received result")
         mockTransportSession.federatedDomains = ["example.com"]
 
         let searchRequest = SearchRequest(query: "john@example.com", searchOptions: .federated)
@@ -1181,7 +1181,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatRemoteResultsIncludePreviousLocalResults() {
         // given
         setCurrentAPIVersion(.v2)
-        let localResultArrived = expectation(description: "received local result")
+        let localResultArrived = customExpectation(description: "received local result")
         let user = createConnectedUser(withName: "userA")
 
         mockTransportSession.performRemoteChanges { (remoteChanges) in
@@ -1202,7 +1202,7 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
         // given
-        let remoteResultArrived = expectation(description: "received remote result")
+        let remoteResultArrived = customExpectation(description: "received remote result")
 
         // expect
         task.onResult { (result, _) in
@@ -1218,7 +1218,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatLocalResultsIncludePreviousRemoteResults() {
         // given
         setCurrentAPIVersion(.v2)
-        let remoteResultArrived = expectation(description: "received remote result")
+        let remoteResultArrived = customExpectation(description: "received remote result")
         _ = createConnectedUser(withName: "userA")
 
         mockTransportSession.performRemoteChanges { (remoteChanges) in
@@ -1239,7 +1239,7 @@ class SearchTaskTests: DatabaseTest {
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
 
         // given
-        let localResultArrived = expectation(description: "received local result")
+        let localResultArrived = customExpectation(description: "received local result")
 
         // expect
         task.onResult { (result, _) in
@@ -1254,7 +1254,7 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatTaskIsCompletedAfterLocalResult() {
         // given
-        let localResultArrived = expectation(description: "received local result")
+        let localResultArrived = customExpectation(description: "received local result")
         let user = createConnectedUser(withName: "userA")
         let request = SearchRequest(query: "user", searchOptions: [.contacts])
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
@@ -1274,7 +1274,7 @@ class SearchTaskTests: DatabaseTest {
     func testThatTaskIsCompletedAfterRemoteResults() {
         // given
         setCurrentAPIVersion(.v2)
-        let remoteResultArrived = expectation(description: "received remote result")
+        let remoteResultArrived = customExpectation(description: "received remote result")
         mockTransportSession.performRemoteChanges { (remoteChanges) in
             remoteChanges.insertUser(withName: "UserB")
         }
@@ -1296,8 +1296,8 @@ class SearchTaskTests: DatabaseTest {
 
     func testThatTaskIsCompletedOnlyAfterFinalResultArrives() {
         // given
-        let intermediateResultArrived = expectation(description: "received intermediate result")
-        let finalResultsArrived = expectation(description: "received final result")
+        let intermediateResultArrived = customExpectation(description: "received intermediate result")
+        let finalResultsArrived = customExpectation(description: "received final result")
         _ = createConnectedUser(withName: "userA")
 
         mockTransportSession.performRemoteChanges { (remoteChanges) in

--- a/wire-ios-sync-engine/Tests/Source/UserSession/TeamInvitationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/TeamInvitationStatusTests.swift
@@ -96,7 +96,7 @@ class TeamInvitationStatusTests: ZMTBaseTest {
 
     func testThatCompletionHandlerIsCalledWhenProcessingResponse() {
         // given
-        let expectaction = expectation(description: "Completion handler was called")
+        let expectaction = customExpectation(description: "Completion handler was called")
         sut.invite(exampleEmailAddress1, completionHandler: { _ in
             expectaction.fulfill()
         })

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+DomainLookup.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+DomainLookup.swift
@@ -84,7 +84,7 @@ public final class UnauthenticatedSessionTests_DomainLookup: ZMTBaseTest {
         setCurrentAPIVersion(nil)
         let domain = "example com"
 
-        let expectation = self.expectation(description: "should get an error")
+        let expectation = self.customExpectation(description: "should get an error")
         var gettingExpectedError = false
         // when
         sut.lookup(domain: domain) { result in
@@ -147,7 +147,7 @@ public final class UnauthenticatedSessionTests_DomainLookup: ZMTBaseTest {
     // MARK: - Helpers
 
     func checkThat(statusCode: Int, isProcessedAs expectedResult: Result<DomainInfo>, payload: ZMTransportData?) {
-        let resultExpectation = expectation(description: "Expected result: \(expectedResult)")
+        let resultExpectation = customExpectation(description: "Expected result: \(expectedResult)")
 
         // given
         sut.lookup(domain: "example.com") { result in

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+SSO.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+SSO.swift
@@ -109,7 +109,7 @@ public final class UnauthenticatedSessionTests_SSO: ZMTBaseTest {
     // MARK: - Helpers
 
     func checkThat(statusCode: Int, isProcessedAs expectedResult: Result<SSOSettings>, payload: ZMTransportData?) {
-        let resultExpectation = expectation(description: "Expected result: \(expectedResult)")
+        let resultExpectation = customExpectation(description: "Expected result: \(expectedResult)")
 
         // given
         sut.fetchSSOSettings { result in

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
@@ -519,7 +519,7 @@ extension UserProfileImageUpdateStatusTests {
     }
 
     func testThatItSignalsThereIsRequestAvailableAfterPreprocessingCompletes() {
-        expectation(forNotification: NSNotification.Name(rawValue: "RequestAvailableNotification"), object: nil)
+        customExpectation(forNotification: NSNotification.Name(rawValue: "RequestAvailableNotification"), object: nil)
 
         syncMOC.performGroupedBlock {
             // GIVEN

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
@@ -183,7 +183,7 @@ class UserProfileImageUpdateStatusTests: MessagingTest {
     }
 
     func operationWithExpectation(description: String) -> Operation {
-        let expectation = self.expectation(description: description)
+        let expectation = self.customExpectation(description: description)
         return BlockOperation {
             expectation.fulfill()
         }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UserSessionGiphyRequestStateTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UserSessionGiphyRequestStateTests.swift
@@ -27,7 +27,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
         let path = "foo/bar"
         let url = URL(string: path, relativeTo: nil)!
 
-        let exp = self.expectation(description: "expected callback")
+        let exp = self.customExpectation(description: "expected callback")
         let callback: (Data?, HTTPURLResponse?, Error?) -> Void = { (_, _, _) -> Void in
             exp.fulfill()
         }
@@ -48,7 +48,7 @@ class UserSessionGiphyRequestStateTests: ZMUserSessionTestsBase {
     func testThatAddingRequestStartsOperationLoop() {
 
         // given
-        let exp = self.expectation(description: "new operation loop started")
+        let exp = self.customExpectation(description: "new operation loop started")
         let token = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "RequestAvailableNotification"), object: nil, queue: nil) { (_) -> Void in
             exp.fulfill()
         }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMBlacklistDownloaderTest.m
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMBlacklistDownloaderTest.m
@@ -161,7 +161,7 @@
         id blackList = [self validBlackListWithMinimumVersion:expectedMinVersion exclude:expectedExclude];
         [self stubRequestWithSuccessfulResponseObject:blackList];
         
-        XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete"];
+        XCTestExpectation *didComplete = [self customExpectationWithDescription:@"did complete"];
         
         // when
         [self createSUTWithCompletionHandler:^(NSString *minVersion, NSArray *excludeVersions) {
@@ -208,7 +208,7 @@
         [self stubRequestWithSuccessfulResponseObject:blackList];
 
         //expect that method will be called for second time after check interval
-        XCTestExpectation *exp = [self expectationWithDescription:@"download called again"];
+        XCTestExpectation *exp = [self customExpectationWithDescription:@"download called again"];
         __block NSUInteger timesCalled = 0;
         ZM_WEAK(self);
         dispatch_block_t didDownload = ^{
@@ -249,7 +249,7 @@ typedef NS_ENUM(int, TestPhase) {
         [self stubRequestWithSuccessfulResponseObject:blackList];
         
         //expect that method will be called for second time after check interval
-        XCTestExpectation *doneExp = [self expectationWithDescription:@"download called again"];
+        XCTestExpectation *doneExp = [self customExpectationWithDescription:@"download called again"];
         
         __block NSUInteger downloadWhileSuspendedCount = 0;
         __block NSUInteger downloadWhileResumedCount = 0;

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMBlacklistVerificatorTest.m
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMBlacklistVerificatorTest.m
@@ -85,7 +85,7 @@ static MockBlacklistDownloader *generatedDownloader;
 - (BOOL)checkVersion:(NSString *)version againstMinVersion:(NSString *)minVersion andExcludedVersions:(NSArray *)excludedVersions
 {
     __block BOOL verificationResult = NO;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     ZMBlacklistVerificator * sut = [[ZMBlacklistVerificator alloc] initWithCheckInterval:1000
                                                                                  version:version
                                                                              environment:[[MockEnvironment alloc] init]

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
@@ -110,7 +110,7 @@ class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
 
         // expect
-        let completionHandlerCalled = expectation(description: "Completion handler called")
+        let completionHandlerCalled = customExpectation(description: "Completion handler called")
 
         // when
         sut.logout(credentials: credentials, {result in
@@ -138,7 +138,7 @@ class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
 
         // expect
-        let completionHandlerCalled = expectation(description: "Completion handler called")
+        let completionHandlerCalled = customExpectation(description: "Completion handler called")
 
         // when
         sut.logout(credentials: credentials, {result in

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -244,7 +244,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         setEncryptionAtRest(enabled: true)
 
         // expect
-        let databaseIsLocked = expectation(description: "database is locked")
+        let databaseIsLocked = customExpectation(description: "database is locked")
         var token: Any? = sut.registerDatabaseLockedHandler { (isDatabaseLocked) in
             if isDatabaseLocked {
                 databaseIsLocked.fulfill()
@@ -270,7 +270,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // expect
-        let databaseIsUnlocked = expectation(description: "database is unlocked")
+        let databaseIsUnlocked = customExpectation(description: "database is unlocked")
         var token: Any? = sut.registerDatabaseLockedHandler { (isDatabaseLocked) in
             if !isDatabaseLocked {
                 databaseIsUnlocked.fulfill()

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.h
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.h
@@ -68,6 +68,9 @@ typedef BOOL(^VerificationBlock)(void);
 
 - (XCTestExpectation *_Nonnull)customExpectationWithDescription:(NSString *_Nonnull)description NS_SWIFT_NAME(customExpectation(description:));
 
+- (XCTestExpectation *_Nonnull)customExpectationForNotification:(NSNotificationName _Nonnull)notificationName object:(id _Nullable)objectToObserve handler:(XCNotificationExpectationHandler _Nullable)handlerOrNil;
+// NS_SWIFT_NAME(customExpectation(forNotification:object:handler:))
+
 - (XCTestExpectation *_Nonnull)customKeyValueObservingExpectationForObject:(id _Nonnull)objectToObserve keyPath:(NSString *_Nonnull)keyPath expectedValue:(id  _Nullable)expectedValue;
 
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout handler:(nullable XCWaitCompletionHandler)handlerOrNil ZM_MUST_USE_RETURN;

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.h
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.h
@@ -68,7 +68,6 @@ typedef BOOL(^VerificationBlock)(void);
 
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout handler:(nullable XCWaitCompletionHandler)handlerOrNil ZM_MUST_USE_RETURN;
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout ZM_MUST_USE_RETURN;
-- (BOOL)verifyAllExpectationsNow ZM_MUST_USE_RETURN;
 
 /// perform operations while not considering ZMLogErrors as test failure
 - (void)performIgnoringZMLogError:(nonnull void(^)(void))block;

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.h
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.h
@@ -69,7 +69,6 @@ typedef BOOL(^VerificationBlock)(void);
 - (XCTestExpectation *_Nonnull)customExpectationWithDescription:(NSString *_Nonnull)description NS_SWIFT_NAME(customExpectation(description:));
 
 - (XCTestExpectation *_Nonnull)customExpectationForNotification:(NSNotificationName _Nonnull)notificationName object:(id _Nullable)objectToObserve handler:(XCNotificationExpectationHandler _Nullable)handlerOrNil;
-// NS_SWIFT_NAME(customExpectation(forNotification:object:handler:))
 
 - (XCTestExpectation *_Nonnull)customKeyValueObservingExpectationForObject:(id _Nonnull)objectToObserve keyPath:(NSString *_Nonnull)keyPath expectedValue:(id  _Nullable)expectedValue;
 

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.h
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.h
@@ -68,6 +68,8 @@ typedef BOOL(^VerificationBlock)(void);
 
 - (XCTestExpectation *_Nonnull)customExpectationWithDescription:(NSString *_Nonnull)description NS_SWIFT_NAME(customExpectation(description:));
 
+- (XCTestExpectation *_Nonnull)customKeyValueObservingExpectationForObject:(id _Nonnull)objectToObserve keyPath:(NSString *_Nonnull)keyPath expectedValue:(id  _Nullable)expectedValue;
+
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout handler:(nullable XCWaitCompletionHandler)handlerOrNil ZM_MUST_USE_RETURN;
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout ZM_MUST_USE_RETURN;
 

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.h
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.h
@@ -66,6 +66,8 @@ typedef BOOL(^VerificationBlock)(void);
 /// Wait for all dispatch groups to be empty
 - (BOOL)waitForAllGroupsToBeEmptyWithTimeout:(NSTimeInterval)timeout ZM_MUST_USE_RETURN;
 
+- (XCTestExpectation *_Nonnull)customExpectationWithDescription:(NSString *_Nonnull)description NS_SWIFT_NAME(customExpectation(description:));
+
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout handler:(nullable XCWaitCompletionHandler)handlerOrNil ZM_MUST_USE_RETURN;
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout ZM_MUST_USE_RETURN;
 

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.m
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.m
@@ -223,7 +223,7 @@
     return (XCTestExpectation *) expectation;
 }
 
-- (XCTestExpectation *)expectationForNotification:(NSString *)notificationName object:(id)objectToObserve handler:(XCNotificationExpectationHandler)handlerOrNil;
+- (XCTestExpectation *_Nonnull)customExpectationForNotification:(NSNotificationName _Nonnull)notificationName object:(id _Nullable)objectToObserve handler:(XCNotificationExpectationHandler _Nullable)handlerOrNil;
 {
     ZMTNotificationExpectation *expectation = [[ZMTNotificationExpectation alloc] init];
     ZM_ALLOW_MISSING_SELECTOR([[NSNotificationCenter defaultCenter] addObserver:expectation selector:@selector(observe:) name:notificationName object:objectToObserve]);

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.m
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.m
@@ -239,7 +239,7 @@
     return (XCTestExpectation *) expectation;
 }
 
-- (XCTestExpectation *)keyValueObservingExpectationForObject:(id)objectToObserve keyPath:(NSString *)keyPath expectedValue:(id)expectedValue;
+- (XCTestExpectation *)customKeyValueObservingExpectationForObject:(id)objectToObserve keyPath:(NSString *)keyPath expectedValue:(id)expectedValue;
 {
     RequireString(expectedValue == nil, "Not implemented");
     ZMTKeyValueObservingExpectation *expectation = [[ZMTKeyValueObservingExpectation alloc] init];

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.m
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.m
@@ -309,11 +309,6 @@
     return YES;
 }
 
-- (BOOL)verifyAllExpectationsNow
-{
-    return [self waitForCustomExpectationsWithTimeout:0];
-}
-
 - (BOOL)waitForCustomExpectationsWithTimeout:(NSTimeInterval)timeout;
 {
     BOOL result = [self waitForCustomExpectationsWithTimeout:timeout handler:nil];

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.m
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.m
@@ -209,7 +209,7 @@
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
 }
 
-- (XCTestExpectation *)expectationWithDescription:(NSString *)description;
+- (XCTestExpectation *_Nonnull)customExpectationWithDescription:(NSString *_Nonnull)description;
 {
     ZMTExpectation *expectation = [[ZMTExpectation alloc] init];
     expectation.name = description;

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -46,4 +46,11 @@ extension ZMTBaseTest {
         XCTAssert(waitForCustomExpectations(withTimeout: timeout), file: file, line: line)
     }
 
+//    public func customExpectation(
+//        forNotification notificationName: NSNotification.Name,
+//        object: Any?,
+//        handler: XCTNSNotificationExpectation.Handler? = nil
+//    ) -> XCTestExpectation {
+//        self.customExpectation(forNotification: notificationName.rawValue, object: object, handler: handler)
+//    }
 }

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -45,12 +45,4 @@ extension ZMTBaseTest {
 
         XCTAssert(waitForCustomExpectations(withTimeout: timeout), file: file, line: line)
     }
-
-//    public func customExpectation(
-//        forNotification notificationName: NSNotification.Name,
-//        object: Any?,
-//        handler: XCTNSNotificationExpectation.Handler? = nil
-//    ) -> XCTestExpectation {
-//        self.customExpectation(forNotification: notificationName.rawValue, object: object, handler: handler)
-//    }
 }

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -31,7 +31,7 @@ extension ZMTBaseTest {
                      file: StaticString = #filePath,
                      line: UInt = #line,
                      forAsyncBlock block: @escaping () async throws -> Void) {
-        let expectation = self.expectation(description: "isDone")
+        let expectation = self.customExpectation(description: "isDone")
 
         Task {
             do {

--- a/wire-ios-testing/Tests/ZMTExpectationTests.swift
+++ b/wire-ios-testing/Tests/ZMTExpectationTests.swift
@@ -25,7 +25,7 @@ class ZMTExpectationTests: ZMTBaseTest {
     func testNotificationExpectationNotSent() {
 
         var handlerIsCalled = false
-        self.expectation(forNotification: NSNotification.Name(rawValue: notificationName), object: nil, handler: {
+        self.customExpectation(forNotification: NSNotification.Name(rawValue: notificationName), object: nil, handler: {
             _ in handlerIsCalled = true
             return true
         })
@@ -38,7 +38,7 @@ class ZMTExpectationTests: ZMTBaseTest {
     func testNotificationExpectationSent() {
 
         var handlerIsCalled = false
-        self.expectation(forNotification: NSNotification.Name(rawValue: notificationName), object: nil, handler: {
+        self.customExpectation(forNotification: NSNotification.Name(rawValue: notificationName), object: nil, handler: {
             _ in handlerIsCalled = true
             return true
         })

--- a/wire-ios-transport/Tests/Source/PushChannel/ZMNetworkSocketTest.m
+++ b/wire-ios-transport/Tests/Source/PushChannel/ZMNetworkSocketTest.m
@@ -90,7 +90,7 @@
     // when
     [socket open];
     [socket writeData:requestData];
-    [self expectationForNotification:@"ZMNetworkSocketTest" object:nil handler:^BOOL(NSNotification *notification) {
+    [self customExpectationForNotification:@"ZMNetworkSocketTest" object:nil handler:^BOOL(NSNotification *notification) {
         NOT_USED(notification);
         return YES;
     }];
@@ -155,7 +155,7 @@
 
         [self.sut open];
         [self.sut writeData:requestData];
-        [self expectationForNotification:@"ZMNetworkSocketClosed" object:nil handler:^BOOL(NSNotification *notification) {
+        [self customExpectationForNotification:@"ZMNetworkSocketClosed" object:nil handler:^BOOL(NSNotification *notification) {
             NOT_USED(notification);
             return YES;
         }];
@@ -181,7 +181,7 @@
     XCTAssertNotNil(self.sut);
     
     // WHEN
-    [self expectationForNotification:@"ZMNetworkSocketClosed" object:nil handler:^BOOL(NSNotification *notification) {
+    [self customExpectationForNotification:@"ZMNetworkSocketClosed" object:nil handler:^BOOL(NSNotification *notification) {
         NOT_USED(notification);
         return YES;
     }];

--- a/wire-ios-transport/Tests/Source/PushChannel/ZMWebSocketTests.m
+++ b/wire-ios-transport/Tests/Source/PushChannel/ZMWebSocketTests.m
@@ -139,7 +139,7 @@
 - (void)testThatItAnswersAPingWithAPong
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"didReceiveData"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"didReceiveData"];
     NSString *stringData = [[@[@"HTTP/1.1 101", @"Connection: upgrade", @"Upgrade: websocket", @"Sec-WebSocket-Accept: websocket"] componentsJoinedByString:@"\r\n"] stringByAppendingString:@"\r\n\r\n"];
     [self.fakeUIContext performGroupedBlock:^{
         [self.sut networkSocketDidOpen:self.networkSocketMock];
@@ -169,7 +169,7 @@
 {
     // given
     NSString *stringData = [[@[@"HTTP/1.1 101", @"Connection: upgrade", @"Upgrade: websocket", @"Sec-WebSocket-Accept: websocket"] componentsJoinedByString:@"\r\n"] stringByAppendingString:@"\r\n\r\n"];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"didReceiveData"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"didReceiveData"];
     [self.fakeUIContext performGroupedBlock:^{
         [self.sut networkSocketDidOpen:self.networkSocketMock];
     }];
@@ -203,7 +203,7 @@
 {
     // given
     __block NSData *sentData;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Did receive data."];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Did receive data."];
     [[(id) self.networkSocketMock expect] writeData:[OCMArg checkWithBlock:^BOOL(id obj) {
         [expectation fulfill];
         sentData = obj;
@@ -253,7 +253,7 @@
                                            trustProvider:self.trustProvider
                                   additionalHeaderFields:extraHeaders];
     __block NSData *sentData;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Did receive data."];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Did receive data."];
     [[(id) self.networkSocketMock expect] writeData:[OCMArg checkWithBlock:^BOOL(id obj) {
         [expectation fulfill];
         sentData = obj;
@@ -300,7 +300,7 @@
                             @"\r\n" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *dataToBeSent = [NSData dataWithBytes:((char []){'A', 'B'}) length:2];
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Did receive data."];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Did receive data."];
     [[(id) self.networkSocketMock stub] writeData:[OCMArg checkWithBlock:^BOOL(id obj) {
         [sentData addObject:obj];
         if (sentData.count == 2) {
@@ -335,7 +335,7 @@
 {
     // given
     NSString *stringData = [[@[@"HTTP/1.1 101", @"Connection: upgrade", @"Upgrade: websocket", @"Sec-WebSocket-Accept: websocket"] componentsJoinedByString:@"\r\n"] stringByAppendingString:@"\r\n\r\n"];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"didReceiveData"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"didReceiveData"];
 
     // when
     [self.fakeUIContext performGroupedBlock:^{
@@ -363,7 +363,7 @@
 {
     // given
     NSString *stringData = [[@[@"HTTP/1.1 101", @"Connection: upgrade", @"Upgrade: websocket", @"Sec-WebSocket-Accept: websocket"] componentsJoinedByString:@"\r\n"] stringByAppendingString:@"\r\n\r"];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"didReceiveData"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"didReceiveData"];
 
     // when
     [self.fakeUIContext performGroupedBlock:^{
@@ -421,7 +421,7 @@
 {
     // given
     NSString *stringData = [[@[@"HTTP/1.1 400", @"Server: Apache"] componentsJoinedByString:@"\r\n"] stringByAppendingString:@"\r\n\r\n"];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"didReceiveData"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"didReceiveData"];
 
     // when
     [self performIgnoringZMLogError:^{

--- a/wire-ios-transport/Tests/Source/Requests/ZMTransportRequestTests.m
+++ b/wire-ios-transport/Tests/Source/Requests/ZMTransportRequestTests.m
@@ -406,7 +406,7 @@
 - (void)testThatItCallsTaskCreatedHandler
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Task created handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Task created handler called"];
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     ZMTaskIdentifier *expectedIdentifier = [ZMTaskIdentifier identifierWithIdentifier:2 sessionIdentifier:@"test-session"];
     
@@ -427,8 +427,8 @@
 - (void)testThatItCallsMultipleTaskCreatedHandlers
 {
     // given
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"First task created handler called"];
-    XCTestExpectation *secondExpectation = [self expectationWithDescription:@"Second task created handler called"];;
+    XCTestExpectation *firstExpectation = [self customExpectationWithDescription:@"First task created handler called"];
+    XCTestExpectation *secondExpectation = [self customExpectationWithDescription:@"Second task created handler called"];;
     
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     ZMTaskIdentifier *expectedIdentifier = [ZMTaskIdentifier identifierWithIdentifier:2 sessionIdentifier:@"test-session"];
@@ -480,7 +480,7 @@
 - (void)testThatItCallsTheCompletionHandler
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
 
     [transportRequest addCompletionHandler:
@@ -498,8 +498,8 @@
 - (void)testThatItCallsMultipleCompletionHandlers
 {
     // given
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Completion 1 handler called"];
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Completion 2 handler called"];
+    XCTestExpectation *expectation1 = [self customExpectationWithDescription:@"Completion 1 handler called"];
+    XCTestExpectation *expectation2 = [self customExpectationWithDescription:@"Completion 2 handler called"];
 
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
@@ -534,7 +534,7 @@
 - (void)testThatCompletionHandlerIsExecutedWithTheResponse;
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil apiVersion:0];
     __block ZMTransportResponse *receivedResponse;
     
@@ -557,9 +557,9 @@
 - (void)testThatCompletionHandlersAreExecutedFromFirstToLast
 {
     // given
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Completion 1 handler called"];
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Completion 2 handler called"];
-    XCTestExpectation *expectation3 = [self expectationWithDescription:@"Completion 3 handler called"];
+    XCTestExpectation *expectation1 = [self customExpectationWithDescription:@"Completion 1 handler called"];
+    XCTestExpectation *expectation2 = [self customExpectationWithDescription:@"Completion 2 handler called"];
+    XCTestExpectation *expectation3 = [self customExpectationWithDescription:@"Completion 3 handler called"];
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{} HTTPStatus:200 transportSessionError:nil apiVersion:0];
 
     __block NSMutableString *responses = [[NSMutableString alloc] init];
@@ -599,7 +599,7 @@
     // given
     const float expectedProgress = 0.5f;
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Task progress handler called"];
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
@@ -620,7 +620,7 @@
     const static float expectedProgress[] = {0.0f, 0.1f, 0.5f, 0.9f, 1.0f};
     const static size_t expectedProgressSize = sizeof(expectedProgress) / sizeof(expectedProgress[0]);
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Task progress handler called"];
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     NSUInteger __block currentCallIndex = 0;
@@ -649,7 +649,7 @@
     const float randomProgress = 1000234.0f;
     const float expectedProgress = 1.0f;
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Task progress handler called"];
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
@@ -670,7 +670,7 @@
     const float randomProgress = -123.0f;
     const float expectedProgress = 0.0f;
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Task progress handler called"];
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
@@ -690,8 +690,8 @@
     // given
     const float expectedProgress = 0.5f;
     
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Task progress handler 1 called"];
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Task progress handler 2 called"];
+    XCTestExpectation *expectation1 = [self customExpectationWithDescription:@"Task progress handler 1 called"];
+    XCTestExpectation *expectation2 = [self customExpectationWithDescription:@"Task progress handler 2 called"];
 
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMTransportRequestMethodPut payload:@{} apiVersion:0];
     

--- a/wire-ios-transport/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/wire-ios-transport/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -224,7 +224,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
     func testThatPostsANewRequestAvailableNotificationAfterCompletingARunningRequest() {
         // given && then
-        _ = expectation(
+        _ = customExpectation(
             forNotification: NSNotification.Name(rawValue: NSNotification.Name.ZMTransportSessionNewRequestAvailable.rawValue),
             object: nil,
             handler: nil

--- a/wire-ios-transport/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/wire-ios-transport/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -205,7 +205,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         // given
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
         sessionMock.nextCompletionParameters = (nil, response, nil)
-        let completionExpectation = expectation(description: "Completion handler should be called")
+        let completionExpectation = customExpectation(description: "Completion handler should be called")
         let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
 
         request.add(ZMCompletionHandler(on: fakeUIContext) { response in
@@ -244,7 +244,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         // given
         let response = URLResponse(url: url, mimeType: "", expectedContentLength: 1, textEncodingName: nil)
         sessionMock.nextCompletionParameters = (nil, response, NSError.requestExpiredError())
-        let completionExpectation = expectation(description: "Completion handler should be called with errors")
+        let completionExpectation = customExpectation(description: "Completion handler should be called with errors")
         let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
 
         request.add(ZMCompletionHandler(on: fakeUIContext) { response in

--- a/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -1125,7 +1125,7 @@ static XCTestCase *currentTestCase;
     }
     
     // This is what will get called on the ZMOperationLoop:
-    [self expectationForNotification:ZMTransportSessionNewRequestAvailableNotification object:nil handler:nil];
+    [self customExpectationForNotification:ZMTransportSessionNewRequestAvailableNotification object:nil handler:nil];
     
     // when
     // enqueuing max + 1 requests

--- a/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -573,7 +573,7 @@ static XCTestCase *currentTestCase;
                 minTLSVersion:nil];
     
     self.sut.accessToken = self.validAccessToken;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     NSString *path = @"path/to/something/interesting";
     NSURL *expectedURL = [url URLByAppendingPathComponent:path];
@@ -670,7 +670,7 @@ static XCTestCase *currentTestCase;
         requestHeaders = request.allHTTPHeaderFields;
         return [TestResponse testResponse];
     }];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     // when
     ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodPost payload:@{} apiVersion:0];
@@ -695,7 +695,7 @@ static XCTestCase *currentTestCase;
         requestHeaders = request.allHTTPHeaderFields;
         return [TestResponse testResponse];
     }];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     // when
     ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
@@ -720,7 +720,7 @@ static XCTestCase *currentTestCase;
         requestHeaders = request.allHTTPHeaderFields;
         return [TestResponse testResponse];
     }];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     // when
     ZMTransportRequest *request = [ZMTransportRequest imageGetRequestFromPath:self.dummyPath apiVersion:0];
@@ -751,7 +751,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     id<ZMTransportData> payload = @{@"numbers": @[@4, @8, @15, @16, @23, @42]};
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     __block NSData *requestData;
     [self mockURLSessionTaskWithResponseGenerator:^TestResponse *(NSURLRequest *request ZM_UNUSED, NSData *data) {
@@ -822,7 +822,7 @@ static XCTestCase *currentTestCase;
     [self mockURLSessionTaskWithResponseGenerator:^TestResponse *(NSURLRequest *request ZM_UNUSED, NSData *data ZM_UNUSED) {
         return [TestResponse testResponse];
     }];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     // when
     ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
@@ -841,7 +841,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     NSArray *expectedPayload = @[@"this is my test data", @213143];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     [self mockURLSessionTaskWithResponseGenerator:^TestResponse *(NSURLRequest *request ZM_UNUSED, NSData *data ZM_UNUSED) {
         TestResponse *testResponse = [TestResponse testResponse];
@@ -869,7 +869,7 @@ static XCTestCase *currentTestCase;
 {
     // given
     self.sut.accessToken = self.validAccessToken;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     [self mockURLSessionTaskWithResponseGenerator:^TestResponse *(NSURLRequest *request ZM_UNUSED, NSData *data ZM_UNUSED) {
         XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Content-Type"], @"image/jpeg");
@@ -902,7 +902,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     NSInteger expectedStatusCode = 432;
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     [self mockURLSessionTaskWithResponseGenerator:^TestResponse *(NSURLRequest *request ZM_UNUSED, NSData *data ZM_UNUSED) {
         TestResponse *testResponse = [TestResponse testResponse];
@@ -1551,7 +1551,7 @@ static XCTestCase *currentTestCase;
     WaitForAllGroupsToBeEmpty(0.1);
     
     __block ZMTransportResponse *response;
-    XCTestExpectation *requestCompletedExpectation = [self expectationWithDescription:@"request completed"];
+    XCTestExpectation *requestCompletedExpectation = [self customExpectationWithDescription:@"request completed"];
     ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodPut payload:dummyPayload apiVersion:0];
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *r) {
         response = r;
@@ -1634,7 +1634,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    XCTestExpectation *didRun = [self expectationWithDescription:@"completion handler"];
+    XCTestExpectation *didRun = [self customExpectationWithDescription:@"completion handler"];
     ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     ZMPersistentCookieStorage *cookieStorage = self.sut.cookieStorage;
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse * ZM_UNUSED r) {
@@ -1782,7 +1782,7 @@ static XCTestCase *currentTestCase;
                              @"Content-Type": @"image/jpeg"};
         return response;
     }];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     
     // when
     ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
@@ -1811,7 +1811,7 @@ static XCTestCase *currentTestCase;
 
     
     [[(id)self.URLSession expect] setTimeoutTimer:OCMOCK_ANY forTask:dataTask];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"did cancel task"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"did cancel task"];
     
     // expect
     [[[(id)self.URLSession expect] andDo:^(NSInvocation * ZM_UNUSED i) {
@@ -1904,7 +1904,7 @@ static XCTestCase *currentTestCase;
         return response;
     }];
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     __block ZMTransportResponse *receivedResponse;
     
     // expect
@@ -1953,7 +1953,7 @@ static XCTestCase *currentTestCase;
 //        return YES;
 //    }]];
 //    
-//    XCTestExpectation *expectation = [self expectationWithDescription:@"did cancel task"];
+//    XCTestExpectation *expectation = [self customExpectationWithDescription:@"did cancel task"];
 //    
 //    // expect
 //    [[[(id)dataTask expect] andDo:^(NSInvocation * ZM_UNUSED i) {
@@ -2072,7 +2072,7 @@ static XCTestCase *currentTestCase;
     ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // expect
-    XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete response"];
+    XCTestExpectation *didComplete = [self customExpectationWithDescription:@"did complete response"];
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse *response){
         XCTAssertEqualObjects(response.transportSessionError.domain, ZMTransportSessionErrorDomain);
         XCTAssertEqual(response.transportSessionError.code, ZMTransportSessionErrorCodeTryAgainLater);
@@ -2112,7 +2112,7 @@ static XCTestCase *currentTestCase;
     ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMTransportRequestMethodGet payload:nil apiVersion:0];
     
     // expect
-    XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete response"];
+    XCTestExpectation *didComplete = [self customExpectationWithDescription:@"did complete response"];
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse *response){
         FHAssertEqualObjects(fr, response.transportSessionError.domain, ZMTransportSessionErrorDomain);
         FHAssertEqual(fr, response.transportSessionError.code, ZMTransportSessionErrorCodeTryAgainLater);
@@ -2163,7 +2163,7 @@ static XCTestCase *currentTestCase;
     [self setAuthenticationCookieData];
     
     // expect
-    XCTestExpectation *accessToken = [self expectationWithDescription:@"access token requested"];
+    XCTestExpectation *accessToken = [self customExpectationWithDescription:@"access token requested"];
     [self mockURLSessionTaskWithResponseGenerator:^(NSURLRequest *request ZM_UNUSED, NSData *data ZM_UNUSED) {
         XCTAssertEqualObjects(request.URL.path, @"/access");
         XCTAssertEqualObjects(request.HTTPMethod, @"POST");
@@ -2269,7 +2269,7 @@ static XCTestCase *currentTestCase;
     
     // expect (1)
     __block void(^countHandler)(NSUInteger);
-    XCTestExpectation *countExpectation = [self expectationWithDescription:@"get task count"];
+    XCTestExpectation *countExpectation = [self customExpectationWithDescription:@"get task count"];
     [[(id) self.URLSession stub] countTasksWithCompletionHandler:[OCMArg checkWithBlock:^BOOL(id obj) {
         countHandler = obj;
         [countExpectation fulfill];
@@ -2279,7 +2279,7 @@ static XCTestCase *currentTestCase;
     XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
     
     // expect
-    XCTestExpectation *accessToken = [self expectationWithDescription:@"access token requested"];
+    XCTestExpectation *accessToken = [self customExpectationWithDescription:@"access token requested"];
     [self mockURLSessionTaskWithResponseGenerator:^(NSURLRequest *request ZM_UNUSED, NSData *data ZM_UNUSED) {
         XCTAssertEqualObjects(request.URL.path, @"/access");
         XCTAssertEqualObjects(request.HTTPMethod, @"POST");
@@ -2304,7 +2304,7 @@ static XCTestCase *currentTestCase;
     
     // expect (1)
     __block void(^countHandler)(NSUInteger);
-    XCTestExpectation *countExpectation = [self expectationWithDescription:@"get task count"];
+    XCTestExpectation *countExpectation = [self customExpectationWithDescription:@"get task count"];
     [[(id) self.URLSession stub] countTasksWithCompletionHandler:[OCMArg checkWithBlock:^BOOL(id obj) {
         countHandler = obj;
         [countExpectation fulfill];
@@ -2346,7 +2346,7 @@ static XCTestCase *currentTestCase;
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(ZMURLSessionDelegate)];
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:self.name];
     ZMURLSession *session = [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.environment delegate:mockDelegate delegateQueue:self.queue identifier:@"test-session" userAgent:@"TestSession"];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"It should call the completion handler on the main thread"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"It should call the completion handler on the main thread"];
     
     // when
     [self.sut addCompletionHandlerForBackgroundSessionWithIdentifier:configuration.identifier handler:^{
@@ -2374,7 +2374,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItGetsTheCurrentTasksForTheBackgroundSession
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"It should get the resumed background session tasks"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"It should get the resumed background session tasks"];
     ZMTransportRequest *foregroundRequest = [ZMTransportRequest requestGetFromPath:@"/some/path/foreground" apiVersion:0];
     ZMTransportRequest *backgroundRequest = [ZMTransportRequest requestGetFromPath:@"/some/path/background" apiVersion:0];
 
@@ -2442,7 +2442,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItCompletesAnExpiredTransportRequestWithErrorCodeRequestExpired
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"Completion handler called"];
     __block ZMTransportResponse *receivedResponse;
         
     // when

--- a/wire-ios-transport/Tests/Source/URLSession/ZMURLSessionTests.m
+++ b/wire-ios-transport/Tests/Source/URLSession/ZMURLSessionTests.m
@@ -267,7 +267,7 @@ static NSString * const DataKey = @"data";
                                verifyBlock:(void (^)(NSURLSessionTask *, NSArray<NSURLSessionTask *> *))verifyBlock
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"It should call the completionHandler"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"It should call the completionHandler"];
     
     ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/some/path/" apiVersion:0];
     NSURLSessionTask *task = [self.sut taskWithRequest:self.URLRequestA bodyData:nil transportRequest:request];
@@ -312,7 +312,7 @@ static NSString * const DataKey = @"data";
 {
     // given
     NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://foo.example.com"] MIMEType:@"application/binary" expectedContentLength:1234 textEncodingName:@"utf8"];
-    XCTestExpectation *e = [self expectationWithDescription:@"completion handler"];
+    XCTestExpectation *e = [self customExpectationWithDescription:@"completion handler"];
     
     // when
     [self.sut URLSession:self.sut.backingSession dataTask:(id) self.taskA didReceiveResponse:response completionHandler:^(NSURLSessionResponseDisposition disposition) {
@@ -364,7 +364,7 @@ static NSString * const DataKey = @"data";
     
     NSURLRequest *newRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:finalURL]];
     
-    XCTestExpectation *completionHandlerCalled = [self expectationWithDescription:@"Completion handler invoked"];
+    XCTestExpectation *completionHandlerCalled = [self customExpectationWithDescription:@"Completion handler invoked"];
     
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"foo"] statusCode:302 HTTPVersion:@"1.1" headerFields:@{}];
     

--- a/wire-ios-utilities/Tests/DispatchGroupContextTests.swift
+++ b/wire-ios-utilities/Tests/DispatchGroupContextTests.swift
@@ -77,7 +77,7 @@ class DispatchGroupContextTests: ZMTBaseTest {
 
     func testGroupsCanBeLeft() {
         // given
-        let groupIsEmpty = expectation(description: "group did become empty")
+        let groupIsEmpty = customExpectation(description: "group did become empty")
         let group = ZMSDispatchGroup(label: "group1")!
         sut = DispatchGroupContext(groups: [group])
         let enteredGroups = sut.enterAll()
@@ -94,8 +94,8 @@ class DispatchGroupContextTests: ZMTBaseTest {
 
     func testSelectedGroupsCanBeLeft() {
         // given
-        let group1IsEmpty = expectation(description: "group1 did become empty")
-        let group2IsEmpty = expectation(description: "group2 did become empty")
+        let group1IsEmpty = customExpectation(description: "group1 did become empty")
+        let group2IsEmpty = customExpectation(description: "group2 did become empty")
         let group1 = ZMSDispatchGroup(label: "group1")!
         let group2 = ZMSDispatchGroup(label: "group2")!
         sut = DispatchGroupContext(groups: [group1, group2])

--- a/wire-ios-utilities/Tests/DispatchGroupQueueTests.swift
+++ b/wire-ios-utilities/Tests/DispatchGroupQueueTests.swift
@@ -31,7 +31,7 @@ class DispatchGroupQueueTests: ZMTBaseTest {
 
     func testPerformedGroupedBlockEntersAndLeavesAllGroups() {
         // given
-        let groupIsEmpty = expectation(description: "group1 is emtpy")
+        let groupIsEmpty = customExpectation(description: "group1 is emtpy")
         let group = ZMSDispatchGroup(label: "group1")!
         sut = DispatchGroupQueue(queue: DispatchQueue.main)
         sut.add(group)

--- a/wire-ios-utilities/Tests/Source/NSManagedObjectContext+WireUtilitiesTests.m
+++ b/wire-ios-utilities/Tests/Source/NSManagedObjectContext+WireUtilitiesTests.m
@@ -63,7 +63,7 @@
 - (void)testThatEnteringGroupsWithoutAllGroupsLeavingDoesNotNofity;
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"notifyWhenGroupIsEmpty"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"notifyWhenGroupIsEmpty"];
     
     NSArray *groups = [self.MOC enterAllGroups];
     
@@ -83,7 +83,7 @@
 - (void)testThatManagedObjextAutomaticallyEnterLeaveGroupWhenUsingPerformGroup;
 {
     // given
-    XCTestExpectation *expectation = [self expectationWithDescription:@"notifyWhenGroupIsEmpty called"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"notifyWhenGroupIsEmpty called"];
     
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     

--- a/wire-ios-utilities/Tests/Source/ZMTimerTests.m
+++ b/wire-ios-utilities/Tests/Source/ZMTimerTests.m
@@ -75,7 +75,7 @@
 
 - (void)setUpTimerExpectation
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"timer fired"];
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"timer fired"];
     
     ZM_WEAK(self);
     self.timerClient.block = ^(ZMTimer *timer) {
@@ -188,8 +188,8 @@
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     [self.sut cancel];
     self.sut = [ZMTimer timerWithTarget:self.timerClient operationQueue:queue];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"timer fired"];
-    
+    XCTestExpectation *expectation = [self customExpectationWithDescription:@"timer fired"];
+
     ZM_WEAK(self);
     self.timerClient.block = ^(ZMTimer *timer) {
         ZM_STRONG(self);

--- a/wire-ios-utilities/Tests/Source/ZMTimerTests.m
+++ b/wire-ios-utilities/Tests/Source/ZMTimerTests.m
@@ -163,7 +163,7 @@
     
     // then
     [self spinMainQueueWithTimeout:1.3];
-    XCTAssertFalse([self verifyAllExpectationsNow]); // Should *not* have fire
+    XCTAssertFalse([self waitForCustomExpectationsWithTimeout:0]); // Should *not* have fire
 }
 
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`ZMTBaseTest` overwrote the Apple default expectations functions with customised `ZMTExpectation`, thus some default behaviour was broken. For example only `waitForCustomExpectationsWithTimeout` was working instead of the Apple `waitForExpectations`.

🕵️‍♂️ Start your review with `ZMTBaseTest.m` and the header file.

### Solutions

Rename places with `custom`, so for the developer it's clear that the logic in this place is different from the Apple default classes:
- `expectationWithdescription`
- `expectationForNotification`
- `keyValueObservingExpectationForObject`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Run automated test suites!

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
