### PR TITLE
fix: E2ei enrollment part

### DIFF
--- a/wire-ios-data-model/Source/Model/FeatureConfig/E2EId/Feature.E2EId.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/E2EId/Feature.E2EId.swift
@@ -46,13 +46,15 @@ public extension Feature {
 
         public struct Config: Codable, Equatable {
 
-            public let acmeDiscoveryUrl: String
+            public let acmeDiscoveryUrl: String?
             public let verificationExpiration: UInt
 
-            public init(acmeDiscoveryUrl: String = "", verificationExpiration: UInt = 60) {
-                self.acmeDiscoveryUrl = acmeDiscoveryUrl
-                self.verificationExpiration = verificationExpiration
-            }
+            public init(
+                acmeDiscoveryUrl: String? = nil,
+                verificationExpiration: UInt = 86400) {
+                    self.acmeDiscoveryUrl = acmeDiscoveryUrl
+                    self.verificationExpiration = verificationExpiration
+                }
 
         }
 

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2eIKeyPackageRotator.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2eIKeyPackageRotator.swift
@@ -130,10 +130,11 @@ public class E2eIKeyPackageRotator: E2eIKeyPackageRotating {
     }
 
     private func migrateConversation(with groupID: String, commit: CommitBundle) async throws {
-        guard let groupID = MLSGroupID(base64Encoded: groupID) else {
+        guard let groupData = groupID.zmHexDecodedData() else {
             throw Error.invalidGroupID
         }
 
+        let groupID = MLSGroupID(groupData)
         let events = try await commitSender.sendCommitBundle(
             commit,
             for: groupID

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -266,7 +266,9 @@ public class ZMUserSession: NSObject {
     }()
 
     public lazy var enrollE2eICertificate: EnrollE2eICertificateUseCaseInterface? = {
-        let acmeDiscoveryPath = e2eiFeature.config.acmeDiscoveryUrl
+        guard let acmeDiscoveryPath = e2eiFeature.config.acmeDiscoveryUrl else {
+            return nil
+        }
         let acmeApi = AcmeAPI(acmeDiscoveryPath: acmeDiscoveryPath)
         let httpClient = HttpClientImpl(
             transportSession: transportSession,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There are 2 fixes in this PR:
1. Make` acmeDiscoveryUrl` e2ei feature config property as optional. BE sends it to us as nill for the default configuration.
2. Change the groupID format that we pass to CC when `sendCommitBundle`.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
