### PR TITLE
fix: sync engine unit tests target - WPB-6479

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMSyncStrategyTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMSyncStrategyTests.m
@@ -65,17 +65,19 @@
 {
     [super setUp];
     
-    ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
-    selfUser.remoteIdentifier = self.userIdentifier;
-    
-    ZMConversation *selfConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
-    selfConversation.remoteIdentifier = self.userIdentifier;
-    selfConversation.conversationType = ZMConversationTypeSelf;
+    [self.syncMOC performBlockAndWait:^{
+        ZMUser *selfUser = [ZMUser selfUserInContext:self.syncMOC];
+        selfUser.remoteIdentifier = self.userIdentifier;
 
-    [self.lastEventIDRepository storeLastEventID:[NSUUID UUID]];
-    
-    [self.syncMOC saveOrRollback];
-        
+        ZMConversation *selfConversation = [ZMConversation insertNewObjectInManagedObjectContext:self.syncMOC];
+        selfConversation.remoteIdentifier = self.userIdentifier;
+        selfConversation.conversationType = ZMConversationTypeSelf;
+
+        [self.lastEventIDRepository storeLastEventID:[NSUUID UUID]];
+
+        [self.syncMOC saveOrRollback];
+    }];
+
     self.syncStateDelegate = [[MockSyncStateDelegate alloc] init];
     self.mockEventConsumer = [[MockEventConsumer alloc]  init];
     self.mockContextChangeTracker = [[MockContextChangeTracker alloc] init];
@@ -141,7 +143,10 @@
     self.mockContextChangeTracker.fetchRequest = self.fetchRequestForTrackedObjects2;
         
     // when
-    (void)[self.sut nextRequestForAPIVersion:APIVersionV0];
+    [self.syncMOC performBlockAndWait:^{
+        (void)[self.sut nextRequestForAPIVersion:APIVersionV0];
+    }];
+
     
     // then
     XCTAssertTrue(self.mockContextChangeTracker.addTrackedObjectsCalled);
@@ -318,9 +323,11 @@
     for (NSNotification *note in didSaveNotificationsA) {
         [[NSNotificationCenter defaultCenter] postNotification:note];
     }
-    for (NSNotification *note in didSaveNotificationsB) {
-        [[NSNotificationCenter defaultCenter] postNotification:note];
-    }
+    [self.syncMOC performGroupedBlock:^{
+        for (NSNotification *note in didSaveNotificationsB) {
+            [[NSNotificationCenter defaultCenter] postNotification:note];
+        }
+    }];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -81,8 +81,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatDelegateIsCalled_WhenEncryptionAtRestIsEnabled() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         let userSessionDelegate = MockUserSessionDelegate()
         sut.delegate = userSessionDelegate
 
@@ -96,8 +98,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatDelegateIsCalled_WhenEncryptionAtRestIsDisabled() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
         let userSessionDelegate = MockUserSessionDelegate()
         sut.delegate = userSessionDelegate
@@ -113,8 +117,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseIsUnlocked_WhenEncryptionAtRestIsDisabled() {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
 
         // when
         setEncryptionAtRest(enabled: false)
@@ -125,8 +131,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseIsUnlocked_AfterActivatingEncryptionAtRest() {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
 
         // when
         setEncryptionAtRest(enabled: true)
@@ -137,8 +145,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseIsUnlocked_AfterDeactivatingEncryptionAtRest() {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         // when
@@ -150,8 +160,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseIsUnlocked_AfterUnlockingDatabase() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
         sut.applicationDidEnterBackground(nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -168,8 +180,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatDatabaseIsLocked_AfterEnteringBackground() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         // when
@@ -182,8 +196,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseIsLocked_AfterBackgroundTaskCompletesInTheBackground() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         // when
@@ -199,8 +215,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseIsNotLocked_IfThereIsAnActiveBackgroundTask() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         // when
@@ -217,9 +235,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     func testThatDatabaseIsLocked_WhenTheCustomTimeoutHasExpiredInTheBackground() throws {
         // given
         factory.backgroundTaskTimeout = 2
-
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         // when
@@ -239,8 +258,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatDatabaseLockedHandlerIsCalled_AfterDatabaseIsLocked() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         // expect
@@ -263,8 +284,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatDatabaseLockedHandlerIsCalled_AfterUnlockingDatabase() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
         sut.applicationDidEnterBackground(nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
@@ -294,8 +317,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
     func testThatIfDatabaseIsLocked_ThenUserSessionLockIsSet() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: true)
 
         sut.applicationDidEnterBackground(nil)
@@ -309,8 +334,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     func testThatIfDatabaseIsNotLocked_ThenUserSessionLockIsNotSet() throws {
         // given
-        simulateLoggedInUser()
-        syncMOC.saveOrRollback()
+        syncMOC.performAndWait {
+            simulateLoggedInUser()
+            syncMOC.saveOrRollback()
+        }
         setEncryptionAtRest(enabled: false)
         XCTAssertFalse(sut.isDatabaseLocked)
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -323,7 +323,10 @@ extension ZMUserSessionTests_PushNotifications {
     }
 
     func handle(action: String, category: String, userInfo: NotificationUserInfo, userText: String? = nil) {
-        sut.handleNotificationResponse(actionIdentifier: action, categoryIdentifier: category, userInfo: userInfo, userText: userText) {}
+        uiMOC.performAndWait {
+            sut.handleNotificationResponse(actionIdentifier: action, categoryIdentifier: category, userInfo: userInfo, userText: userText) {}
+        }
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         syncMOC.performAndWait {
             sut.didFinishQuickSync()

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
@@ -46,7 +46,10 @@ final class ZMUserSessionTests_RecurringActions: ZMUserSessionTestsBase {
 
         // When
         XCTAssertTrue(mockRecurringActionService.performActionsIfNeeded_Invocations.isEmpty)
-        sut.didFinishQuickSync()
+        syncMOC.performAndWait {
+            sut.didFinishQuickSync()
+        }
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // Then

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Syncing.swift
@@ -50,16 +50,23 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
     }
 
     func finishQuickSync() {
-        sut.applicationStatusDirectory.syncStatus.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
+        syncMOC.performAndWait {
+            sut.applicationStatusDirectory.syncStatus.finishCurrentSyncPhase(phase: .fetchingMissedEvents)
+        }
     }
 
     func startSlowSync() {
-        sut.applicationStatusDirectory.syncStatus.forceSlowSync()
+        syncMOC.performAndWait {
+            sut.applicationStatusDirectory.syncStatus.forceSlowSync()
+        }
     }
 
     func finishSlowSync() {
-        sut.applicationStatusDirectory.syncStatus.currentSyncPhase = .lastSlowSyncPhase
-        sut.applicationStatusDirectory.syncStatus.finishCurrentSyncPhase(phase: .lastSlowSyncPhase)
+        syncMOC.performAndWait {
+            sut.applicationStatusDirectory.syncStatus.currentSyncPhase = .lastSlowSyncPhase
+            sut.applicationStatusDirectory.syncStatus.finishCurrentSyncPhase(phase: .lastSlowSyncPhase)
+
+        }
     }
 
     // MARK: Slow Sync
@@ -72,7 +79,9 @@ class ZMUserSessionTests_Syncing: ZMUserSessionTestsBase {
         XCTAssertTrue(sut.notificationDispatcher.isEnabled)
 
         // when
-        startSlowSync()
+        syncMOC.performAndWait {
+            startSlowSync()
+        }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -26,7 +26,9 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         // given
         XCTAssertNotNil(self.sut.syncManagedObjectContext)
         // when & then
-        XCTAssertEqual(self.sut.syncManagedObjectContext, self.sut.syncManagedObjectContext.zm_sync)
+        coreDataStack.syncContext.performAndWait {
+            XCTAssertEqual(self.sut.syncManagedObjectContext, self.sut.syncManagedObjectContext.zm_sync)
+        }
     }
 
     func testThatUIContextReturnsSelfForLinkedUIContext() {
@@ -40,7 +42,9 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         // given
         XCTAssertNotNil(self.sut.syncManagedObjectContext)
         // when & then
-        XCTAssertEqual(self.sut.syncManagedObjectContext.zm_userInterface, self.sut.managedObjectContext)
+        coreDataStack.syncContext.performAndWait {
+            XCTAssertEqual(self.sut.syncManagedObjectContext.zm_userInterface, self.sut.managedObjectContext)
+        }
     }
 
     func testThatUIContextReturnsLinkedSyncContext() {
@@ -56,17 +60,21 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         var mocUI: NSManagedObjectContext? = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
 
         mocUI?.zm_sync = mocSync
-        mocSync?.zm_userInterface = mocUI
-
+        mocSync?.performAndWait {
+            mocSync?.zm_userInterface = mocUI
+        }
         XCTAssertNotNil(mocUI?.zm_sync)
-        XCTAssertNotNil(mocSync?.zm_userInterface)
-
+        mocSync?.performAndWait {
+            XCTAssertNotNil(mocSync?.zm_userInterface)
+        }
         // when
         mocUI = nil
 
         // then
         XCTAssertNotNil(mocSync)
-        XCTAssertNil(mocSync?.zm_userInterface)
+        mocSync?.performAndWait {
+            XCTAssertNil(mocSync?.zm_userInterface)
+        }
     }
 
     func testThatLinkedSyncContextIsNotStrongReferenced() {
@@ -75,11 +83,14 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         let mocUI: NSManagedObjectContext? = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
 
         mocUI?.zm_sync = mocSync
-        mocSync?.zm_userInterface = mocUI
+        mocSync?.performAndWait {
+            mocSync?.zm_userInterface = mocUI
+        }
 
         XCTAssertNotNil(mocUI?.zm_sync)
-        XCTAssertNotNil(mocSync?.zm_userInterface)
-
+        mocSync?.performAndWait {
+            XCTAssertNotNil(mocSync?.zm_userInterface)
+        }
         // when
         mocSync = nil
 
@@ -94,12 +105,17 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
             self.createSelfClient()
         }
 
-        // when
-        sut.didRegisterSelfUserClient(userClient)
+            // when
+        syncMOC.performGroupedBlock { [self] in
+            sut.didRegisterSelfUserClient(userClient)
+        }
+
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertEqual(mockPushChannel.clientID, userClient.remoteIdentifier)
+        syncMOC.performAndWait {
+            XCTAssertEqual(mockPushChannel.clientID, userClient.remoteIdentifier)
+        }
     }
 
     func testThatPerformChangesAreDoneSynchronouslyOnTheMainQueue() {
@@ -274,7 +290,9 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(thirdPartyServices.uploadCount, 0)
 
         // when
-        sut.didFinishQuickSync()
+        syncMOC.performAndWait {
+            sut.didFinishQuickSync()
+        }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -286,9 +304,11 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(thirdPartyServices.uploadCount, 0)
 
         // when
-        sut.didFinishQuickSync()
-        sut.didStartQuickSync()
-        sut.didFinishQuickSync()
+        syncMOC.performAndWait {
+            sut.didFinishQuickSync()
+            sut.didStartQuickSync()
+            sut.didFinishQuickSync()
+        }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -325,7 +345,9 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(thirdPartyServices.uploadCount, 0)
 
         // when
-        sut.didFinishQuickSync()
+        syncMOC.performAndWait {
+            sut.didFinishQuickSync()
+        }
         sut.applicationDidEnterBackground(nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -333,8 +355,10 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(thirdPartyServices.uploadCount, 1)
 
         sut.applicationWillEnterForeground(nil)
-        sut.didStartQuickSync()
-        sut.didFinishQuickSync()
+        syncMOC.performAndWait {
+            sut.didStartQuickSync()
+            sut.didFinishQuickSync()
+        }
         sut.applicationDidEnterBackground(nil)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -345,7 +369,9 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
     func testThatWeDoNotSetUserSessionToSyncDoneWhenSyncIsDoneIfWeWereNotSynchronizing() {
         // when
         sut.didGoOffline()
-        sut.didFinishQuickSync()
+        syncMOC.performAndWait {
+            sut.didFinishQuickSync()
+        }
 
         // then
         XCTAssertTrue(waitForOfflineStatus())
@@ -353,7 +379,9 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
 
     func testThatWeSetUserSessionToSynchronizingWhenSyncIsStarted() {
         // when
-        sut.didStartQuickSync()
+        syncMOC.performAndWait {
+            sut.didStartQuickSync()
+        }
 
         // then
         XCTAssertTrue(waitForOnlineSynchronizingStatus())
@@ -497,11 +525,10 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
             selfUserClient.mlsPublicKeys = UserClient.MLSPublicKeys(ed25519: "somekey")
             selfUserClient.needsToUploadMLSPublicKeys = false
             syncMOC.saveOrRollback()
+
+            // when
+            sut.didFinishQuickSync()
         }
-
-        // when
-        sut.didFinishQuickSync()
-
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -105,7 +105,7 @@ class ZMUserSessionTests: ZMUserSessionTestsBase {
             self.createSelfClient()
         }
 
-            // when
+        // when
         syncMOC.performGroupedBlock { [self] in
             sut.didRegisterSelfUserClient(userClient)
         }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -121,9 +121,11 @@ class ZMUserSessionTestsBase: MessagingTest {
     }
 
     func simulateLoggedInUser() {
-        syncMOC.setPersistentStoreMetadata("clientID", key: ZMPersistedClientIdKey)
-        ZMUser.selfUser(in: syncMOC).remoteIdentifier = UUID.create()
-        cookieStorage.authenticationCookieData = validCookie
+        syncMOC.performAndWait {
+            syncMOC.setPersistentStoreMetadata("clientID", key: ZMPersistedClientIdKey)
+            ZMUser.selfUser(in: syncMOC).remoteIdentifier = UUID.create()
+            cookieStorage.authenticationCookieData = validCookie
+        }
     }
 
     private func clearCache() {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests_NetworkState.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests_NetworkState.swift
@@ -57,8 +57,9 @@ final class ZMUserSessionTests_NetworkState: ZMUserSessionTestsBase {
         // then
         XCTAssertTrue(self.transportSession.didCallSetNetworkStateDelegate)
         XCTAssertEqual(mockPushChannel.keepOpen, true)
-        XCTAssertEqual(mockPushChannel.clientID, selfClient.remoteIdentifier)
-
+        syncMOC.performAndWait {
+            XCTAssertEqual(mockPushChannel.clientID, selfClient.remoteIdentifier)
+        }
         testSession.tearDown()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6479" title="WPB-6479" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-6479</a>  [iOS] update Unit Tests for SyncEngine
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

This PR is part of a series of PRs aiming to re-enable CoreData concurrency checks for SyncEngine.

This is the last PR for the UnitTests target of SyncEngine.

Remains to cover IntegrationTests target in order to re-enable the flag.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution
