### PR TITLE
feat(mls-migration): handle mixed protocol for conversation operations WPB-529

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -135,7 +135,7 @@ struct ConversationEventPayloadProcessor {
             return Logging.eventProcessing.error("Member leave update missing conversation or users, aborting...")
         }
 
-        let (isSelfUserRemoved, isMessageProtocolMLS) = await context.perform {
+        let (isSelfUserRemoved, messageProtocol) = await context.perform {
             if !conversation.localParticipants.isDisjoint(with: removedUsers) {
                 // TODO jacob refactor to append method on conversation
                 _ = ZMSystemMessage.createOrUpdate(
@@ -154,11 +154,10 @@ struct ConversationEventPayloadProcessor {
             conversation.removeParticipantsAndUpdateConversationState(users: Set(removedUsers), initiatingUser: initiatingUser)
 
             let isSelfUserRemoved = removedUsers.contains(where: \.isSelfUser)
-            let isMessageProtocolMLS = conversation.messageProtocol == .mls
-            return (isSelfUserRemoved, isMessageProtocolMLS)
+            return (isSelfUserRemoved, conversation.messageProtocol)
         }
 
-        if isSelfUserRemoved, isMessageProtocolMLS {
+        if isSelfUserRemoved, messageProtocol.isOne(of: .mls, .mixed) {
             await mlsEventProcessor.wipeMLSGroup(forConversation: conversation, context: context)
         }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -66,11 +66,19 @@ public class MLSEventProcessor: MLSEventProcessing {
     ) async {
         WireLogger.mls.debug("MLS event processor updating conversation if needed")
 
-        guard await context.perform({ conversation.messageProtocol }) == .mls else {
-            return logWarn(aborting: .conversationUpdate, withReason: .notMLSConversation)
+        let (messageProtocol, mlsGroupID, mlsService) = await context.perform {
+            return (
+                conversation.messageProtocol,
+                conversation.mlsGroupID,
+                context.mlsService
+            )
         }
 
-        guard let mlsGroupID = await context.perform({ conversation.mlsGroupID }) ?? MLSGroupID(from: groupID) else {
+        guard messageProtocol.isOne(of: .mls, .mixed) else {
+            return logWarn(aborting: .conversationUpdate, withReason: .conversationNotMLSCapable)
+        }
+
+        guard let mlsGroupID = mlsGroupID ?? MLSGroupID(from: groupID) else {
             return logWarn(aborting: .conversationUpdate, withReason: .missingGroupID)
         }
 
@@ -81,7 +89,7 @@ public class MLSEventProcessor: MLSEventProcessing {
             }
         }
 
-        guard let mlsService = await context.perform({ context.mlsService }) else {
+        guard let mlsService else {
             return logWarn(aborting: .conversationUpdate, withReason: .missingMLSService)
         }
 
@@ -219,8 +227,8 @@ public class MLSEventProcessor: MLSEventProcessing {
             )
         }
 
-        guard messageProtocol == .mls else {
-            return logWarn(aborting: .conversationWipe, withReason: .notMLSConversation)
+        guard messageProtocol.isOne(of: .mls, .mixed) else {
+            return logWarn(aborting: .conversationWipe, withReason: .conversationNotMLSCapable)
         }
 
         guard let groupID else {
@@ -255,15 +263,15 @@ public class MLSEventProcessor: MLSEventProcessing {
     }
 
     private enum AbortReason {
-        case notMLSConversation
+        case conversationNotMLSCapable
         case missingGroupID
         case missingMLSService
         case other(reason: String)
 
         var stringValue: String {
             switch self {
-            case .notMLSConversation:
-                return "not an MLS conversation"
+            case .conversationNotMLSCapable:
+                return "conversation is not MLS capable"
             case .missingGroupID:
                 return "missing group ID"
             case .missingMLSService:

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -159,7 +159,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
         )
     }
 
-    func test_UpdateConversationMemberLeave_DoesntWipeMLSGroup_WhenProtocolIsNotMLS() async throws {
+    func test_UpdateConversationMemberLeave_DoesntWipeMLSGroup_WhenProtocolIsProteus() async throws {
         try await internalTest_UpdateConversationMemberLeave(
             messageProtocol: .proteus,
             shouldWipeMLSGroup: false
@@ -242,39 +242,6 @@ final class ConversationEventProcessorTests: MessagingTestBase {
             updateEvent = self.updateEvent(from: payload)
         }
         let event = try XCTUnwrap(updateEvent)
-        // When
-        await self.sut.processConversationEvents([event])
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        // Then
-        XCTAssertTrue(mockMLSEventProcessor.wipeMLSGroupForConversationContext_Invocations.isEmpty)
-    }
-
-    func test_UpdateConversationMemberLeave_DoesntWipeMLSGroup_WhenProtocolIsNotMLS() async throws {
-
-        // Given
-        var updateEvent: ZMUpdateEvent?
-
-        await syncMOC.perform { [self] in
-
-            // create self user
-            let selfUser = ZMUser.selfUser(in: syncMOC)
-            selfUser.remoteIdentifier = UUID.create()
-            selfUser.domain = groupConversation.domain
-
-            // set message protocol
-            groupConversation.messageProtocol = .proteus
-
-            // create the event
-            let payload = Payload.UpdateConverationMemberLeave(
-                userIDs: [selfUser.remoteIdentifier],
-                qualifiedUserIDs: [selfUser.qualifiedID!],
-                reason: .userDeleted
-            )
-            updateEvent = self.updateEvent(from: payload)
-        }
-        let event = try XCTUnwrap(updateEvent)
-
         // When
         await self.sut.processConversationEvents([event])
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -145,7 +145,33 @@ final class ConversationEventProcessorTests: MessagingTestBase {
 
     // MARK: - MLS conversation member leave
 
-    func test_UpdateConversationMemberLeave_WipesMLSGroup() async throws {
+    func test_UpdateConversationMemberLeave_WipesMLSGroup_WithProtocolMLS() async throws {
+        try await internalTest_UpdateConversationMemberLeave(
+            messageProtocol: .mls,
+            shouldWipeMLSGroup: true
+        )
+    }
+
+    func test_UpdateConversationMemberLeave_WipesMLSGroup_WithProtocolMixed() async throws {
+        try await internalTest_UpdateConversationMemberLeave(
+            messageProtocol: .mixed,
+            shouldWipeMLSGroup: true
+        )
+    }
+
+    func test_UpdateConversationMemberLeave_DoesntWipeMLSGroup_WhenProtocolIsNotMLS() async throws {
+        try await internalTest_UpdateConversationMemberLeave(
+            messageProtocol: .proteus,
+            shouldWipeMLSGroup: false
+        )
+    }
+
+    func internalTest_UpdateConversationMemberLeave(
+        messageProtocol: MessageProtocol,
+        shouldWipeMLSGroup: Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws {
         // Given
         var updateEvent: ZMUpdateEvent?
 
@@ -156,7 +182,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
             selfUser.domain = groupConversation.domain
 
             // Set message protocol
-            groupConversation.messageProtocol = .mls
+            groupConversation.messageProtocol = messageProtocol
 
             // Create the event
             let payload = Payload.UpdateConverationMemberLeave(
@@ -167,18 +193,30 @@ final class ConversationEventProcessorTests: MessagingTestBase {
             updateEvent = self.updateEvent(from: payload)
         }
 
-        let event = try XCTUnwrap(updateEvent)
+        let event = try XCTUnwrap(updateEvent, file: file, line: line)
 
         // When
         await sut.processConversationEvents([event])
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
 
         // Then
         let wipeGroupInvocations = mockMLSEventProcessor.wipeMLSGroupForConversationContext_Invocations
-        await syncMOC.perform {
-            XCTAssertEqual(wipeGroupInvocations.count, 1)
-            XCTAssertEqual(wipeGroupInvocations.first?.conversation, self.groupConversation)
+      
+        if shouldWipeMLSGroup {
+            XCTAssertEqual(wipeGroupInvocations.count, 1, file: file, line: line)
+
+            await syncMOC.perform {
+                XCTAssertEqual(
+                    wipeGroupInvocations.first?.conversation,
+                    self.groupConversation,
+                    file: file,
+                    line: line
+                )
+            }
+        } else {
+            XCTAssertTrue(wipeGroupInvocations.isEmpty, file: file, line: line)
         }
+
     }
 
     func test_UpdateConversationMemberLeave_DoesntWipeMLSGroup_WhenSelfUserIsNotRemoved() async throws {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -201,7 +201,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
 
         // Then
         let wipeGroupInvocations = mockMLSEventProcessor.wipeMLSGroupForConversationContext_Invocations
-      
+
         if shouldWipeMLSGroup {
             XCTAssertEqual(wipeGroupInvocations.count, 1, file: file, line: line)
 

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -1001,7 +1001,7 @@ private extension ZMConversation {
         case (.oneOnOne, _):
             return .oneToOne
 
-        case (.group, .proteus):
+        case (.group, .proteus), (.group, .mixed):
             return .conference
 
         case (.group, .mls), (.`self`, .mls):

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
@@ -144,7 +144,7 @@ class DeepLinkURLActionProcessor: URLActionProcessor {
                 return
             }
 
-            guard 
+            guard
                 let groupId = upToDateConversation.mlsGroupID,
                 upToDateConversation.messageProtocol.isOne(of: .mls, .mixed)
             else {

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
@@ -144,7 +144,10 @@ class DeepLinkURLActionProcessor: URLActionProcessor {
                 return
             }
 
-            guard let groupId = upToDateConversation.mlsGroupID, upToDateConversation.messageProtocol == .mls else {
+            guard 
+                let groupId = upToDateConversation.mlsGroupID,
+                upToDateConversation.messageProtocol.isOne(of: .mls, .mixed)
+            else {
                 completion(.success(upToDateConversation))
                 return
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-529" title="WPB-529" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-529</a>  [iOS] Maintaining MLS group's clients list during migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Updates normal MLS group operations (adds, removes, updates etc) for conversations in mixed mode

This PR is the same as https://github.com/wireapp/wire-ios/pull/734 except we're targeting latest develop

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution