### PR TITLE
feat: handle federation errors when adding participants to a MLS conversation WPB-2228

### DIFF
--- a/wire-ios-data-model/Source/MLS/Actions/SendMLSMessageAction.swift
+++ b/wire-ios-data-model/Source/MLS/Actions/SendMLSMessageAction.swift
@@ -140,7 +140,7 @@ public final class SendMLSMessageAction: EntityAction {
                 return "Unknown error (response status: \(status), label: \(label), message: \(message))"
 
             case .unreachableDomains(let domains):
-                return "Some domains were unrechable: \(domains)"
+                return "Some domains were unreachable: \(domains)"
             }
         }
     }

--- a/wire-ios-data-model/Source/MLS/Actions/SendMLSMessageAction.swift
+++ b/wire-ios-data-model/Source/MLS/Actions/SendMLSMessageAction.swift
@@ -54,10 +54,14 @@ public final class SendMLSMessageAction: EntityAction {
         // 409
         case mlsStaleMessage
         case mlsClientMismatch
+        case unreachableDomains(Set<String>)
 
         // 422
         case mlsUnsupportedProposal
         case mlsUnsupportedMessage
+
+        // 503
+        case nonFederatingDomains(Set<String>)
 
         case unknown(status: Int, label: String, message: String)
 
@@ -123,6 +127,9 @@ public final class SendMLSMessageAction: EntityAction {
             case .mlsClientMismatch:
                 return "A proposal of type Add or Remove does not apply to the full list of clients for a user"
 
+            case .nonFederatingDomains(let domains):
+                return "Some domains are note fully connected: \(domains)"
+
             case .mlsUnsupportedProposal:
                 return "Unsupported proposal type"
 
@@ -131,6 +138,9 @@ public final class SendMLSMessageAction: EntityAction {
 
             case let .unknown(status, label, message):
                 return "Unknown error (response status: \(status), label: \(label), message: \(message))"
+
+            case .unreachableDomains(let domains):
+                return "Some domains were unrechable: \(domains)"
             }
         }
     }

--- a/wire-ios-data-model/Source/MLS/CommitError.swift
+++ b/wire-ios-data-model/Source/MLS/CommitError.swift
@@ -21,7 +21,7 @@ import Foundation
 enum CommitError: Error, Equatable {
 
     case failedToGenerateCommit
-    case failedToSendCommit(recovery: RecoveryStrategy)
+    case failedToSendCommit(recovery: RecoveryStrategy, cause: SendCommitBundleAction.Failure)
     case failedToMergeCommit
     case failedToClearCommit
     case noPendingProposals

--- a/wire-ios-data-model/Source/MLS/CommitSender.swift
+++ b/wire-ios-data-model/Source/MLS/CommitSender.swift
@@ -100,7 +100,7 @@ public actor CommitSender: CommitSending {
                 try await discardPendingCommit(in: groupID)
             }
 
-            throw CommitError.failedToSendCommit(recovery: recoveryStrategy)
+            throw CommitError.failedToSendCommit(recovery: recoveryStrategy, cause: error)
         }
     }
 
@@ -127,7 +127,7 @@ public actor CommitSender: CommitSending {
                 try await clearPendingGroup(in: groupID)
             }
 
-            throw ExternalCommitError.failedToSendCommit(recovery: recoveryStrategy)
+            throw ExternalCommitError.failedToSendCommit(recovery: recoveryStrategy, cause: error)
         }
     }
 

--- a/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
+++ b/wire-ios-data-model/Source/MLS/ExternalCommitError.swift
@@ -20,7 +20,7 @@ import Foundation
 
 enum ExternalCommitError: Error, Equatable {
 
-    case failedToSendCommit(recovery: RecoveryStrategy)
+    case failedToSendCommit(recovery: RecoveryStrategy, cause: SendCommitBundleAction.Failure)
     case failedToMergePendingGroup
     case failedToClearPendingGroup
 

--- a/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
@@ -163,7 +163,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         }
 
         // Then
-        await assertItThrows(error: CommitError.failedToSendCommit(recovery: recovery)) {
+        await assertItThrows(error: CommitError.failedToSendCommit(recovery: recovery, cause: error)) {
             // When
             _ = try await sut.sendCommitBundle(commitBundle, for: groupID)
         }
@@ -242,7 +242,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         }
 
         // Then
-        await assertItThrows(error: ExternalCommitError.failedToSendCommit(recovery: recovery)) {
+        await assertItThrows(error: ExternalCommitError.failedToSendCommit(recovery: recovery, cause: error)) {
             // When
             _ = try await sut.sendExternalCommitBundle(commitBundle, for: groupID)
         }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1167,9 +1167,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     }
 
     func test_PerformPendingJoins_GivesUp() async throws {
-        await assertItThrows(error: SendCommitBundleAction.Failure.mlsCommitMissingReferences) {
-            try await test_PerformPendingJoinsRecovery(.giveUp, cause: .mlsCommitMissingReferences)
-        }
+        try await test_PerformPendingJoinsRecovery(.giveUp, cause: .mlsCommitMissingReferences)
     }
 
     private func test_PerformPendingJoinsRecovery(

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1163,19 +1163,18 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     }
 
     func test_PerformPendingJoins_Retries() async throws {
-        try await test_PerformPendingJoinsRecovery(.retry)
+        try await test_PerformPendingJoinsRecovery(.retry, cause: .mlsStaleMessage)
     }
 
     func test_PerformPendingJoins_GivesUp() async throws {
-        do {
-            try await test_PerformPendingJoinsRecovery(.giveUp)
-        } catch ExternalCommitError.failedToSendCommit(recovery: .giveUp) {
-            // expected
+        await assertItThrows(error: SendCommitBundleAction.Failure.mlsCommitMissingReferences) {
+            try await test_PerformPendingJoinsRecovery(.giveUp, cause: .mlsCommitMissingReferences)
         }
     }
 
     private func test_PerformPendingJoinsRecovery(
         _ recovery: ExternalCommitError.RecoveryStrategy,
+        cause: SendCommitBundleAction.Failure,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
@@ -1208,7 +1207,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             joinGroupCount += 1
 
             if joinGroupCount == 1 {
-                throw ExternalCommitError.failedToSendCommit(recovery: recovery)
+                throw ExternalCommitError.failedToSendCommit(
+                    recovery: recovery,
+                    cause: cause
+                )
             }
 
             return []
@@ -1844,7 +1846,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockUpdateKeyMaterialCount += 1 }
             switch mockUpdateKeyMaterialCount {
             case 0:
-                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync, cause: .mlsStaleMessage)
             default:
                 return []
             }
@@ -1884,7 +1886,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockUpdateKeyMaterialCount += 1 }
             switch mockUpdateKeyMaterialCount {
             case 0..<3:
-                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync, cause: .mlsStaleMessage)
             default:
                 return []
             }
@@ -1919,7 +1921,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockCommitPendingProposalsCount += 1 }
             switch mockCommitPendingProposalsCount {
             case 0..<2:
-                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync, cause: .mlsStaleMessage)
             default:
                 return []
             }
@@ -1931,7 +1933,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             defer { mockUpdateKeyMaterialCount += 1 }
             switch mockUpdateKeyMaterialCount {
             case 0..<3:
-                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync)
+                throw CommitError.failedToSendCommit(recovery: .retryAfterQuickSync, cause: .mlsStaleMessage)
             default:
                 return []
             }
@@ -1982,7 +1984,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         var mockUpdateKeyMaterialCount = 0
         mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
             defer { mockUpdateKeyMaterialCount += 1 }
-            throw CommitError.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync)
+            throw CommitError.failedToSendCommit(recovery: .commitPendingProposalsAfterQuickSync, cause: .mlsStaleMessage)
         }
 
         // Mock quick sync.
@@ -2020,7 +2022,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         var mockUpdateKeyMaterialCount = 0
         mockMLSActionExecutor.mockUpdateKeyMaterial = { _ in
             defer { mockUpdateKeyMaterialCount += 1 }
-            throw CommitError.failedToSendCommit(recovery: .giveUp)
+            throw CommitError.failedToSendCommit(recovery: .giveUp, cause: .mlsProtocolError)
         }
 
         // Mock quick sync.
@@ -2030,7 +2032,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         }
 
         // Then
-        await assertItThrows(error: CommitError.failedToSendCommit(recovery: .giveUp)) {
+        await assertItThrows(error: SendCommitBundleAction.Failure.mlsProtocolError) {
             // When
             try await sut.updateKeyMaterial(for: groupID)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/MLSConversationParticipantsService.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/MLSConversationParticipantsService.swift
@@ -105,8 +105,15 @@ struct MLSConversationParticipantsService: MLSConversationParticipantsServiceInt
             let failedUsers = await context.perform {
                 users.filter { failedMLSUsers.contains(MLSUser(from: $0)) }
             }
-
             throw MLSConversationParticipantsError.failedToClaimKeyPackages(users: Set(failedUsers))
+
+        } catch SendCommitBundleAction.Failure.nonFederatingDomains(domains: let domains) {
+
+            throw FederationError.nonFederatingDomains(domains)
+
+        } catch SendCommitBundleAction.Failure.unreachableDomains(domains: let domains) {
+
+            throw FederationError.unreachableDomains(domains)
 
         } catch {
             WireLogger.mls.warn("failed to add members to conversation (\(String(describing: qualifiedID))): \(String(describing: error))")

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/MLSConversationParticipantsServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/MLSConversationParticipantsServiceTests.swift
@@ -123,6 +123,42 @@ class MLSConversationParticipantsServiceTests: MessagingTestBase {
         }
     }
 
+    func test_AddParticipants_Throws_UnreachableDomainsError() async {
+        // GIVEN
+        let unreachableDomains = Set(["example.com"])
+        let mlsUser = await syncMOC.perform { [self] in
+            MLSUser(from: user)
+        }
+
+        mockMLSService.addMembersToConversationWithFor_MockMethod = { _, _ in
+            throw SendCommitBundleAction.Failure.unreachableDomains(unreachableDomains)
+        }
+
+        // THEN
+        await assertItThrows(error: FederationError.unreachableDomains(unreachableDomains)) {
+            // WHEN
+            try await sut.addParticipants([user], to: conversation)
+        }
+    }
+
+    func test_AddParticipants_Throws_NonFederatingDomainsError() async {
+        // GIVEN
+        let unreachableDomains = Set(["example"])
+        let mlsUser = await syncMOC.perform { [self] in
+            MLSUser(from: user)
+        }
+
+        mockMLSService.addMembersToConversationWithFor_MockMethod = { _, _ in
+            throw SendCommitBundleAction.Failure.nonFederatingDomains(unreachableDomains)
+        }
+
+        // THEN
+        await assertItThrows(error: FederationError.nonFederatingDomains(unreachableDomains)) {
+            // WHEN
+            try await sut.addParticipants([user], to: conversation)
+        }
+    }
+
     func test_AddParticipants_RethrowsErrors() async {
         // GIVEN
         mockMLSService.addMembersToConversationWithFor_MockMethod = { _, _ in

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/SendCommitBundleActionHandlerTests.swift
@@ -58,6 +58,7 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
     }
 
     // MARK: - Response handling
+
     func test_itHandlesSuccess() throws {
         // Given
         let payload: [AnyHashable: Any] = [
@@ -113,5 +114,23 @@ class SendCommitBundleActionHandlerTests: ActionHandlerTestBase<SendCommitBundle
             .failure(status: 422, error: .mlsUnsupportedMessage, label: "mls-unsupported-message"),
             .failure(status: 999, error: .unknown(status: 999, label: "foo", message: "?"), label: "foo")
         ])
+    }
+
+    func test_itHandlesUnreachableBackendsFailure() {
+        let domains = ["example.com"]
+        let payload = ["unreachable_backends": domains]
+        test_itHandlesFailure(
+            status: 533,
+            payload: payload as ZMTransportData,
+            expectedError: SendCommitBundleAction.Failure.unreachableDomains(Set(domains)))
+    }
+
+    func test_itHandlesNonFederatingBackendsFailure() {
+        let domains = ["example.com"]
+        let payload = ["non_federating_backends": domains]
+        test_itHandlesFailure(
+            status: 409,
+            payload: payload as ZMTransportData,
+            expectedError: SendCommitBundleAction.Failure.nonFederatingDomains(Set(domains)))
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-2228" title="WPB-2228" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-2228</a>  [iOS] Implement MLS client protocol for adding users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Re-opened since https://github.com/wireapp/wire-ios/pull/846 was closed by mistake

---

When adding federated users (or creating a new group) to a conversation, the backends of those users might not be reachable or might not be properly configured to allow the users to be added. If this happens a client should remove exclude these users and insert a system informing the user about the users who couldn't be added.

This logic was already implemented for proteus conversations, this PR enables this logic to also be applied to MLS conversations by parsing and bubbling up federation errors during the MLS add participant action.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
