### PR TITLE
chore: remove zmsdispatchgroup optionality

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Backup.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Backup.swift
@@ -62,7 +62,7 @@ extension CoreDataStack {
 
     // Calling this method will delete all backups stored inside `backupsDirectory`
     // as well as inside `importsDirectory` if there are any.
-    public static func clearBackupDirectory(dispatchGroup: ZMSDispatchGroup? = nil) {
+    public static func clearBackupDirectory(dispatchGroup: ZMSDispatchGroup) {
         func remove(at url: URL) {
             do {
                 guard fileManager.fileExists(atPath: url.path) else { return }
@@ -91,7 +91,7 @@ extension CoreDataStack {
         accountIdentifier: UUID,
         clientIdentifier: String,
         applicationContainer: URL,
-        dispatchGroup: ZMSDispatchGroup? = nil,
+        dispatchGroup: ZMSDispatchGroup,
         databaseKey: VolatileData? = nil,
         completion: @escaping (Result<BackupInfo, Error>) -> Void
     ) {
@@ -166,7 +166,7 @@ extension CoreDataStack {
         accountIdentifier: UUID,
         from backupDirectory: URL,
         applicationContainer: URL,
-        dispatchGroup: ZMSDispatchGroup? = nil,
+        dispatchGroup: ZMSDispatchGroup,
         completion: @escaping ((Result<URL, Error>) -> Void)
     ) {
         guard let activity = BackgroundActivityFactory.shared.startBackgroundActivity(withName: "import backup") else {
@@ -192,7 +192,7 @@ extension CoreDataStack {
         accountIdentifier: UUID,
         from backupDirectory: URL,
         applicationContainer: URL,
-        dispatchGroup: ZMSDispatchGroup? = nil,
+        dispatchGroup: ZMSDispatchGroup,
         messagingMigrator: CoreDataMessagingMigratorProtocol,
         completion: @escaping ((Result<URL, Error>) -> Void)
     ) {

--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Migration.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Migration.swift
@@ -37,7 +37,7 @@ extension CoreDataStack {
     }
 
     // Calling this method will delete all migrations stored inside `migrationDirectory`.
-    public static func clearMigrationDirectory(dispatchGroup: ZMSDispatchGroup? = nil) {
+    public static func clearMigrationDirectory(dispatchGroup: ZMSDispatchGroup) {
         workQueue.async(group: dispatchGroup) {
             removeDirectory(at: migrationDirectory)
         }
@@ -66,7 +66,7 @@ extension CoreDataStack {
     public static func migrateLocalStorage(
         accountIdentifier: UUID,
         applicationContainer: URL,
-        dispatchGroup: ZMSDispatchGroup? = nil,
+        dispatchGroup: ZMSDispatchGroup,
         migration: @escaping (NSManagedObjectContext) throws -> Void,
         completion: @escaping (Result<Void, Error>) -> Void
         ) {

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -158,7 +158,7 @@ public class NotificationSession {
         // Don't cache the cookie because if the user logs out and back in again in the main app
         // process, then the cached cookie will be invalid.
         let cookieStorage = ZMPersistentCookieStorage(forServerName: environment.backendURL.host!, userIdentifier: accountIdentifier, useCache: false)
-        let reachabilityGroup = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Sharing session reachability")!
+        let reachabilityGroup = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Sharing session reachability")
         let serverNames = [environment.backendURL, environment.backendWSURL].compactMap { $0.host }
         let reachability = ZMReachability(serverNames: serverNames, group: reachabilityGroup)
 

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -245,7 +245,7 @@ public class SharingSession {
         // Don't cache the cookie because if the user logs out and back in again in the main app
         // process, then the cached cookie will be invalid.
         let cookieStorage = ZMPersistentCookieStorage(forServerName: environment.backendURL.host!, userIdentifier: accountIdentifier, useCache: false)
-        let reachabilityGroup = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Sharing session reachability")!
+        let reachabilityGroup = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Sharing session reachability")
         let serverNames = [environment.backendURL, environment.backendWSURL].compactMap { $0.host }
         let reachability = ZMReachability(serverNames: serverNames, group: reachabilityGroup)
 

--- a/wire-ios-sync-engine/Source/SessionManager/BackendEnvironmentProvider+Reachability.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/BackendEnvironmentProvider+Reachability.swift
@@ -24,7 +24,7 @@ extension BackendEnvironmentProvider {
 
     var reachability: ZMReachability {
 
-        let group = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Reachability")!
+        let group = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Reachability")
 
         let serverNames: [String]
         if let proxy = self.proxy {

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -115,25 +115,25 @@ extension SessionManager: APIVersionResolverDelegate {
             }
 
             // The migration above will call enter() / leave() on the dispatch group
-            dispatchGroup?.wait(forInterval: 5)
+            dispatchGroup.wait(forInterval: 5)
 
             // 3. Reload sessions
             self.accountManager.accounts.forEach { account in
-                dispatchGroup?.enter()
+                dispatchGroup.enter()
 
                 if account == self.accountManager.selectedAccount {
                     // When completed, this should trigger an AppState change through the SessionManagerDelegate
                     self.loadSession(for: account) { _ in
-                        dispatchGroup?.leave()
+                        dispatchGroup.leave()
                     }
                 } else {
                     self.withSession(for: account) { _ in
-                        dispatchGroup?.leave()
+                        dispatchGroup.leave()
                     }
                 }
             }
 
-            dispatchGroup?.wait(forInterval: 1)
+            dispatchGroup.wait(forInterval: 1)
             self.delegate?.sessionManagerDidPerformFederationMigration(activeSession: activeUserSession)
         }
     }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+Backup.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+Backup.swift
@@ -73,7 +73,7 @@ extension SessionManager {
         result: Result<CoreDataStack.BackupInfo, Error>,
         password: String,
         accountId: UUID,
-        dispatchGroup: ZMSDispatchGroup? = nil,
+        dispatchGroup: ZMSDispatchGroup,
         completion: @escaping (Result<URL, Error>) -> Void,
         handle: String
         ) {
@@ -170,9 +170,11 @@ extension SessionManager {
     // MARK: - Helper
 
     /// Deletes all previously exported and imported backups.
-    public static func clearPreviousBackups(dispatchGroup: ZMSDispatchGroup? = nil) {
+    public func clearPreviousBackups() {
         CoreDataStack.clearBackupDirectory(dispatchGroup: dispatchGroup)
     }
+
+    // MARK: - Static Helpers
 
     private static func unzippedBackupURL(for url: URL) -> URL {
         let filename = url.deletingPathExtension().lastPathComponent

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+SwitchBackend.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+SwitchBackend.swift
@@ -38,8 +38,7 @@ extension SessionManager {
             completed(.failure(error))
             return
         }
-        let group = self.dispatchGroup
-        group?.enter()
+        dispatchGroup.enter()
         BackendEnvironment.fetchEnvironment(url: url) { result in
             DispatchQueue.main.async {
                 switch result {
@@ -50,7 +49,7 @@ extension SessionManager {
                 case .failure:
                     completed(.failure(SwitchBackendError.invalidBackend))
                 }
-                group?.leave()
+                self.dispatchGroup.leave()
             }
         }
     }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -263,7 +263,7 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     let sharedContainerURL: URL
-    let dispatchGroup: ZMSDispatchGroup?
+    let dispatchGroup: ZMSDispatchGroup
     let jailbreakDetector: JailbreakDetectorProtocol?
     fileprivate var accountTokens: [UUID: [Any]] = [:]
     fileprivate var memoryWarningObserver: NSObjectProtocol?
@@ -337,6 +337,8 @@ public final class SessionManager: NSObject, SessionManagerType {
             proxyCredentials = ProxyCredentials.retrieve(for: proxy)
         }
 
+        let dispatchGroup = ZMSDispatchGroup(label: "WireSyncEngine.SessionManager.private")
+
         let unauthenticatedSessionFactory = UnauthenticatedSessionFactory(
             appVersion: appVersion,
             environment: environment,
@@ -368,6 +370,7 @@ public final class SessionManager: NSObject, SessionManagerType {
             delegate: delegate,
             application: application,
             pushRegistry: PKPushRegistry(queue: nil),
+            dispatchGroup: dispatchGroup,
             environment: environment,
             configuration: configuration,
             detector: detector,
@@ -387,8 +390,8 @@ public final class SessionManager: NSObject, SessionManagerType {
             forName: UIApplication.didReceiveMemoryWarningNotification,
             object: nil,
             queue: nil,
-            using: {[weak self] _ in
-                guard let `self` = self else {
+            using: { [weak self] _ in
+                guard let self else {
                     return
                 }
                 log.debug("Received memory warning, tearing down background user sessions.")
@@ -430,7 +433,7 @@ public final class SessionManager: NSObject, SessionManagerType {
          delegate: SessionManagerDelegate?,
          application: ZMApplication,
          pushRegistry: PushRegistry,
-         dispatchGroup: ZMSDispatchGroup? = nil,
+         dispatchGroup: ZMSDispatchGroup,
          environment: BackendEnvironmentProvider,
          configuration: SessionManagerConfiguration = SessionManagerConfiguration(),
          detector: JailbreakDetectorProtocol = JailbreakDetector(),
@@ -839,13 +842,13 @@ public final class SessionManager: NSObject, SessionManagerType {
         log.debug("Request to load session for \(account)")
         let group = self.dispatchGroup
 
-        group?.enter()
+        group.enter()
         self.sessionLoadingQueue.serialAsync { onWorkDone in
             if let session = self.backgroundUserSessions[account.userIdentifier] {
                 log.debug("Session for \(account) is already loaded")
                 completion(session)
                 onWorkDone()
-                group?.leave()
+                group.leave()
             } else {
                 self.setupUserSession(account: account) { userSession in
                     if let userSession {
@@ -853,7 +856,7 @@ public final class SessionManager: NSObject, SessionManagerType {
                     }
 
                     onWorkDone()
-                    group?.leave()
+                    group.leave()
                 }
             }
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -628,7 +628,7 @@ public class ZMUserSession: NSObject {
             let group = ZMSDispatchGroup(label: "enqueueDelayedChanges")
             self?.managedObjectContext.enqueueDelayedSave(with: group)
 
-            group?.notify(on: DispatchQueue.global(qos: .background), block: {
+            group.notify(on: DispatchQueue.global(qos: .background), block: {
                 self?.managedObjectContext.performGroupedBlock {
                     completionHandler?()
                 }

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+ClearingHistory.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+ClearingHistory.swift
@@ -24,7 +24,6 @@ class ConversationTests_ClearingHistory: ConversationTestsBase {
         XCTAssertTrue(login())
 
         var conversation = self.conversation(for: mockConversation)
-        let selfUserSet: Set<AnyHashable> = [self.selfUser]
         let otherUser = mockConversation.activeUsers.first { ($0 as? MockUser) != self.selfUser } as! MockUser
 
         // given

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+Backup.swift
@@ -20,7 +20,7 @@ import XCTest
 import WireTesting
 @testable import WireSyncEngine
 
-class SessionManagerTests_Backup: IntegrationTest {
+final class SessionManagerTests_Backup: IntegrationTest {
 
     override var useInMemoryStore: Bool {
         return false
@@ -196,6 +196,7 @@ class SessionManagerTests_Backup: IntegrationTest {
 
     func testThatItDeletesABackup() throws {
         // Given
+        let sessionManager = try XCTUnwrap(sessionManager)
         XCTAssert(login())
 
         let result = backupActiveAcount(password: "idontneednopassword")
@@ -205,7 +206,7 @@ class SessionManagerTests_Backup: IntegrationTest {
         XCTAssert(FileManager.default.fileExists(atPath: CoreDataStack.importsDirectory.path))
 
         // When
-        SessionManager.clearPreviousBackups(dispatchGroup: dispatchGroup)
+        sessionManager.clearPreviousBackups()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
 
         // Then

--- a/wire-ios-system/Source/DispatchQueue+ZMSDispatchGroup.swift
+++ b/wire-ios-system/Source/DispatchQueue+ZMSDispatchGroup.swift
@@ -19,11 +19,11 @@
 import Foundation
 
 extension DispatchQueue {
-    public func async(group: ZMSDispatchGroup?, execute: @escaping  () -> Void) {
-        group?.enter()
+    public func async(group: ZMSDispatchGroup, execute: @escaping  () -> Void) {
+        group.enter()
         async {
             execute()
-            group?.leave()
+            group.leave()
         }
     }
 }

--- a/wire-ios-system/Source/ZMSDispatchGroup.h
+++ b/wire-ios-system/Source/ZMSDispatchGroup.h
@@ -21,16 +21,16 @@
 
 @interface ZMSDispatchGroup : NSObject
 
-@property (nonatomic, readonly, copy) NSString* label;
+@property (nonatomic, readonly, copy, nonnull) NSString* label;
 
-+ (instancetype)groupWithLabel:(NSString *)label;
-+ (instancetype)groupWithDispatchGroup:(dispatch_group_t)group label:(NSString *)label;
++ (nonnull instancetype)groupWithLabel:(NSString * _Nonnull)label;
++ (nonnull instancetype)groupWithDispatchGroup:(dispatch_group_t _Nonnull)group label:(NSString * _Nonnull)label;
 
 - (void)enter;
 - (void)leave;
-- (void)notifyOnQueue:(dispatch_queue_t)queue block:(dispatch_block_t)block;
+- (void)notifyOnQueue:(dispatch_queue_t _Nonnull)queue block:(dispatch_block_t _Nonnull)block;
 - (long)waitWithTimeout:(dispatch_time_t)timeout;
 - (long)waitForInterval:(NSTimeInterval)timeout;
-- (void)asyncOnQueue:(dispatch_queue_t)queue block:(dispatch_block_t)block;
+- (void)asyncOnQueue:(dispatch_queue_t _Nonnull)queue block:(dispatch_block_t _Nonnull)block;
 
 @end

--- a/wire-ios-system/Tests/DispatchQueueHelperTests.swift
+++ b/wire-ios-system/Tests/DispatchQueueHelperTests.swift
@@ -33,7 +33,7 @@ class DispatchQueueHelperTests: XCTestCase {
         }
 
         // Then
-        group?.notify(on: .main) {
+        group.notify(on: .main) {
             XCTAssertEqual(result, 42)
             groupExpectation.fulfill()
         }

--- a/wire-ios/Wire-iOS Tests/BackupViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/BackupViewControllerTests.swift
@@ -20,8 +20,10 @@ import Foundation
 import XCTest
 @testable import Wire
 
-class MockBackupSource: BackupSource {
+final class MockBackupSource: BackupSource {
     func backupActiveAccount(password: Password, completion: @escaping (Result<URL, Error>) -> Void) { }
+
+    func clearPreviousBackups() { }
 }
 
 class BackupViewControllerTests: ZMSnapshotTestCase {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/BackupViewController.swift
@@ -107,6 +107,8 @@ final class BackupActionCell: UITableViewCell {
 
 protocol BackupSource {
     func backupActiveAccount(password: Password, completion: @escaping (Result<URL, Error>) -> Void)
+
+    func clearPreviousBackups()
 }
 
 extension SessionManager: BackupSource {
@@ -229,13 +231,14 @@ private extension BackupViewController {
 
     private func presentShareSheet(with url: URL, from indexPath: IndexPath) {
         let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        activityController.completionWithItemsHandler = { _, _, _, _ in
-            SessionManager.clearPreviousBackups()
+        activityController.completionWithItemsHandler = { [weak self] _, _, _, _ in
+            self?.backupSource.clearPreviousBackups()
         }
         activityController.popoverPresentationController.apply {
             $0.sourceView = tableView
             $0.sourceRect = tableView.rectForRow(at: indexPath)
         }
-        self.present(activityController, animated: true)
+
+        present(activityController, animated: true)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During coding I found this missing optionality in `ZMSDispatchGroup.h` and code with optional argument. The optionality doesn't make sense, because the behaviour is exactly `async(execute: @escaping  () -> Void)`, that should be used instead.

```swift
extension DispatchQueue {
    public func async(group: ZMSDispatchGroup?, execute: @escaping  () -> Void) {
        group?.enter()
        async {
            execute()
            group?.leave()
        }
    }
}
```

### Solutions

- Add optionality to declaration
- Update code accordingly

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Run unit tests and 
- Tested behaviour of `BackupViewController` to clear previous backups ✅

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
