### PR TITLE
fix: disable mls feature flag still creates mls client  [WPB-6528]

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -588,12 +588,16 @@ struct ConversationEventPayloadProcessor {
         guard let context = conversation.managedObjectContext else {
             return WireLogger.mls.warn("conversation.managedObjectContext is nil")
         }
-        let (groupID, mlsService) = await context.perform {
-            (conversation.mlsGroupID, conversation.managedObjectContext?.mlsService)
+        let (groupID, mlsService, hasRegisteredMLSClient) = await context.perform {
+            (
+                conversation.mlsGroupID,
+                context.mlsService,
+                ZMUser.selfUser(in: context).selfClient()?.hasRegisteredMLSClient == true
+            )
         }
 
-        guard let groupID, let mlsService else {
-            WireLogger.mls.warn("no mlsService to createOrJoinSelfConversation")
+        guard let groupID, let mlsService, hasRegisteredMLSClient else {
+            WireLogger.mls.warn("no mlsService or not registered mls client to createOrJoinSelfConversation")
             return
         }
 

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
@@ -1013,12 +1013,40 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
     // MARK: - MLS Self Group
 
-    func testUpdateOrCreate_withMLSSelfGroupEpoch0_callsMLSServiceCreateGroup() async {
+    func testUpdateOrCreate_withoutRegisteredMLSClient_dontEstablishMLSSelfGroup() async throws {
+        // given
+        let expectation = XCTestExpectation(description: "didCallCreateGroup")
+        expectation.isInverted = true
+        mockMLSService.createSelfGroupFor_MockMethod = { _ in
+            expectation.fulfill()
+        }
+        try await syncMOC.perform {
+            let selfClient = try XCTUnwrap(ZMUser.selfUser(in: self.syncMOC).selfClient())
+            selfClient.mlsPublicKeys = .init(ed25519: "mock_ed25519")
+            selfClient.needsToUploadMLSPublicKeys = true
+        }
+
+        // when
+        await internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 0)
+        await fulfillment(of: [expectation], timeout: 0.5)
+
+        // then
+        XCTAssertTrue(mockMLSService.createSelfGroupFor_Invocations.isEmpty)
+    }
+
+    func testUpdateOrCreate_withMLSSelfGroupEpoch0_callsMLSServiceCreateGroup() async throws {
+        // given
         let didCallCreateGroup = XCTestExpectation(description: "didCallCreateGroup")
         mockMLSService.createSelfGroupFor_MockMethod = { _ in
             didCallCreateGroup.fulfill()
         }
+        try await syncMOC.perform {
+            let selfClient = try XCTUnwrap(ZMUser.selfUser(in: self.syncMOC).selfClient())
+            selfClient.mlsPublicKeys = .init(ed25519: "mock_ed25519")
+            selfClient.needsToUploadMLSPublicKeys = false
+        }
 
+        // when
         await internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 0)
         await fulfillment(of: [didCallCreateGroup], timeout: 0.5)
 
@@ -1026,13 +1054,21 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
         XCTAssertFalse(mockMLSService.createSelfGroupFor_Invocations.isEmpty)
     }
 
-    func testUpdateOrCreate_withMLSSelfGroupEpoch1_callsMLSServiceJoinGroup() async {
+    func testUpdateOrCreate_withMLSSelfGroupEpoch1_callsMLSServiceJoinGroup() async throws {
+        // given
         let didJoinGroup = XCTestExpectation(description: "didJoinGroup")
         mockMLSService.joinGroupWith_MockMethod = { _ in
             didJoinGroup.fulfill()
         }
         mockMLSService.conversationExistsGroupID_MockValue = false
 
+        try await syncMOC.perform {
+            let selfClient = try XCTUnwrap(ZMUser.selfUser(in: self.syncMOC).selfClient())
+            selfClient.mlsPublicKeys = .init(ed25519: "mock_ed25519")
+            selfClient.needsToUploadMLSPublicKeys = false
+        }
+
+        // when
         await internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 1)
         await fulfillment(of: [didJoinGroup], timeout: 0.5)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6528" title="WPB-6528" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6528</a>  iOS: disabled feature flag still creates mls client
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- the feature flag `enableMLSSupport` has been ignored and a self conversation with mls protocol initiated the mls key creation etc.

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

- Create a new user
- Build app and make sure the feature flag `enableMLSSupport` is disabled 
- Login 
- Open debug menu to see your supported protocols
  - before it was `mls, proteus`
  - now it should be `proteus` only

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
