### PR TITLE
fix: clean up user defaults only if file exists

### DIFF
--- a/wire-ios-system/Source/UserDefaults+Temporary.swift
+++ b/wire-ios-system/Source/UserDefaults+Temporary.swift
@@ -59,7 +59,9 @@ private final class SuiteCleanUp {
                 .url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: .init(string: "/")!, create: false)
                 .appendingPathComponent("Preferences")
                 .appendingPathComponent(suiteName + ".plist")
-            try fileManager.removeItem(at: url)
+            if fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+            }
         } catch {
             zmLog.warn("Could not remove temporary user defaults file: " + String(reflecting: error))
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes warnings are printed hinting an error deleting the temporary user defaults file.

### Causes (Optional)

The file never existed, probably because the UserDefaults instance wasn't used.

### Solutions

Check if file exists before any attempt of deleting it. Print an error only if the deletion actually fails.

#### Test Coverage

#### How to Test

Call UserDefaults.temporary() and let the instance being destructed immediately. No warning should appear anymore.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
