### PR TITLE
feat: add tests for handling unreachable domains when creating mls group WPB-3696

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
@@ -278,9 +278,11 @@ final class ConversationServiceTests: MessagingTestBase {
 
     func test_CreateGroupConversation_CreatesMLSGroup() {
         // Given
+        let groupID = MLSGroupID.random()
+
         syncMOC.performAndWait {
             groupConversation.messageProtocol = .mls
-            groupConversation.mlsGroupID = .random()
+            groupConversation.mlsGroupID = groupID
             syncMOC.saveOrRollback()
         }
 
@@ -292,22 +294,17 @@ final class ConversationServiceTests: MessagingTestBase {
             context: uiMOC.notificationContext
         )
 
-        mockConversationParticipantsService.addParticipantsTo_MockMethod = { users, conversation in
-            self.syncMOC.performAndWait {
-                XCTAssertEqual(conversation.remoteIdentifier, self.groupConversation.remoteIdentifier)
-            }
-            XCTAssertEqual(self.user1.objectID, users.first?.objectID)
+        let mlsService = MockMLSServiceInterface()
+        mlsService.createGroupForWith_MockMethod = { _, _ in
+            // no op
         }
 
-        let mlsService = MockMLSServiceInterface()
-        mlsService.createGroupForWith_MockMethod = { groupId, users in
-            XCTAssertTrue(users.isEmpty)
-            self.syncMOC.performAndWait {
-                XCTAssertEqual(groupId, self.groupConversation.mlsGroupID)
-            }
-        }
         syncMOC.performAndWait {
             syncMOC.mlsService = mlsService
+        }
+
+        mockConversationParticipantsService.addParticipantsTo_MockMethod = { _, _ in
+            // no op
         }
 
         // When
@@ -328,9 +325,94 @@ final class ConversationServiceTests: MessagingTestBase {
             }
         }
 
-        // Then we got the expected failure.
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+
+        // Then we created the group via the action..
         XCTAssertEqual(mockActionHandler.performedActions.count, 1)
+
+        // Then we created the mls group once with no users.
+        let createGroupCalls = mlsService.createGroupForWith_Invocations
+        XCTAssertEqual(createGroupCalls.count, 1)
+        XCTAssertEqual(createGroupCalls.first?.groupID, groupID)
+        XCTAssertEqual(createGroupCalls.first?.users, [])
+
+        // Then we only added the user.
+        let addParticipantCalls = mockConversationParticipantsService.addParticipantsTo_Invocations
+        XCTAssertEqual(addParticipantCalls.count, 1)
+        XCTAssertEqual(addParticipantCalls.first?.conversation, groupConversation)
+        XCTAssertEqual(addParticipantCalls.first?.users, [user1])
+    }
+
+    func test_CreateGroupConversation_CreatesMLSGroup_WithOnlyReachableUsers() {
+        // Given
+        let groupID = MLSGroupID.random()
+        let unreachableDomain = "foma.wire.link"
+
+        syncMOC.performAndWait {
+            groupConversation.messageProtocol = .mls
+            groupConversation.mlsGroupID = groupID
+            user2.domain = unreachableDomain
+            syncMOC.saveOrRollback()
+        }
+
+        let objectID = groupConversation.objectID
+        let didFinish = customExpectation(description: "didFinish")
+
+        let mockActionHandler = MockActionHandler<CreateGroupConversationAction>(
+            results: [
+                .failure(.unreachableDomains([unreachableDomain])),
+                .success(objectID)
+            ],
+            context: uiMOC.notificationContext
+        )
+
+        let mlsService = MockMLSServiceInterface()
+        mlsService.createGroupForWith_MockMethod = { _, _ in
+            // no op
+        }
+
+        syncMOC.performAndWait {
+            syncMOC.mlsService = mlsService
+        }
+
+        mockConversationParticipantsService.addParticipantsTo_MockMethod = { _, _ in
+            // no op
+        }
+
+        // When
+        sut.createGroupConversation(
+            name: nil,
+            users: [user1, user2],
+            allowGuests: true,
+            allowServices: true,
+            enableReceipts: true,
+            messageProtocol: .mls
+        ) {
+            switch $0 {
+            case .success:
+                didFinish.fulfill()
+
+            case .failure(let error):
+                XCTFail("unexpected error: \(error)")
+            }
+        }
+
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+
+        // Then we tried to create the group twice.
+        XCTAssertEqual(mockActionHandler.performedActions.count, 2)
+
+        // Then we created the mls group once with no users.
+        let createGroupCalls = mlsService.createGroupForWith_Invocations
+        XCTAssertEqual(createGroupCalls.count, 1)
+        XCTAssertEqual(createGroupCalls.first?.groupID, groupID)
+        XCTAssertEqual(createGroupCalls.first?.users, [])
+
+        // Then we only added the reachable user.
+        let addParticipantCalls = mockConversationParticipantsService.addParticipantsTo_Invocations
+        XCTAssertEqual(addParticipantCalls.count, 1)
+        XCTAssertEqual(addParticipantCalls.first?.conversation, groupConversation)
+        XCTAssertEqual(addParticipantCalls.first?.users, [user1])
     }
 
     func test_CreateGroupConversation_WithUsersWithNoPackages_IsSuccessful() {
@@ -453,7 +535,7 @@ final class ConversationServiceTests: MessagingTestBase {
             allowGuests: true,
             allowServices: true,
             enableReceipts: true,
-            messageProtocol: .proteus
+            messageProtocol: .mls
         ) {
             defer { didFinish.fulfill() }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3696" title="WPB-3696" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-3696</a>  [iOS] MLS Conversation creation when a participant is on a remote offline backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The handling of the "unreachable domain" error when creating a group does not depend on the message protocol, so this functionality is already implemented for both proteus and mls conversations. This PR adds the missing tests for the `ConversationService` for mls conversations.

### Testing

#### Test Coverage

- unit test asserting mls group is created only with reachable users.

#### How to Test

1. User A on backend A creates an mls group with user B (backend B) and user C (from unreachable backend C)
2. Assert the conversation is created only with user B.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
