### PR TITLE
fix: crash fetching MLS config - WPB-6184

### DIFF
--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
@@ -154,22 +154,21 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
     // MARK: - Helpers (migration start)
 
     private func resolveMigrationStartStatus() async -> MigrationStartStatus {
-        let features = await fetchFeatures()
-
         if (BackendInfo.apiVersion ?? .v0) < .v5 {
             return .cannotStart(reason: .unsupportedAPIVersion)
         }
-
-        if !features.mls.config.supportedProtocols.contains(.mls) {
-            return .cannotStart(reason: .mlsProtocolIsNotSupported)
-        }
-
         if !DeveloperFlag.enableMLSSupport.isOn {
             return .cannotStart(reason: .clientDoesntSupportMLS)
         }
 
         if await !isMLSEnabledOnBackend() {
             return .cannotStart(reason: .backendDoesntSupportMLS)
+        }
+
+        let features = await fetchFeatures()
+
+        if !features.mls.config.supportedProtocols.contains(.mls) {
+            return .cannotStart(reason: .mlsProtocolIsNotSupported)
         }
 
         if features.mlsMigration.status == .disabled {

--- a/wire-ios-data-model/Source/Model/User/ZMUser.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.swift
@@ -133,6 +133,9 @@ extension ZMUser: UserType {
         else {
             return false
         }
+        guard (BackendInfo.apiVersion ?? .v0) >= .v5 && DeveloperFlag.enableMLSSupport.isOn  else {
+            return false
+        }
 
         let featureRepository = FeatureRepository(context: context)
         return featureRepository.fetchMLS().config.protocolToggleUsers.contains(id)

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -138,6 +138,69 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
         XCTAssertFalse(startedMigration)
     }
 
+    func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfAPIV5NotSupported() async throws {
+        // GIVEN
+        await createUserAndGroupConversation()
+
+        setMockValues(
+            isAPIV5Supported: false,
+            isClientSupportingMLS: true,
+            isBackendSupportingMLS: true,
+            isMLSProtocolSupported: true,
+            isMLSMigrationFeatureEnabled: true,
+            hasStartTimeBeenReached: true
+        )
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        // WHEN
+        try await sut.updateMigrationStatus()
+
+        // THEN
+        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0)
+    }
+
+    func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfClientNotSupportingMLS() async throws {
+        // GIVEN
+        await createUserAndGroupConversation()
+
+        setMockValues(
+            isAPIV5Supported: true,
+            isClientSupportingMLS: false,
+            isBackendSupportingMLS: true,
+            isMLSProtocolSupported: true,
+            isMLSMigrationFeatureEnabled: true,
+            hasStartTimeBeenReached: true
+        )
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        // WHEN
+        try await sut.updateMigrationStatus()
+
+        // THEN
+        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0)
+    }
+
+    func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfBackendNotSupportingMLS() async throws {
+        // GIVEN
+        await createUserAndGroupConversation()
+
+        setMockValues(
+            isAPIV5Supported: true,
+            isClientSupportingMLS: true,
+            isBackendSupportingMLS: false,
+            isMLSProtocolSupported: true,
+            isMLSMigrationFeatureEnabled: true,
+            hasStartTimeBeenReached: true
+        )
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        // WHEN
+        try await sut.updateMigrationStatus()
+
+        // THEN
+        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0)
+    }
+
     // MARK: - Migration finalisation
 
     func test_ItSyncsUsers_IfFinalisationTimeHasNotBeenReached() async throws {

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -139,55 +139,29 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
     }
 
     func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfAPIV5NotSupported() async throws {
-        // GIVEN
-        await createUserAndGroupConversation()
-
-        setMockValues(
-            isAPIV5Supported: false,
-            isClientSupportingMLS: true,
-            isBackendSupportingMLS: true,
-            isMLSProtocolSupported: true,
-            isMLSMigrationFeatureEnabled: true,
-            hasStartTimeBeenReached: true
-        )
-        mockStorage.underlyingMigrationStatus = .notStarted
-
-        // WHEN
-        try await sut.updateMigrationStatus()
-
-        // THEN
-        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0)
+        try await internalTest_updateMigrationStatusDoesntFetchFeaturesConfig(isAPIV5Supported: false)
     }
 
     func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfClientNotSupportingMLS() async throws {
-        // GIVEN
-        await createUserAndGroupConversation()
-
-        setMockValues(
-            isAPIV5Supported: true,
-            isClientSupportingMLS: false,
-            isBackendSupportingMLS: true,
-            isMLSProtocolSupported: true,
-            isMLSMigrationFeatureEnabled: true,
-            hasStartTimeBeenReached: true
-        )
-        mockStorage.underlyingMigrationStatus = .notStarted
-
-        // WHEN
-        try await sut.updateMigrationStatus()
-
-        // THEN
-        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0)
+        try await internalTest_updateMigrationStatusDoesntFetchFeaturesConfig(isClientSupportingMLS: false)
     }
 
     func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfBackendNotSupportingMLS() async throws {
+        try await internalTest_updateMigrationStatusDoesntFetchFeaturesConfig(isBackendSupportingMLS: false)
+    }
+
+    private func internalTest_updateMigrationStatusDoesntFetchFeaturesConfig(
+        isAPIV5Supported: Bool = true,
+        isClientSupportingMLS: Bool = true,
+        isBackendSupportingMLS: Bool = true
+    ) async throws {
         // GIVEN
         await createUserAndGroupConversation()
 
         setMockValues(
-            isAPIV5Supported: true,
-            isClientSupportingMLS: true,
-            isBackendSupportingMLS: false,
+            isAPIV5Supported: isAPIV5Supported,
+            isClientSupportingMLS: isClientSupportingMLS,
+            isBackendSupportingMLS: isBackendSupportingMLS,
             isMLSProtocolSupported: true,
             isMLSMigrationFeatureEnabled: true,
             hasStartTimeBeenReached: true

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -153,7 +153,9 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
     private func internalTest_updateMigrationStatusDoesntFetchFeaturesConfig(
         isAPIV5Supported: Bool = true,
         isClientSupportingMLS: Bool = true,
-        isBackendSupportingMLS: Bool = true
+        isBackendSupportingMLS: Bool = true,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) async throws {
         // GIVEN
         await createUserAndGroupConversation()

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -174,7 +174,7 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
         try await sut.updateMigrationStatus()
 
         // THEN
-        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0)
+        XCTAssertEqual(mockFeatureRepository.fetchMLS_Invocations.count, 0, file: file, line: line)
     }
 
     // MARK: - Migration finalisation


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6184" title="WPB-6184" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6184</a>  [iOS] crash on migration to proteus by CC build 3.112
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We fetched the MLS config from the backend when MLS was not enabled. 
### Causes (Optional)

During the playtest, we updated the app from different old versions that had a previous MLS config stored in database. We recently changed the Feature.Config.MLS to contain supportedProtocols, so when decoding the stored config, we made it crash (we expect not to break decoding compability).


### Solutions

Move the MLS checks around fetching the MLS config. As of now, it hasn't been released

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Install old playground build 3.110.1 or 3.111.7 and update to latest 3.112
-> It should not crash

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
