### PR TITLE
feat: Move verification shield for the conversation title

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -25,19 +25,19 @@ extension VoiceChannel {
     func accessoryType() -> CallInfoViewControllerAccessoryType {
         switch state {
         case .incoming(_, shouldRing: true, _),
-             .answered,
-             .establishedDataChannel,
-             .outgoing:
+                .answered,
+                .establishedDataChannel,
+                .outgoing:
             guard !videoState.isSending,
                   let initiator = initiator
             else { return .none }
             return .avatar(HashBox(value: initiator))
         case .unknown,
-             .none,
-             .terminating,
-             .mediaStopped,
-             .established,
-             .incoming(_, shouldRing: false, _):
+                .none,
+                .terminating,
+                .mediaStopped,
+                .established,
+                .incoming(_, shouldRing: false, _):
             return .participantsList(sortedParticipants().map {
                 .callParticipant(user: HashBox(value: $0.user),
                                  callParticipantState: $0.state,
@@ -150,7 +150,7 @@ struct CallInfoConfiguration: CallInfoViewControllerInput {
             callState = voiceChannel.state
             videoGridPresentationMode = voiceChannel.videoGridPresentationMode
             allowPresentationModeUpdates = voiceChannel.allowPresentationModeUpdates
-    }
+        }
 
     // This property has to be computed in order to return the correct call duration
     var state: CallStatusViewState {
@@ -235,8 +235,8 @@ fileprivate extension VoiceChannel {
 
     var isAnyParticipantSendingVideo: Bool {
         return videoState.isSending                                  // Current user is sending video and can toggle off
-            || participants.any { $0.state.isSendingVideo } // Other participants are sending video
-            || isIncomingVideoCall                                   // This is an incoming video call
+        || participants.any { $0.state.isSendingVideo } // Other participants are sending video
+        || isIncomingVideoCall                                   // This is an incoming video call
     }
 
     func sortedParticipants() -> [CallParticipant] {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallViewController/CallInfoConfiguration.swift
@@ -287,9 +287,9 @@ extension VoiceChannel {
         guard let conversation else { return nil }
 
         switch conversation.messageProtocol {
-        case .mls, .mixed:
+        case .mls:
             return .invalidCertificate
-        case .proteus:
+        case .proteus, .mixed:
             return .degradedUser(user: hashboxFirstDegradedUser)
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
@@ -130,9 +130,9 @@ extension GroupDetailsConversation {
 
     var isVerified: Bool {
         switch messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             return securityLevel == .secure
-        case .mls, .mixed:
+        case .mls:
             return mlsVerificationStatus == .verified
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -1,20 +1,20 @@
 //
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 import UIKit
 import WireCommonComponents

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationTitleView.swift
@@ -41,13 +41,14 @@ final class ConversationTitleView: TitleView {
         titleFont = .normalSemiboldFont
 
         var attachments: [NSTextAttachment] = []
+        var trailingIcons: [NSTextAttachment] = []
 
         if conversation.isUnderLegalHold {
             attachments.append(.legalHold())
         }
 
         if conversation.isVerified {
-            attachments.append(verifiedShield)
+            trailingIcons.append(verifiedShield)
         }
 
         var subtitle: String?
@@ -60,7 +61,7 @@ final class ConversationTitleView: TitleView {
         super.configure(
             leadingIcons: attachments,
             title: conversation.displayNameWithFallback,
-            trailingIcons: [],
+            trailingIcons: trailingIcons,
             subtitle: subtitle,
             interactive: interactive && conversation.relatedConnectionState != .sent,
             showInteractiveIcon: true
@@ -71,9 +72,9 @@ final class ConversationTitleView: TitleView {
 
     private var verifiedShield: NSTextAttachment {
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             return .proteusVerifiedShield()
-        case .mls, .mixed:
+        case .mls:
             return .e2eiVerifiedShield()
         }
     }
@@ -118,7 +119,7 @@ extension NSTextAttachment {
         attachment.image = shield
         let ratio = shield.size.width / shield.size.height
         let height: CGFloat = 12
-        attachment.bounds = CGRect(x: 0, y: -2, width: height * ratio, height: height)
+        attachment.bounds = CGRect(x: 0, y: 0, width: height * ratio, height: height)
         return attachment
     }
 
@@ -126,7 +127,7 @@ extension NSTextAttachment {
         let attachment = NSTextAttachment()
         let shield = Asset.Images.certificateValid.image
         attachment.image = shield
-        attachment.bounds = CGRect(x: 0, y: -4, width: shield.size.width, height: shield.size.height)
+        attachment.bounds = CGRect(x: 0, y: -2, width: shield.size.width, height: shield.size.height)
         return attachment
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -352,27 +352,27 @@ private extension GroupDetailsViewController {
         typealias ConversationVerificationStatus = L10n.Localizable.GroupDetails.ConversationVerificationStatus
 
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             return ConversationVerificationStatus.proteus
-        case .mls, .mixed:
+        case .mls:
             return ConversationVerificationStatus.e2ei
         }
     }
 
     var verificationStatusIcon: UIImage {
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             return Asset.Images.verifiedShield.image
-        case .mls, .mixed:
+        case .mls:
             return Asset.Images.certificateValid.image
         }
     }
 
     var verificationStatusColor: UIColor {
         switch conversation.messageProtocol {
-        case .proteus:
+        case .proteus, .mixed:
             return SemanticColors.Label.textCertificateVerified
-        case .mls, .mixed:
+        case .mls:
             return SemanticColors.Label.textCertificateValid
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

According to the new design changes, the verification shield should be located to the right of the conversation title.
[Figma](https://www.figma.com/file/gSmh7BRyq9SGKkyOLSbOdM/E2E-Identity?type=design&node-id=651-43092&mode=design&t=Ev2401pnz4XkPqWj-0)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
