### PR TITLE
chore: move apiV5 to supported versions and add apiV6 - WPB-6013

### DIFF
--- a/wire-ios-request-strategy/Sources/APIs/APIProvider.swift
+++ b/wire-ios-request-strategy/Sources/APIs/APIProvider.swift
@@ -40,6 +40,7 @@ public struct APIProvider: APIProviderInterface {
         case .v3: PrekeyAPIV3(httpClient: httpClient)
         case .v4: PrekeyAPIV4(httpClient: httpClient)
         case .v5: PrekeyAPIV5(httpClient: httpClient)
+        case .v6: PrekeyAPIV6(httpClient: httpClient)
         }
     }
 
@@ -51,6 +52,7 @@ public struct APIProvider: APIProviderInterface {
         case .v3: MessageAPIV3(httpClient: httpClient)
         case .v4: MessageAPIV4(httpClient: httpClient)
         case .v5: MessageAPIV5(httpClient: httpClient)
+        case .v6: MessageAPIV6(httpClient: httpClient)
         }
     }
 }

--- a/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/MessageAPI.swift
@@ -287,3 +287,9 @@ class MessageAPIV5: MessageAPIV4 {
         return (payload, response)
     }
 }
+
+class MessageAPIV6: MessageAPIV5 {
+    override var apiVersion: APIVersion {
+        .v6
+    }
+}

--- a/wire-ios-request-strategy/Sources/APIs/PrekeyAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/PrekeyAPI.swift
@@ -128,6 +128,12 @@ class PrekeyAPIV5: PrekeyAPIV4 {
     }
 }
 
+class PrekeyAPIV6: PrekeyAPIV5 {
+    override var apiVersion: APIVersion {
+        return .v6
+    }
+}
+
 extension Collection where Element == QualifiedClientID {
 
     var clientListByUserID: Payload.ClientListByUserID {

--- a/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactory.swift
@@ -60,7 +60,7 @@ public final class AssetRequestFactory: NSObject {
         case .v0, .v1:
             path = "/assets/v3"
 
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             path = "/assets"
         }
 
@@ -77,7 +77,7 @@ public final class AssetRequestFactory: NSObject {
         case .v0, .v1:
             path = "/assets/v3"
 
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             path = "/assets"
         }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Conversation/Payload+Conversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Conversation/Payload+Conversation.swift
@@ -129,7 +129,7 @@ extension Payload {
             case .v0, .v1, .v2:
                 legacyAccessRole = try container.decodeIfPresent(String.self, forKey: .accessRole)
                 accessRoles = try container.decodeIfPresent([String].self, forKey: .accessRoleV2)
-            case .v3, .v4, .v5:
+            case .v3, .v4, .v5, .v6:
 
                 // v3 replaces the field "access_role_v2" with "access_role".
                 // However, since the format of update events does not depend on versioning,
@@ -149,7 +149,7 @@ extension Payload {
             case .v0, .v1, .v2, .v3, .v4:
                 cipherSuite = nil
                 epochTimestamp = nil
-            case .v5:
+            case .v5, .v6:
                 cipherSuite = try container.decodeIfPresent(UInt16.self, forKey: .cipherSuite)
                 epochTimestamp = try container.decodeIfPresent(Date.self, forKey: .epochTimestamp)
             }
@@ -178,7 +178,7 @@ extension Payload {
             case .v0, .v1, .v2:
                 try container.encodeIfPresent(legacyAccessRole, forKey: .accessRole)
                 try container.encodeIfPresent(accessRoles, forKey: .accessRoleV2)
-            case .v3, .v4, .v5:
+            case .v3, .v4, .v5, .v6:
                 if legacyAccessRole == nil {
                     try container.encodeIfPresent(accessRoles, forKey: .accessRole)
                 } else {

--- a/wire-ios-request-strategy/Sources/Payloads/Conversation/Payload+NewConversation.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Conversation/Payload+NewConversation.swift
@@ -121,7 +121,7 @@ extension Payload {
             case .v0, .v1, .v2:
                 legacyAccessRole = try container.decodeIfPresent(String.self, forKey: .accessRole)
                 accessRoles = try container.decodeIfPresent([String].self, forKey: .accessRoleV2)
-            case .v3, .v4, .v5:
+            case .v3, .v4, .v5, .v6:
                 accessRoles = try container.decodeIfPresent([String].self, forKey: .accessRole)
                 legacyAccessRole = nil
             }
@@ -145,7 +145,7 @@ extension Payload {
             case .v0, .v1, .v2:
                 try container.encodeIfPresent(legacyAccessRole, forKey: .accessRole)
                 try container.encodeIfPresent(accessRoles, forKey: .accessRoleV2)
-            case .v3, .v4, .v5:
+            case .v3, .v4, .v5, .v6:
                 try container.encodeIfPresent(accessRoles, forKey: .accessRole)
             }
         }

--- a/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
@@ -146,7 +146,7 @@ extension OTREntity {
                 in: context
             )
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             guard let payload = Payload.MessageSendingStatus(response) else {
                 return (missingClients: Set(), deletedClients: Set())
             }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Helpers/AssetDownloadRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Helpers/AssetDownloadRequestFactory.swift
@@ -30,7 +30,7 @@ public final class AssetDownloadRequestFactory: NSObject {
         case .v1:
             guard let domain = domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
             path = "/assets/v4/\(domain)/\(key)"
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             guard let domain = domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
             path = "/assets/\(domain)/\(key)"
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/V2/AssetV2DownloadRequestStrategy.swift
@@ -157,7 +157,7 @@ import WireTransport
 
             fatalError("Cannot generate request for \(object.safeForLoggingDescription)")
 
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             return nil
         }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/V2/ImageV2DownloadRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/V2/ImageV2DownloadRequestStrategy.swift
@@ -90,7 +90,7 @@ extension ImageV2DownloadRequestStrategy: ZMDownstreamTranscoder {
                     return requestFactory.requestToGetAsset(assetId, inConversation: conversation.remoteIdentifier!, apiVersion: apiVersion)
                 }
 
-            case .v2, .v3, .v4, .v5:
+            case .v2, .v3, .v4, .v5, .v6:
                 // v2 assets are legacy and no longer supported in API v2
                 return nil
             }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestFactory.swift
@@ -51,7 +51,7 @@ public final class ClientMessageRequestFactory: NSObject {
                 nativePush: false,
                 recipients: []
             )
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             guard let domain = domain.nonEmptyValue ?? BackendInfo.domain else {
                 zmLog.error("could not create request: missing domain")
                 return nil

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/ConnectToUserActionHandler.swift
@@ -28,7 +28,7 @@ class ConnectToUserActionHandler: ActionHandler<ConnectToUserAction> {
         switch apiVersion {
         case .v0:
             return nonFederatedRequest(for: action, apiVersion: apiVersion)
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             return federatedRequest(for: action, apiVersion: apiVersion)
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/Actions/UpdateConnectionActionHandler.swift
@@ -29,7 +29,7 @@ class UpdateConnectionActionHandler: ActionHandler<UpdateConnectionAction> {
         case .v0:
             return v0Request(for: action)
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             return v1Request(for: action)
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/ConnectionRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/ConnectionRequestStrategy.swift
@@ -100,7 +100,7 @@ public class ConnectionRequestStrategy: AbstractRequestStrategy, ZMRequestGenera
                 }
             }
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             connectionListSync.fetch { [weak self] result in
                 switch result {
                 case .success(let connectionList):
@@ -165,7 +165,7 @@ extension ConnectionRequestStrategy: KeyPathObjectSyncTranscoder {
                 connectionByIDSync.sync(identifiers: userIdSet)
             }
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             if let qualifiedID = object.to.qualifiedID {
                 let qualifiedIdSet: Set<ConnectionByQualifiedIDTranscoder.T> = [qualifiedID]
                 connectionByQualifiedIDSync.sync(identifiers: qualifiedIdSet)

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
@@ -62,7 +62,7 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
             return v0Request(for: action)
         case .v1:
             return v1Request(for: action)
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             return v2Request(for: action, apiVersion: apiVersion)
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/RemoveParticipantActionHandler.swift
@@ -38,7 +38,7 @@ class RemoveParticipantActionHandler: ActionHandler<RemoveParticipantAction> {
         switch apiVersion {
         case .v0:
             return nonFederatedRequest(for: action, apiVersion: apiVersion)
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             return federatedRequest(for: action, apiVersion: apiVersion)
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncConversationActionHandler.swift
@@ -51,7 +51,7 @@ final class SyncConversationActionHandler: ActionHandler<SyncConversationAction>
                 apiVersion: apiVersion.rawValue
             )
 
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             return ZMTransportRequest(
                 path: "/conversations/list",
                 method: .post,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncUsersActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncUsersActionHandler.swift
@@ -60,7 +60,7 @@ class SyncUsersActionHandler: ActionHandler<SyncUsersAction> {
             action.fail(with: .endpointUnavailable)
             return nil
 
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             guard
                 let payloadData = RequestPayload(qualified_users: action.qualifiedIDs).payloadString()
             else {
@@ -95,7 +95,7 @@ class SyncUsersActionHandler: ActionHandler<SyncUsersAction> {
             action.fail(with: .endpointUnavailable)
             return
 
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             switch response.httpStatus {
             case 200:
                 guard let rawData = response.rawData,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateAccessRolesActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/UpdateAccessRolesActionHandler.swift
@@ -55,7 +55,7 @@ final class UpdateAccessRolesActionHandler: ActionHandler<UpdateAccessRolesActio
                                       method: .put,
                                       payload: payloadAsString as ZMTransportData?,
                                       apiVersion: apiVersion.rawValue)
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
             return ZMTransportRequest(path: "/conversations/\(domain)/\(conversationID)/access",
                                       method: .put,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -174,7 +174,7 @@ mlsService: mlsService,
         case .v0:
             conversationByIDSync.sync(identifiers: conversations.compactMap(\.remoteIdentifier))
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             if let qualifiedIDs = conversations.qualifiedIDs {
                 conversationByQualifiedIDSync.sync(identifiers: qualifiedIDs)
             } else if let domain = BackendInfo.domain {
@@ -207,7 +207,7 @@ mlsService: mlsService,
                 }
             }
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             conversationQualifiedIDsSync.fetch { [weak self] (result) in
                 switch result {
                 case .success(let qualifiedConversationIDList):
@@ -254,7 +254,7 @@ extension ConversationRequestStrategy: KeyPathObjectSyncTranscoder {
             guard let identifier = object.remoteIdentifier else { return }
             synchronize(unqualifiedID: identifier)
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             if let qualifiedID = object.qualifiedID {
                 synchronize(qualifiedID: qualifiedID)
             } else if let identifier = object.remoteIdentifier, let domain = BackendInfo.domain {
@@ -412,7 +412,7 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
                                              payload: payloadAsString as ZMTransportData?,
                                              apiVersion: apiVersion.rawValue)
 
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
                 request = ZMTransportRequest(path: "/conversations/\(domain)/\(conversationID)/name",
                                              method: .put,
@@ -444,7 +444,7 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
                                              method: .put,
                                              payload: payloadAsString as ZMTransportData?,
                                              apiVersion: apiVersion.rawValue)
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
                 request = ZMTransportRequest(path: "/conversations/\(domain)/\(conversationID)/self",
                                              method: .put,

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchBackendMLSPublicKeysActionHandler.swift
@@ -32,7 +32,7 @@ class FetchBackendMLSPublicKeysActionHandler: ActionHandler<FetchBackendMLSPubli
             action.fail(with: .endpointUnavailable)
             return nil
 
-        case .v5:
+        case .v5, .v6:
             return ZMTransportRequest(
                 path: "/mls/public-keys",
                 method: .get,

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchUserClientsActionHandler.swift
@@ -40,7 +40,7 @@ final class FetchUserClientsActionHandler: ActionHandler<FetchUserClientsAction>
             action.fail(with: .endpointUnavailable)
             return nil
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             guard
                 let payloadData = RequestPayload(qualified_users: action.userIDs).payloadData(),
                 let payloadString = String(bytes: payloadData, encoding: .utf8)
@@ -80,7 +80,7 @@ final class FetchUserClientsActionHandler: ActionHandler<FetchUserClientsAction>
         case .v0:
             return
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             switch response.httpStatus {
             case 200:
                 guard let rawData = response.rawData else {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -97,7 +97,7 @@ public final class FetchingClientRequestStrategy: AbstractRequestStrategy {
                         self.userClientsByUserID.sync(identifiers: userIdSet)
                     }
 
-                case .v2, .v3, .v4, .v5:
+                case .v2, .v3, .v4, .v5, .v6:
                     if let domain = user.domain.nonEmptyValue ?? BackendInfo.domain {
                         let qualifiedID = QualifiedID(uuid: userID, domain: domain)
                         self.userClientsByQualifiedUserID.sync(identifiers: [qualifiedID])
@@ -167,7 +167,7 @@ extension FetchingClientRequestStrategy: ZMContextChangeTracker, ZMContextChange
                     // Fallback.
                     result.1.append(userClientID)
                 }
-            case .v2, .v3, .v4, .v5:
+            case .v2, .v3, .v4, .v5, .v6:
                 if let qualifiedID = qualifiedIDWithFallback(from: userClient) {
                     result.0.append(qualifiedID)
                 }
@@ -312,7 +312,7 @@ final class UserClientByQualifiedUserIDTranscoder: IdentifierObjectSyncTranscode
         case .v1:
             return v1Request(for: identifiers)
 
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             return v2Request(for: identifiers, apiVersion: apiVersion)
         }
     }
@@ -368,7 +368,7 @@ final class UserClientByQualifiedUserIDTranscoder: IdentifierObjectSyncTranscode
             completionHandler()
             return
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             WaitingGroupTask(context: managedObjectContext) { [self] in
                 await commonResponseHandling(response: response, for: identifiers)
                 completionHandler()

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
@@ -101,7 +101,7 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 expectedPath = "/conversations/\(conversation.remoteIdentifier!.transportString())/otr/messages"
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 expectedPath = "/v\(apiVersion.rawValue)/conversations/\(conversation.domain!)/\(conversation.remoteIdentifier!.transportString())/proteus/messages"
             }
 
@@ -155,7 +155,7 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: clientListByUserID).transportData
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 transportData = Payload.MessageSendingStatus(missing: [self.otherUser.domain!: clientListByUserID]).transportData
 
             }
@@ -199,7 +199,7 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: clientListByUserID).transportData
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 transportData = Payload.MessageSendingStatus(missing: [self.otherUser.domain!: clientListByUserID]).transportData
             }
 
@@ -240,7 +240,7 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: ClientListByUser()).transportData
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 transportData = Payload.MessageSendingStatus(missing: UserListByDomain()).transportData
             }
 
@@ -280,7 +280,7 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: clientListByUserID).transportData
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 transportData = Payload.MessageSendingStatus(missing: [selfUser.domain!: clientListByUserID]).transportData
             }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -98,7 +98,7 @@ public class UserProfileRequestStrategy: AbstractRequestStrategy, IdentifierObje
         case .v0:
             userProfileByID.sync(identifiers: users.compactMap(\.remoteIdentifier))
 
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             if let qualifiedUserIDs = users.qualifiedUserIDs {
                 userProfileByQualifiedID.sync(identifiers: qualifiedUserIDs)
             } else if let domain = BackendInfo.domain {
@@ -349,7 +349,7 @@ class UserProfileByQualifiedIDTranscoder: IdentifierObjectSyncTranscoder {
             let missingIdentifiers = identifiers.subtracting(payload.compactMap(\.qualifiedID))
             markUserProfilesAsFetched(missingIdentifiers)
 
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             guard
                 let rawData = response.rawData,
                 let payload = Payload.UserProfilesV4(rawData, decoder: decoder)

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -527,7 +527,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
         switch apiVersion {
         case .v0, .v1, .v2, .v3:
             payloadData = userProfiles.payloadData()
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             let userProfiles = Payload.UserProfilesV4(found: userProfiles, failed: failed)
             payloadData = userProfiles.payloadData()
         }

--- a/wire-ios-sync-engine/Source/Data Model/Conversation+AccessMode.swift
+++ b/wire-ios-sync-engine/Source/Data Model/Conversation+AccessMode.swift
@@ -282,7 +282,7 @@ internal struct WirelessRequestFactory {
         switch apiVersion {
         case .v0, .v1, .v2, .v3:
             return .init(path: "/conversations/\(identifier)/code", method: .post, payload: nil, apiVersion: apiVersion.rawValue)
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             let payload: [String: Any] = [:]
             return .init(path: "/conversations/\(identifier)/code", method: .post, payload: payload as ZMTransportData, apiVersion: apiVersion.rawValue)
         }
@@ -322,7 +322,7 @@ internal struct WirelessRequestFactory {
         let path: String
 
         switch apiVersion {
-        case .v3, .v4, .v5:
+        case .v3, .v4, .v5, .v6:
             guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else {
                 fatal("no domain associated with conversation, can't make the request")
             }

--- a/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
@@ -181,7 +181,7 @@ public extension APIVersion {
     /// Only if these critera are met should we explicitly mark the version
     /// as production ready.
 
-    static let productionVersions: Set<Self> = [.v0, .v1, .v2, .v3, .v4]
+    static let productionVersions: Set<Self> = [.v0, .v1, .v2, .v3, .v4, .v5]
 
     /// API versions currently under development and not suitable for production
     /// environments.

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/Asset Deletion/AssetDeletionRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/Asset Deletion/AssetDeletionRequestStrategy.swift
@@ -26,7 +26,7 @@ fileprivate extension AssetRequestFactory {
         switch apiVersion {
         case .v0, .v1:
             path = "/assets/v3/\(identifier)"
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             guard let domain = BackendInfo.domain else {
                 return nil
             }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -608,7 +608,7 @@ extension CallingRequestStrategy {
             case .v0:
                 // `nestedContainer` contains all the user ids with no notion of domain, we can extract clients directly
                allClients = try extractClientsFromContainer(nestedContainer, nil)
-            case .v1, .v2, .v3, .v4, .v5:
+            case .v1, .v2, .v3, .v4, .v5, .v6:
                 // `nestedContainer` has further nested containers each dynamically keyed by a domain name.
                 // we need to loop over each container to extract the clients.
                 try nestedContainer.allKeys.forEach { domainKey in

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
@@ -144,7 +144,7 @@ public class SearchUserImageStrategy: AbstractRequestStrategy {
 
                 path = "/assets/v4/\(domain)/\(key)"
 
-            case .v2, .v3, .v4, .v5:
+            case .v2, .v3, .v4, .v5, .v6:
                 guard let domain = requestedUserDomain[user].nonEmptyValue ?? BackendInfo.domain else {
                     return nil
                 }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
@@ -209,7 +209,7 @@ public final class TeamDownloadRequestStrategy: AbstractRequestStrategy, ZMConte
         switch apiVersion {
         case .v0, .v1, .v2, .v3:
             return TeamDownloadRequestFactory.getTeamsRequest(apiVersion: apiVersion)
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             guard let teamID = ZMUser.selfUser(in: managedObjectContext).teamIdentifier else {
                 syncStatus.finishCurrentSyncPhase(phase: expectedSyncPhase)
                 return nil
@@ -235,7 +235,7 @@ public final class TeamDownloadRequestStrategy: AbstractRequestStrategy, ZMConte
 
             syncStatus.finishCurrentSyncPhase(phase: expectedSyncPhase)
 
-        case .v4, .v5:
+        case .v4, .v5, .v6:
             guard
                 let rawData = response.rawData,
                 let teamPayload = TeamPayload(rawData)

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamImageAssetUpdateStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamImageAssetUpdateStrategy.swift
@@ -68,7 +68,7 @@ public final class TeamImageAssetUpdateStrategy: AbstractRequestStrategy, ZMCont
         switch apiVersion {
         case .v0, .v1:
             path = "/assets/v3/\(assetId)"
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             guard let domain = BackendInfo.domain else { return nil }
             path = "/assets/\(domain)/\(assetId)"
         }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TypingStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TypingStrategy.swift
@@ -196,7 +196,7 @@ public class TypingStrategy: AbstractRequestStrategy, TearDownCapable, ZMEventCo
         case .v0, .v1, .v2:
             path = "/conversations/\(remoteIdentifier.transportString())/typing"
 
-        case .v3, .v4, .v5:
+        case .v3, .v4, .v5, .v6:
             guard let domain = conversation.domain.nonEmptyValue ?? BackendInfo.domain else { return nil }
             path = "/conversations/\(domain)/\(remoteIdentifier.transportString())/typing"
         }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
@@ -181,7 +181,7 @@ public final class UserImageAssetUpdateStrategy: AbstractRequestStrategy, ZMCont
 
             path = "/assets/v4/\(domain)/\(assetId)"
 
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             guard let domain = user.domain.nonEmptyValue ?? BackendInfo.domain else {
                 return nil
             }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/AssetDeletionRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/AssetDeletionRequestStrategyTests.swift
@@ -122,7 +122,7 @@ extension AssetDeletionRequestStrategyTests {
             expectedPath = "/assets/v3/\(identifier)"
         case .v1:
             expectedPath = "/v1/assets/v3/\(identifier)"
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             expectedPath = "/v\(apiVersion.rawValue)/assets/\(domain)/\(identifier)"
         }
         XCTAssertNotNil(request)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
@@ -269,7 +269,7 @@ extension SearchUserImageStrategyTests {
             expectedPath = "/assets/v3/\(assetID)"
         case .v1:
             expectedPath = "/v1/assets/v4/\(domain)/\(assetID)"
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             expectedPath = "/v\(apiVersion.rawValue)/assets/\(domain)/\(assetID)"
         }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/UserImageAssetUpdateStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/UserImageAssetUpdateStrategyTests.swift
@@ -303,7 +303,7 @@ extension UserImageAssetUpdateStrategyTests {
             expectedPath = "/assets/v3/\(assetId)"
         case .v1:
             expectedPath = "/v1/assets/v4/\(domain)/\(assetId)"
-        case .v2, .v3, .v4, .v5:
+        case .v2, .v3, .v4, .v5, .v6:
             expectedPath = "/v\(apiVersion.rawValue)/assets/\(domain)/\(assetId)"
         }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMConversationAccessModeTests.swift
@@ -98,7 +98,7 @@ public class ZMConversationAccessModeTests: MessagingTest {
         switch apiVersion {
         case .v0:
             XCTAssertEqual(request.path, "/conversations/\(conversation.remoteIdentifier!.transportString())/access")
-        case .v1, .v2, .v3, .v4, .v5:
+        case .v1, .v2, .v3, .v4, .v5, .v6:
             XCTAssertEqual(request.path, "/v\(apiVersion.rawValue)/conversations/\(conversation.remoteIdentifier!.transportString())/access")
         }
 

--- a/wire-ios-transport/Source/Public/APIVersion.swift
+++ b/wire-ios-transport/Source/Public/APIVersion.swift
@@ -29,6 +29,7 @@ public enum APIVersion: Int32 {
     case v3 = 3
     case v4 = 4
     case v5 = 5
+    case v6 = 6
 
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6013" title="WPB-6013" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6013</a>  [iOS] Clients should support API v5 as "stable"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

* Move apiV5 to production versions
* Added apiV6

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
