### PR TITLE
fix: deadlock on app start [WPB-765]

### DIFF
--- a/wire-ios-data-model/Source/UseCases/IsSelfUserVerifiedUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/IsSelfUserVerifiedUseCase.swift
@@ -22,19 +22,24 @@ import Foundation
 /// Determines if the self user has is Proteus verified.
 public protocol IsSelfUserProteusVerifiedUseCaseProtocol {
     /// Returns `true` if the self user is verified, `false` otherwise.
-    func invoke() -> Bool
+    func invoke() async -> Bool
 }
 
 public struct IsSelfUserProteusVerifiedUseCase: IsSelfUserProteusVerifiedUseCaseProtocol {
 
     private let context: NSManagedObjectContext
+    private let schedule: NSManagedObjectContext.ScheduledTaskType
 
-    public init(context: NSManagedObjectContext) {
+    public init(
+        context: NSManagedObjectContext,
+        schedule: NSManagedObjectContext.ScheduledTaskType
+    ) {
         self.context = context
+        self.schedule = schedule
     }
 
-    public func invoke() -> Bool {
-        context.performAndWait {
+    public func invoke() async -> Bool {
+        await context.perform(schedule: schedule) {
             ZMUser.selfUser(in: context)
                 .allClients
                 .allSatisfy(\.verified)

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -2739,14 +2739,14 @@ public class MockIsSelfUserProteusVerifiedUseCaseProtocol: IsSelfUserProteusVeri
     // MARK: - invoke
 
     public var invoke_Invocations: [Void] = []
-    public var invoke_MockMethod: (() -> Bool)?
+    public var invoke_MockMethod: (() async -> Bool)?
     public var invoke_MockValue: Bool?
 
-    public func invoke() -> Bool {
+    public func invoke() async -> Bool {
         invoke_Invocations.append(())
 
         if let mock = invoke_MockMethod {
-            return mock()
+            return await mock()
         } else if let mock = invoke_MockValue {
             return mock
         } else {

--- a/wire-ios-data-model/Tests/UseCases/IsSelfUserVerifiedUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/IsSelfUserVerifiedUseCaseTests.swift
@@ -30,7 +30,7 @@ final class IsSelfUserProteusVerifiedUseCaseTests: ZMBaseManagedObjectTest {
         super.setUp()
 
         setupUsersClientsAndConversation()
-        sut = .init(context: context)
+        sut = .init(context: context, schedule: .immediate)
     }
 
     override func tearDown() {
@@ -39,15 +39,15 @@ final class IsSelfUserProteusVerifiedUseCaseTests: ZMBaseManagedObjectTest {
         super.tearDown()
     }
 
-    func testResultIsVerified() {
+    func testResultIsVerified() async {
         // When
-        let isVerified = sut.invoke()
+        let isVerified = await sut.invoke()
 
         // Then
         XCTAssertTrue(isVerified)
     }
 
-    func testResultIsNotVerified() throws {
+    func testResultIsNotVerified() async throws {
         // Given
         try context.performAndWait {
             let selfClient = try XCTUnwrap(ZMUser.selfUser(in: context).selfClient())
@@ -55,7 +55,7 @@ final class IsSelfUserProteusVerifiedUseCaseTests: ZMBaseManagedObjectTest {
         }
 
         // When
-        let isVerified = sut.invoke()
+        let isVerified = await sut.invoke()
 
         // Then
         XCTAssertFalse(isVerified)

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -505,11 +505,11 @@ extension ZMUserSession: UserSession {
     }
 
     public var isSelfUserProteusVerifiedUseCase: IsSelfUserProteusVerifiedUseCaseProtocol {
-        IsSelfUserProteusVerifiedUseCase(context: syncContext)
+        IsSelfUserProteusVerifiedUseCase(context: syncContext, schedule: .immediate)
     }
 
     public var isSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol {
-        IsSelfUserE2EICertifiedUseCase(context: syncContext, coreCryptoProvider: coreCryptoProvider)
+        IsSelfUserE2EICertifiedUseCase(context: syncContext, schedule: .immediate, coreCryptoProvider: coreCryptoProvider)
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Availability/UserStatusViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Availability/UserStatusViewController.swift
@@ -72,10 +72,10 @@ final class UserStatusViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        userStatusView.userStatus.isVerified = isSelfUserProteusVerifiedUseCase.invoke()
         Task {
             do {
                 userStatusView.userStatus.isCertified = try await isSelfUserE2EICertifiedUseCase.invoke()
+                userStatusView.userStatus.isVerified = await isSelfUserProteusVerifiedUseCase.invoke()
             } catch {
                 WireLogger.e2ei.error("failed to get self user's verification status: \(String(reflecting: error))")
             }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -233,10 +233,10 @@ final class ProfileHeaderViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        userStatus.isVerified = isSelfUserProteusVerifiedUseCase.invoke()
         Task {
             do {
                 userStatus.isCertified = try await isSelfUserE2EICertifiedUseCase.invoke()
+                userStatus.isVerified = await isSelfUserProteusVerifiedUseCase.invoke()
             } catch {
                 WireLogger.e2ei.error("failed to get self user's verification status: \(String(reflecting: error))")
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-765" title="WPB-765" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-765</a>  [iOS] 5.3.16 Indicate verified user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

On app start the app hangs before any UI is shown.

### Causes (Optional)

Sync context is triggering UI logic on the main thread, which tries to update its state by waiting for the sync context.

### Solutions

Make updating the view's state non-blocking.

Additionally a bug in `IsSelfUserE2EICertifiedUseCase` is fixed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
