### PR TITLE
refactor: register MLS client within the client registration flow WBP-6152

### DIFF
--- a/wire-ios-data-model/Source/Utilis/CoreCryptoProtocolExt.swift
+++ b/wire-ios-data-model/Source/Utilis/CoreCryptoProtocolExt.swift
@@ -23,7 +23,7 @@ import WireCoreCrypto
 // This file is not member of any target!
 
 // sourcery: AutoMockable
-protocol CoreCryptoProtocol: WireCoreCrypto.CoreCryptoProtocol {
+public protocol CoreCryptoProtocol: WireCoreCrypto.CoreCryptoProtocol {
 
     func addClientsToConversation(conversationId: Data, keyPackages: [Data]) async throws -> WireCoreCrypto.MemberAddedMessages
 

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -169,20 +169,21 @@ public class MockConversationEventProcessorProtocol: ConversationEventProcessorP
 
 }
 
-class MockCoreCryptoProtocol: CoreCryptoProtocol {
+public class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - Life cycle
 
+    public init() {}
 
 
     // MARK: - addClientsToConversation
 
-    var addClientsToConversationConversationIdKeyPackages_Invocations: [(conversationId: Data, keyPackages: [Data])] = []
-    var addClientsToConversationConversationIdKeyPackages_MockError: Error?
-    var addClientsToConversationConversationIdKeyPackages_MockMethod: ((Data, [Data]) async throws -> WireCoreCrypto.MemberAddedMessages)?
-    var addClientsToConversationConversationIdKeyPackages_MockValue: WireCoreCrypto.MemberAddedMessages?
+    public var addClientsToConversationConversationIdKeyPackages_Invocations: [(conversationId: Data, keyPackages: [Data])] = []
+    public var addClientsToConversationConversationIdKeyPackages_MockError: Error?
+    public var addClientsToConversationConversationIdKeyPackages_MockMethod: ((Data, [Data]) async throws -> WireCoreCrypto.MemberAddedMessages)?
+    public var addClientsToConversationConversationIdKeyPackages_MockValue: WireCoreCrypto.MemberAddedMessages?
 
-    func addClientsToConversation(conversationId: Data, keyPackages: [Data]) async throws -> WireCoreCrypto.MemberAddedMessages {
+    public func addClientsToConversation(conversationId: Data, keyPackages: [Data]) async throws -> WireCoreCrypto.MemberAddedMessages {
         addClientsToConversationConversationIdKeyPackages_Invocations.append((conversationId: conversationId, keyPackages: keyPackages))
 
         if let error = addClientsToConversationConversationIdKeyPackages_MockError {
@@ -200,11 +201,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - clearPendingCommit
 
-    var clearPendingCommitConversationId_Invocations: [Data] = []
-    var clearPendingCommitConversationId_MockError: Error?
-    var clearPendingCommitConversationId_MockMethod: ((Data) async throws -> Void)?
+    public var clearPendingCommitConversationId_Invocations: [Data] = []
+    public var clearPendingCommitConversationId_MockError: Error?
+    public var clearPendingCommitConversationId_MockMethod: ((Data) async throws -> Void)?
 
-    func clearPendingCommit(conversationId: Data) async throws {
+    public func clearPendingCommit(conversationId: Data) async throws {
         clearPendingCommitConversationId_Invocations.append(conversationId)
 
         if let error = clearPendingCommitConversationId_MockError {
@@ -220,11 +221,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - clearPendingGroupFromExternalCommit
 
-    var clearPendingGroupFromExternalCommitConversationId_Invocations: [Data] = []
-    var clearPendingGroupFromExternalCommitConversationId_MockError: Error?
-    var clearPendingGroupFromExternalCommitConversationId_MockMethod: ((Data) async throws -> Void)?
+    public var clearPendingGroupFromExternalCommitConversationId_Invocations: [Data] = []
+    public var clearPendingGroupFromExternalCommitConversationId_MockError: Error?
+    public var clearPendingGroupFromExternalCommitConversationId_MockMethod: ((Data) async throws -> Void)?
 
-    func clearPendingGroupFromExternalCommit(conversationId: Data) async throws {
+    public func clearPendingGroupFromExternalCommit(conversationId: Data) async throws {
         clearPendingGroupFromExternalCommitConversationId_Invocations.append(conversationId)
 
         if let error = clearPendingGroupFromExternalCommitConversationId_MockError {
@@ -240,11 +241,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - clearPendingProposal
 
-    var clearPendingProposalConversationIdProposalRef_Invocations: [(conversationId: Data, proposalRef: Data)] = []
-    var clearPendingProposalConversationIdProposalRef_MockError: Error?
-    var clearPendingProposalConversationIdProposalRef_MockMethod: ((Data, Data) async throws -> Void)?
+    public var clearPendingProposalConversationIdProposalRef_Invocations: [(conversationId: Data, proposalRef: Data)] = []
+    public var clearPendingProposalConversationIdProposalRef_MockError: Error?
+    public var clearPendingProposalConversationIdProposalRef_MockMethod: ((Data, Data) async throws -> Void)?
 
-    func clearPendingProposal(conversationId: Data, proposalRef: Data) async throws {
+    public func clearPendingProposal(conversationId: Data, proposalRef: Data) async throws {
         clearPendingProposalConversationIdProposalRef_Invocations.append((conversationId: conversationId, proposalRef: proposalRef))
 
         if let error = clearPendingProposalConversationIdProposalRef_MockError {
@@ -260,12 +261,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - clientKeypackages
 
-    var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_Invocations: [(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType, amountRequested: UInt32)] = []
-    var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockError: Error?
-    var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockMethod: ((WireCoreCrypto.Ciphersuite, WireCoreCrypto.MlsCredentialType, UInt32) async throws -> [Data])?
-    var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockValue: [Data]?
+    public var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_Invocations: [(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType, amountRequested: UInt32)] = []
+    public var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockError: Error?
+    public var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockMethod: ((WireCoreCrypto.Ciphersuite, WireCoreCrypto.MlsCredentialType, UInt32) async throws -> [Data])?
+    public var clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockValue: [Data]?
 
-    func clientKeypackages(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType, amountRequested: UInt32) async throws -> [Data] {
+    public func clientKeypackages(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType, amountRequested: UInt32) async throws -> [Data] {
         clientKeypackagesCiphersuiteCredentialTypeAmountRequested_Invocations.append((ciphersuite: ciphersuite, credentialType: credentialType, amountRequested: amountRequested))
 
         if let error = clientKeypackagesCiphersuiteCredentialTypeAmountRequested_MockError {
@@ -283,12 +284,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - clientPublicKey
 
-    var clientPublicKeyCiphersuite_Invocations: [WireCoreCrypto.Ciphersuite] = []
-    var clientPublicKeyCiphersuite_MockError: Error?
-    var clientPublicKeyCiphersuite_MockMethod: ((WireCoreCrypto.Ciphersuite) async throws -> Data)?
-    var clientPublicKeyCiphersuite_MockValue: Data?
+    public var clientPublicKeyCiphersuite_Invocations: [WireCoreCrypto.Ciphersuite] = []
+    public var clientPublicKeyCiphersuite_MockError: Error?
+    public var clientPublicKeyCiphersuite_MockMethod: ((WireCoreCrypto.Ciphersuite) async throws -> Data)?
+    public var clientPublicKeyCiphersuite_MockValue: Data?
 
-    func clientPublicKey(ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> Data {
+    public func clientPublicKey(ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> Data {
         clientPublicKeyCiphersuite_Invocations.append(ciphersuite)
 
         if let error = clientPublicKeyCiphersuite_MockError {
@@ -306,12 +307,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - clientValidKeypackagesCount
 
-    var clientValidKeypackagesCountCiphersuiteCredentialType_Invocations: [(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType)] = []
-    var clientValidKeypackagesCountCiphersuiteCredentialType_MockError: Error?
-    var clientValidKeypackagesCountCiphersuiteCredentialType_MockMethod: ((WireCoreCrypto.Ciphersuite, WireCoreCrypto.MlsCredentialType) async throws -> UInt64)?
-    var clientValidKeypackagesCountCiphersuiteCredentialType_MockValue: UInt64?
+    public var clientValidKeypackagesCountCiphersuiteCredentialType_Invocations: [(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType)] = []
+    public var clientValidKeypackagesCountCiphersuiteCredentialType_MockError: Error?
+    public var clientValidKeypackagesCountCiphersuiteCredentialType_MockMethod: ((WireCoreCrypto.Ciphersuite, WireCoreCrypto.MlsCredentialType) async throws -> UInt64)?
+    public var clientValidKeypackagesCountCiphersuiteCredentialType_MockValue: UInt64?
 
-    func clientValidKeypackagesCount(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> UInt64 {
+    public func clientValidKeypackagesCount(ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> UInt64 {
         clientValidKeypackagesCountCiphersuiteCredentialType_Invocations.append((ciphersuite: ciphersuite, credentialType: credentialType))
 
         if let error = clientValidKeypackagesCountCiphersuiteCredentialType_MockError {
@@ -329,12 +330,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - commitAccepted
 
-    var commitAcceptedConversationId_Invocations: [Data] = []
-    var commitAcceptedConversationId_MockError: Error?
-    var commitAcceptedConversationId_MockMethod: ((Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]?)?
-    var commitAcceptedConversationId_MockValue: [WireCoreCrypto.BufferedDecryptedMessage]??
+    public var commitAcceptedConversationId_Invocations: [Data] = []
+    public var commitAcceptedConversationId_MockError: Error?
+    public var commitAcceptedConversationId_MockMethod: ((Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]?)?
+    public var commitAcceptedConversationId_MockValue: [WireCoreCrypto.BufferedDecryptedMessage]??
 
-    func commitAccepted(conversationId: Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]? {
+    public func commitAccepted(conversationId: Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]? {
         commitAcceptedConversationId_Invocations.append(conversationId)
 
         if let error = commitAcceptedConversationId_MockError {
@@ -352,12 +353,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - commitPendingProposals
 
-    var commitPendingProposalsConversationId_Invocations: [Data] = []
-    var commitPendingProposalsConversationId_MockError: Error?
-    var commitPendingProposalsConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.CommitBundle?)?
-    var commitPendingProposalsConversationId_MockValue: WireCoreCrypto.CommitBundle??
+    public var commitPendingProposalsConversationId_Invocations: [Data] = []
+    public var commitPendingProposalsConversationId_MockError: Error?
+    public var commitPendingProposalsConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.CommitBundle?)?
+    public var commitPendingProposalsConversationId_MockValue: WireCoreCrypto.CommitBundle??
 
-    func commitPendingProposals(conversationId: Data) async throws -> WireCoreCrypto.CommitBundle? {
+    public func commitPendingProposals(conversationId: Data) async throws -> WireCoreCrypto.CommitBundle? {
         commitPendingProposalsConversationId_Invocations.append(conversationId)
 
         if let error = commitPendingProposalsConversationId_MockError {
@@ -375,12 +376,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - conversationEpoch
 
-    var conversationEpochConversationId_Invocations: [Data] = []
-    var conversationEpochConversationId_MockError: Error?
-    var conversationEpochConversationId_MockMethod: ((Data) async throws -> UInt64)?
-    var conversationEpochConversationId_MockValue: UInt64?
+    public var conversationEpochConversationId_Invocations: [Data] = []
+    public var conversationEpochConversationId_MockError: Error?
+    public var conversationEpochConversationId_MockMethod: ((Data) async throws -> UInt64)?
+    public var conversationEpochConversationId_MockValue: UInt64?
 
-    func conversationEpoch(conversationId: Data) async throws -> UInt64 {
+    public func conversationEpoch(conversationId: Data) async throws -> UInt64 {
         conversationEpochConversationId_Invocations.append(conversationId)
 
         if let error = conversationEpochConversationId_MockError {
@@ -398,11 +399,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - conversationExists
 
-    var conversationExistsConversationId_Invocations: [Data] = []
-    var conversationExistsConversationId_MockMethod: ((Data) async -> Bool)?
-    var conversationExistsConversationId_MockValue: Bool?
+    public var conversationExistsConversationId_Invocations: [Data] = []
+    public var conversationExistsConversationId_MockMethod: ((Data) async -> Bool)?
+    public var conversationExistsConversationId_MockValue: Bool?
 
-    func conversationExists(conversationId: Data) async -> Bool {
+    public func conversationExists(conversationId: Data) async -> Bool {
         conversationExistsConversationId_Invocations.append(conversationId)
 
         if let mock = conversationExistsConversationId_MockMethod {
@@ -416,11 +417,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - createConversation
 
-    var createConversationConversationIdCreatorCredentialTypeConfig_Invocations: [(conversationId: Data, creatorCredentialType: WireCoreCrypto.MlsCredentialType, config: WireCoreCrypto.ConversationConfiguration)] = []
-    var createConversationConversationIdCreatorCredentialTypeConfig_MockError: Error?
-    var createConversationConversationIdCreatorCredentialTypeConfig_MockMethod: ((Data, WireCoreCrypto.MlsCredentialType, WireCoreCrypto.ConversationConfiguration) async throws -> Void)?
+    public var createConversationConversationIdCreatorCredentialTypeConfig_Invocations: [(conversationId: Data, creatorCredentialType: WireCoreCrypto.MlsCredentialType, config: WireCoreCrypto.ConversationConfiguration)] = []
+    public var createConversationConversationIdCreatorCredentialTypeConfig_MockError: Error?
+    public var createConversationConversationIdCreatorCredentialTypeConfig_MockMethod: ((Data, WireCoreCrypto.MlsCredentialType, WireCoreCrypto.ConversationConfiguration) async throws -> Void)?
 
-    func createConversation(conversationId: Data, creatorCredentialType: WireCoreCrypto.MlsCredentialType, config: WireCoreCrypto.ConversationConfiguration) async throws {
+    public func createConversation(conversationId: Data, creatorCredentialType: WireCoreCrypto.MlsCredentialType, config: WireCoreCrypto.ConversationConfiguration) async throws {
         createConversationConversationIdCreatorCredentialTypeConfig_Invocations.append((conversationId: conversationId, creatorCredentialType: creatorCredentialType, config: config))
 
         if let error = createConversationConversationIdCreatorCredentialTypeConfig_MockError {
@@ -436,12 +437,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - decryptMessage
 
-    var decryptMessageConversationIdPayload_Invocations: [(conversationId: Data, payload: Data)] = []
-    var decryptMessageConversationIdPayload_MockError: Error?
-    var decryptMessageConversationIdPayload_MockMethod: ((Data, Data) async throws -> WireCoreCrypto.DecryptedMessage)?
-    var decryptMessageConversationIdPayload_MockValue: WireCoreCrypto.DecryptedMessage?
+    public var decryptMessageConversationIdPayload_Invocations: [(conversationId: Data, payload: Data)] = []
+    public var decryptMessageConversationIdPayload_MockError: Error?
+    public var decryptMessageConversationIdPayload_MockMethod: ((Data, Data) async throws -> WireCoreCrypto.DecryptedMessage)?
+    public var decryptMessageConversationIdPayload_MockValue: WireCoreCrypto.DecryptedMessage?
 
-    func decryptMessage(conversationId: Data, payload: Data) async throws -> WireCoreCrypto.DecryptedMessage {
+    public func decryptMessage(conversationId: Data, payload: Data) async throws -> WireCoreCrypto.DecryptedMessage {
         decryptMessageConversationIdPayload_Invocations.append((conversationId: conversationId, payload: payload))
 
         if let error = decryptMessageConversationIdPayload_MockError {
@@ -459,11 +460,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - deleteKeypackages
 
-    var deleteKeypackagesRefs_Invocations: [[Data]] = []
-    var deleteKeypackagesRefs_MockError: Error?
-    var deleteKeypackagesRefs_MockMethod: (([Data]) async throws -> Void)?
+    public var deleteKeypackagesRefs_Invocations: [[Data]] = []
+    public var deleteKeypackagesRefs_MockError: Error?
+    public var deleteKeypackagesRefs_MockMethod: (([Data]) async throws -> Void)?
 
-    func deleteKeypackages(refs: [Data]) async throws {
+    public func deleteKeypackages(refs: [Data]) async throws {
         deleteKeypackagesRefs_Invocations.append(refs)
 
         if let error = deleteKeypackagesRefs_MockError {
@@ -479,12 +480,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiConversationState
 
-    var e2eiConversationStateConversationId_Invocations: [Data] = []
-    var e2eiConversationStateConversationId_MockError: Error?
-    var e2eiConversationStateConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.E2eiConversationState)?
-    var e2eiConversationStateConversationId_MockValue: WireCoreCrypto.E2eiConversationState?
+    public var e2eiConversationStateConversationId_Invocations: [Data] = []
+    public var e2eiConversationStateConversationId_MockError: Error?
+    public var e2eiConversationStateConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.E2eiConversationState)?
+    public var e2eiConversationStateConversationId_MockValue: WireCoreCrypto.E2eiConversationState?
 
-    func e2eiConversationState(conversationId: Data) async throws -> WireCoreCrypto.E2eiConversationState {
+    public func e2eiConversationState(conversationId: Data) async throws -> WireCoreCrypto.E2eiConversationState {
         e2eiConversationStateConversationId_Invocations.append(conversationId)
 
         if let error = e2eiConversationStateConversationId_MockError {
@@ -502,12 +503,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiEnrollmentStash
 
-    var e2eiEnrollmentStashEnrollment_Invocations: [WireCoreCrypto.E2eiEnrollment] = []
-    var e2eiEnrollmentStashEnrollment_MockError: Error?
-    var e2eiEnrollmentStashEnrollment_MockMethod: ((WireCoreCrypto.E2eiEnrollment) async throws -> Data)?
-    var e2eiEnrollmentStashEnrollment_MockValue: Data?
+    public var e2eiEnrollmentStashEnrollment_Invocations: [WireCoreCrypto.E2eiEnrollment] = []
+    public var e2eiEnrollmentStashEnrollment_MockError: Error?
+    public var e2eiEnrollmentStashEnrollment_MockMethod: ((WireCoreCrypto.E2eiEnrollment) async throws -> Data)?
+    public var e2eiEnrollmentStashEnrollment_MockValue: Data?
 
-    func e2eiEnrollmentStash(enrollment: WireCoreCrypto.E2eiEnrollment) async throws -> Data {
+    public func e2eiEnrollmentStash(enrollment: WireCoreCrypto.E2eiEnrollment) async throws -> Data {
         e2eiEnrollmentStashEnrollment_Invocations.append(enrollment)
 
         if let error = e2eiEnrollmentStashEnrollment_MockError {
@@ -525,12 +526,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiEnrollmentStashPop
 
-    var e2eiEnrollmentStashPopHandle_Invocations: [Data] = []
-    var e2eiEnrollmentStashPopHandle_MockError: Error?
-    var e2eiEnrollmentStashPopHandle_MockMethod: ((Data) async throws -> WireCoreCrypto.E2eiEnrollment)?
-    var e2eiEnrollmentStashPopHandle_MockValue: WireCoreCrypto.E2eiEnrollment?
+    public var e2eiEnrollmentStashPopHandle_Invocations: [Data] = []
+    public var e2eiEnrollmentStashPopHandle_MockError: Error?
+    public var e2eiEnrollmentStashPopHandle_MockMethod: ((Data) async throws -> WireCoreCrypto.E2eiEnrollment)?
+    public var e2eiEnrollmentStashPopHandle_MockValue: WireCoreCrypto.E2eiEnrollment?
 
-    func e2eiEnrollmentStashPop(handle: Data) async throws -> WireCoreCrypto.E2eiEnrollment {
+    public func e2eiEnrollmentStashPop(handle: Data) async throws -> WireCoreCrypto.E2eiEnrollment {
         e2eiEnrollmentStashPopHandle_Invocations.append(handle)
 
         if let error = e2eiEnrollmentStashPopHandle_MockError {
@@ -548,12 +549,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiIsEnabled
 
-    var e2eiIsEnabledCiphersuite_Invocations: [WireCoreCrypto.Ciphersuite] = []
-    var e2eiIsEnabledCiphersuite_MockError: Error?
-    var e2eiIsEnabledCiphersuite_MockMethod: ((WireCoreCrypto.Ciphersuite) async throws -> Bool)?
-    var e2eiIsEnabledCiphersuite_MockValue: Bool?
+    public var e2eiIsEnabledCiphersuite_Invocations: [WireCoreCrypto.Ciphersuite] = []
+    public var e2eiIsEnabledCiphersuite_MockError: Error?
+    public var e2eiIsEnabledCiphersuite_MockMethod: ((WireCoreCrypto.Ciphersuite) async throws -> Bool)?
+    public var e2eiIsEnabledCiphersuite_MockValue: Bool?
 
-    func e2eiIsEnabled(ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> Bool {
+    public func e2eiIsEnabled(ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> Bool {
         e2eiIsEnabledCiphersuite_Invocations.append(ciphersuite)
 
         if let error = e2eiIsEnabledCiphersuite_MockError {
@@ -571,11 +572,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiMlsInitOnly
 
-    var e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_Invocations: [(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, nbKeyPackage: UInt32?)] = []
-    var e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_MockError: Error?
-    var e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_MockMethod: ((WireCoreCrypto.E2eiEnrollment, String, UInt32?) async throws -> Void)?
+    public var e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_Invocations: [(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, nbKeyPackage: UInt32?)] = []
+    public var e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_MockError: Error?
+    public var e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_MockMethod: ((WireCoreCrypto.E2eiEnrollment, String, UInt32?) async throws -> Void)?
 
-    func e2eiMlsInitOnly(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, nbKeyPackage: UInt32?) async throws {
+    public func e2eiMlsInitOnly(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, nbKeyPackage: UInt32?) async throws {
         e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_Invocations.append((enrollment: enrollment, certificateChain: certificateChain, nbKeyPackage: nbKeyPackage))
 
         if let error = e2eiMlsInitOnlyEnrollmentCertificateChainNbKeyPackage_MockError {
@@ -591,12 +592,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiNewActivationEnrollment
 
-    var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations: [(displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite)] = []
-    var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockError: Error?
-    var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockMethod: ((String, String, String?, UInt32, WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment)?
-    var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockValue: WireCoreCrypto.E2eiEnrollment?
+    public var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations: [(displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite)] = []
+    public var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockError: Error?
+    public var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockMethod: ((String, String, String?, UInt32, WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment)?
+    public var e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockValue: WireCoreCrypto.E2eiEnrollment?
 
-    func e2eiNewActivationEnrollment(displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment {
+    public func e2eiNewActivationEnrollment(displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment {
         e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations.append((displayName: displayName, handle: handle, team: team, expiryDays: expiryDays, ciphersuite: ciphersuite))
 
         if let error = e2eiNewActivationEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockError {
@@ -614,12 +615,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiNewEnrollment
 
-    var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations: [(clientId: String, displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite)] = []
-    var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockError: Error?
-    var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockMethod: ((String, String, String, String?, UInt32, WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment)?
-    var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockValue: WireCoreCrypto.E2eiEnrollment?
+    public var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations: [(clientId: String, displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite)] = []
+    public var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockError: Error?
+    public var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockMethod: ((String, String, String, String?, UInt32, WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment)?
+    public var e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockValue: WireCoreCrypto.E2eiEnrollment?
 
-    func e2eiNewEnrollment(clientId: String, displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment {
+    public func e2eiNewEnrollment(clientId: String, displayName: String, handle: String, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment {
         e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations.append((clientId: clientId, displayName: displayName, handle: handle, team: team, expiryDays: expiryDays, ciphersuite: ciphersuite))
 
         if let error = e2eiNewEnrollmentClientIdDisplayNameHandleTeamExpiryDaysCiphersuite_MockError {
@@ -637,12 +638,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiNewRotateEnrollment
 
-    var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations: [(displayName: String?, handle: String?, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite)] = []
-    var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockError: Error?
-    var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockMethod: ((String?, String?, String?, UInt32, WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment)?
-    var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockValue: WireCoreCrypto.E2eiEnrollment?
+    public var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations: [(displayName: String?, handle: String?, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite)] = []
+    public var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockError: Error?
+    public var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockMethod: ((String?, String?, String?, UInt32, WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment)?
+    public var e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockValue: WireCoreCrypto.E2eiEnrollment?
 
-    func e2eiNewRotateEnrollment(displayName: String?, handle: String?, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment {
+    public func e2eiNewRotateEnrollment(displayName: String?, handle: String?, team: String?, expiryDays: UInt32, ciphersuite: WireCoreCrypto.Ciphersuite) async throws -> WireCoreCrypto.E2eiEnrollment {
         e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_Invocations.append((displayName: displayName, handle: handle, team: team, expiryDays: expiryDays, ciphersuite: ciphersuite))
 
         if let error = e2eiNewRotateEnrollmentDisplayNameHandleTeamExpiryDaysCiphersuite_MockError {
@@ -723,12 +724,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiRotateAll
 
-    var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_Invocations: [(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, newKeyPackagesCount: UInt32)] = []
-    var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockError: Error?
-    var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockMethod: ((WireCoreCrypto.E2eiEnrollment, String, UInt32) async throws -> WireCoreCrypto.RotateBundle)?
-    var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockValue: WireCoreCrypto.RotateBundle?
+    public var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_Invocations: [(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, newKeyPackagesCount: UInt32)] = []
+    public var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockError: Error?
+    public var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockMethod: ((WireCoreCrypto.E2eiEnrollment, String, UInt32) async throws -> WireCoreCrypto.RotateBundle)?
+    public var e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockValue: WireCoreCrypto.RotateBundle?
 
-    func e2eiRotateAll(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, newKeyPackagesCount: UInt32) async throws -> WireCoreCrypto.RotateBundle {
+    public func e2eiRotateAll(enrollment: WireCoreCrypto.E2eiEnrollment, certificateChain: String, newKeyPackagesCount: UInt32) async throws -> WireCoreCrypto.RotateBundle {
         e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_Invocations.append((enrollment: enrollment, certificateChain: certificateChain, newKeyPackagesCount: newKeyPackagesCount))
 
         if let error = e2eiRotateAllEnrollmentCertificateChainNewKeyPackagesCount_MockError {
@@ -746,12 +747,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - encryptMessage
 
-    var encryptMessageConversationIdMessage_Invocations: [(conversationId: Data, message: Data)] = []
-    var encryptMessageConversationIdMessage_MockError: Error?
-    var encryptMessageConversationIdMessage_MockMethod: ((Data, Data) async throws -> Data)?
-    var encryptMessageConversationIdMessage_MockValue: Data?
+    public var encryptMessageConversationIdMessage_Invocations: [(conversationId: Data, message: Data)] = []
+    public var encryptMessageConversationIdMessage_MockError: Error?
+    public var encryptMessageConversationIdMessage_MockMethod: ((Data, Data) async throws -> Data)?
+    public var encryptMessageConversationIdMessage_MockValue: Data?
 
-    func encryptMessage(conversationId: Data, message: Data) async throws -> Data {
+    public func encryptMessage(conversationId: Data, message: Data) async throws -> Data {
         encryptMessageConversationIdMessage_Invocations.append((conversationId: conversationId, message: message))
 
         if let error = encryptMessageConversationIdMessage_MockError {
@@ -769,12 +770,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - exportSecretKey
 
-    var exportSecretKeyConversationIdKeyLength_Invocations: [(conversationId: Data, keyLength: UInt32)] = []
-    var exportSecretKeyConversationIdKeyLength_MockError: Error?
-    var exportSecretKeyConversationIdKeyLength_MockMethod: ((Data, UInt32) async throws -> Data)?
-    var exportSecretKeyConversationIdKeyLength_MockValue: Data?
+    public var exportSecretKeyConversationIdKeyLength_Invocations: [(conversationId: Data, keyLength: UInt32)] = []
+    public var exportSecretKeyConversationIdKeyLength_MockError: Error?
+    public var exportSecretKeyConversationIdKeyLength_MockMethod: ((Data, UInt32) async throws -> Data)?
+    public var exportSecretKeyConversationIdKeyLength_MockValue: Data?
 
-    func exportSecretKey(conversationId: Data, keyLength: UInt32) async throws -> Data {
+    public func exportSecretKey(conversationId: Data, keyLength: UInt32) async throws -> Data {
         exportSecretKeyConversationIdKeyLength_Invocations.append((conversationId: conversationId, keyLength: keyLength))
 
         if let error = exportSecretKeyConversationIdKeyLength_MockError {
@@ -792,12 +793,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - getClientIds
 
-    var getClientIdsConversationId_Invocations: [Data] = []
-    var getClientIdsConversationId_MockError: Error?
-    var getClientIdsConversationId_MockMethod: ((Data) async throws -> [WireCoreCrypto.ClientId])?
-    var getClientIdsConversationId_MockValue: [WireCoreCrypto.ClientId]?
+    public var getClientIdsConversationId_Invocations: [Data] = []
+    public var getClientIdsConversationId_MockError: Error?
+    public var getClientIdsConversationId_MockMethod: ((Data) async throws -> [WireCoreCrypto.ClientId])?
+    public var getClientIdsConversationId_MockValue: [WireCoreCrypto.ClientId]?
 
-    func getClientIds(conversationId: Data) async throws -> [WireCoreCrypto.ClientId] {
+    public func getClientIds(conversationId: Data) async throws -> [WireCoreCrypto.ClientId] {
         getClientIdsConversationId_Invocations.append(conversationId)
 
         if let error = getClientIdsConversationId_MockError {
@@ -815,12 +816,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - getCredentialInUse
 
-    var getCredentialInUseGroupInfoCredentialType_Invocations: [(groupInfo: Data, credentialType: WireCoreCrypto.MlsCredentialType)] = []
-    var getCredentialInUseGroupInfoCredentialType_MockError: Error?
-    var getCredentialInUseGroupInfoCredentialType_MockMethod: ((Data, WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.E2eiConversationState)?
-    var getCredentialInUseGroupInfoCredentialType_MockValue: WireCoreCrypto.E2eiConversationState?
+    public var getCredentialInUseGroupInfoCredentialType_Invocations: [(groupInfo: Data, credentialType: WireCoreCrypto.MlsCredentialType)] = []
+    public var getCredentialInUseGroupInfoCredentialType_MockError: Error?
+    public var getCredentialInUseGroupInfoCredentialType_MockMethod: ((Data, WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.E2eiConversationState)?
+    public var getCredentialInUseGroupInfoCredentialType_MockValue: WireCoreCrypto.E2eiConversationState?
 
-    func getCredentialInUse(groupInfo: Data, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.E2eiConversationState {
+    public func getCredentialInUse(groupInfo: Data, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.E2eiConversationState {
         getCredentialInUseGroupInfoCredentialType_Invocations.append((groupInfo: groupInfo, credentialType: credentialType))
 
         if let error = getCredentialInUseGroupInfoCredentialType_MockError {
@@ -838,12 +839,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - getDeviceIdentities
 
-    var getDeviceIdentitiesConversationIdDeviceIds_Invocations: [(conversationId: Data, deviceIds: [WireCoreCrypto.ClientId])] = []
-    var getDeviceIdentitiesConversationIdDeviceIds_MockError: Error?
-    var getDeviceIdentitiesConversationIdDeviceIds_MockMethod: ((Data, [WireCoreCrypto.ClientId]) async throws -> [WireCoreCrypto.WireIdentity])?
-    var getDeviceIdentitiesConversationIdDeviceIds_MockValue: [WireCoreCrypto.WireIdentity]?
+    public var getDeviceIdentitiesConversationIdDeviceIds_Invocations: [(conversationId: Data, deviceIds: [WireCoreCrypto.ClientId])] = []
+    public var getDeviceIdentitiesConversationIdDeviceIds_MockError: Error?
+    public var getDeviceIdentitiesConversationIdDeviceIds_MockMethod: ((Data, [WireCoreCrypto.ClientId]) async throws -> [WireCoreCrypto.WireIdentity])?
+    public var getDeviceIdentitiesConversationIdDeviceIds_MockValue: [WireCoreCrypto.WireIdentity]?
 
-    func getDeviceIdentities(conversationId: Data, deviceIds: [WireCoreCrypto.ClientId]) async throws -> [WireCoreCrypto.WireIdentity] {
+    public func getDeviceIdentities(conversationId: Data, deviceIds: [WireCoreCrypto.ClientId]) async throws -> [WireCoreCrypto.WireIdentity] {
         getDeviceIdentitiesConversationIdDeviceIds_Invocations.append((conversationId: conversationId, deviceIds: deviceIds))
 
         if let error = getDeviceIdentitiesConversationIdDeviceIds_MockError {
@@ -861,12 +862,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - getUserIdentities
 
-    var getUserIdentitiesConversationIdUserIds_Invocations: [(conversationId: Data, userIds: [String])] = []
-    var getUserIdentitiesConversationIdUserIds_MockError: Error?
-    var getUserIdentitiesConversationIdUserIds_MockMethod: ((Data, [String]) async throws -> [String: [WireCoreCrypto.WireIdentity]])?
-    var getUserIdentitiesConversationIdUserIds_MockValue: [String: [WireCoreCrypto.WireIdentity]]?
+    public var getUserIdentitiesConversationIdUserIds_Invocations: [(conversationId: Data, userIds: [String])] = []
+    public var getUserIdentitiesConversationIdUserIds_MockError: Error?
+    public var getUserIdentitiesConversationIdUserIds_MockMethod: ((Data, [String]) async throws -> [String: [WireCoreCrypto.WireIdentity]])?
+    public var getUserIdentitiesConversationIdUserIds_MockValue: [String: [WireCoreCrypto.WireIdentity]]?
 
-    func getUserIdentities(conversationId: Data, userIds: [String]) async throws -> [String: [WireCoreCrypto.WireIdentity]] {
+    public func getUserIdentities(conversationId: Data, userIds: [String]) async throws -> [String: [WireCoreCrypto.WireIdentity]] {
         getUserIdentitiesConversationIdUserIds_Invocations.append((conversationId: conversationId, userIds: userIds))
 
         if let error = getUserIdentitiesConversationIdUserIds_MockError {
@@ -884,12 +885,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - joinByExternalCommit
 
-    var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_Invocations: [(groupInfo: Data, customConfiguration: WireCoreCrypto.CustomConfiguration, credentialType: WireCoreCrypto.MlsCredentialType)] = []
-    var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockError: Error?
-    var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockMethod: ((Data, WireCoreCrypto.CustomConfiguration, WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.ConversationInitBundle)?
-    var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockValue: WireCoreCrypto.ConversationInitBundle?
+    public var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_Invocations: [(groupInfo: Data, customConfiguration: WireCoreCrypto.CustomConfiguration, credentialType: WireCoreCrypto.MlsCredentialType)] = []
+    public var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockError: Error?
+    public var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockMethod: ((Data, WireCoreCrypto.CustomConfiguration, WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.ConversationInitBundle)?
+    public var joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockValue: WireCoreCrypto.ConversationInitBundle?
 
-    func joinByExternalCommit(groupInfo: Data, customConfiguration: WireCoreCrypto.CustomConfiguration, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.ConversationInitBundle {
+    public func joinByExternalCommit(groupInfo: Data, customConfiguration: WireCoreCrypto.CustomConfiguration, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> WireCoreCrypto.ConversationInitBundle {
         joinByExternalCommitGroupInfoCustomConfigurationCredentialType_Invocations.append((groupInfo: groupInfo, customConfiguration: customConfiguration, credentialType: credentialType))
 
         if let error = joinByExternalCommitGroupInfoCustomConfigurationCredentialType_MockError {
@@ -907,11 +908,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - markConversationAsChildOf
 
-    var markConversationAsChildOfChildIdParentId_Invocations: [(childId: Data, parentId: Data)] = []
-    var markConversationAsChildOfChildIdParentId_MockError: Error?
-    var markConversationAsChildOfChildIdParentId_MockMethod: ((Data, Data) async throws -> Void)?
+    public var markConversationAsChildOfChildIdParentId_Invocations: [(childId: Data, parentId: Data)] = []
+    public var markConversationAsChildOfChildIdParentId_MockError: Error?
+    public var markConversationAsChildOfChildIdParentId_MockMethod: ((Data, Data) async throws -> Void)?
 
-    func markConversationAsChildOf(childId: Data, parentId: Data) async throws {
+    public func markConversationAsChildOf(childId: Data, parentId: Data) async throws {
         markConversationAsChildOfChildIdParentId_Invocations.append((childId: childId, parentId: parentId))
 
         if let error = markConversationAsChildOfChildIdParentId_MockError {
@@ -927,12 +928,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - mergePendingGroupFromExternalCommit
 
-    var mergePendingGroupFromExternalCommitConversationId_Invocations: [Data] = []
-    var mergePendingGroupFromExternalCommitConversationId_MockError: Error?
-    var mergePendingGroupFromExternalCommitConversationId_MockMethod: ((Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]?)?
-    var mergePendingGroupFromExternalCommitConversationId_MockValue: [WireCoreCrypto.BufferedDecryptedMessage]??
+    public var mergePendingGroupFromExternalCommitConversationId_Invocations: [Data] = []
+    public var mergePendingGroupFromExternalCommitConversationId_MockError: Error?
+    public var mergePendingGroupFromExternalCommitConversationId_MockMethod: ((Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]?)?
+    public var mergePendingGroupFromExternalCommitConversationId_MockValue: [WireCoreCrypto.BufferedDecryptedMessage]??
 
-    func mergePendingGroupFromExternalCommit(conversationId: Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]? {
+    public func mergePendingGroupFromExternalCommit(conversationId: Data) async throws -> [WireCoreCrypto.BufferedDecryptedMessage]? {
         mergePendingGroupFromExternalCommitConversationId_Invocations.append(conversationId)
 
         if let error = mergePendingGroupFromExternalCommitConversationId_MockError {
@@ -950,12 +951,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - mlsGenerateKeypairs
 
-    var mlsGenerateKeypairsCiphersuites_Invocations: [WireCoreCrypto.Ciphersuites] = []
-    var mlsGenerateKeypairsCiphersuites_MockError: Error?
-    var mlsGenerateKeypairsCiphersuites_MockMethod: ((WireCoreCrypto.Ciphersuites) async throws -> [WireCoreCrypto.ClientId])?
-    var mlsGenerateKeypairsCiphersuites_MockValue: [WireCoreCrypto.ClientId]?
+    public var mlsGenerateKeypairsCiphersuites_Invocations: [WireCoreCrypto.Ciphersuites] = []
+    public var mlsGenerateKeypairsCiphersuites_MockError: Error?
+    public var mlsGenerateKeypairsCiphersuites_MockMethod: ((WireCoreCrypto.Ciphersuites) async throws -> [WireCoreCrypto.ClientId])?
+    public var mlsGenerateKeypairsCiphersuites_MockValue: [WireCoreCrypto.ClientId]?
 
-    func mlsGenerateKeypairs(ciphersuites: WireCoreCrypto.Ciphersuites) async throws -> [WireCoreCrypto.ClientId] {
+    public func mlsGenerateKeypairs(ciphersuites: WireCoreCrypto.Ciphersuites) async throws -> [WireCoreCrypto.ClientId] {
         mlsGenerateKeypairsCiphersuites_Invocations.append(ciphersuites)
 
         if let error = mlsGenerateKeypairsCiphersuites_MockError {
@@ -973,11 +974,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - mlsInit
 
-    var mlsInitClientIdCiphersuitesNbKeyPackage_Invocations: [(clientId: WireCoreCrypto.ClientId, ciphersuites: WireCoreCrypto.Ciphersuites, nbKeyPackage: UInt32?)] = []
-    var mlsInitClientIdCiphersuitesNbKeyPackage_MockError: Error?
-    var mlsInitClientIdCiphersuitesNbKeyPackage_MockMethod: ((WireCoreCrypto.ClientId, WireCoreCrypto.Ciphersuites, UInt32?) async throws -> Void)?
+    public var mlsInitClientIdCiphersuitesNbKeyPackage_Invocations: [(clientId: WireCoreCrypto.ClientId, ciphersuites: WireCoreCrypto.Ciphersuites, nbKeyPackage: UInt32?)] = []
+    public var mlsInitClientIdCiphersuitesNbKeyPackage_MockError: Error?
+    public var mlsInitClientIdCiphersuitesNbKeyPackage_MockMethod: ((WireCoreCrypto.ClientId, WireCoreCrypto.Ciphersuites, UInt32?) async throws -> Void)?
 
-    func mlsInit(clientId: WireCoreCrypto.ClientId, ciphersuites: WireCoreCrypto.Ciphersuites, nbKeyPackage: UInt32?) async throws {
+    public func mlsInit(clientId: WireCoreCrypto.ClientId, ciphersuites: WireCoreCrypto.Ciphersuites, nbKeyPackage: UInt32?) async throws {
         mlsInitClientIdCiphersuitesNbKeyPackage_Invocations.append((clientId: clientId, ciphersuites: ciphersuites, nbKeyPackage: nbKeyPackage))
 
         if let error = mlsInitClientIdCiphersuitesNbKeyPackage_MockError {
@@ -993,11 +994,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - mlsInitWithClientId
 
-    var mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_Invocations: [(clientId: WireCoreCrypto.ClientId, tmpClientIds: [WireCoreCrypto.ClientId], ciphersuites: WireCoreCrypto.Ciphersuites)] = []
-    var mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_MockError: Error?
-    var mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_MockMethod: ((WireCoreCrypto.ClientId, [WireCoreCrypto.ClientId], WireCoreCrypto.Ciphersuites) async throws -> Void)?
+    public var mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_Invocations: [(clientId: WireCoreCrypto.ClientId, tmpClientIds: [WireCoreCrypto.ClientId], ciphersuites: WireCoreCrypto.Ciphersuites)] = []
+    public var mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_MockError: Error?
+    public var mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_MockMethod: ((WireCoreCrypto.ClientId, [WireCoreCrypto.ClientId], WireCoreCrypto.Ciphersuites) async throws -> Void)?
 
-    func mlsInitWithClientId(clientId: WireCoreCrypto.ClientId, tmpClientIds: [WireCoreCrypto.ClientId], ciphersuites: WireCoreCrypto.Ciphersuites) async throws {
+    public func mlsInitWithClientId(clientId: WireCoreCrypto.ClientId, tmpClientIds: [WireCoreCrypto.ClientId], ciphersuites: WireCoreCrypto.Ciphersuites) async throws {
         mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_Invocations.append((clientId: clientId, tmpClientIds: tmpClientIds, ciphersuites: ciphersuites))
 
         if let error = mlsInitWithClientIdClientIdTmpClientIdsCiphersuites_MockError {
@@ -1013,12 +1014,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - newAddProposal
 
-    var newAddProposalConversationIdKeypackage_Invocations: [(conversationId: Data, keypackage: Data)] = []
-    var newAddProposalConversationIdKeypackage_MockError: Error?
-    var newAddProposalConversationIdKeypackage_MockMethod: ((Data, Data) async throws -> WireCoreCrypto.ProposalBundle)?
-    var newAddProposalConversationIdKeypackage_MockValue: WireCoreCrypto.ProposalBundle?
+    public var newAddProposalConversationIdKeypackage_Invocations: [(conversationId: Data, keypackage: Data)] = []
+    public var newAddProposalConversationIdKeypackage_MockError: Error?
+    public var newAddProposalConversationIdKeypackage_MockMethod: ((Data, Data) async throws -> WireCoreCrypto.ProposalBundle)?
+    public var newAddProposalConversationIdKeypackage_MockValue: WireCoreCrypto.ProposalBundle?
 
-    func newAddProposal(conversationId: Data, keypackage: Data) async throws -> WireCoreCrypto.ProposalBundle {
+    public func newAddProposal(conversationId: Data, keypackage: Data) async throws -> WireCoreCrypto.ProposalBundle {
         newAddProposalConversationIdKeypackage_Invocations.append((conversationId: conversationId, keypackage: keypackage))
 
         if let error = newAddProposalConversationIdKeypackage_MockError {
@@ -1036,12 +1037,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - newExternalAddProposal
 
-    var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_Invocations: [(conversationId: Data, epoch: UInt64, ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType)] = []
-    var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockError: Error?
-    var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockMethod: ((Data, UInt64, WireCoreCrypto.Ciphersuite, WireCoreCrypto.MlsCredentialType) async throws -> Data)?
-    var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockValue: Data?
+    public var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_Invocations: [(conversationId: Data, epoch: UInt64, ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType)] = []
+    public var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockError: Error?
+    public var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockMethod: ((Data, UInt64, WireCoreCrypto.Ciphersuite, WireCoreCrypto.MlsCredentialType) async throws -> Data)?
+    public var newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockValue: Data?
 
-    func newExternalAddProposal(conversationId: Data, epoch: UInt64, ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> Data {
+    public func newExternalAddProposal(conversationId: Data, epoch: UInt64, ciphersuite: WireCoreCrypto.Ciphersuite, credentialType: WireCoreCrypto.MlsCredentialType) async throws -> Data {
         newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_Invocations.append((conversationId: conversationId, epoch: epoch, ciphersuite: ciphersuite, credentialType: credentialType))
 
         if let error = newExternalAddProposalConversationIdEpochCiphersuiteCredentialType_MockError {
@@ -1059,12 +1060,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - newRemoveProposal
 
-    var newRemoveProposalConversationIdClientId_Invocations: [(conversationId: Data, clientId: WireCoreCrypto.ClientId)] = []
-    var newRemoveProposalConversationIdClientId_MockError: Error?
-    var newRemoveProposalConversationIdClientId_MockMethod: ((Data, WireCoreCrypto.ClientId) async throws -> WireCoreCrypto.ProposalBundle)?
-    var newRemoveProposalConversationIdClientId_MockValue: WireCoreCrypto.ProposalBundle?
+    public var newRemoveProposalConversationIdClientId_Invocations: [(conversationId: Data, clientId: WireCoreCrypto.ClientId)] = []
+    public var newRemoveProposalConversationIdClientId_MockError: Error?
+    public var newRemoveProposalConversationIdClientId_MockMethod: ((Data, WireCoreCrypto.ClientId) async throws -> WireCoreCrypto.ProposalBundle)?
+    public var newRemoveProposalConversationIdClientId_MockValue: WireCoreCrypto.ProposalBundle?
 
-    func newRemoveProposal(conversationId: Data, clientId: WireCoreCrypto.ClientId) async throws -> WireCoreCrypto.ProposalBundle {
+    public func newRemoveProposal(conversationId: Data, clientId: WireCoreCrypto.ClientId) async throws -> WireCoreCrypto.ProposalBundle {
         newRemoveProposalConversationIdClientId_Invocations.append((conversationId: conversationId, clientId: clientId))
 
         if let error = newRemoveProposalConversationIdClientId_MockError {
@@ -1082,12 +1083,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - newUpdateProposal
 
-    var newUpdateProposalConversationId_Invocations: [Data] = []
-    var newUpdateProposalConversationId_MockError: Error?
-    var newUpdateProposalConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.ProposalBundle)?
-    var newUpdateProposalConversationId_MockValue: WireCoreCrypto.ProposalBundle?
+    public var newUpdateProposalConversationId_Invocations: [Data] = []
+    public var newUpdateProposalConversationId_MockError: Error?
+    public var newUpdateProposalConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.ProposalBundle)?
+    public var newUpdateProposalConversationId_MockValue: WireCoreCrypto.ProposalBundle?
 
-    func newUpdateProposal(conversationId: Data) async throws -> WireCoreCrypto.ProposalBundle {
+    public func newUpdateProposal(conversationId: Data) async throws -> WireCoreCrypto.ProposalBundle {
         newUpdateProposalConversationId_Invocations.append(conversationId)
 
         if let error = newUpdateProposalConversationId_MockError {
@@ -1105,12 +1106,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - processWelcomeMessage
 
-    var processWelcomeMessageWelcomeMessageCustomConfiguration_Invocations: [(welcomeMessage: Data, customConfiguration: WireCoreCrypto.CustomConfiguration)] = []
-    var processWelcomeMessageWelcomeMessageCustomConfiguration_MockError: Error?
-    var processWelcomeMessageWelcomeMessageCustomConfiguration_MockMethod: ((Data, WireCoreCrypto.CustomConfiguration) async throws -> Data)?
-    var processWelcomeMessageWelcomeMessageCustomConfiguration_MockValue: Data?
+    public var processWelcomeMessageWelcomeMessageCustomConfiguration_Invocations: [(welcomeMessage: Data, customConfiguration: WireCoreCrypto.CustomConfiguration)] = []
+    public var processWelcomeMessageWelcomeMessageCustomConfiguration_MockError: Error?
+    public var processWelcomeMessageWelcomeMessageCustomConfiguration_MockMethod: ((Data, WireCoreCrypto.CustomConfiguration) async throws -> Data)?
+    public var processWelcomeMessageWelcomeMessageCustomConfiguration_MockValue: Data?
 
-    func processWelcomeMessage(welcomeMessage: Data, customConfiguration: WireCoreCrypto.CustomConfiguration) async throws -> Data {
+    public func processWelcomeMessage(welcomeMessage: Data, customConfiguration: WireCoreCrypto.CustomConfiguration) async throws -> Data {
         processWelcomeMessageWelcomeMessageCustomConfiguration_Invocations.append((welcomeMessage: welcomeMessage, customConfiguration: customConfiguration))
 
         if let error = processWelcomeMessageWelcomeMessageCustomConfiguration_MockError {
@@ -1128,11 +1129,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusCryptoboxMigrate
 
-    var proteusCryptoboxMigratePath_Invocations: [String] = []
-    var proteusCryptoboxMigratePath_MockError: Error?
-    var proteusCryptoboxMigratePath_MockMethod: ((String) async throws -> Void)?
+    public var proteusCryptoboxMigratePath_Invocations: [String] = []
+    public var proteusCryptoboxMigratePath_MockError: Error?
+    public var proteusCryptoboxMigratePath_MockMethod: ((String) async throws -> Void)?
 
-    func proteusCryptoboxMigrate(path: String) async throws {
+    public func proteusCryptoboxMigrate(path: String) async throws {
         proteusCryptoboxMigratePath_Invocations.append(path)
 
         if let error = proteusCryptoboxMigratePath_MockError {
@@ -1148,12 +1149,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusDecrypt
 
-    var proteusDecryptSessionIdCiphertext_Invocations: [(sessionId: String, ciphertext: Data)] = []
-    var proteusDecryptSessionIdCiphertext_MockError: Error?
-    var proteusDecryptSessionIdCiphertext_MockMethod: ((String, Data) async throws -> Data)?
-    var proteusDecryptSessionIdCiphertext_MockValue: Data?
+    public var proteusDecryptSessionIdCiphertext_Invocations: [(sessionId: String, ciphertext: Data)] = []
+    public var proteusDecryptSessionIdCiphertext_MockError: Error?
+    public var proteusDecryptSessionIdCiphertext_MockMethod: ((String, Data) async throws -> Data)?
+    public var proteusDecryptSessionIdCiphertext_MockValue: Data?
 
-    func proteusDecrypt(sessionId: String, ciphertext: Data) async throws -> Data {
+    public func proteusDecrypt(sessionId: String, ciphertext: Data) async throws -> Data {
         proteusDecryptSessionIdCiphertext_Invocations.append((sessionId: sessionId, ciphertext: ciphertext))
 
         if let error = proteusDecryptSessionIdCiphertext_MockError {
@@ -1171,12 +1172,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusEncrypt
 
-    var proteusEncryptSessionIdPlaintext_Invocations: [(sessionId: String, plaintext: Data)] = []
-    var proteusEncryptSessionIdPlaintext_MockError: Error?
-    var proteusEncryptSessionIdPlaintext_MockMethod: ((String, Data) async throws -> Data)?
-    var proteusEncryptSessionIdPlaintext_MockValue: Data?
+    public var proteusEncryptSessionIdPlaintext_Invocations: [(sessionId: String, plaintext: Data)] = []
+    public var proteusEncryptSessionIdPlaintext_MockError: Error?
+    public var proteusEncryptSessionIdPlaintext_MockMethod: ((String, Data) async throws -> Data)?
+    public var proteusEncryptSessionIdPlaintext_MockValue: Data?
 
-    func proteusEncrypt(sessionId: String, plaintext: Data) async throws -> Data {
+    public func proteusEncrypt(sessionId: String, plaintext: Data) async throws -> Data {
         proteusEncryptSessionIdPlaintext_Invocations.append((sessionId: sessionId, plaintext: plaintext))
 
         if let error = proteusEncryptSessionIdPlaintext_MockError {
@@ -1194,12 +1195,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusEncryptBatched
 
-    var proteusEncryptBatchedSessionsPlaintext_Invocations: [(sessions: [String], plaintext: Data)] = []
-    var proteusEncryptBatchedSessionsPlaintext_MockError: Error?
-    var proteusEncryptBatchedSessionsPlaintext_MockMethod: (([String], Data) async throws -> [String: Data])?
-    var proteusEncryptBatchedSessionsPlaintext_MockValue: [String: Data]?
+    public var proteusEncryptBatchedSessionsPlaintext_Invocations: [(sessions: [String], plaintext: Data)] = []
+    public var proteusEncryptBatchedSessionsPlaintext_MockError: Error?
+    public var proteusEncryptBatchedSessionsPlaintext_MockMethod: (([String], Data) async throws -> [String: Data])?
+    public var proteusEncryptBatchedSessionsPlaintext_MockValue: [String: Data]?
 
-    func proteusEncryptBatched(sessions: [String], plaintext: Data) async throws -> [String: Data] {
+    public func proteusEncryptBatched(sessions: [String], plaintext: Data) async throws -> [String: Data] {
         proteusEncryptBatchedSessionsPlaintext_Invocations.append((sessions: sessions, plaintext: plaintext))
 
         if let error = proteusEncryptBatchedSessionsPlaintext_MockError {
@@ -1217,12 +1218,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusFingerprint
 
-    var proteusFingerprint_Invocations: [Void] = []
-    var proteusFingerprint_MockError: Error?
-    var proteusFingerprint_MockMethod: (() async throws -> String)?
-    var proteusFingerprint_MockValue: String?
+    public var proteusFingerprint_Invocations: [Void] = []
+    public var proteusFingerprint_MockError: Error?
+    public var proteusFingerprint_MockMethod: (() async throws -> String)?
+    public var proteusFingerprint_MockValue: String?
 
-    func proteusFingerprint() async throws -> String {
+    public func proteusFingerprint() async throws -> String {
         proteusFingerprint_Invocations.append(())
 
         if let error = proteusFingerprint_MockError {
@@ -1240,12 +1241,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusFingerprintLocal
 
-    var proteusFingerprintLocalSessionId_Invocations: [String] = []
-    var proteusFingerprintLocalSessionId_MockError: Error?
-    var proteusFingerprintLocalSessionId_MockMethod: ((String) async throws -> String)?
-    var proteusFingerprintLocalSessionId_MockValue: String?
+    public var proteusFingerprintLocalSessionId_Invocations: [String] = []
+    public var proteusFingerprintLocalSessionId_MockError: Error?
+    public var proteusFingerprintLocalSessionId_MockMethod: ((String) async throws -> String)?
+    public var proteusFingerprintLocalSessionId_MockValue: String?
 
-    func proteusFingerprintLocal(sessionId: String) async throws -> String {
+    public func proteusFingerprintLocal(sessionId: String) async throws -> String {
         proteusFingerprintLocalSessionId_Invocations.append(sessionId)
 
         if let error = proteusFingerprintLocalSessionId_MockError {
@@ -1263,12 +1264,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusFingerprintPrekeybundle
 
-    var proteusFingerprintPrekeybundlePrekey_Invocations: [Data] = []
-    var proteusFingerprintPrekeybundlePrekey_MockError: Error?
-    var proteusFingerprintPrekeybundlePrekey_MockMethod: ((Data) throws -> String)?
-    var proteusFingerprintPrekeybundlePrekey_MockValue: String?
+    public var proteusFingerprintPrekeybundlePrekey_Invocations: [Data] = []
+    public var proteusFingerprintPrekeybundlePrekey_MockError: Error?
+    public var proteusFingerprintPrekeybundlePrekey_MockMethod: ((Data) throws -> String)?
+    public var proteusFingerprintPrekeybundlePrekey_MockValue: String?
 
-    func proteusFingerprintPrekeybundle(prekey: Data) throws -> String {
+    public func proteusFingerprintPrekeybundle(prekey: Data) throws -> String {
         proteusFingerprintPrekeybundlePrekey_Invocations.append(prekey)
 
         if let error = proteusFingerprintPrekeybundlePrekey_MockError {
@@ -1286,12 +1287,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusFingerprintRemote
 
-    var proteusFingerprintRemoteSessionId_Invocations: [String] = []
-    var proteusFingerprintRemoteSessionId_MockError: Error?
-    var proteusFingerprintRemoteSessionId_MockMethod: ((String) async throws -> String)?
-    var proteusFingerprintRemoteSessionId_MockValue: String?
+    public var proteusFingerprintRemoteSessionId_Invocations: [String] = []
+    public var proteusFingerprintRemoteSessionId_MockError: Error?
+    public var proteusFingerprintRemoteSessionId_MockMethod: ((String) async throws -> String)?
+    public var proteusFingerprintRemoteSessionId_MockValue: String?
 
-    func proteusFingerprintRemote(sessionId: String) async throws -> String {
+    public func proteusFingerprintRemote(sessionId: String) async throws -> String {
         proteusFingerprintRemoteSessionId_Invocations.append(sessionId)
 
         if let error = proteusFingerprintRemoteSessionId_MockError {
@@ -1309,11 +1310,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusInit
 
-    var proteusInit_Invocations: [Void] = []
-    var proteusInit_MockError: Error?
-    var proteusInit_MockMethod: (() async throws -> Void)?
+    public var proteusInit_Invocations: [Void] = []
+    public var proteusInit_MockError: Error?
+    public var proteusInit_MockMethod: (() async throws -> Void)?
 
-    func proteusInit() async throws {
+    public func proteusInit() async throws {
         proteusInit_Invocations.append(())
 
         if let error = proteusInit_MockError {
@@ -1329,11 +1330,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusLastErrorCode
 
-    var proteusLastErrorCode_Invocations: [Void] = []
-    var proteusLastErrorCode_MockMethod: (() -> UInt32)?
-    var proteusLastErrorCode_MockValue: UInt32?
+    public var proteusLastErrorCode_Invocations: [Void] = []
+    public var proteusLastErrorCode_MockMethod: (() -> UInt32)?
+    public var proteusLastErrorCode_MockValue: UInt32?
 
-    func proteusLastErrorCode() -> UInt32 {
+    public func proteusLastErrorCode() -> UInt32 {
         proteusLastErrorCode_Invocations.append(())
 
         if let mock = proteusLastErrorCode_MockMethod {
@@ -1347,12 +1348,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusLastResortPrekey
 
-    var proteusLastResortPrekey_Invocations: [Void] = []
-    var proteusLastResortPrekey_MockError: Error?
-    var proteusLastResortPrekey_MockMethod: (() async throws -> Data)?
-    var proteusLastResortPrekey_MockValue: Data?
+    public var proteusLastResortPrekey_Invocations: [Void] = []
+    public var proteusLastResortPrekey_MockError: Error?
+    public var proteusLastResortPrekey_MockMethod: (() async throws -> Data)?
+    public var proteusLastResortPrekey_MockValue: Data?
 
-    func proteusLastResortPrekey() async throws -> Data {
+    public func proteusLastResortPrekey() async throws -> Data {
         proteusLastResortPrekey_Invocations.append(())
 
         if let error = proteusLastResortPrekey_MockError {
@@ -1370,12 +1371,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusLastResortPrekeyId
 
-    var proteusLastResortPrekeyId_Invocations: [Void] = []
-    var proteusLastResortPrekeyId_MockError: Error?
-    var proteusLastResortPrekeyId_MockMethod: (() throws -> UInt16)?
-    var proteusLastResortPrekeyId_MockValue: UInt16?
+    public var proteusLastResortPrekeyId_Invocations: [Void] = []
+    public var proteusLastResortPrekeyId_MockError: Error?
+    public var proteusLastResortPrekeyId_MockMethod: (() throws -> UInt16)?
+    public var proteusLastResortPrekeyId_MockValue: UInt16?
 
-    func proteusLastResortPrekeyId() throws -> UInt16 {
+    public func proteusLastResortPrekeyId() throws -> UInt16 {
         proteusLastResortPrekeyId_Invocations.append(())
 
         if let error = proteusLastResortPrekeyId_MockError {
@@ -1393,12 +1394,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusNewPrekey
 
-    var proteusNewPrekeyPrekeyId_Invocations: [UInt16] = []
-    var proteusNewPrekeyPrekeyId_MockError: Error?
-    var proteusNewPrekeyPrekeyId_MockMethod: ((UInt16) async throws -> Data)?
-    var proteusNewPrekeyPrekeyId_MockValue: Data?
+    public var proteusNewPrekeyPrekeyId_Invocations: [UInt16] = []
+    public var proteusNewPrekeyPrekeyId_MockError: Error?
+    public var proteusNewPrekeyPrekeyId_MockMethod: ((UInt16) async throws -> Data)?
+    public var proteusNewPrekeyPrekeyId_MockValue: Data?
 
-    func proteusNewPrekey(prekeyId: UInt16) async throws -> Data {
+    public func proteusNewPrekey(prekeyId: UInt16) async throws -> Data {
         proteusNewPrekeyPrekeyId_Invocations.append(prekeyId)
 
         if let error = proteusNewPrekeyPrekeyId_MockError {
@@ -1416,12 +1417,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusNewPrekeyAuto
 
-    var proteusNewPrekeyAuto_Invocations: [Void] = []
-    var proteusNewPrekeyAuto_MockError: Error?
-    var proteusNewPrekeyAuto_MockMethod: (() async throws -> WireCoreCrypto.ProteusAutoPrekeyBundle)?
-    var proteusNewPrekeyAuto_MockValue: WireCoreCrypto.ProteusAutoPrekeyBundle?
+    public var proteusNewPrekeyAuto_Invocations: [Void] = []
+    public var proteusNewPrekeyAuto_MockError: Error?
+    public var proteusNewPrekeyAuto_MockMethod: (() async throws -> WireCoreCrypto.ProteusAutoPrekeyBundle)?
+    public var proteusNewPrekeyAuto_MockValue: WireCoreCrypto.ProteusAutoPrekeyBundle?
 
-    func proteusNewPrekeyAuto() async throws -> WireCoreCrypto.ProteusAutoPrekeyBundle {
+    public func proteusNewPrekeyAuto() async throws -> WireCoreCrypto.ProteusAutoPrekeyBundle {
         proteusNewPrekeyAuto_Invocations.append(())
 
         if let error = proteusNewPrekeyAuto_MockError {
@@ -1439,11 +1440,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusSessionDelete
 
-    var proteusSessionDeleteSessionId_Invocations: [String] = []
-    var proteusSessionDeleteSessionId_MockError: Error?
-    var proteusSessionDeleteSessionId_MockMethod: ((String) async throws -> Void)?
+    public var proteusSessionDeleteSessionId_Invocations: [String] = []
+    public var proteusSessionDeleteSessionId_MockError: Error?
+    public var proteusSessionDeleteSessionId_MockMethod: ((String) async throws -> Void)?
 
-    func proteusSessionDelete(sessionId: String) async throws {
+    public func proteusSessionDelete(sessionId: String) async throws {
         proteusSessionDeleteSessionId_Invocations.append(sessionId)
 
         if let error = proteusSessionDeleteSessionId_MockError {
@@ -1459,12 +1460,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusSessionExists
 
-    var proteusSessionExistsSessionId_Invocations: [String] = []
-    var proteusSessionExistsSessionId_MockError: Error?
-    var proteusSessionExistsSessionId_MockMethod: ((String) async throws -> Bool)?
-    var proteusSessionExistsSessionId_MockValue: Bool?
+    public var proteusSessionExistsSessionId_Invocations: [String] = []
+    public var proteusSessionExistsSessionId_MockError: Error?
+    public var proteusSessionExistsSessionId_MockMethod: ((String) async throws -> Bool)?
+    public var proteusSessionExistsSessionId_MockValue: Bool?
 
-    func proteusSessionExists(sessionId: String) async throws -> Bool {
+    public func proteusSessionExists(sessionId: String) async throws -> Bool {
         proteusSessionExistsSessionId_Invocations.append(sessionId)
 
         if let error = proteusSessionExistsSessionId_MockError {
@@ -1482,12 +1483,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusSessionFromMessage
 
-    var proteusSessionFromMessageSessionIdEnvelope_Invocations: [(sessionId: String, envelope: Data)] = []
-    var proteusSessionFromMessageSessionIdEnvelope_MockError: Error?
-    var proteusSessionFromMessageSessionIdEnvelope_MockMethod: ((String, Data) async throws -> Data)?
-    var proteusSessionFromMessageSessionIdEnvelope_MockValue: Data?
+    public var proteusSessionFromMessageSessionIdEnvelope_Invocations: [(sessionId: String, envelope: Data)] = []
+    public var proteusSessionFromMessageSessionIdEnvelope_MockError: Error?
+    public var proteusSessionFromMessageSessionIdEnvelope_MockMethod: ((String, Data) async throws -> Data)?
+    public var proteusSessionFromMessageSessionIdEnvelope_MockValue: Data?
 
-    func proteusSessionFromMessage(sessionId: String, envelope: Data) async throws -> Data {
+    public func proteusSessionFromMessage(sessionId: String, envelope: Data) async throws -> Data {
         proteusSessionFromMessageSessionIdEnvelope_Invocations.append((sessionId: sessionId, envelope: envelope))
 
         if let error = proteusSessionFromMessageSessionIdEnvelope_MockError {
@@ -1505,11 +1506,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusSessionFromPrekey
 
-    var proteusSessionFromPrekeySessionIdPrekey_Invocations: [(sessionId: String, prekey: Data)] = []
-    var proteusSessionFromPrekeySessionIdPrekey_MockError: Error?
-    var proteusSessionFromPrekeySessionIdPrekey_MockMethod: ((String, Data) async throws -> Void)?
+    public var proteusSessionFromPrekeySessionIdPrekey_Invocations: [(sessionId: String, prekey: Data)] = []
+    public var proteusSessionFromPrekeySessionIdPrekey_MockError: Error?
+    public var proteusSessionFromPrekeySessionIdPrekey_MockMethod: ((String, Data) async throws -> Void)?
 
-    func proteusSessionFromPrekey(sessionId: String, prekey: Data) async throws {
+    public func proteusSessionFromPrekey(sessionId: String, prekey: Data) async throws {
         proteusSessionFromPrekeySessionIdPrekey_Invocations.append((sessionId: sessionId, prekey: prekey))
 
         if let error = proteusSessionFromPrekeySessionIdPrekey_MockError {
@@ -1525,11 +1526,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - proteusSessionSave
 
-    var proteusSessionSaveSessionId_Invocations: [String] = []
-    var proteusSessionSaveSessionId_MockError: Error?
-    var proteusSessionSaveSessionId_MockMethod: ((String) async throws -> Void)?
+    public var proteusSessionSaveSessionId_Invocations: [String] = []
+    public var proteusSessionSaveSessionId_MockError: Error?
+    public var proteusSessionSaveSessionId_MockMethod: ((String) async throws -> Void)?
 
-    func proteusSessionSave(sessionId: String) async throws {
+    public func proteusSessionSave(sessionId: String) async throws {
         proteusSessionSaveSessionId_Invocations.append(sessionId)
 
         if let error = proteusSessionSaveSessionId_MockError {
@@ -1545,12 +1546,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - randomBytes
 
-    var randomBytesLen_Invocations: [UInt32] = []
-    var randomBytesLen_MockError: Error?
-    var randomBytesLen_MockMethod: ((UInt32) async throws -> Data)?
-    var randomBytesLen_MockValue: Data?
+    public var randomBytesLen_Invocations: [UInt32] = []
+    public var randomBytesLen_MockError: Error?
+    public var randomBytesLen_MockMethod: ((UInt32) async throws -> Data)?
+    public var randomBytesLen_MockValue: Data?
 
-    func randomBytes(len: UInt32) async throws -> Data {
+    public func randomBytes(len: UInt32) async throws -> Data {
         randomBytesLen_Invocations.append(len)
 
         if let error = randomBytesLen_MockError {
@@ -1568,12 +1569,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - removeClientsFromConversation
 
-    var removeClientsFromConversationConversationIdClients_Invocations: [(conversationId: Data, clients: [WireCoreCrypto.ClientId])] = []
-    var removeClientsFromConversationConversationIdClients_MockError: Error?
-    var removeClientsFromConversationConversationIdClients_MockMethod: ((Data, [WireCoreCrypto.ClientId]) async throws -> WireCoreCrypto.CommitBundle)?
-    var removeClientsFromConversationConversationIdClients_MockValue: WireCoreCrypto.CommitBundle?
+    public var removeClientsFromConversationConversationIdClients_Invocations: [(conversationId: Data, clients: [WireCoreCrypto.ClientId])] = []
+    public var removeClientsFromConversationConversationIdClients_MockError: Error?
+    public var removeClientsFromConversationConversationIdClients_MockMethod: ((Data, [WireCoreCrypto.ClientId]) async throws -> WireCoreCrypto.CommitBundle)?
+    public var removeClientsFromConversationConversationIdClients_MockValue: WireCoreCrypto.CommitBundle?
 
-    func removeClientsFromConversation(conversationId: Data, clients: [WireCoreCrypto.ClientId]) async throws -> WireCoreCrypto.CommitBundle {
+    public func removeClientsFromConversation(conversationId: Data, clients: [WireCoreCrypto.ClientId]) async throws -> WireCoreCrypto.CommitBundle {
         removeClientsFromConversationConversationIdClients_Invocations.append((conversationId: conversationId, clients: clients))
 
         if let error = removeClientsFromConversationConversationIdClients_MockError {
@@ -1591,11 +1592,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - reseedRng
 
-    var reseedRngSeed_Invocations: [Data] = []
-    var reseedRngSeed_MockError: Error?
-    var reseedRngSeed_MockMethod: ((Data) async throws -> Void)?
+    public var reseedRngSeed_Invocations: [Data] = []
+    public var reseedRngSeed_MockError: Error?
+    public var reseedRngSeed_MockMethod: ((Data) async throws -> Void)?
 
-    func reseedRng(seed: Data) async throws {
+    public func reseedRng(seed: Data) async throws {
         reseedRngSeed_Invocations.append(seed)
 
         if let error = reseedRngSeed_MockError {
@@ -1611,11 +1612,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - restoreFromDisk
 
-    var restoreFromDisk_Invocations: [Void] = []
-    var restoreFromDisk_MockError: Error?
-    var restoreFromDisk_MockMethod: (() async throws -> Void)?
+    public var restoreFromDisk_Invocations: [Void] = []
+    public var restoreFromDisk_MockError: Error?
+    public var restoreFromDisk_MockMethod: (() async throws -> Void)?
 
-    func restoreFromDisk() async throws {
+    public func restoreFromDisk() async throws {
         restoreFromDisk_Invocations.append(())
 
         if let error = restoreFromDisk_MockError {
@@ -1631,11 +1632,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - setCallbacks
 
-    var setCallbacksCallbacks_Invocations: [WireCoreCrypto.CoreCryptoCallbacks] = []
-    var setCallbacksCallbacks_MockError: Error?
-    var setCallbacksCallbacks_MockMethod: ((WireCoreCrypto.CoreCryptoCallbacks) async throws -> Void)?
+    public var setCallbacksCallbacks_Invocations: [WireCoreCrypto.CoreCryptoCallbacks] = []
+    public var setCallbacksCallbacks_MockError: Error?
+    public var setCallbacksCallbacks_MockMethod: ((WireCoreCrypto.CoreCryptoCallbacks) async throws -> Void)?
 
-    func setCallbacks(callbacks: WireCoreCrypto.CoreCryptoCallbacks) async throws {
+    public func setCallbacks(callbacks: WireCoreCrypto.CoreCryptoCallbacks) async throws {
         setCallbacksCallbacks_Invocations.append(callbacks)
 
         if let error = setCallbacksCallbacks_MockError {
@@ -1651,11 +1652,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - unload
 
-    var unload_Invocations: [Void] = []
-    var unload_MockError: Error?
-    var unload_MockMethod: (() async throws -> Void)?
+    public var unload_Invocations: [Void] = []
+    public var unload_MockError: Error?
+    public var unload_MockMethod: (() async throws -> Void)?
 
-    func unload() async throws {
+    public func unload() async throws {
         unload_Invocations.append(())
 
         if let error = unload_MockError {
@@ -1671,12 +1672,12 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - updateKeyingMaterial
 
-    var updateKeyingMaterialConversationId_Invocations: [Data] = []
-    var updateKeyingMaterialConversationId_MockError: Error?
-    var updateKeyingMaterialConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.CommitBundle)?
-    var updateKeyingMaterialConversationId_MockValue: WireCoreCrypto.CommitBundle?
+    public var updateKeyingMaterialConversationId_Invocations: [Data] = []
+    public var updateKeyingMaterialConversationId_MockError: Error?
+    public var updateKeyingMaterialConversationId_MockMethod: ((Data) async throws -> WireCoreCrypto.CommitBundle)?
+    public var updateKeyingMaterialConversationId_MockValue: WireCoreCrypto.CommitBundle?
 
-    func updateKeyingMaterial(conversationId: Data) async throws -> WireCoreCrypto.CommitBundle {
+    public func updateKeyingMaterial(conversationId: Data) async throws -> WireCoreCrypto.CommitBundle {
         updateKeyingMaterialConversationId_Invocations.append(conversationId)
 
         if let error = updateKeyingMaterialConversationId_MockError {
@@ -1694,11 +1695,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - wipe
 
-    var wipe_Invocations: [Void] = []
-    var wipe_MockError: Error?
-    var wipe_MockMethod: (() async throws -> Void)?
+    public var wipe_Invocations: [Void] = []
+    public var wipe_MockError: Error?
+    public var wipe_MockMethod: (() async throws -> Void)?
 
-    func wipe() async throws {
+    public func wipe() async throws {
         wipe_Invocations.append(())
 
         if let error = wipe_MockError {
@@ -1714,11 +1715,11 @@ class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - wipeConversation
 
-    var wipeConversationConversationId_Invocations: [Data] = []
-    var wipeConversationConversationId_MockError: Error?
-    var wipeConversationConversationId_MockMethod: ((Data) async throws -> Void)?
+    public var wipeConversationConversationId_Invocations: [Data] = []
+    public var wipeConversationConversationId_MockError: Error?
+    public var wipeConversationConversationId_MockMethod: ((Data) async throws -> Void)?
 
-    func wipeConversation(conversationId: Data) async throws {
+    public func wipeConversation(conversationId: Data) async throws {
         wipeConversationConversationId_Invocations.append(conversationId)
 
         if let error = wipeConversationConversationId_MockError {

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -661,11 +661,11 @@ public class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiRegisterAcmeCa
 
-    var e2eiRegisterAcmeCaTrustAnchorPem_Invocations: [String] = []
-    var e2eiRegisterAcmeCaTrustAnchorPem_MockError: Error?
-    var e2eiRegisterAcmeCaTrustAnchorPem_MockMethod: ((String) async throws -> Void)?
+    public var e2eiRegisterAcmeCaTrustAnchorPem_Invocations: [String] = []
+    public var e2eiRegisterAcmeCaTrustAnchorPem_MockError: Error?
+    public var e2eiRegisterAcmeCaTrustAnchorPem_MockMethod: ((String) async throws -> Void)?
 
-    func e2eiRegisterAcmeCa(trustAnchorPem: String) async throws {
+    public func e2eiRegisterAcmeCa(trustAnchorPem: String) async throws {
         e2eiRegisterAcmeCaTrustAnchorPem_Invocations.append(trustAnchorPem)
 
         if let error = e2eiRegisterAcmeCaTrustAnchorPem_MockError {
@@ -681,12 +681,12 @@ public class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiRegisterCrl
 
-    var e2eiRegisterCrlCrlDpCrlDer_Invocations: [(crlDp: String, crlDer: Data)] = []
-    var e2eiRegisterCrlCrlDpCrlDer_MockError: Error?
-    var e2eiRegisterCrlCrlDpCrlDer_MockMethod: ((String, Data) async throws -> WireCoreCrypto.CrlRegistration)?
-    var e2eiRegisterCrlCrlDpCrlDer_MockValue: WireCoreCrypto.CrlRegistration?
+    public var e2eiRegisterCrlCrlDpCrlDer_Invocations: [(crlDp: String, crlDer: Data)] = []
+    public var e2eiRegisterCrlCrlDpCrlDer_MockError: Error?
+    public var e2eiRegisterCrlCrlDpCrlDer_MockMethod: ((String, Data) async throws -> WireCoreCrypto.CrlRegistration)?
+    public var e2eiRegisterCrlCrlDpCrlDer_MockValue: WireCoreCrypto.CrlRegistration?
 
-    func e2eiRegisterCrl(crlDp: String, crlDer: Data) async throws -> WireCoreCrypto.CrlRegistration {
+    public func e2eiRegisterCrl(crlDp: String, crlDer: Data) async throws -> WireCoreCrypto.CrlRegistration {
         e2eiRegisterCrlCrlDpCrlDer_Invocations.append((crlDp: crlDp, crlDer: crlDer))
 
         if let error = e2eiRegisterCrlCrlDpCrlDer_MockError {
@@ -704,11 +704,11 @@ public class MockCoreCryptoProtocol: CoreCryptoProtocol {
 
     // MARK: - e2eiRegisterIntermediateCa
 
-    var e2eiRegisterIntermediateCaCertPem_Invocations: [String] = []
-    var e2eiRegisterIntermediateCaCertPem_MockError: Error?
-    var e2eiRegisterIntermediateCaCertPem_MockMethod: ((String) async throws -> Void)?
+    public var e2eiRegisterIntermediateCaCertPem_Invocations: [String] = []
+    public var e2eiRegisterIntermediateCaCertPem_MockError: Error?
+    public var e2eiRegisterIntermediateCaCertPem_MockMethod: ((String) async throws -> Void)?
 
-    func e2eiRegisterIntermediateCa(certPem: String) async throws {
+    public func e2eiRegisterIntermediateCa(certPem: String) async throws {
         e2eiRegisterIntermediateCaCertPem_Invocations.append(certPem)
 
         if let error = e2eiRegisterIntermediateCaCertPem_MockError {

--- a/wire-ios-data-model/Support/Sources/MockSafeCoreCrypto.swift
+++ b/wire-ios-data-model/Support/Sources/MockSafeCoreCrypto.swift
@@ -20,11 +20,11 @@ import Foundation
 import WireDataModel
 import WireCoreCrypto
 
-class MockSafeCoreCrypto: SafeCoreCryptoProtocol {
+public class MockSafeCoreCrypto: SafeCoreCryptoProtocol {
 
     var coreCrypto: MockCoreCryptoProtocol
 
-    init(coreCrypto: MockCoreCryptoProtocol = .init()) {
+    public init(coreCrypto: MockCoreCryptoProtocol = .init()) {
         self.coreCrypto = coreCrypto
     }
 
@@ -35,19 +35,19 @@ class MockSafeCoreCrypto: SafeCoreCryptoProtocol {
     }
 
     var unsafePerformCount = 0
-    func unsafePerform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T {
+    public func unsafePerform<T>(_ block: (CoreCryptoProtocol) throws -> T) rethrows -> T {
         unsafePerformCount += 1
         return try block(coreCrypto)
     }
 
     var performAsyncCount = 0
-    func perform<T>(_ block: (WireCoreCrypto.CoreCryptoProtocol) async throws -> T) async rethrows -> T {
+    public func perform<T>(_ block: (WireCoreCrypto.CoreCryptoProtocol) async throws -> T) async rethrows -> T {
         return try await block(coreCrypto)
     }
 
     var mockMlsInit: ((String) throws -> Void)?
 
-    func mlsInit(clientID: String) throws {
+    public func mlsInit(clientID: String) throws {
         guard let mock = mockMlsInit else {
             fatalError("no mock for `mlsInit`")
         }
@@ -56,7 +56,7 @@ class MockSafeCoreCrypto: SafeCoreCryptoProtocol {
     }
 
     var tearDownCount = 0
-    func tearDown() throws {
+    public func tearDown() throws {
         tearDownCount += 1
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -607,7 +607,7 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
     private lazy var processor = ConversationEventPayloadProcessor(
         mlsEventProcessor: MLSEventProcessor(context: context),
         removeLocalConversation: removeLocalConversation
-    )
+    ) // TODO jacob
     private let removeLocalConversation: RemoveLocalConversationUseCaseProtocol
 
     init(

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -607,7 +607,7 @@ class ConversationByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
     private lazy var processor = ConversationEventPayloadProcessor(
         mlsEventProcessor: MLSEventProcessor(context: context),
         removeLocalConversation: removeLocalConversation
-    ) // TODO jacob
+    )
     private let removeLocalConversation: RemoveLocalConversationUseCaseProtocol
 
     init(

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -480,6 +480,7 @@ final class UserClientByUserIDTranscoder: IdentifierObjectSyncTranscoder {
                 for: user,
                 selfClient: selfClient
             )
+            managedObjectContext.enqueueDelayedSave()
             completionHandler()
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -144,6 +144,7 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
 
     public func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
         guard let managedObjectContext = managedObjectContext else {
+            assertionFailure("UserClientRequestStrategy has no context")
             return nil
         }
 

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -51,7 +51,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         lastEventIDRepository: LastEventIDRepositoryInterface,
         transportSession: TransportSessionType,
         proteusProvider: ProteusProviding,
-        mlsService: MLSServiceInterface
+        mlsService: MLSServiceInterface,
+        coreCryptoProvider: CoreCryptoProviderProtocol
     ) {
 
         self.strategies = Self.buildStrategies(
@@ -66,7 +67,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             lastEventIDRepository: lastEventIDRepository,
             transportSession: transportSession,
             proteusProvider: proteusProvider,
-            mlsService: mlsService
+            mlsService: mlsService,
+            coreCryptoProvider: coreCryptoProvider
         )
 
         self.requestStrategies = strategies.compactMap({ $0 as? RequestStrategy})
@@ -103,7 +105,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         lastEventIDRepository: LastEventIDRepositoryInterface,
         transportSession: TransportSessionType,
         proteusProvider: ProteusProviding,
-        mlsService: MLSServiceInterface
+        mlsService: MLSServiceInterface,
+        coreCryptoProvider: CoreCryptoProviderProtocol
     ) -> [Any] {
         let syncMOC = contextProvider.syncContext
 
@@ -131,7 +134,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 clientRegistrationStatus: applicationStatusDirectory.clientRegistrationStatus,
                 clientUpdateStatus: applicationStatusDirectory.clientUpdateStatus,
                 context: syncMOC,
-                proteusProvider: proteusProvider
+                proteusProvider: proteusProvider,
+                coreCryptoProvider: coreCryptoProvider
             ),
             ZMMissingUpdateEventsTranscoder(
                 managedObjectContext: syncMOC,

--- a/wire-ios-sync-engine/Source/Synchronization/ZMSyncStateDelegate.h
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMSyncStateDelegate.h
@@ -21,8 +21,6 @@
 
 
 @protocol ZMClientRegistrationStatusDelegate <NSObject>
-
-- (void)didRegisterMLSClient:(UserClient *_Nonnull)userClient;
 - (void)didRegisterSelfUserClient:(UserClient *_Nonnull)userClient;
 - (void)didFailToRegisterSelfUserClient:(NSError *_Nonnull)error NS_SWIFT_NAME(didFailToRegisterSelfUserClient(error:));
 - (void)didDeleteSelfUserClient:(NSError *_Nonnull)error NS_SWIFT_NAME(didDeleteSelfUserClient(error:));

--- a/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.h
+++ b/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.h
@@ -49,6 +49,8 @@ typedef NS_ENUM(NSUInteger, ZMClientRegistrationPhase) {
 
     ZMClientRegistrationPhaseGeneratingPrekeys,
 
+    ZMClientRegistrationPhaseRegisteringMLSClient,
+
     /// The client is registered
     ZMClientRegistrationPhaseRegistered
 };
@@ -66,7 +68,7 @@ extern NSString *const ZMPersistedClientIdKey;
 - (BOOL)needsToRegisterClient;
 + (BOOL)needsToRegisterClientInContext:(NSManagedObjectContext *)moc;
 
-- (void)didRegisterClient:(UserClient *)client;
+- (void)didRegisterProteusClient:(UserClient *)client;
 - (void)didRegisterMLSClient:(UserClient *)client;
 
 - (void)didDetectCurrentClientDeletion;
@@ -90,5 +92,6 @@ extern NSString *const ZMPersistedClientIdKey;
 @property (nonatomic) BOOL isWaitingForUserClients;
 @property (nonatomic) BOOL isWaitingForClientsToBeDeleted;
 @property (nonatomic) BOOL isGeneratingPrekeys;
+@property (nonatomic) BOOL isWaitingForMLSClientToBeRegistered;
 
 @end

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -560,7 +560,7 @@ public class ZMUserSession: NSObject {
     }
 
     func createMLSClientIfNeeded() {
-        // TODO: [jacob] refactor out
+        // TODO: [jacob] refactor out WPB-6198
         if applicationStatusDirectory.clientRegistrationStatus.needsToRegisterMLSCLient {
             WaitingGroupTask(context: syncContext) { [self] in
                 do {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -464,7 +464,8 @@ public class ZMUserSession: NSObject {
             lastEventIDRepository: lastEventIDRepository,
             transportSession: transportSession,
             proteusProvider: self.proteusProvider,
-            mlsService: mlsService
+            mlsService: mlsService,
+            coreCryptoProvider: coreCryptoProvider
         )
     }
 
@@ -559,6 +560,7 @@ public class ZMUserSession: NSObject {
     }
 
     func createMLSClientIfNeeded() {
+        // TODO: [jacob] refactor out
         if applicationStatusDirectory.clientRegistrationStatus.needsToRegisterMLSCLient {
             WaitingGroupTask(context: syncContext) { [self] in
                 do {
@@ -839,15 +841,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
         action.send(in: syncContext.notificationContext)
     }
 
-    public func didRegisterMLSClient(_ userClient: UserClient) {
-        Task {
-            await mlsService.uploadKeyPackagesIfNeeded()
-        }
-    }
-
     public func didRegisterSelfUserClient(_ userClient: UserClient) {
-        createMLSClientIfNeeded()
-
         // If during registration user allowed notifications,
         // The push token can only be registered after client registration
         transportSession.pushChannel.clientID = userClient.remoteIdentifier

--- a/wire-ios-sync-engine/Tests/Source/Calling/MLSConferenceStaleParticipantsRemoverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/MLSConferenceStaleParticipantsRemoverTests.swift
@@ -59,7 +59,6 @@ class MLSConferenceStaleParticipantsRemoverTests: MessagingTest {
         // create call participants
         let participants = [
             createMLSParticipant(state: .connecting),
-            createMLSParticipant(state: .connecting),
             createMLSParticipant(state: connectedState),
             createMLSParticipant(state: connectedState)
         ]

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -65,6 +65,8 @@ class UserClientRequestStrategyTests: RequestStrategyTestBase {
     var spyKeyStore: SpyUserClientKeyStore!
     var proteusService: MockProteusServiceInterface!
     var proteusProvider: MockProteusProvider!
+    var coreCrypto: MockSafeCoreCrypto!
+    var coreCryptoProvider: MockCoreCryptoProviderProtocol!
 
     var postLoginAuthenticationObserverToken: Any?
 
@@ -81,6 +83,9 @@ class UserClientRequestStrategyTests: RequestStrategyTestBase {
                 mockProteusService: self.proteusService,
                 mockKeyStore: spyKeyStore
             )
+            self.coreCrypto = MockSafeCoreCrypto()
+            self.coreCryptoProvider = MockCoreCryptoProviderProtocol()
+            self.coreCryptoProvider.coreCryptoRequireMLS_MockValue = self.coreCrypto
             self.cookieStorage = ZMPersistentCookieStorage(forServerName: "myServer", userIdentifier: self.userIdentifier, useCache: true)
             self.mockClientRegistrationStatusDelegate = MockClientRegistrationStatusDelegate()
             self.clientRegistrationStatus = ZMMockClientRegistrationStatus(
@@ -93,7 +98,8 @@ class UserClientRequestStrategyTests: RequestStrategyTestBase {
                 clientRegistrationStatus: self.clientRegistrationStatus,
                 clientUpdateStatus: self.clientUpdateStatus,
                 context: self.syncMOC,
-                proteusProvider: self.proteusProvider
+                proteusProvider: self.proteusProvider,
+                coreCryptoProvider: self.coreCryptoProvider
             )
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.remoteIdentifier = self.userIdentifier
@@ -124,6 +130,24 @@ extension UserClientRequestStrategyTests {
         selfClient.remoteIdentifier = nil
         selfClient.user = ZMUser.selfUser(in: context)
         return selfClient
+    }
+
+    func testThatMLSPublicKeysAreCreatedBeforeAttemptingToRegisterMLSClient() {
+        syncMOC.performGroupedBlockAndWait {
+
+            // given
+            let client = self.createSelfClient(self.sut.managedObjectContext!)
+            self.clientRegistrationStatus.mockPhase = .registeringMLSClient
+
+            // when
+            XCTAssertNil(self.sut.nextRequest(for: .v0))
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        syncMOC.performGroupedBlockAndWait {
+            // then
+            XCTAssertEqual(self.coreCryptoProvider.coreCryptoRequireMLS_Invocations.count, 1)
+        }
     }
 
     func testThatPrekeysAreGeneratedBeforeAttemptingToRegisterClient() {
@@ -540,6 +564,29 @@ extension UserClientRequestStrategyTests {
 
             // then
             XCTAssertEqual(client.numberOfKeysRemaining, expectedNumberOfKeys)
+        }
+    }
+
+    func testThatItReturnsRequestIfItNeedsToRegisterMLSClient() {
+        var selfClient: UserClient!
+        let request = syncMOC.performAndWait {
+            // given
+            selfClient = UserClient.insertNewObject(in: self.sut.managedObjectContext!)
+            selfClient.remoteIdentifier = UUID.create().transportString()
+            selfClient.mlsPublicKeys = UserClient.MLSPublicKeys.init(ed25519: "key")
+            self.sut.managedObjectContext!.saveOrRollback()
+            self.clientRegistrationStatus.mockPhase = .registeringMLSClient
+            self.sut.notifyChangeTrackers(selfClient)
+
+            // when
+            return self.sut.nextRequest(for: .v0)
+        }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        syncMOC.performAndWait {
+            XCTAssertEqual(request?.method, .put)
+            XCTAssertEqual(request?.path, "/clients/\(selfClient.remoteIdentifier!)")
         }
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
@@ -238,7 +238,7 @@
     UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
     client.remoteIdentifier = [NSUUID createUUID].transportString;
 
-    [self.sut didRegisterClient:client];
+    [self.sut didRegisterProteusClient:client];
 
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
@@ -257,7 +257,7 @@
     [[self.mockClientRegistrationDelegate expect] didRegisterSelfUserClient:client];
     
     // when
-    [self.sut didRegisterClient:client];
+    [self.sut didRegisterProteusClient:client];
     
     // then
     [self.mockClientRegistrationDelegate verify];
@@ -360,7 +360,7 @@
     [[self.mockClientRegistrationDelegate expect] didRegisterSelfUserClient:client];
     
     // when
-    [self.sut didRegisterClient:client];
+    [self.sut didRegisterProteusClient:client];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.m
@@ -91,60 +91,68 @@
 
 - (void)testThatItInsertsANewClientIfThereIsNoneWaitingToBeSynced
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-    client.user = selfUser;
-    client.remoteIdentifier = @"identifier";
-    
-    XCTAssertEqual(selfUser.clients.count, 1u);
-    
-    // when
-    [self.sut prepareForClientRegistration];
-    
-    // then
-    XCTAssertEqual(selfUser.clients.count, 2u);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.user = selfUser;
+        client.remoteIdentifier = @"identifier";
+
+        XCTAssertEqual(selfUser.clients.count, 1u);
+
+        // when
+        [self.sut prepareForClientRegistration];
+
+        // then
+        XCTAssertEqual(selfUser.clients.count, 2u);
+    }];
 }
 
 
 - (void)testThatItDoesNotInsertANewClientIfThereIsAlreadyOneWaitingToBeSynced
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
-    client.user = selfUser;
-    
-    XCTAssertEqual(selfUser.clients.count, 1u);
-    
-    // when
-    [self.sut prepareForClientRegistration];
-    
-    // then
-    XCTAssertEqual(selfUser.clients.count, 1u);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.user = selfUser;
+
+        XCTAssertEqual(selfUser.clients.count, 1u);
+
+        // when
+        [self.sut prepareForClientRegistration];
+
+        // then
+        XCTAssertEqual(selfUser.clients.count, 1u);
+    }];
 }
 
 - (void)testThatItReturns_WaitingForSelfUser_IFSelfUserDoesNotHaveRemoteID
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    selfUser.remoteIdentifier = nil;
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForSelfUser);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = nil;
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForSelfUser);
+    }];
 }
 
 
 - (void)testThatItReturns_Registered_IfSelfClientIsSet
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    [self.syncMOC setPersistentStoreMetadata:@"lala" forKey:ZMPersistedClientIdKey];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        [self.syncMOC setPersistentStoreMetadata:@"lala" forKey:ZMPersistedClientIdKey];
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
+    }];
 }
 
 - (void)testThatItReturns_WaitingForDeletion_AfterUserSelectedClientToDelete
@@ -176,170 +184,190 @@
 
 - (void)testThatItResets_LocallyModifiedKeys_AfterUserSelectedClientToDelete
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = NSUUID.createUUID;
-    
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-    client.remoteIdentifier = @"identifier";
-    client.user = selfUser;
-    [client setLocallyModifiedKeys:[NSSet setWithObject:@"numberOfKeysRemaining"]];
-    
-    [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
-    
-    // when
-    [self.sut didDetectCurrentClientDeletion];
-    
-    // then
-    XCTAssertFalse([client hasLocalModificationsForKey:@"numberOfKeysRemaining"]);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = NSUUID.createUUID;
+
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"identifier";
+        client.user = selfUser;
+        [client setLocallyModifiedKeys:[NSSet setWithObject:@"numberOfKeysRemaining"]];
+
+        [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+
+        // when
+        [self.sut didDetectCurrentClientDeletion];
+
+        // then
+        XCTAssertFalse([client hasLocalModificationsForKey:@"numberOfKeysRemaining"]);
+    }];
 }
 
 - (void)testThatItInvalidatesSelfClientAndDeletesAndRecreatesCryptoBoxOnDidDetectCurrentClientDeletion
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = @"email@domain.com";
-    
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
-    client.user = selfUser;
-    [self.uiMOC saveOrRollback];
-    
-    // when
-    [self.sut didFailToRegisterClient:[self tooManyClientsError]];
-    [ZMClientUpdateNotification notifyFetchingClientsCompletedWithUserClients:@[client] context:self.uiMOC];
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        selfUser.emailAddress = @"email@domain.com";
+
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.user = selfUser;
+        [self.syncMOC saveOrRollback];
+
+        // when
+        [self.sut didFailToRegisterClient:[self tooManyClientsError]];
+        [ZMClientUpdateNotification notifyFetchingClientsCompletedWithUserClients:@[client] context:self.uiMOC];
+    }];
     WaitForAllGroupsToBeEmpty(0.5);
-    
+
     // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForDeletion);
+    [self.syncMOC performBlockAndWait:^{
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForDeletion);
+    }];
 }
 
 - (void)testThatItReturnsYESForNeedsToRegisterClientIfNoClientIdInMetadata
 {
-    [self.uiMOC setPersistentStoreMetadata:nil forKey:ZMPersistedClientIdKey];
-    XCTAssertTrue([ZMClientRegistrationStatus needsToRegisterClientInContext:self.uiMOC]);
+    [self.syncMOC performBlockAndWait:^{
+        [self.syncMOC setPersistentStoreMetadata:nil forKey:ZMPersistedClientIdKey];
+        XCTAssertTrue([ZMClientRegistrationStatus needsToRegisterClientInContext:self.syncMOC]);
+    }];
 }
 
 - (void)testThatItReturnsNOForNeedsToRegisterClientIfThereIsClientIdInMetadata
 {
-    [self.uiMOC setPersistentStoreMetadata:@"lala" forKey:ZMPersistedClientIdKey];
-    XCTAssertFalse([ZMClientRegistrationStatus needsToRegisterClientInContext:self.uiMOC]);
+    [self.syncMOC performBlockAndWait:^{
+        [self.syncMOC setPersistentStoreMetadata:@"lala" forKey:ZMPersistedClientIdKey];
+        XCTAssertFalse([ZMClientRegistrationStatus needsToRegisterClientInContext:self.syncMOC]);
+    }];
 }
 
 - (void)testThatItNotfiesCredentialProviderWhenClientIsRegistered
 {
-    //given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID new];
+    [self.syncMOC performBlockAndWait:^{
+        //given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID new];
 
-    //when
-    [self.sut prepareForClientRegistration];
+        //when
+        [self.sut prepareForClientRegistration];
 
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-    client.remoteIdentifier = [NSUUID createUUID].transportString;
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = [NSUUID createUUID].transportString;
 
-    [self.sut didRegisterProteusClient:client];
+        [self.sut didRegisterProteusClient:client];
 
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
+    }];
 }
 
 - (void)testThatItNotfiesDelegateWhenClientIsRegistered
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    selfUser.remoteIdentifier = [NSUUID new];
-    
-    [self.sut prepareForClientRegistration];
-    
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
-    client.remoteIdentifier = [NSUUID createUUID].transportString;
-    [[self.mockClientRegistrationDelegate expect] didRegisterSelfUserClient:client];
-    
-    // when
-    [self.sut didRegisterProteusClient:client];
-    
-    // then
-    [self.mockClientRegistrationDelegate verify];
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID new];
+
+        [self.sut prepareForClientRegistration];
+
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = [NSUUID createUUID].transportString;
+        [[self.mockClientRegistrationDelegate expect] didRegisterSelfUserClient:client];
+
+        // when
+        [self.sut didRegisterProteusClient:client];
+
+        // then
+        [self.mockClientRegistrationDelegate verify];
+    }];
 }
 
 - (void)testThatItTransitionsFrom_WaitingForEmail_To_WaitingForPrekeys_WhenSelfUserChangesWithEmailAddress
 {
-    // given
-    
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = nil;
-    selfUser.phoneNumber = nil;
-    
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
-    
-    // when
-    selfUser.emailAddress = @"me@example.com";
-    [self.sut didFetchSelfUser];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        selfUser.emailAddress = nil;
+        selfUser.phoneNumber = nil;
+
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
+
+        // when
+        selfUser.emailAddress = @"me@example.com";
+        [self.sut didFetchSelfUser];
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+    }];
 }
 
 
 - (void)testThatItDoesNotTransitionsFrom_WaitingForEmail_To_Unregistered_WhenSelfUserChangesWithoutEmailAddress
 {
-    // given
-    
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = nil;
-    selfUser.phoneNumber = nil;
-    
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
-    
-    // when
-    selfUser.emailAddress = nil;
-    [self.sut didFetchSelfUser];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        selfUser.emailAddress = nil;
+        selfUser.phoneNumber = nil;
+
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
+
+        // when
+        selfUser.emailAddress = nil;
+        [self.sut didFetchSelfUser];
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForEmailVerfication);
+    }];
 }
 
 - (void)testThatItResetsThePhaseToWaitingForLoginIfItNeedsPasswordToRegisterClient
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = @"email@domain.com";
-    [[[self.mockCookieStorage stub] andReturn:[NSData data]] authenticationCookieData];
-    self.sut.emailCredentials = nil;
-    
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        selfUser.emailAddress = @"email@domain.com";
+        [[[self.mockCookieStorage stub] andReturn:[NSData data]] authenticationCookieData];
+        self.sut.emailCredentials = nil;
 
-    NSError *error = [NSError errorWithDomain:@"ZMUserSession" code:ZMUserSessionNeedsPasswordToRegisterClient userInfo:nil];
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
 
-    // when
-    [self.sut didFailToRegisterClient:error];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForLogin);
-    
-    // and when
-    // the user entered the password, we can proceed trying to register the client
-    self.sut.emailCredentials = [ZMEmailCredentials credentialsWithEmail:@"john.doe@domain.com" password:@"12345789"];
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+        NSError *error = [NSError errorWithDomain:@"ZMUserSession" code:ZMUserSessionNeedsPasswordToRegisterClient userInfo:nil];
+
+        // when
+        [self.sut didFailToRegisterClient:error];
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForLogin);
+
+        // and when
+        // the user entered the password, we can proceed trying to register the client
+        self.sut.emailCredentials = [ZMEmailCredentials credentialsWithEmail:@"john.doe@domain.com" password:@"12345789"];
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+    }];
 }
 
 - (void)testThatItDoesNotRequireEmailRegistrationForTeamUser
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    selfUser.emailAddress = nil;
-    selfUser.phoneNumber = nil;
-    selfUser.usesCompanyLogin = YES;
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
+        selfUser.emailAddress = nil;
+        selfUser.phoneNumber = nil;
+        selfUser.usesCompanyLogin = YES;
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseWaitingForPrekeys);
+    }];
 }
 
 @end
@@ -350,22 +378,24 @@
 
 - (void)testThatItNotifiesTheUIAboutSuccessfulRegistration
 {
-    // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.uiMOC];
-    selfUser.remoteIdentifier = self.userIdentifier;
-    [self.uiMOC saveOrRollback];
-    
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.uiMOC];
-    client.remoteIdentifier = @"yay";
-    [[self.mockClientRegistrationDelegate expect] didRegisterSelfUserClient:client];
-    
-    // when
-    [self.sut didRegisterProteusClient:client];
-    WaitForAllGroupsToBeEmpty(0.5);
-    
-    // then
-    XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
-    [self.mockClientRegistrationDelegate verify];
+    [self.syncMOC performBlockAndWait:^{
+        // given
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = self.userIdentifier;
+        [self.uiMOC saveOrRollback];
+
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.remoteIdentifier = @"yay";
+        [[self.mockClientRegistrationDelegate expect] didRegisterSelfUserClient:client];
+
+        // when
+        [self.sut didRegisterProteusClient:client];
+        WaitForAllGroupsToBeEmpty(0.5);
+
+        // then
+        XCTAssertEqual(self.sut.currentPhase, ZMClientRegistrationPhaseRegistered);
+        [self.mockClientRegistrationDelegate verify];
+    }];
 }
 
 - (void)testThatItNotifiesTheUIIfTheRegistrationFailsWithMissingEmailVerification
@@ -381,7 +411,9 @@
     [[self.mockClientRegistrationDelegate expect] didFailToRegisterSelfUserClient: error];
     
     // when
-    [self.sut didFetchSelfUser];
+    [self.syncMOC performBlockAndWait:^{
+        [self.sut didFetchSelfUser];
+    }];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -400,7 +432,9 @@
     [[self.mockClientRegistrationDelegate expect] didFailToRegisterSelfUserClient: [OCMArg any]];
     
     // when
-    [self.sut didFailToRegisterClient:error];
+    [self.syncMOC performBlockAndWait:^{
+        [self.sut didFailToRegisterClient:error];
+    }];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -418,7 +452,9 @@
     [[self.mockClientRegistrationDelegate expect] didFailToRegisterSelfUserClient: error];
     
     // when
-    [self.sut didFailToRegisterClient:error];
+    [self.syncMOC performBlockAndWait:^{
+        [self.sut didFailToRegisterClient:error];
+    }];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
@@ -432,8 +468,10 @@
     [[self.mockClientRegistrationDelegate expect] didFailToRegisterSelfUserClient: error];
     
     // when
-    [self.sut didFailToRegisterClient:error];
-    
+    [self.syncMOC performBlockAndWait:^{
+        [self.sut didFailToRegisterClient:error];
+    }];
+
     // then
     [self.mockClientRegistrationDelegate reject];
 }
@@ -441,17 +479,19 @@
 - (void)testThatItDeletesTheCookieIfFetchingClientsFailedWithError_SelfClientIsInvalid
 {
     // given
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = [NSUUID UUID];
-    
-    UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
-    client.user = selfUser;
-    client.remoteIdentifier = @"identifer";
-    [self.syncMOC saveOrRollback];
-    [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+    [self.syncMOC performBlockAndWait:^{
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = [NSUUID UUID];
 
-    XCTAssertNotNil(selfUser.selfClient);
-    
+        UserClient *client = [UserClient insertNewObjectInManagedObjectContext:self.syncMOC];
+        client.user = selfUser;
+        client.remoteIdentifier = @"identifer";
+        [self.syncMOC saveOrRollback];
+        [self.syncMOC setPersistentStoreMetadata:client.remoteIdentifier forKey:ZMPersistedClientIdKey];
+
+        XCTAssertNotNil(selfUser.selfClient);
+    }];
+
     NSError *error = [NSError errorWithDomain:@"ClientManagement" code:ClientUpdateErrorSelfClientIsInvalid userInfo:nil];
 
     // expect
@@ -462,8 +502,10 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then
-    XCTAssertNil([self.syncMOC persistentStoreMetadataForKey:ZMPersistedClientIdKey]);
-    [self.mockCookieStorage verify];
+    [self.syncMOC performBlockAndWait:^{
+        XCTAssertNil([self.syncMOC persistentStoreMetadataForKey:ZMPersistedClientIdKey]);
+        [self.mockCookieStorage verify];
+    }];
 }
 
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
@@ -21,163 +21,185 @@ import XCTest
 
 extension ZMClientRegistrationStatusTests {
     func testThatItReturns_FetchingClients_WhenReceivingAnErrorWithTooManyClients() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
 
-        // when
-        sut.didFail(toRegisterClient: tooManyClientsError()! as NSError)
+            // when
+            sut.didFail(toRegisterClient: tooManyClientsError()! as NSError)
 
-        // then
-        XCTAssertEqual(sut.currentPhase, ZMClientRegistrationPhase.fetchingClients)
+            // then
+            XCTAssertEqual(sut.currentPhase, ZMClientRegistrationPhase.fetchingClients)
+        }
     }
 
     func testThatItDoesNotNeedToRegisterMLSClient_WhenNoClientIsAlreadyRegisteredAndAllowed() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        DeveloperFlag.storage = .temporary()
-        DeveloperFlag.enableMLSSupport.enable(true)
-        BackendInfo.storage = .temporary()
-        BackendInfo.apiVersion = .v5
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            DeveloperFlag.storage = .temporary()
+            DeveloperFlag.enableMLSSupport.enable(true)
+            BackendInfo.storage = .temporary()
+            BackendInfo.apiVersion = .v5
 
-        // then
-        XCTAssertFalse(sut.needsToRegisterMLSCLient)
+            // then
+            XCTAssertFalse(sut.needsToRegisterMLSCLient)
+        }
     }
 
     func testThatItNeeddToRegisterMLSClient_WhenClientIsRegisteredAndAllowed() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
 
-        let selfClient =  UserClient.insertNewObject(in: self.syncMOC)
-        selfClient.remoteIdentifier = UUID.create().transportString()
-        sut.didRegisterProteusClient(selfClient)
+            let selfClient =  UserClient.insertNewObject(in: self.syncMOC)
+            selfClient.remoteIdentifier = UUID.create().transportString()
+            sut.didRegisterProteusClient(selfClient)
 
-        DeveloperFlag.storage = .temporary()
-        DeveloperFlag.enableMLSSupport.enable(true)
-        BackendInfo.storage = .temporary()
-        BackendInfo.apiVersion = .v5
+            DeveloperFlag.storage = .temporary()
+            DeveloperFlag.enableMLSSupport.enable(true)
+            BackendInfo.storage = .temporary()
+            BackendInfo.apiVersion = .v5
 
-        // then
-        XCTAssertTrue(sut.needsToRegisterMLSCLient)
+            // then
+            XCTAssertTrue(sut.needsToRegisterMLSCLient)
+        }
     }
 
     func testThatItDoesntNeedsToRegisterMLSClient_WhenClientIsAlreadyRegistered() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        let selfClient = createSelfClient()
-        selfClient.mlsPublicKeys = UserClient.MLSPublicKeys(ed25519: "someKey")
-        selfClient.needsToUploadMLSPublicKeys = false
-        DeveloperFlag.storage = .temporary()
-        DeveloperFlag.enableMLSSupport.enable(true)
-        BackendInfo.storage = .temporary()
-        BackendInfo.apiVersion = .v5
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            let selfClient = createSelfClient()
+            selfClient.mlsPublicKeys = UserClient.MLSPublicKeys(ed25519: "someKey")
+            selfClient.needsToUploadMLSPublicKeys = false
+            DeveloperFlag.storage = .temporary()
+            DeveloperFlag.enableMLSSupport.enable(true)
+            BackendInfo.storage = .temporary()
+            BackendInfo.apiVersion = .v5
 
-        // then
-        XCTAssertFalse(sut.needsToRegisterMLSCLient)
+            // then
+            XCTAssertFalse(sut.needsToRegisterMLSCLient)
+        }
     }
 
     func testThatItDoesntNeedsToRegisterMLSClient_WhenNotAllowed() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        DeveloperFlag.enableMLSSupport.enable(false)
-        BackendInfo.apiVersion = .v5
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            DeveloperFlag.enableMLSSupport.enable(false)
+            BackendInfo.apiVersion = .v5
 
-        // then
-        XCTAssertFalse(sut.needsToRegisterMLSCLient)
+            // then
+            XCTAssertFalse(sut.needsToRegisterMLSCLient)
+        }
     }
 
     func testThatItReturnsWaitsForPrekeys_WhenItNeedsToRegisterAClient() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        selfUser.emailAddress = "email@domain.com"
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            selfUser.emailAddress = "email@domain.com"
 
-        // then
-        XCTAssertEqual(self.sut.currentPhase, .waitingForPrekeys)
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .waitingForPrekeys)
+        }
     }
 
     func testThatItReturnsGeneratesPrekeys_AfterPrekeyGenerationAsBegun() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        selfUser.emailAddress = "email@domain.com"
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            selfUser.emailAddress = "email@domain.com"
 
-        // when
-        sut.willGeneratePrekeys()
+            // when
+            sut.willGeneratePrekeys()
 
-        // then
-        XCTAssertEqual(self.sut.currentPhase, .generatingPrekeys)
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .generatingPrekeys)
+        }
     }
 
     func testThatItReturnsRegisteringMLSClient_IfIfMLSIsEnabledAfterRegisteringProteusClient() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        selfUser.emailAddress = "email@domain.com"
-        let selfUserClient = createSelfClient()
-        selfUserClient.remoteIdentifier = "clientID"
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            selfUser.emailAddress = "email@domain.com"
+            let selfUserClient = createSelfClient()
+            selfUserClient.remoteIdentifier = "clientID"
 
-        DeveloperFlag.storage = .temporary()
-        DeveloperFlag.enableMLSSupport.enable(true)
-        BackendInfo.storage = .temporary()
-        BackendInfo.apiVersion = .v5
+            DeveloperFlag.storage = .temporary()
+            DeveloperFlag.enableMLSSupport.enable(true)
+            BackendInfo.storage = .temporary()
+            BackendInfo.apiVersion = .v5
 
-        // when
-        sut.didRegisterProteusClient(selfUserClient)
+            // when
+            sut.didRegisterProteusClient(selfUserClient)
 
-        // then
-        XCTAssertEqual(self.sut.currentPhase, .registeringMLSClient)
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .registeringMLSClient)
+        }
     }
 
     func testThatItReturnsRegistered_IfMLSIsDisabledAfterRegisteringProteusClient() {
-        // given
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        selfUser.emailAddress = "email@domain.com"
-        let selfUserClient = createSelfClient()
-        selfUserClient.remoteIdentifier = "clientID"
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            selfUser.emailAddress = "email@domain.com"
+            let selfUserClient = createSelfClient()
+            selfUserClient.remoteIdentifier = "clientID"
 
-        // when
-        sut.didRegisterProteusClient(selfUserClient)
+            // when
+            sut.didRegisterProteusClient(selfUserClient)
 
-        // then
-        XCTAssertEqual(self.sut.currentPhase, .registered)
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .registered)
+        }
     }
 
     func testThatItReturnsUnregistered_AfterPrekeyGenerationIsCompleted() {
-        // given
-        let prekey = IdPrekeyTuple(id: 1, prekey: "prekey1")
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        selfUser.emailAddress = "email@domain.com"
-        sut.willGeneratePrekeys()
+        syncMOC.performAndWait {
+            // given
+            let prekey = IdPrekeyTuple(id: 1, prekey: "prekey1")
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            selfUser.emailAddress = "email@domain.com"
+            sut.willGeneratePrekeys()
 
-        // when
-        sut.didGeneratePrekeys([prekey], lastResortPrekey: prekey)
+            // when
+            sut.didGeneratePrekeys([prekey], lastResortPrekey: prekey)
 
-        // then
-        XCTAssertEqual(self.sut.currentPhase, .unregistered)
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .unregistered)
+        }
     }
 
     func testThatItReturnsRegistered_AfterClientHasBeenCreated() {
-        // given
-        let prekey = IdPrekeyTuple(id: 1, prekey: "prekey1")
-        let selfUser = ZMUser.selfUser(in: syncMOC)
-        selfUser.remoteIdentifier = UUID()
-        selfUser.emailAddress = "email@domain.com"
-        sut.willGeneratePrekeys()
-        sut.didGeneratePrekeys([prekey], lastResortPrekey: prekey)
+        syncMOC.performAndWait {
+            // given
+            let prekey = IdPrekeyTuple(id: 1, prekey: "prekey1")
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            selfUser.emailAddress = "email@domain.com"
+            sut.willGeneratePrekeys()
+            sut.didGeneratePrekeys([prekey], lastResortPrekey: prekey)
 
-        // when
-        let selfClient =  UserClient.insertNewObject(in: self.syncMOC)
-        selfClient.remoteIdentifier = UUID.create().transportString()
-        sut.didRegisterProteusClient(selfClient)
+            // when
+            let selfClient =  UserClient.insertNewObject(in: self.syncMOC)
+            selfClient.remoteIdentifier = UUID.create().transportString()
+            sut.didRegisterProteusClient(selfClient)
 
-        // then
-        XCTAssertEqual(self.sut.currentPhase, .registered)
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .registered)
+        }
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
@@ -54,31 +54,37 @@ final class ZMUserSessionTests_RecurringActions: ZMUserSessionTestsBase {
     }
 
     func testUpdatesUsersMissingMetadataAction() {
-        // Given
-        let otherUser = createUserIsPendingMetadataRefresh(moc: syncMOC, domain: UUID().uuidString)
-        syncMOC.saveOrRollback()
-        let action = sut.refreshUsersMissingMetadataAction
+        syncMOC.performAndWait {
+            // Given
+            let otherUser = createUserIsPendingMetadataRefresh(moc: syncMOC, domain: UUID().uuidString)
+            syncMOC.saveOrRollback()
+            let action = sut.refreshUsersMissingMetadataAction
 
-        // When
-        action()
+            // When
+            action()
+            syncMOC.refreshAllObjects()
 
-        // Then
-        XCTAssertEqual(action.interval, 3 * .oneHour)
-        XCTAssertTrue(otherUser.needsToBeUpdatedFromBackend)
+            // Then
+            XCTAssertEqual(action.interval, 3 * .oneHour)
+            XCTAssertTrue(otherUser.needsToBeUpdatedFromBackend)
+        }
     }
 
     func testThatItUpdatesConversationsMissingMetadata() {
-        // Given
-        let conversation = createConversationIsPendingMetadataRefresh(moc: syncMOC, domain: UUID().uuidString)
-        syncMOC.saveOrRollback()
-        let action = sut.refreshConversationsMissingMetadataAction
+        syncMOC.performAndWait {
+            // Given
+            let conversation = createConversationIsPendingMetadataRefresh(moc: syncMOC, domain: UUID().uuidString)
+            syncMOC.saveOrRollback()
+            let action = sut.refreshConversationsMissingMetadataAction
 
-        // When
-        action()
+            // When
+            action()
+            syncMOC.refreshAllObjects()
 
-        // Then
-        XCTAssertEqual(action.interval, 3 * .oneHour)
-        XCTAssertTrue(conversation.needsToBeUpdatedFromBackend)
+            // Then
+            XCTAssertEqual(action.interval, 3 * .oneHour)
+            XCTAssertTrue(conversation.needsToBeUpdatedFromBackend)
+        }
     }
 
     // MARK: - Helpers

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+SecurityClassification.swift
@@ -40,16 +40,14 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnsNone_WhenFeatureIsEnabled_WhenSelfDomainIsNil() {
         // given
-        let otherUser = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser = createUser(moc: uiMOC, domain: UUID().uuidString)
 
-        storeClassifiedDomains(with: .enabled, domains: [])
-
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: [])
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = nil
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -61,16 +59,14 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnsNone_WhenFeatureIsDisabled_WhenSelfDomainIsNotNil() {
         // given
-        let otherUser = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser = createUser(moc: uiMOC, domain: UUID().uuidString)
 
-        storeClassifiedDomains(with: .disabled, domains: [])
-
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .disabled, domains: [])
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -82,20 +78,18 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnClassified_WhenFeatureIsEnabled_WhenAllOtherUserDomainIsClassified() {
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser3 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser3 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2, otherUser3]
         let classifiedDomains = otherUsers.map { $0.domain! }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -107,22 +101,20 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnsNotClassified_WhenFeatureIsEnabled_WhenAtLeastOneOtherUserDomainIsNotClassified() {
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser3 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser3 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2, otherUser3]
 
         var classifiedDomains = otherUsers.map { $0.domain! }
         classifiedDomains.removeFirst()
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -134,21 +126,19 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnsNotClassified_WhenFeatureIsEnabled_WhenAtLeastOneOtherUserDomainIsNil() {
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: nil)
-        let otherUser3 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: nil)
+        let otherUser3 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2, otherUser3]
 
         let classifiedDomains = otherUsers.compactMap { $0.domain }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -166,25 +156,24 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
             BackendInfo.domain = backendDomainBackup
         }
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: nil)
-        let otherUser3 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: nil)
+        let otherUser3 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2, otherUser3]
         let localDomain = UUID().uuidString
 
         let otherUsersDomains = otherUsers.compactMap { $0.domain }
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
         BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -201,26 +190,26 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
             BackendInfo.isFederationEnabled = federationFlagBackup
             BackendInfo.domain = backendDomainBackup
         }
+
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: nil)
-        let otherUser3 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: nil)
+        let otherUser3 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2, otherUser3]
         let localDomain = UUID().uuidString
+
+        BackendInfo.isFederationEnabled = false
+        BackendInfo.domain = localDomain
 
         let otherUsersDomains = otherUsers.compactMap { $0.domain }
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
-        BackendInfo.isFederationEnabled = false
-        BackendInfo.domain = localDomain
-
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -232,9 +221,9 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnsNotClassified_WhenFeatureIsEnabled_WhenAtLeastOneOtherUserIsTemporary() {
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: nil)
-        let otherUser3 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: nil)
+        let otherUser3 = createUser(moc: uiMOC, domain: UUID().uuidString)
         otherUser3.expiresAt = Date(timeIntervalSinceNow: 100.0)
         let otherUsers = [otherUser1, otherUser2, otherUser3]
         let localDomain = UUID().uuidString
@@ -242,16 +231,15 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
         let otherUsersDomains = otherUsers.compactMap { $0.domain }
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
         BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -263,24 +251,23 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
 
     func testThatItReturnsNotClassified_WhenFeatureIsEnabled_WhenConversationDomainNotClassified() {
         // given
-        let otherUser1 = createUser(moc: syncMOC, domain: UUID().uuidString)
-        let otherUser2 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: UUID().uuidString)
+        let otherUser2 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2]
         let localDomain = UUID().uuidString
 
         let otherUsersDomains = otherUsers.compactMap { $0.domain }
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
         BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -293,24 +280,23 @@ final class ZMUserSessionTests_SecurityClassification: ZMUserSessionTestsBase {
     func testThatItReturnsClassified_WhenFeatureIsEnabled_WhenConversationDomainIsClassified() {
         // given
         let otherDomain = UUID().uuidString
-        let otherUser1 = createUser(moc: syncMOC, domain: otherDomain)
-        let otherUser2 = createUser(moc: syncMOC, domain: UUID().uuidString)
+        let otherUser1 = createUser(moc: uiMOC, domain: otherDomain)
+        let otherUser2 = createUser(moc: uiMOC, domain: UUID().uuidString)
         let otherUsers = [otherUser1, otherUser2]
         let localDomain = UUID().uuidString
 
         let otherUsersDomains = otherUsers.compactMap { $0.domain }
         let classifiedDomains = [otherUsersDomains, [localDomain]].flatMap { $0 }
 
-        storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
         BackendInfo.isFederationEnabled = true
         BackendInfo.domain = localDomain
 
-        syncMOC.performGroupedBlock {
+        syncMOC.performAndWait {
+            storeClassifiedDomains(with: .enabled, domains: classifiedDomains)
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.domain = UUID().uuidString
             self.syncMOC.saveOrRollback()
         }
-
         XCTAssertTrue(self.waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -799,7 +799,6 @@
 		161C886423FD248A00CB0B8E /* RecordingMockTransportSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingMockTransportSession.swift; sourceTree = "<group>"; };
 		161C887623FD4CFD00CB0B8E /* MockPushChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPushChannel.swift; sourceTree = "<group>"; };
 		162113032B2756EB008F0F9F /* PrekeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrekeyGenerator.swift; sourceTree = "<group>"; };
-		1621D2701D770FB1007108C2 /* ZMSyncStateDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMSyncStateDelegate.h; sourceTree = "<group>"; };
 		1626344620D79C22000D4063 /* ZMUserSessionTests+PushNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSessionTests+PushNotifications.swift"; sourceTree = "<group>"; };
 		162A81D3202B453000F6200C /* SessionManager+AVS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManager+AVS.swift"; sourceTree = "<group>"; };
 		162A81D5202B5BC600F6200C /* SessionManagerAVSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerAVSTests.swift; sourceTree = "<group>"; };
@@ -2447,7 +2446,6 @@
 				F96DBEE91DF9A570008FE832 /* ZMSyncStrategy+ManagedObjectChanges.m */,
 				1693151025836E5800709F15 /* EventProcessor.swift */,
 				160C31431E8049320012E4BC /* ApplicationStatusDirectory.swift */,
-				1621D2701D770FB1007108C2 /* ZMSyncStateDelegate.h */,
 				F95ECF4C1B94A553009F91BA /* ZMHotFix.h */,
 				F95ECF4D1B94A553009F91BA /* ZMHotFix.m */,
 				54DE26B11BC56E62002B5FBC /* ZMHotFixDirectory.h */,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In preparation for E2EI enrollment during login I'm moving the MLS client registration inside the client registration flow.

This means that the `didRegisterSelfUserClient()` delegate method will now be called after the MLS client has registered with the backend if MLS is enabled. If MLS is disabled it will be called after the proteus client has been registered.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
