### PR TITLE
feat: copy handle with domain - WPB-6438

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -141,7 +141,7 @@ final class DeveloperToolsViewModel: ObservableObject {
             sections.append(Section(
                 header: "Self user",
                 items: [
-                    .text(TextItem(title: "Handle", value: selfUser.handle ?? "None")),
+                    .text(TextItem(title: "Handle", value: selfUser.handleDisplayString(withDomain: true) ?? "None")),
                     .text(TextItem(title: "Email", value: selfUser.emailAddress ?? "None")),
                     .text(TextItem(title: "User ID", value: selfUser.remoteIdentifier.uuidString)),
                     .text(TextItem(title: "Analytics ID", value: selfUser.analyticsIdentifier?.uppercased() ?? "None")),

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -42,15 +42,15 @@ protocol SettingsCellDescriptorType: AnyObject {
     var title: String {get}
     var identifier: String? {get}
     var group: SettingsGroupCellDescriptorType? {get}
-    var canCopy: Bool { get }
+    var copiableText: String? { get }
 
     func select(_: SettingsPropertyValue?)
     func featureCell(_: SettingsCellType)
 }
 
 extension SettingsCellDescriptorType {
-    var canCopy: Bool {
-        return false
+    var copiableText: String? {
+        return nil
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -42,9 +42,16 @@ protocol SettingsCellDescriptorType: AnyObject {
     var title: String {get}
     var identifier: String? {get}
     var group: SettingsGroupCellDescriptorType? {get}
+    var canCopy: Bool { get }
 
     func select(_: SettingsPropertyValue?)
     func featureCell(_: SettingsCellType)
+}
+
+extension SettingsCellDescriptorType {
+    var canCopy: Bool {
+        return false
+    }
 }
 
 func == (left: SettingsCellDescriptorType, right: SettingsCellDescriptorType) -> Bool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -233,7 +233,8 @@ extension SettingsCellDescriptorFactory {
                     presentationStyle: .navigation,
                     presentationAction: presentation,
                     previewGenerator: preview,
-                    accessoryViewMode: .alwaysHide
+                    accessoryViewMode: .alwaysHide,
+                    canCopy: true
                 )
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -221,12 +221,16 @@ extension SettingsCellDescriptorFactory {
             }
 
             if let selfUser = ZMUser.selfUser(), nil != selfUser.handle {
+
                 let preview: PreviewGeneratorType = { _ in
                     guard let handleDisplayString = selfUser.handleDisplayString(withDomain: federationEnabled) else {
                         return .none
                     }
                     return .text(handleDisplayString)
                 }
+
+                let copiableText = selfUser.handleDisplayString(withDomain: federationEnabled)
+
                 return SettingsExternalScreenCellDescriptor(
                     title: AccountSection.Handle.title,
                     isDestructive: false,
@@ -234,7 +238,7 @@ extension SettingsCellDescriptorFactory {
                     presentationAction: presentation,
                     previewGenerator: preview,
                     accessoryViewMode: .alwaysHide,
-                    canCopy: true
+                    copiableText: copiableText
                 )
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -63,7 +63,8 @@ class SettingsCellDescriptorFactory {
                                                     },
                                                     previewGenerator: nil,
                                                     icon: .team,
-                                                    accessoryViewMode: .alwaysHide)
+                                                    accessoryViewMode: .alwaysHide,
+                                                    canCopy: false)
     }
 
     func addAccountOrTeamCell() -> SettingsCellDescriptorType {
@@ -92,7 +93,8 @@ class SettingsCellDescriptorFactory {
                                                     presentationAction: presentationAction,
                                                     previewGenerator: nil,
                                                     icon: .plus,
-                                                    accessoryViewMode: .alwaysHide)
+                                                    accessoryViewMode: .alwaysHide,
+                                                    canCopy: false)
     }
 
     func settingsGroup(isTeamMember: Bool, userSession: UserSession) -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
@@ -135,7 +137,8 @@ class SettingsCellDescriptorFactory {
             previewGenerator: { _ -> SettingsCellPreview in
                 return SettingsCellPreview.badge(ZMUser.selfUser()?.clients.count ?? 0)
             },
-           icon: .devices)
+           icon: .devices,
+                                                    canCopy: false)
     }
 
     func soundGroupForSetting(_ settingsProperty: SettingsProperty, title: String, customSounds: [ZMSound], defaultSound: ZMSound) -> SettingsCellDescriptorType {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -64,7 +64,7 @@ class SettingsCellDescriptorFactory {
                                                     previewGenerator: nil,
                                                     icon: .team,
                                                     accessoryViewMode: .alwaysHide,
-                                                    canCopy: false)
+                                                    copiableText: nil)
     }
 
     func addAccountOrTeamCell() -> SettingsCellDescriptorType {
@@ -94,7 +94,7 @@ class SettingsCellDescriptorFactory {
                                                     previewGenerator: nil,
                                                     icon: .plus,
                                                     accessoryViewMode: .alwaysHide,
-                                                    canCopy: false)
+                                                    copiableText: nil)
     }
 
     func settingsGroup(isTeamMember: Bool, userSession: UserSession) -> SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
@@ -137,8 +137,7 @@ class SettingsCellDescriptorFactory {
             previewGenerator: { _ -> SettingsCellPreview in
                 return SettingsCellPreview.badge(ZMUser.selfUser()?.clients.count ?? 0)
             },
-           icon: .devices,
-                                                    canCopy: false)
+           icon: .devices, copiableText: nil)
     }
 
     func soundGroupForSetting(_ settingsProperty: SettingsProperty, title: String, customSounds: [ZMSound], defaultSound: ZMSound) -> SettingsCellDescriptorType {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -40,7 +40,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
     let presentationStyle: PresentationStyle
     let identifier: String?
     let icon: StyleKitIcon?
-    var canCopy: Bool
+    var copiableText: String?
 
     private let accessoryViewMode: AccessoryViewMode
 
@@ -60,7 +60,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
             presentationAction: presentationAction,
             previewGenerator: nil,
             icon: .none,
-            canCopy: false
+            copiableText: nil
         )
     }
 
@@ -71,7 +71,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
                      previewGenerator: PreviewGeneratorType? = .none,
                      icon: StyleKitIcon? = nil,
                      accessoryViewMode: AccessoryViewMode = .default,
-                     canCopy: Bool = false) {
+                     copiableText: String? = nil) {
         self.init(
             title: title,
             isDestructive: isDestructive,
@@ -81,7 +81,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
             previewGenerator: previewGenerator,
             icon: icon,
             accessoryViewMode: accessoryViewMode,
-            canCopy: canCopy
+            copiableText: copiableText
         )
     }
 
@@ -93,7 +93,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
          previewGenerator: PreviewGeneratorType? = .none,
          icon: StyleKitIcon? = nil,
          accessoryViewMode: AccessoryViewMode = .default,
-         canCopy: Bool) {
+         copiableText: String?) {
 
         self.title = title
         self.destructive = isDestructive
@@ -103,7 +103,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         self.previewGenerator = previewGenerator
         self.icon = icon
         self.accessoryViewMode = accessoryViewMode
-        self.canCopy = canCopy
+        self.copiableText = copiableText
     }
 
     func select(_ value: SettingsPropertyValue?) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -40,6 +40,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
     let presentationStyle: PresentationStyle
     let identifier: String?
     let icon: StyleKitIcon?
+    var canCopy: Bool
 
     private let accessoryViewMode: AccessoryViewMode
 
@@ -58,7 +59,8 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
             identifier: nil,
             presentationAction: presentationAction,
             previewGenerator: nil,
-            icon: .none
+            icon: .none,
+            canCopy: false
         )
     }
 
@@ -68,7 +70,8 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
                      presentationAction: @escaping () -> (UIViewController?),
                      previewGenerator: PreviewGeneratorType? = .none,
                      icon: StyleKitIcon? = nil,
-                     accessoryViewMode: AccessoryViewMode = .default) {
+                     accessoryViewMode: AccessoryViewMode = .default,
+                     canCopy: Bool = false) {
         self.init(
             title: title,
             isDestructive: isDestructive,
@@ -77,7 +80,8 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
             presentationAction: presentationAction,
             previewGenerator: previewGenerator,
             icon: icon,
-            accessoryViewMode: accessoryViewMode
+            accessoryViewMode: accessoryViewMode,
+            canCopy: canCopy
         )
     }
 
@@ -88,7 +92,8 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
          presentationAction: @escaping () -> (UIViewController?),
          previewGenerator: PreviewGeneratorType? = .none,
          icon: StyleKitIcon? = nil,
-         accessoryViewMode: AccessoryViewMode = .default) {
+         accessoryViewMode: AccessoryViewMode = .default,
+         canCopy: Bool) {
 
         self.title = title
         self.destructive = isDestructive
@@ -98,6 +103,7 @@ class SettingsExternalScreenCellDescriptor: SettingsExternalScreenCellDescriptor
         self.previewGenerator = previewGenerator
         self.icon = icon
         self.accessoryViewMode = accessoryViewMode
+        self.canCopy = canCopy
     }
 
     func select(_ value: SettingsPropertyValue?) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
@@ -33,7 +33,7 @@ final class SettingsSignOutCellDescriptor: SettingsExternalScreenCellDescriptor 
                    previewGenerator: nil,
                    icon: nil,
                    accessoryViewMode: .default,
-                   canCopy: false)
+                   copiableText: nil)
 
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsSignOutCellDescriptor.swift
@@ -32,7 +32,8 @@ final class SettingsSignOutCellDescriptor: SettingsExternalScreenCellDescriptor 
                    presentationAction: { return nil },
                    previewGenerator: nil,
                    icon: nil,
-                   accessoryViewMode: .default)
+                   accessoryViewMode: .default,
+                   canCopy: false)
 
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -255,6 +255,37 @@ final class SettingsTableViewController: SettingsBaseTableViewController {
         fatalError("Cannot dequeue cell for index path \(indexPath) and cellDescriptor \(cellDescriptor)")
     }
 
+    func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
+        let sectionDescriptor = sections[(indexPath as NSIndexPath).section]
+        let cellDescriptor = sectionDescriptor.visibleCellDescriptors[(indexPath as NSIndexPath).row]
+        return cellDescriptor.canCopy
+    }
+
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        let sectionDescriptor = sections[(indexPath as NSIndexPath).section]
+        let cellDescriptor = sectionDescriptor.visibleCellDescriptors[(indexPath as NSIndexPath).row]
+
+        guard cellDescriptor.canCopy else {
+            return nil
+        }
+
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
+          let copy = UIAction(title: "Copy", image: UIImage(systemName: "doc.on.doc")) { _ in
+            if let cell = tableView.cellForRow(at: indexPath) as? SettingsCellType {
+              let pasteboard = UIPasteboard.general
+                switch cell.preview {
+                case .text(let value):
+                    pasteboard.string = value
+                default:
+                    assertionFailure("this is not handle, please implement support")
+                }
+
+            }
+          }
+          return UIMenu(children: [copy])
+        }
+    }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let sectionDescriptor = sections[(indexPath as NSIndexPath).section]
         let property = sectionDescriptor.visibleCellDescriptors[(indexPath as NSIndexPath).row]

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -258,29 +258,21 @@ final class SettingsTableViewController: SettingsBaseTableViewController {
     func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
         let sectionDescriptor = sections[(indexPath as NSIndexPath).section]
         let cellDescriptor = sectionDescriptor.visibleCellDescriptors[(indexPath as NSIndexPath).row]
-        return cellDescriptor.canCopy
+        return cellDescriptor.copiableText != nil
     }
 
     func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         let sectionDescriptor = sections[(indexPath as NSIndexPath).section]
         let cellDescriptor = sectionDescriptor.visibleCellDescriptors[(indexPath as NSIndexPath).row]
 
-        guard cellDescriptor.canCopy else {
+        guard let copiableText = cellDescriptor.copiableText else {
             return nil
         }
 
         return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
-          let copy = UIAction(title: "Copy", image: UIImage(systemName: "doc.on.doc")) { _ in
-            if let cell = tableView.cellForRow(at: indexPath) as? SettingsCellType {
-              let pasteboard = UIPasteboard.general
-                switch cell.preview {
-                case .text(let value):
-                    pasteboard.string = value
-                default:
-                    assertionFailure("this is not handle, please implement support")
-                }
-
-            }
+            let copy = UIAction(title: L10n.Localizable.Content.Message.copy, image: UIImage(systemName: "doc.on.doc")) { _ in
+            let pasteboard = UIPasteboard.general
+            pasteboard.string = copiableText
           }
           return UIMenu(children: [copy])
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6438" title="WPB-6438" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6438</a>  [iOS] copy handle with domain in account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

During playtest it is hard to share its handle.
### Causes (Optional)

Can't copy domain in federated backend.

### Solutions

* add long press copy on handle in account
* display full handle with domain in developer tools

### Attachments (Optional)

![IMG_6484](https://github.com/wireapp/wire-ios/assets/254198/3ab6735d-c53e-4efe-a4fd-7a271c63a46b)
