### PR TITLE
fix: swiftlint precommit less strict [WPB-6545]

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -41,7 +41,6 @@ end
 def compose_swiftlint_command(changed_files, autoformat)
   command = "./scripts/run-swiftlint.sh"
   command << " --fix" if autoformat
-  command << " --strict"
   command << " --reporter emoji"
   files = changed_files.map.with_index(0) { |f, i| "SCRIPT_INPUT_FILE_#{i}=#{f.shellescape}" }.join(" ")
   command = command.prepend("SCRIPT_INPUT_FILE_COUNT=#{changed_files.count} #{files} ")

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -76,7 +76,7 @@ staged_swift_files.each { |filename|
 print "Linting Swift in your changed Swift files (if any)...\n"
 result = `#{compose_swiftlint_command(relative_staged_swift_files, false)}`
 unless result.empty? 
-    abort(result)
+    print result
 end
 
 staged_swift_files = get_swift_files(get_paths_to_staged_files)

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -20,4 +20,4 @@ jobs:
         - uses: actions/checkout@v4
         - name: GitHub Action for SwiftLint
           run: |
-            swiftlint --reporter github-actions-logging --strict
+            swiftlint --reporter github-actions-logging --strict --quiet

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,8 +11,6 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    // TODO: another test
-
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     return true

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,6 +11,8 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    // TODO: test local commit
+
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     return true

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,7 +11,7 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    // TODO: test local commit
+    // TODO: test local commit -
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,8 +11,6 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    // TODO: test local commit.
-
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     return true

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,6 +11,8 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    // TODO: another test
+
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     return true

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,7 +11,7 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    // TODO: test local commit -
+    // TODO: test local commit
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -11,7 +11,7 @@ import UIKit
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    // TODO: test local commit
+    // TODO: test local commit.
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6545" title="WPB-6545" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6545</a>  iOS: make SwiftLint pre-commit less strict
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

See ticket.

### Testing

Do some commits locally and for CI.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
