### PR TITLE
fix: Theme Switching Issue by Restoring keyValueString Usage

### DIFF
--- a/wire-ios/Wire-iOS/Settings+ColorScheme.swift
+++ b/wire-ios/Wire-iOS/Settings+ColorScheme.swift
@@ -64,6 +64,14 @@ enum SettingsColorScheme: Int, CaseIterable {
         return .system
     }
 
+    var keyValueString: String {
+        switch self {
+        case .dark: return "dark"
+        case .light: return "light"
+        case .system: return "system"
+        }
+    }
+
     var displayString: String {
         switch self {
         case .dark: return L10n.Localizable.DarkTheme.Option.dark

--- a/wire-ios/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -178,7 +178,7 @@ final class SettingsPropertyFactory {
                 switch value {
                 case .number(let number):
                     if let settingsColorScheme = SettingsColorScheme(rawValue: Int(number.int64Value)) {
-                        self.userDefaults.set(settingsColorScheme.displayString,
+                        self.userDefaults.set(settingsColorScheme.keyValueString,
                                               forKey: SettingKey.colorScheme.rawValue)
                     } else {
                         throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Problem:

We observed an issue where users were unable to switch between light and dark modes after recent changes were introduced to the theme handling logic. The root cause was identified as a discrepancy in the values expected by the system and those stored in UserDefaults. The keyValueString property was modified to return a struct, which conflicted with the existing UserDefaults setup that anticipates string values for the theme settings.

### Solution:

This pull request resolves the theme switching issue by reverting the keyValueString changes. We restore the original functionality where keyValueString returns a simple string that is used for setting and retrieving the theme preference from UserDefaults. This ensures compatibility with the existing theme application logic and maintains the expected behavior for persisting user preferences.

### Implementation Details:

- Reverted the keyValueString property changes to return string literals corresponding to the theme modes (.dark, .light, .system).
- Ensured that UserDefaults correctly stores and retrieves these string values.
- Conducted thorough testing to confirm that theme switching is functioning as expected across the application.
- By restoring the keyValueString usage, we align with the original design principle of simplicity and reliability in user settings persistence.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
