### PR TITLE
fix: crash due accessing user on wrong thread during group creation WPB-6202 WBP-6379

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationService.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationService.swift
@@ -298,7 +298,9 @@ public final class ConversationService: ConversationServiceInterface {
                 case .success(let objectID):
                     Task {
                         do {
-                            try await self.handleMLSConversationIfNeeded(for: objectID, participants: usersExcludingSelfUser)
+                            try await self.handleMLSConversationIfNeeded(
+                                for: objectID,
+                                participantObjectIDs: Set(usersExcludingSelfUser.map(\.objectID)))
                         } catch {
                             if error.isFailedToAddSomeUsersError {
                                 // we ignore the error a system message is inserted
@@ -332,7 +334,8 @@ public final class ConversationService: ConversationServiceInterface {
         }
     }
 
-    private func handleMLSConversationIfNeeded(for conversationObjectId: NSManagedObjectID, participants: Set<ZMUser>) async throws {
+    private func handleMLSConversationIfNeeded(for conversationObjectId: NSManagedObjectID,
+                                               participantObjectIDs: Set<NSManagedObjectID>) async throws {
         guard let syncContext = await context.perform({ self.context.zm_sync }) else {
             assertionFailure("handleMLSConversationIfNeeded must be done on syncContext")
             return
@@ -346,6 +349,12 @@ public final class ConversationService: ConversationServiceInterface {
                 return ZMConversation?.none
             }
             return conversation
+        }) else {
+            return
+        }
+
+        guard let syncParticipants: [ZMUser] = await syncContext.perform({
+            return participantObjectIDs.existingObjects(in: syncContext)
         }) else {
             return
         }
@@ -368,9 +377,9 @@ public final class ConversationService: ConversationServiceInterface {
         try await mlsService.createGroup(for: mlsGroupID, with: [])
 
         let participantsService = participantsServiceBuilder(syncContext)
-        if !participants.isEmpty {
-            self.createGroupFlow.checkpoint(description: MLSAddParticipantLog(users: Array(participants), groupId: mlsGroupID))
-            try await participantsService.addParticipants(Array(participants), to: syncConversation)
+        if !syncParticipants.isEmpty {
+            self.createGroupFlow.checkpoint(description: MLSAddParticipantLog(users: syncParticipants, groupId: mlsGroupID))
+            try await participantsService.addParticipants(syncParticipants, to: syncConversation)
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
@@ -276,7 +276,7 @@ final class ConversationServiceTests: MessagingTestBase {
         XCTAssertEqual(mockActionHandler.performedActions.count, 1)
     }
 
-    func test_CreateGroupConversation_CreatesMLSGroup() {
+    func test_CreateGroupConversation_CreatesMLSGroup() throws {
         // Given
         let groupID = MLSGroupID.random()
 
@@ -297,6 +297,10 @@ final class ConversationServiceTests: MessagingTestBase {
         let mlsService = MockMLSServiceInterface()
         mlsService.createGroupForWith_MockMethod = { _, _ in
             // no op
+        }
+
+        let user1Sync = try syncMOC.performAndWait {
+            try ZMUser.existingObject(for: user1.objectID, in: syncMOC)
         }
 
         syncMOC.performAndWait {
@@ -340,10 +344,10 @@ final class ConversationServiceTests: MessagingTestBase {
         let addParticipantCalls = mockConversationParticipantsService.addParticipantsTo_Invocations
         XCTAssertEqual(addParticipantCalls.count, 1)
         XCTAssertEqual(addParticipantCalls.first?.conversation, groupConversation)
-        XCTAssertEqual(addParticipantCalls.first?.users, [user1])
+        XCTAssertEqual(addParticipantCalls.first?.users, [user1Sync])
     }
 
-    func test_CreateGroupConversation_CreatesMLSGroup_WithOnlyReachableUsers() {
+    func test_CreateGroupConversation_CreatesMLSGroup_WithOnlyReachableUsers() throws {
         // Given
         let groupID = MLSGroupID.random()
         let unreachableDomain = "foma.wire.link"
@@ -369,6 +373,10 @@ final class ConversationServiceTests: MessagingTestBase {
         let mlsService = MockMLSServiceInterface()
         mlsService.createGroupForWith_MockMethod = { _, _ in
             // no op
+        }
+
+        let user1Sync = try syncMOC.performAndWait {
+            try ZMUser.existingObject(for: user1.objectID, in: syncMOC)
         }
 
         syncMOC.performAndWait {
@@ -412,7 +420,7 @@ final class ConversationServiceTests: MessagingTestBase {
         let addParticipantCalls = mockConversationParticipantsService.addParticipantsTo_Invocations
         XCTAssertEqual(addParticipantCalls.count, 1)
         XCTAssertEqual(addParticipantCalls.first?.conversation, groupConversation)
-        XCTAssertEqual(addParticipantCalls.first?.users, [user1])
+        XCTAssertEqual(addParticipantCalls.first?.users, [user1Sync])
     }
 
     func test_CreateGroupConversation_WithUsersWithNoPackages_IsSuccessful() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6202" title="WPB-6202" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6202</a>  [iOS] MLS: Could not create MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App crashes when creating a group if MOC thread checking is enabled

### Causes

Users from the main context are accessed from the sync context

### Solutions

Re-fetch the users on the sync context by passing objectIDs.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
