### PR TITLE
chore: fix warnings, improve code style as preparation for the main PR of [WPB-4549]

### DIFF
--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -2663,7 +2663,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         BackendInfo.storage = .temporary()
         BackendInfo.domain = "example.com"
         let mlsGroupID = MLSGroupID.random()
-        let conversation = await uiMOC.perform { [self] in
+        await uiMOC.perform { [self] in
             let selfUser = ZMUser.selfUser(in: uiMOC)
             selfUser.teamIdentifier = .create()
             selfUser.domain = BackendInfo.domain
@@ -2673,7 +2673,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation.messageProtocol = .proteus
             conversation.domain = BackendInfo.domain
             conversation.teamRemoteIdentifier = selfUser.teamIdentifier
-            return conversation
         }
 
         mockActionsProvider.updateConversationProtocolQualifiedIDMessageProtocolContext_MockMethod = { _, _, _ in }

--- a/wire-ios-data-model/Tests/Source/Model/Messages/GenericMessageTests+NativePush.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/GenericMessageTests+NativePush.swift
@@ -50,7 +50,7 @@ class GenericMessageTests_NativePush: BaseZMMessageTests {
 
     func assertThatItSetsNativePush(to nativePush: Bool, for message: GenericMessage, line: UInt = #line) async {
         await uiMOC.perform { [self] in
-            createSelfClient()
+            _ = createSelfClient()
         }
 
         let conversation = await syncMOC.perform { [self] in

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -941,7 +941,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
         conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
         uiMOC.saveOrRollback()
 
-        let modifier: (ZMConversation, ConversationObserver) -> Void = { [uiMOC, legalHoldClient] _, _ in
+        let modifier: (ZMConversation, ConversationObserver) -> Void = { _, _ in
             self.performPretendingUiMocIsSyncMoc {
                 // Can't call async function inside the synchronous modifier block.
                 // We need an async version of `checkThatItNotifiesTheObserverOfAChange`

--- a/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2024 Wire Swiss GmbH
+// Copyright (C) 2017 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-final class ConversationEventPayloadProcessor {
+struct ConversationEventPayloadProcessor {
 
     enum Source {
         case slowSync
@@ -28,8 +28,8 @@ final class ConversationEventPayloadProcessor {
 
     private let removeLocalConversation: RemoveLocalConversationUseCaseProtocol
 
-    init(removeLocalConversation: RemoveLocalConversationUseCaseProtocol? = nil) {
-        self.removeLocalConversation = removeLocalConversation ?? RemoveLocalConversationUseCase()
+    init(removeLocalConversation: RemoveLocalConversationUseCaseProtocol) {
+        self.removeLocalConversation = removeLocalConversation
     }
 
     // MARK: - Conversation creation

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -27,7 +28,7 @@ protocol MLSEventProcessing {
 
 }
 
-final class MLSEventProcessor: MLSEventProcessing {
+struct MLSEventProcessor: MLSEventProcessing {
 
     private(set) static var shared: MLSEventProcessing = MLSEventProcessor()
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2021 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -39,6 +40,13 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
     let decoder: JSONDecoder = .defaultDecoder
 
     private let eventProcessor: ConversationEventProcessorProtocol
+
+    convenience override init(context: NSManagedObjectContext) {
+        self.init(
+            context: context,
+            eventProcessor: ConversationEventProcessor(context: context)
+        )
+    }
 
     init(
         context: NSManagedObjectContext,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandler.swift
@@ -1,6 +1,6 @@
-////
+//
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -83,15 +83,16 @@ public final class CreateGroupConversationAction: EntityAction {
 
 final class CreateGroupConversationActionHandler: ActionHandler<CreateGroupConversationAction> {
 
-    private let processor = ConversationEventPayloadProcessor()
+    private let processor: ConversationEventPayloadProcessor
     private let mlsService: MLSServiceInterface
 
     required init(
         context: NSManagedObjectContext,
-        mlsService: MLSServiceInterface
+        mlsService: MLSServiceInterface,
+        removeLocalConversationUseCase: RemoveLocalConversationUseCaseProtocol
     ) {
         self.mlsService = mlsService
-
+        processor = .init(removeLocalConversation: removeLocalConversationUseCase)
         super.init(context: context)
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/CreateGroupConversationActionHandlerTests.swift
@@ -1,6 +1,6 @@
-////
+//
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -42,7 +42,11 @@ final class CreateGroupConversationActionHandlerTests: ActionHandlerTestBase<Cre
     override func setUp() {
         super.setUp()
         mlsService = MockMLSServiceInterface()
-        sut = CreateGroupConversationActionHandler(context: syncMOC, mlsService: mlsService)
+        sut = CreateGroupConversationActionHandler(
+            context: syncMOC,
+            mlsService: mlsService,
+            removeLocalConversationUseCase: RemoveLocalConversationUseCase()
+        )
         conversationID = .randomID()
         mlsGroupID = MLSGroupID([1, 2, 3])
         teamID = .create()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandlerTests.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2021 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,7 +21,7 @@ import WireDataModel
 
 final class SyncConversationActionHandler: ActionHandler<SyncConversationAction> {
 
-    private let processor = ConversationEventPayloadProcessor()
+    private let processor = ConversationEventPayloadProcessor(removeLocalConversation: RemoveLocalConversationUseCase())
 
     // MARK: - Request generation
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationByQualifiedIDListTranscoderTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationByQualifiedIDListTranscoderTests.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2021 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,7 +26,10 @@ class ConversationByQualifiedIDListTranscoderTests: MessagingTestBase {
 
     func testRequestGeneration_V1() throws {
         // Given
-        let sut = ConversationByQualifiedIDListTranscoder(context: uiMOC)
+        let sut = ConversationByQualifiedIDListTranscoder(
+            context: uiMOC,
+            removeLocalConversationUseCase: RemoveLocalConversationUseCase()
+        )
         let ids: [QualifiedID] = [QualifiedID(uuid: .create(), domain: "example.com")]
 
         // When
@@ -43,7 +47,10 @@ class ConversationByQualifiedIDListTranscoderTests: MessagingTestBase {
 
     func testRequestGeneration_V2() throws {
         // Given
-        let sut = ConversationByQualifiedIDListTranscoder(context: uiMOC)
+        let sut = ConversationByQualifiedIDListTranscoder(
+            context: uiMOC,
+            removeLocalConversationUseCase: RemoveLocalConversationUseCase()
+        )
         let ids: [QualifiedID] = [QualifiedID(uuid: .create(), domain: "example.com")]
 
         // When

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -135,7 +135,9 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
             from: event.payload
         ) else { return }
 
-        await processor.processPayload(payload, originalEvent: event, in: context)
+        await context.perform {
+            self.processor.processPayload(payload, originalEvent: event, in: self.context)
+        }
     }
 
     private func processConversationMemberJoin(_ event: ZMUpdateEvent) async {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -24,7 +25,9 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
 
     let context: NSManagedObjectContext
     let conversationService: ConversationServiceInterface
-    private let processor = ConversationEventPayloadProcessor()
+    private let processor = ConversationEventPayloadProcessor(
+        removeLocalConversation: RemoveLocalConversationUseCase()
+    )
     private let eventPayloadDecoder = EventPayloadDecoder()
 
     // MARK: - Life cycle
@@ -132,9 +135,7 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
             from: event.payload
         ) else { return }
 
-        await context.perform {
-            self.processor.processPayload(payload, originalEvent: event, in: self.context)
-        }
+        await processor.processPayload(payload, originalEvent: event, in: context)
     }
 
     private func processConversationMemberJoin(_ event: ZMUpdateEvent) async {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationService.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationService.swift
@@ -1,5 +1,6 @@
+//
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/xcshareddata/xcschemes/WireRequestStrategy.xcscheme
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/xcshareddata/xcschemes/WireRequestStrategy.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableUBSanitizer = "YES"
       codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -38,16 +39,6 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "PrefersMallocStackLoggingLite"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
          <AdditionalOption
             key = "MallocScribble"
             value = ""

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringAction.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+struct RecurringAction {
+
+    let id: String
+    let interval: TimeInterval
+    let perform: () -> Void
+
+    func callAsFunction() {
+        perform()
+    }
+}

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionService.swift
@@ -18,24 +18,6 @@
 
 import Foundation
 import WireSystem
-import WireUtilities
-
-struct RecurringAction {
-
-    let id: String
-    let interval: TimeInterval
-    let perform: () -> Void
-
-    func callAsFunction() {
-        perform()
-    }
-}
-
-// sourcery: AutoMockable
-protocol RecurringActionServiceInterface {
-    func performActionsIfNeeded()
-    func registerAction(_ action: RecurringAction)
-}
 
 final class RecurringActionService: RecurringActionServiceInterface {
 

--- a/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionServiceInterface.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/RecurringActionService/RecurringActionServiceInterface.swift
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+// sourcery: AutoMockable
+protocol RecurringActionServiceInterface {
+    func performActionsIfNeeded()
+    func registerAction(_ action: RecurringAction)
+}

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -222,7 +222,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,
                 syncProgress: applicationStatusDirectory.syncStatus,
-                mlsService: mlsService),
+mlsService: mlsService,
+                removeLocalConversation: RemoveLocalConversationUseCase()),
             UserProfileRequestStrategy(
                 managedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchDirectory.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchDirectory.swift
@@ -25,24 +25,36 @@ import Foundation
     let transportSession: TransportSessionType
     var isTornDown = false
 
-    private var refetchIncompleteUserMetadata: RecurringAction?
-    private var refetchIncompleteConversationMetadata: RecurringAction?
+    private let refreshUsersMissingMetadataAction: RecurringAction
+    private let refreshConversationsMissingMetadataAction: RecurringAction
 
     deinit {
         assert(isTornDown, "`tearDown` must be called before SearchDirectory is deinitialized")
     }
 
     public convenience init(userSession: ZMUserSession) {
-        self.init(searchContext: userSession.searchManagedObjectContext, contextProvider: userSession, transportSession: userSession.transportSession)
-
-        self.refetchIncompleteUserMetadata = userSession.refreshUsersMissingMetadata()
-        self.refetchIncompleteConversationMetadata = userSession.refreshConversationsMissingMetadata()
+        self.init(
+            searchContext: userSession.searchManagedObjectContext,
+            contextProvider: userSession,
+            transportSession: userSession.transportSession,
+            refreshUsersMissingMetadataAction: userSession.refreshUsersMissingMetadataAction,
+            refreshConversationsMissingMetadataAction: userSession.refreshConversationsMissingMetadataAction
+        )
     }
 
-    init(searchContext: NSManagedObjectContext, contextProvider: ContextProvider, transportSession: TransportSessionType) {
+    init(
+        searchContext: NSManagedObjectContext,
+        contextProvider: ContextProvider,
+        transportSession: TransportSessionType,
+        refreshUsersMissingMetadataAction: RecurringAction,
+        refreshConversationsMissingMetadataAction: RecurringAction
+    ) {
         self.searchContext = searchContext
         self.contextProvider = contextProvider
         self.transportSession = transportSession
+
+        self.refreshUsersMissingMetadataAction = refreshUsersMissingMetadataAction
+        self.refreshConversationsMissingMetadataAction = refreshConversationsMissingMetadataAction
     }
 
     /// Perform a search request.
@@ -51,7 +63,7 @@ import Foundation
     public func perform(_ request: SearchRequest) -> SearchTask {
         let task = SearchTask(task: .search(searchRequest: request), searchContext: searchContext, contextProvider: contextProvider, transportSession: transportSession)
 
-        task.onResult { [weak self] (result, _) in
+        task.addResultHandler { [weak self] result, _ in
             self?.observeSearchUsers(result)
         }
 
@@ -65,7 +77,7 @@ import Foundation
     public func lookup(userId: UUID) -> SearchTask {
         let task = SearchTask(task: .lookup(userId: userId), searchContext: searchContext, contextProvider: contextProvider, transportSession: transportSession)
 
-        task.onResult { [weak self] (result, _) in
+        task.addResultHandler { [weak self] (result, _) in
             self?.observeSearchUsers(result)
         }
 
@@ -79,10 +91,9 @@ import Foundation
     }
 
     public func updateIncompleteMetadataIfNeeded() {
-        refetchIncompleteUserMetadata?.perform()
-        refetchIncompleteConversationMetadata?.perform()
+        refreshUsersMissingMetadataAction()
+        refreshConversationsMissingMetadataAction()
     }
-
 }
 
 extension SearchDirectory: TearDownCapable {

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchResult.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchResult.swift
@@ -19,11 +19,17 @@
 import Foundation
 
 public struct SearchResult {
+    /// Users already connected to.
     public var contacts: [ZMSearchUser]
+    /// Users from the team.
     public var teamMembers: [ZMSearchUser]
+    /// Legacy, not used anymore.
     public var addressBook: [ZMSearchUser]
+    /// Non-connected users.
     public var directory: [ZMSearchUser]
+    /// Group conversations.
     public var conversations: [ZMConversation]
+    /// Bots.
     public var services: [ServiceUser]
 }
 

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -241,7 +241,7 @@ extension SearchTask {
 
     func conversations(matchingQuery query: SearchRequest.Query, selfUser: ZMUser) -> [ZMConversation] {
         /// TODO: use the interface with tean param?
-        let fetchRequest = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: query.string, selfUser: ZMUser.selfUser(in: searchContext)))
+        let fetchRequest = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: query.string, selfUser: selfUser))
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: ZMNormalizedUserDefinedNameKey, ascending: true)]
 
         var conversations = searchContext.fetchOrAssert(request: fetchRequest) as? [ZMConversation] ?? []

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
@@ -17,11 +17,12 @@
 //
 
 import Foundation
+import WireDataModel
 
 extension ZMUserSession {
 
-    func updateProteusToMLSMigrationStatus(interval: TimeInterval = .oneDay) -> RecurringAction {
-        return RecurringAction(id: "updateProteusToMLSMigrationStatus", interval: interval) { [weak self] in
+    var updateProteusToMLSMigrationStatusAction: RecurringAction {
+        .init(id: #function, interval: .oneDay) { [weak self] in
             Task { [weak self] in
                 do {
                     try await self?.proteusToMLSMigrationCoordinator.updateMigrationStatus()
@@ -32,35 +33,40 @@ extension ZMUserSession {
         }
     }
 
-    func refreshUsersMissingMetadata(interval: TimeInterval = 3 * .oneHour) -> RecurringAction {
+    var refreshUsersMissingMetadataAction: RecurringAction {
+        .init(id: #function, interval: 3 * .oneHour) { [weak self] in
 
-        .init(id: "refreshUserMetadata", interval: interval) { [weak self] in
-            self?.perform {
+            guard let context = self?.managedObjectContext else { return }
+            context.performGroupedAndWait { context in
+
                 let fetchRequest = ZMUser.sortedFetchRequest(with: ZMUser.predicateForUsersArePendingToRefreshMetadata())
-                guard let users = self?.managedObjectContext.fetchOrAssert(request: fetchRequest) as? [ZMUser] else {
+                guard let users = context.fetchOrAssert(request: fetchRequest) as? [ZMUser] else {
                     return
                 }
+
                 users.forEach { $0.refreshData() }
+                context.saveOrRollback()
             }
         }
-
     }
 
-    func refreshConversationsMissingMetadata(interval: TimeInterval = 3 * .oneHour) -> RecurringAction {
+    var refreshConversationsMissingMetadataAction: RecurringAction {
+        .init(id: #function, interval: 3 * .oneHour) { [weak self] in
 
-        .init(id: "refreshConversationMetadata", interval: interval) { [weak self] in
-            self?.perform {
+            guard let context = self?.managedObjectContext else { return }
+            context.performGroupedAndWait { context in
+
                 let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ZMConversation.entityName())
                 fetchRequest.predicate = ZMConversation.predicateForConversationsArePendingToRefreshMetadata()
 
-                guard let conversations = self?.managedObjectContext.executeFetchRequestOrAssert(fetchRequest) as? [ZMConversation] else {
+                guard let conversations = context.executeFetchRequestOrAssert(fetchRequest) as? [ZMConversation] else {
                     return
                 }
+
                 conversations.forEach { $0.needsToBeUpdatedFromBackend = true }
+                context.saveOrRollback()
             }
-
         }
-
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -491,7 +491,6 @@ public class ZMUserSession: NSObject {
         recurringActionService.registerAction(refreshUsersMissingMetadataAction)
         recurringActionService.registerAction(refreshConversationsMissingMetadataAction)
         recurringActionService.registerAction(updateProteusToMLSMigrationStatusAction)
-        recurringActionService.registerAction(refreshTeamMetadataAction)
     }
 
     func startRequestLoopTracker() {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireDataModel
+import WireSystem
 
 @objc(ZMThirdPartyServicesDelegate)
 public protocol ThirdPartyServicesDelegate: NSObjectProtocol {
@@ -487,9 +488,10 @@ public class ZMUserSession: NSObject {
     }
 
     private func configureRecurringActions() {
-        recurringActionService.registerAction(refreshUsersMissingMetadata())
-        recurringActionService.registerAction(refreshConversationsMissingMetadata())
-        recurringActionService.registerAction(updateProteusToMLSMigrationStatus())
+        recurringActionService.registerAction(refreshUsersMissingMetadataAction)
+        recurringActionService.registerAction(refreshConversationsMissingMetadataAction)
+        recurringActionService.registerAction(updateProteusToMLSMigrationStatusAction)
+        recurringActionService.registerAction(refreshTeamMetadataAction)
     }
 
     func startRequestLoopTracker() {

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
@@ -33,7 +33,7 @@ extension IntegrationTest {
         let task = sharedSearchDirectory?.perform(request)
         var searchResult: SearchResult?
 
-        task?.onResult { (result, completed) in
+        task?.addResultHandler { (result, completed) in
             if completed {
                 searchResult = result
                 searchCompleted.fulfill()
@@ -68,7 +68,7 @@ extension IntegrationTest {
         let task = sharedSearchDirectory?.perform(request)
         var searchResult: SearchResult?
 
-        task?.onResult { (result, completed) in
+        task?.addResultHandler { (result, completed) in
             if completed {
                 searchResult = result
                 searchCompleted.fulfill()
@@ -92,7 +92,7 @@ extension IntegrationTest {
         let task = sharedSearchDirectory?.perform(request)
         var searchResult: SearchResult?
 
-        task?.onResult { (result, completed) in
+        task?.addResultHandler { (result, completed) in
             if completed {
                 searchResult = result
                 searchCompleted.fulfill()

--- a/wire-ios-sync-engine/Tests/Source/Integration/TeamTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/TeamTests.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireDataModel
 @testable import WireSyncEngine
 
-class TestTeamObserver: NSObject, TeamObserver {
+final class TestTeamObserver: NSObject, TeamObserver {
 
     var token: NSObjectProtocol!
     var observedTeam: Team?
@@ -152,5 +152,4 @@ extension TeamTests {
         }
         XCTAssertTrue(change.membersChanged)
     }
-
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
 import WireTesting
 @testable import WireSyncEngine
 
-class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
+final class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
 
     var sut: TeamDownloadRequestStrategy!
     var mockApplicationStatus: MockApplicationStatus!
@@ -522,7 +522,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
         }
 
         // when
-        await self.sut.processEvents([event], liveEvents: false, prefetchResult: nil)
+        self.sut.processEvents([event], liveEvents: false, prefetchResult: nil)
         syncMOC.performGroupedBlock {
             XCTAssert(self.syncMOC.saveOrRollback(), file: file, line: line)
         }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -17,9 +17,13 @@
 //
 
 import Foundation
+import WireDataModel
+import WireTesting
 import XCTest
 
-class ZMHotFixTests_Integration: MessagingTest {
+@testable import WireSyncEngine
+
+final class ZMHotFixTests_Integration: MessagingTest {
 
     func testThatAllConversationsAreUpdated_198_0_0() {
         var g1: ZMConversation!
@@ -242,13 +246,12 @@ class ZMHotFixTests_Integration: MessagingTest {
     }
 
     func testThatItUpdatesAccessRolesForConversations_432_1_0() {
-        var g1: ZMConversation!
-        syncMOC.performAndWait {
+        let g1 = syncMOC.performAndWait {
             // GIVEN
             self.syncMOC.setPersistentStoreMetadata("432.0.1", key: "lastSavedVersion")
             self.syncMOC.setPersistentStoreMetadata(NSNumber(value: true), key: "HasHistory")
 
-            g1 = ZMConversation.insertNewObject(in: self.syncMOC)
+            let g1 = ZMConversation.insertNewObject(in: self.syncMOC)
             g1.conversationType = .group
             g1.team = nil
             g1.updateAccessStatus(accessModes: ConversationAccessMode.teamOnly.stringValue,
@@ -258,6 +261,8 @@ class ZMHotFixTests_Integration: MessagingTest {
             XCTAssertEqual(g1.accessRoles, [ConversationAccessRoleV2.teamMember])
             XCTAssertEqual(g1.accessMode, ConversationAccessMode.teamOnly)
             XCTAssertNil(g1.team)
+
+            return g1
         }
 
         // WHEN

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchDirectoryTests.swift
@@ -19,15 +19,22 @@
 import Foundation
 
 @testable import WireSyncEngine
+@testable import WireSyncEngineSupport
 
-class SearchDirectoryTests: DatabaseTest {
+final class SearchDirectoryTests: DatabaseTest {
 
     func testThatItEmptiesTheSearchUserCacheOnTeardown() {
         // given
         uiMOC.zm_searchUserCache = NSCache()
         let mockTransport = MockTransportSession(dispatchGroup: dispatchGroup)
         let uuid = UUID.create()
-        let sut = SearchDirectory(searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransport)
+        let sut = SearchDirectory(
+            searchContext: searchMOC,
+            contextProvider: coreDataStack!,
+            transportSession: mockTransport,
+            refreshUsersMissingMetadataAction: .dummy,
+            refreshConversationsMissingMetadataAction: .dummy
+        )
         _ = ZMSearchUser(contextProvider: coreDataStack!, name: "John Doe", handle: "john", accentColor: .brightOrange, remoteIdentifier: uuid)
         XCTAssertNotNil(uiMOC.zm_searchUserCache?.object(forKey: uuid as NSUUID))
 
@@ -38,5 +45,4 @@ class SearchDirectoryTests: DatabaseTest {
         // then
         XCTAssertNil(uiMOC.zm_searchUserCache?.object(forKey: uuid as NSUUID))
     }
-
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -91,7 +91,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             remoteResultArrived.fulfill()
             XCTAssertEqual(result.directory.count, 1)
             let user = result.directory.first
@@ -128,7 +128,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             remoteResultArrived.fulfill()
             XCTAssertEqual(result.directory.count, 0)
         }
@@ -150,7 +150,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertTrue(result.contacts.compactMap(\.user).contains(user))
         }
@@ -170,7 +170,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.count, 1)
         }
@@ -189,7 +189,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertTrue(result.contacts.compactMap(\.user).contains(user))
         }
@@ -210,7 +210,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.compactMap(\.user), [user1])
         }
@@ -231,7 +231,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.compactMap(\.user), [user1, user2])
         }
@@ -250,7 +250,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.compactMap(\.user), [user1])
         }
@@ -269,7 +269,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.compactMap(\.user), [user1])
         }
@@ -292,7 +292,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.compactMap(\.user), [user3])
         }
@@ -313,7 +313,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.contacts.compactMap(\.user), [user])
         }
@@ -343,7 +343,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.compactMap(\.user), [user])
         }
@@ -382,7 +382,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.compactMap(\.user), [userA])
         }
@@ -416,7 +416,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.compactMap(\.user), [userA])
         }
@@ -464,7 +464,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.compactMap(\.user), [userA, userB])
         }
@@ -494,7 +494,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.compactMap(\.user), [userA])
         }
@@ -525,7 +525,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.compactMap(\.user), [userA])
         }
@@ -546,7 +546,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation])
         }
@@ -565,7 +565,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation])
         }
@@ -586,7 +586,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation1, conversation2])
         }
@@ -605,7 +605,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation])
         }
@@ -624,7 +624,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation])
         }
@@ -649,7 +649,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [groupConversation])
         }
@@ -677,7 +677,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation])
             XCTAssertEqual(result.contacts.compactMap(\.user), [user3])
@@ -701,7 +701,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation])
         }
@@ -722,7 +722,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation1, conversation3, conversation2])
         }
@@ -752,7 +752,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [conversation1, conversation3, conversation4])
         }
@@ -772,7 +772,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.conversations, [])
         }
@@ -797,7 +797,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(Set(result.conversations), Set([conversationInTeam, conversationNotInTeam]))
         }
@@ -894,7 +894,7 @@ class SearchTaskTests: DatabaseTest {
         }
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.directory.first?.name, "User A")
         }
@@ -971,7 +971,7 @@ class SearchTaskTests: DatabaseTest {
         }
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.teamMembers.first?.name, "User A")
             XCTAssertEqual(result.teamMembers.first?.teamRole, .admin)
@@ -1023,7 +1023,7 @@ class SearchTaskTests: DatabaseTest {
         }
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.services.first?.name, "Service A")
         }
@@ -1081,7 +1081,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(lookupUserId: userId, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.directory.first?.name, "User A")
         }
@@ -1143,7 +1143,7 @@ class SearchTaskTests: DatabaseTest {
                               transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertEqual(result.directory.first?.name, "John Doe")
         }
@@ -1166,7 +1166,7 @@ class SearchTaskTests: DatabaseTest {
                               transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             resultArrived.fulfill()
             XCTAssertTrue(result.directory.isEmpty)
         }
@@ -1192,7 +1192,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             localResultArrived.fulfill()
             XCTAssertTrue(result.contacts.compactMap(\.user).contains(user))
         }
@@ -1205,7 +1205,7 @@ class SearchTaskTests: DatabaseTest {
         let remoteResultArrived = customExpectation(description: "received remote result")
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             remoteResultArrived.fulfill()
             XCTAssertTrue(result.contacts.compactMap(\.user).contains(user))
         }
@@ -1229,7 +1229,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             remoteResultArrived.fulfill()
             XCTAssertEqual(result.directory.count, 1)
         }
@@ -1242,7 +1242,7 @@ class SearchTaskTests: DatabaseTest {
         let localResultArrived = customExpectation(description: "received local result")
 
         // expect
-        task.onResult { (result, _) in
+        task.addResultHandler { (result, _) in
             localResultArrived.fulfill()
             XCTAssertEqual(result.directory.count, 1)
         }
@@ -1260,7 +1260,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, completed) in
+        task.addResultHandler { (result, completed) in
             localResultArrived.fulfill()
             XCTAssertTrue(result.contacts.compactMap(\.user).contains(user))
             XCTAssertTrue(completed)
@@ -1283,7 +1283,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (result, completed) in
+        task.addResultHandler { (result, completed) in
             remoteResultArrived.fulfill()
             XCTAssertEqual(result.directory.count, 1)
             XCTAssertTrue(completed)
@@ -1308,7 +1308,7 @@ class SearchTaskTests: DatabaseTest {
         let task = SearchTask(request: request, searchContext: searchMOC, contextProvider: coreDataStack!, transportSession: mockTransportSession)
 
         // expect
-        task.onResult { (_, completed) in
+        task.addResultHandler { (_, completed) in
             if completed {
                 finalResultsArrived.fulfill()
             } else {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
@@ -53,16 +53,17 @@ final class ZMUserSessionTests_RecurringActions: ZMUserSessionTestsBase {
         XCTAssertFalse(mockRecurringActionService.performActionsIfNeeded_Invocations.isEmpty)
     }
 
-    func testThatItUpdatesUsersMissingMetadata() {
+    func testUpdatesUsersMissingMetadataAction() {
         // Given
         let otherUser = createUserIsPendingMetadataRefresh(moc: syncMOC, domain: UUID().uuidString)
         syncMOC.saveOrRollback()
-        let recurringAction = sut.refreshUsersMissingMetadata(interval: 1)
+        let action = sut.refreshUsersMissingMetadataAction
 
         // When
-        recurringAction()
+        action()
 
         // Then
+        XCTAssertEqual(action.interval, 3 * .oneHour)
         XCTAssertTrue(otherUser.needsToBeUpdatedFromBackend)
     }
 
@@ -70,14 +71,17 @@ final class ZMUserSessionTests_RecurringActions: ZMUserSessionTestsBase {
         // Given
         let conversation = createConversationIsPendingMetadataRefresh(moc: syncMOC, domain: UUID().uuidString)
         syncMOC.saveOrRollback()
-        let recurringAction = sut.refreshConversationsMissingMetadata(interval: 1)
+        let action = sut.refreshConversationsMissingMetadataAction
 
         // When
-        recurringAction()
+        action()
 
         // Then
+        XCTAssertEqual(action.interval, 3 * .oneHour)
         XCTAssertTrue(conversation.needsToBeUpdatedFromBackend)
     }
+
+    // MARK: - Helpers
 
     private func createUserIsPendingMetadataRefresh(moc: NSManagedObjectContext, domain: String?) -> ZMUser {
         let user = ZMUser(context: moc)

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -371,6 +371,9 @@
 		554FEE2122AFF20600B1A8A1 /* ZMUserSession+LegalHold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554FEE2022AFF20600B1A8A1 /* ZMUserSession+LegalHold.swift */; };
 		597B70C32B03984C006C2121 /* ZMUserSession+DeveloperMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597B70C22B03984C006C2121 /* ZMUserSession+DeveloperMenu.swift */; };
 		59D1C3102B1DEE6E0016F6B2 /* WireDataModelSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59D1C30F2B1DEE6E0016F6B2 /* WireDataModelSupport.framework */; };
+		59E6A9142B4EE5CF00DBCC6B /* RecurringAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E6A9132B4EE5CF00DBCC6B /* RecurringAction.swift */; };
+		59E6A9162B4EE5D500DBCC6B /* RecurringActionServiceInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E6A9152B4EE5D500DBCC6B /* RecurringActionServiceInterface.swift */; };
+		59E6A91A2B4EE62100DBCC6B /* RecurringAction+dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E6A9192B4EE62100DBCC6B /* RecurringAction+dummy.swift */; };
 		5E0EB1F421008C1900B5DC2B /* CompanyLoginRequester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1F321008C1900B5DC2B /* CompanyLoginRequester.swift */; };
 		5E0EB1F72100A14A00B5DC2B /* CompanyLoginRequesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1F52100A13200B5DC2B /* CompanyLoginRequesterTests.swift */; };
 		5E0EB1F92100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0EB1F82100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift */; };
@@ -1039,6 +1042,9 @@
 		554FEE2022AFF20600B1A8A1 /* ZMUserSession+LegalHold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+LegalHold.swift"; sourceTree = "<group>"; };
 		597B70C22B03984C006C2121 /* ZMUserSession+DeveloperMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+DeveloperMenu.swift"; sourceTree = "<group>"; };
 		59D1C30F2B1DEE6E0016F6B2 /* WireDataModelSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDataModelSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		59E6A9132B4EE5CF00DBCC6B /* RecurringAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecurringAction.swift; sourceTree = "<group>"; };
+		59E6A9152B4EE5D500DBCC6B /* RecurringActionServiceInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecurringActionServiceInterface.swift; sourceTree = "<group>"; };
+		59E6A9192B4EE62100DBCC6B /* RecurringAction+dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RecurringAction+dummy.swift"; sourceTree = "<group>"; };
 		5E0EB1F321008C1900B5DC2B /* CompanyLoginRequester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyLoginRequester.swift; sourceTree = "<group>"; };
 		5E0EB1F52100A13200B5DC2B /* CompanyLoginRequesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyLoginRequesterTests.swift; sourceTree = "<group>"; };
 		5E0EB1F82100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCompanyLoginRequesterDelegate.swift; sourceTree = "<group>"; };
@@ -1478,6 +1484,7 @@
 			isa = PBXGroup;
 			children = (
 				0145AE832B1154010097E3B8 /* WireSyncEngineSupport.h */,
+				59E6A9112B4EE57000DBCC6B /* Synchronization */,
 			);
 			path = WireSyncEngineSupport;
 			sourceTree = "<group>";
@@ -2288,6 +2295,32 @@
 			path = Integration;
 			sourceTree = "<group>";
 		};
+		59E6A9112B4EE57000DBCC6B /* Synchronization */ = {
+			isa = PBXGroup;
+			children = (
+				59E6A9182B4EE61000DBCC6B /* RecurringActionService */,
+			);
+			path = Synchronization;
+			sourceTree = "<group>";
+		};
+		59E6A9122B4EE58600DBCC6B /* RecurringActionService */ = {
+			isa = PBXGroup;
+			children = (
+				59E6A9132B4EE5CF00DBCC6B /* RecurringAction.swift */,
+				0664F2E52A0E25C200E5C34E /* RecurringActionService.swift */,
+				59E6A9152B4EE5D500DBCC6B /* RecurringActionServiceInterface.swift */,
+			);
+			path = RecurringActionService;
+			sourceTree = "<group>";
+		};
+		59E6A9182B4EE61000DBCC6B /* RecurringActionService */ = {
+			isa = PBXGroup;
+			children = (
+				59E6A9192B4EE62100DBCC6B /* RecurringAction+dummy.swift */,
+			);
+			path = RecurringActionService;
+			sourceTree = "<group>";
+		};
 		5E8EE1F820FDC7C900DB1F9B /* Company */ = {
 			isa = PBXGroup;
 			children = (
@@ -2385,9 +2418,9 @@
 		85D85DBFC1F3A95767DEEA45 /* Synchronization */ = {
 			isa = PBXGroup;
 			children = (
+				59E6A9122B4EE58600DBCC6B /* RecurringActionService */,
 				54F8D6D619AB525400146664 /* Transcoders */,
 				54A170621B30068B001B41A5 /* Strategies */,
-				BF2A9D591D6B639C00FA7DBC /* Decoding */,
 				85D85F3EC8565FD102AC0E5B /* ZMOperationLoop.h */,
 				F962A8EF19FFD4DC00FD0F80 /* ZMOperationLoop+Private.h */,
 				85D8502FFC4412F91D0CC1A4 /* ZMOperationLoop.m */,
@@ -2416,7 +2449,6 @@
 				5EDF03EB2245563C00C04007 /* LinkPreviewAssetUploadRequestStrategy+Helper.swift */,
 				06DE14CE24B85BD0006CB6B3 /* ZMSyncStateDelegate.h */,
 				2B155969295093360069AE34 /* HotfixPatch.swift */,
-				0664F2E52A0E25C200E5C34E /* RecurringActionService.swift */,
 			);
 			path = Synchronization;
 			sourceTree = "<group>";
@@ -2510,13 +2542,6 @@
 				EE2DF7592875DB1C0028ECA2 /* XCTestCase+APIVersion.swift */,
 			);
 			path = Utility;
-			sourceTree = "<group>";
-		};
-		BF2A9D591D6B639C00FA7DBC /* Decoding */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Decoding;
 			sourceTree = "<group>";
 		};
 		BF44A3521C71D60100C6928E /* DB Fixture 1.27 */ = {
@@ -3059,6 +3084,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59E6A91A2B4EE62100DBCC6B /* RecurringAction+dummy.swift in Sources */,
 				0145AE882B11551C0097E3B8 /* AutoMockable.generated.swift in Sources */,
 				0145AE892B11551C0097E3B8 /* AutoMockable.manual.swift in Sources */,
 			);
@@ -3389,6 +3415,7 @@
 				166507812459D7CA005300C1 /* UserClientEventConsumer.swift in Sources */,
 				F9E577211E77EC6D0065EFE4 /* WireCallCenterV3+Notifications.swift in Sources */,
 				092083401BA95EE100F82B29 /* UserClientRequestFactory.swift in Sources */,
+				59E6A9142B4EE5CF00DBCC6B /* RecurringAction.swift in Sources */,
 				F9FD167C1BDFCDAD00725F5C /* ZMClientRegistrationStatus.m in Sources */,
 				06025664248E5BC700E060E1 /* (null) in Sources */,
 				EE5FEF0521E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift in Sources */,
@@ -3404,6 +3431,7 @@
 				16ED865D23E30F7E00CB1766 /* ZMUserSesson+Proxy.swift in Sources */,
 				A938BDC823A7964200D4C208 /* ConversationRoleDownstreamRequestStrategy.swift in Sources */,
 				F19E55A622B3AAA8005C792D /* PKPushCredentials+SafeLogging.swift in Sources */,
+				59E6A9162B4EE5D500DBCC6B /* RecurringActionServiceInterface.swift in Sources */,
 				09C77C531BA6C77000E2163F /* UserClientRequestStrategy.swift in Sources */,
 				F1B5D53D2181FDA300986911 /* NetworkQuality.swift in Sources */,
 				634976E9268A185A00824A05 /* AVSVideoStreams.swift in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngineSupport/Synchronization/RecurringActionService/RecurringAction+dummy.swift
+++ b/wire-ios-sync-engine/WireSyncEngineSupport/Synchronization/RecurringActionService/RecurringAction+dummy.swift
@@ -1,0 +1,26 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@testable import WireSyncEngine
+
+extension RecurringAction {
+
+    static var dummy: Self {
+        .init(id: .random(length: 16), interval: .infinity) {}
+    }
+}

--- a/wire-ios-transport/Source/Public/ZMUpdateEvent.swift
+++ b/wire-ios-transport/Source/Public/ZMUpdateEvent.swift
@@ -1,6 +1,6 @@
-//
+////
 // Wire
-// Copyright (C) 2024 Wire Swiss GmbH
+// Copyright (C) 2018 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-transport/Source/Public/ZMUpdateEvent.swift
+++ b/wire-ios-transport/Source/Public/ZMUpdateEvent.swift
@@ -1,6 +1,6 @@
-////
+//
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios/Wire-iOS/Sources/Components/TokenField/TokenField.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/TokenField/TokenField.swift
@@ -763,7 +763,7 @@ extension TokenField: UITextViewDelegate {
         // so don’t do any magic in that case
 
         if !text.isEmpty,
-           let attachmentCharacter = UnicodeScalar.textAttachmentCharacter,
+           let attachmentCharacter = Unicode.Scalar.textAttachmentCharacter,
            let textRange = Range(range, in: textView.text),
            textView.text.suffix(from: textRange.upperBound).unicodeScalars.contains(attachmentCharacter) {
             textView.selectedRange = NSRange(location: textView.text.utf16.count, length: 0)
@@ -774,8 +774,8 @@ extension TokenField: UITextViewDelegate {
     }
 }
 
-extension UnicodeScalar {
-    fileprivate static var textAttachmentCharacter: UnicodeScalar? {
-        return UnicodeScalar(NSTextAttachment.character)
+extension Unicode.Scalar {
+    fileprivate static var textAttachmentCharacter: Self? {
+        .init(NSTextAttachment.character)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ContactsUI/ContactsDataSource.swift
@@ -75,7 +75,7 @@ class ContactsDataSource: NSObject {
         let request = SearchRequest(query: searchQuery, searchOptions: [.contacts, .addressBook])
         let task = searchDirectory.perform(request)
 
-        task.onResult { [weak self] (searchResult, _) in
+        task.addResultHandler { [weak self] (searchResult, _) in
             guard let `self` = self else { return }
             self.ungroupedSearchResults = searchResult.addressBook
             self.delegate?.dataSource(self, didReceiveSearchResult: searchResult.addressBook)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -302,7 +302,7 @@ final class SearchResultsViewController: UIViewController {
     }
 
     func searchForLocalUsers(withQuery query: String) {
-        performSearch(query: query, options: [.contacts, .teamMembers])
+        performSearch(query: query, options: [.contacts, .teamMembers, .localResultsOnly])
     }
 
     func searchForServices(withQuery query: String) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/SearchResultsViewController.swift
@@ -279,7 +279,9 @@ final class SearchResultsViewController: UIViewController {
         )
 
         if let task = searchDirectory?.perform(request) {
-            task.onResult({ [weak self] in self?.handleSearchResult(result: $0, isCompleted: $1)})
+            task.addResultHandler { [weak self] result, isCompleted in
+                self?.handleSearchResult(result: result, isCompleted: isCompleted)
+            }
             task.start()
 
             pendingSearchTask = task
@@ -296,15 +298,15 @@ final class SearchResultsViewController: UIViewController {
             options.formUnion(.federated)
         }
 
-        self.performSearch(query: query, options: options)
+        performSearch(query: query, options: options)
     }
 
     func searchForLocalUsers(withQuery query: String) {
-        self.performSearch(query: query, options: [.contacts, .teamMembers, .localResultsOnly])
+        performSearch(query: query, options: [.contacts, .teamMembers])
     }
 
     func searchForServices(withQuery query: String) {
-        self.performSearch(query: query, options: [.services])
+        performSearch(query: query, options: [.services])
     }
 
     func searchContactList() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/SearchUserViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/SearchUserViewController.swift
@@ -74,7 +74,7 @@ final class SearchUserViewController: UIViewController, SpinnerCapable {
         isLoadingViewVisible = true
 
         if let task = searchDirectory?.lookup(userId: userId) {
-            task.onResult({ [weak self] in
+            task.addResultHandler({ [weak self] in
                 self?.handleSearchResult(searchResult: $0, isCompleted: $1)
             })
             task.start()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-4549" title="WPB-4549" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-4549</a>  [iOS] Rely on remote search when searching for users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

A few extracted and easy to review changes from PR https://github.com/wireapp/wire-ios/pull/870.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
