### PR TITLE
feat: fetch trust anchor WPB-3340

### DIFF
--- a/wire-ios-data-model/Source/E2EIdentity/E2eISetupService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2eISetupService.swift
@@ -21,6 +21,8 @@ import WireCoreCrypto
 
 public protocol E2eISetupServiceInterface {
 
+    func registerTrustAnchor(_ trustAnchor: String) async throws
+
     func setupEnrollment(userName: String, handle: String, team: UUID) async throws -> E2eiEnrollment
 
 }
@@ -39,6 +41,12 @@ public final class E2eISetupService: E2eISetupServiceInterface {
     }
 
     // MARK: - Public interface
+
+    public func registerTrustAnchor(_ trustAnchor: String) async throws {
+        try await coreCryptoProvider.coreCrypto(requireMLS: false).perform { coreCrypto in
+            try await coreCrypto.e2eiRegisterAcmeCa(trustAnchorPem: trustAnchor)
+        }
+    }
 
     public func setupEnrollment(userName: String, handle: String, team: UUID) async throws -> E2eiEnrollment {
         do {

--- a/wire-ios-request-strategy/Sources/E2EIdentity/ACME/AcmeAPI.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/ACME/AcmeAPI.swift
@@ -22,6 +22,7 @@ import WireCoreCrypto
 public protocol AcmeAPIInterface {
     func getACMEDirectory() async throws -> Data
     func getACMENonce(path: String) async throws -> String
+    func getTrustAnchor() async throws -> String
     func sendACMERequest(path: String, requestBody: Data) async throws -> ACMEResponse
     func sendChallengeRequest(path: String, requestBody: Data) async throws -> ChallengeResponse
 }
@@ -31,6 +32,7 @@ public class AcmeAPI: NSObject, AcmeAPIInterface {
 
     // MARK: - Properties
 
+    private let rootCertificatePath = "roots.pem"
     private let acmeDiscoveryPath: String
     private let httpClient: HttpClientCustom
 
@@ -74,6 +76,28 @@ public class AcmeAPI: NSObject, AcmeAPIInterface {
 
         return replayNonce
 
+    }
+
+    public func getTrustAnchor() async throws -> String {
+        guard
+            let baseURL = URL(string: acmeDiscoveryPath)?.extractBaseURL,
+            let url = URL(string: rootCertificatePath, relativeTo: baseURL)
+        else {
+            throw NetworkError.errorEncodingRequest
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.get
+
+        let (data, response) = try await httpClient.send(request)
+
+        guard
+            let certificateChain = String(bytes: data, encoding: .utf8)
+        else {
+            throw NetworkError.errorDecodingResponseNew(response)
+        }
+
+        return certificateChain
     }
 
     public func sendACMERequest(path: String, requestBody: Data) async throws -> ACMEResponse {
@@ -167,4 +191,12 @@ public class HttpClientE2EI: NSObject, HttpClientCustom {
         return try await URLSession.shared.data(for: request)
     }
 
+}
+
+extension URL {
+    var extractBaseURL: URL? {
+        var baseURL = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        baseURL?.path = ""
+        return baseURL?.url
+    }
 }

--- a/wire-ios-request-strategy/Sources/E2EIdentity/ACME/AcmeAPITests.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/ACME/AcmeAPITests.swift
@@ -239,13 +239,38 @@ class AcmeAPITests: ZMTBaseTest {
         }
     }
 
+    func testThatItSendsTrustAnchorRequest() async throws {
+        // given
+        let path = "https://acme/roots.pem"
+
+        // mock
+        let mockResponse = HTTPURLResponse(
+            url: URL(string: path)!,
+            statusCode: 200,
+            httpVersion: "",
+            headerFields: nil
+        )!
+        let mockData = Data()
+        mockHttpClient?.mockResponse = (mockData, mockResponse)
+
+        // when
+        _ = try await acmeApi?.getTrustAnchor()
+        let request = try XCTUnwrap(mockHttpClient?.sentRequests.first)
+
+        // then
+        XCTAssertEqual(request.url?.absoluteString, "https://acme/roots.pem")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
 }
 
 class MockHttpClient: HttpClientCustom {
 
     var mockResponse: (Data, URLResponse)?
+    var sentRequests: [URLRequest] = []
 
     func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        sentRequests.append(request)
         guard let mockResponse = mockResponse else {
             throw NetworkError.errorDecodingResponseNew(mockResponse!.1)
         }

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2eIEnrollmentTests.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2eIEnrollmentTests.swift
@@ -347,6 +347,10 @@ class MockAcmeApi: AcmeAPIInterface {
     var mockResponseData: Data?
     var mockChallengeResponse: ChallengeResponse?
 
+    func getTrustAnchor() async throws -> String {
+        return ""
+    }
+
     func getACMEDirectory() async throws -> Data {
         let payload = acmeDirectoriesResponse()
 

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2eIRepository.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2eIRepository.swift
@@ -21,6 +21,8 @@ import WireCoreCrypto
 
 public protocol E2eIRepositoryInterface {
 
+    func fetchTrustAnchor() async throws
+
     func createEnrollment(e2eiClientId: E2eIClientID, userName: String, handle: String, team: UUID) async throws -> E2eIEnrollmentInterface
 }
 
@@ -44,6 +46,11 @@ public final class E2eIRepository: E2eIRepositoryInterface {
         self.e2eiSetupService = e2eiSetupService
         self.keyRotator = keyRotator
         self.coreCryptoProvider = coreCryptoProvider
+    }
+
+    public func fetchTrustAnchor() async throws {
+        let trustAnchor = try await acmeApi.getTrustAnchor()
+        try await e2eiSetupService.registerTrustAnchor(trustAnchor)
     }
 
     public func createEnrollment(

--- a/wire-ios-request-strategy/Sources/E2EIdentity/EnrollE2eICertificateUseCase.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/EnrollE2eICertificateUseCase.swift
@@ -47,6 +47,8 @@ public final class EnrollE2eICertificateUseCase: EnrollE2eICertificateUseCaseInt
                        userHandle: String,
                        team: UUID,
                        authenticate: OAuthBlock) async throws {
+        try await e2eiRepository.fetchTrustAnchor()
+
         let enrollment = try await e2eiRepository.createEnrollment(e2eiClientId: e2eiClientId,
                                                                    userName: userName,
                                                                    handle: userHandle,

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -249,11 +249,15 @@ final class DeveloperToolsViewModel: ObservableObject {
         }
 
         Task {
-            _ = try await e2eiCertificateUseCase?.invoke(e2eiClientId: e2eiClientId,
-                                                         userName: userName,
-                                                         userHandle: handle,
-                                                         team: teamId,
-                                                         authenticate: oauthUseCase.invoke)
+            do {
+                _ = try await e2eiCertificateUseCase?.invoke(e2eiClientId: e2eiClientId,
+                                                             userName: userName,
+                                                             userHandle: handle,
+                                                             team: teamId,
+                                                             authenticate: oauthUseCase.invoke)
+            } catch {
+                WireLogger.e2ei.error("failed to enroll e2ei: \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3340" title="WPB-3340" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-3340</a>  [iOS] Fetch trust anchors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fetch & register trust anchor when enrolling into E2EI

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

### Notes

This only works on CC 32 and above

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
