### PR TITLE
fix: path to Localizable.strings in Wire-iOS Share Extension

### DIFF
--- a/wire-ios/crowdin.yml
+++ b/wire-ios/crowdin.yml
@@ -34,7 +34,7 @@ files: [
   "translation" : "/Wire-iOS/Resources/%osx_code%/%original_file_name%",
  },
  {
-  "source" : "/Wire-iOS Share Extension/Base.lproj/Localizable.strings",
+  "source" : "/Wire-iOS Share Extension/Resources/Base.lproj/Localizable.strings",
   "dest" : "/App/Wire-iOS Share Extension/Localizable.strings",
   "translation" : "/Wire-iOS Share Extension/%osx_code%/%original_file_name%",
  },


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixes the wrong path to Localizable.strings in Wire-iOS Share Extension.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
