### PR TITLE
fix: optional zmsdispatchgroup

### DIFF
--- a/wire-ios-transport/Tests/Source/PushChannel/NativePushChannelTests+ServerTrust.swift
+++ b/wire-ios-transport/Tests/Source/PushChannel/NativePushChannelTests+ServerTrust.swift
@@ -46,7 +46,7 @@ class NativePushChannelTests_ServerTrust: XCTestCase {
         mockSchedulerSession = FakeSchedulerSession()
         mockEnvironment = MockEnvironment()
 
-        let dispatchGroup = ZMSDispatchGroup(label: "scheduler")!
+        let dispatchGroup = ZMSDispatchGroup(label: "scheduler")
         let scheduler = ZMTransportRequestScheduler(session: mockSchedulerSession,
                                     operationQueue: .main,
                                     group: dispatchGroup,

--- a/wire-ios-utilities/Tests/DispatchGroupContextTests.swift
+++ b/wire-ios-utilities/Tests/DispatchGroupContextTests.swift
@@ -31,7 +31,7 @@ class DispatchGroupContextTests: ZMTBaseTest {
 
     func testInjectGroupsAreAdded() {
         // given
-        let group = ZMSDispatchGroup(label: "group1")!
+        let group = ZMSDispatchGroup(label: "group1")
         sut = DispatchGroupContext(groups: [group])
 
         // then
@@ -40,7 +40,7 @@ class DispatchGroupContextTests: ZMTBaseTest {
 
     func testGroupsCanBeAdded() {
         // given
-        let group = ZMSDispatchGroup(label: "group1")!
+        let group = ZMSDispatchGroup(label: "group1")
         sut = DispatchGroupContext(groups: [])
 
         // when
@@ -52,7 +52,7 @@ class DispatchGroupContextTests: ZMTBaseTest {
 
     func testGroupsCanBeEntered() {
         // given
-        let group = ZMSDispatchGroup(label: "group1")!
+        let group = ZMSDispatchGroup(label: "group1")
         sut = DispatchGroupContext(groups: [group])
 
         // when
@@ -64,8 +64,8 @@ class DispatchGroupContextTests: ZMTBaseTest {
 
     func testGroupsCanBeEnteredExcludingOne() {
         // given
-        let group1 = ZMSDispatchGroup(label: "group1")!
-        let group2 = ZMSDispatchGroup(label: "group2")!
+        let group1 = ZMSDispatchGroup(label: "group1")
+        let group2 = ZMSDispatchGroup(label: "group2")
         sut = DispatchGroupContext(groups: [group1, group2])
 
         // when
@@ -78,7 +78,7 @@ class DispatchGroupContextTests: ZMTBaseTest {
     func testGroupsCanBeLeft() {
         // given
         let groupIsEmpty = customExpectation(description: "group did become empty")
-        let group = ZMSDispatchGroup(label: "group1")!
+        let group = ZMSDispatchGroup(label: "group1")
         sut = DispatchGroupContext(groups: [group])
         let enteredGroups = sut.enterAll()
 
@@ -96,8 +96,8 @@ class DispatchGroupContextTests: ZMTBaseTest {
         // given
         let group1IsEmpty = customExpectation(description: "group1 did become empty")
         let group2IsEmpty = customExpectation(description: "group2 did become empty")
-        let group1 = ZMSDispatchGroup(label: "group1")!
-        let group2 = ZMSDispatchGroup(label: "group2")!
+        let group1 = ZMSDispatchGroup(label: "group1")
+        let group2 = ZMSDispatchGroup(label: "group2")
         sut = DispatchGroupContext(groups: [group1, group2])
         let enteredGroups = sut.enterAll()
 

--- a/wire-ios-utilities/Tests/DispatchGroupQueueTests.swift
+++ b/wire-ios-utilities/Tests/DispatchGroupQueueTests.swift
@@ -32,7 +32,7 @@ class DispatchGroupQueueTests: ZMTBaseTest {
     func testPerformedGroupedBlockEntersAndLeavesAllGroups() {
         // given
         let groupIsEmpty = customExpectation(description: "group1 is emtpy")
-        let group = ZMSDispatchGroup(label: "group1")!
+        let group = ZMSDispatchGroup(label: "group1")
         sut = DispatchGroupQueue(queue: DispatchQueue.main)
         sut.add(group)
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Fixes force unwraps on non-optional `ZMSDispatchGroup`.

### Causes (Optional)

- Introduced by #954 although the tests were green.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Run automated test suites

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
