### PR TITLE
fix: duplicate participant added system messages on MLS group creation WPB-6382

### DIFF
--- a/wire-ios-request-strategy/Tests/Sources/Stubs/StubPayloadConversationEvent.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Stubs/StubPayloadConversationEvent.swift
@@ -1,0 +1,40 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import WireRequestStrategy
+
+extension Payload.ConversationEvent {
+    static func stub(
+        data: T,
+        qualifiedID: QualifiedID? = QualifiedID.random(),
+        qualifiedFrom: QualifiedID? = QualifiedID.random(),
+        timestamp: Date? = Date.now,
+        type: String? = nil
+    ) -> Self {
+        self.init(
+            id: qualifiedID?.uuid,
+            data: data,
+            from: qualifiedFrom?.uuid,
+            qualifiedID: qualifiedID,
+            qualifiedFrom: qualifiedFrom,
+            timestamp: timestamp,
+            type: type
+        )
+    }
+}

--- a/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
+++ b/wire-ios-request-strategy/WireRequestStrategy.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		168D7CCE26FB303A00789960 /* AddParticipantActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168D7CCD26FB303A00789960 /* AddParticipantActionHandlerTests.swift */; };
 		168D7CF626FC6D3400789960 /* RemoveParticipantActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168D7CF526FC6D3300789960 /* RemoveParticipantActionHandlerTests.swift */; };
 		168D7D0C26FC81AD00789960 /* ActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 168D7D0B26FC81AD00789960 /* ActionHandlerTests.swift */; };
+		1695B9D42B87FFF100E9342A /* StubPayloadConversationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1695B9D32B87FFF100E9342A /* StubPayloadConversationEvent.swift */; };
 		16972DED2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16972DEC2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift */; };
 		169BA1CB25E9507600374343 /* Payload+Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169BA1CA25E9507600374343 /* Payload+Coding.swift */; };
 		16A4891A2685CECD001F9127 /* ProteusMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A489192685CECC001F9127 /* ProteusMessage.swift */; };
@@ -636,6 +637,7 @@
 		168D7CCD26FB303A00789960 /* AddParticipantActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddParticipantActionHandlerTests.swift; sourceTree = "<group>"; };
 		168D7CF526FC6D3300789960 /* RemoveParticipantActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveParticipantActionHandlerTests.swift; sourceTree = "<group>"; };
 		168D7D0B26FC81AD00789960 /* ActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionHandlerTests.swift; sourceTree = "<group>"; };
+		1695B9D32B87FFF100E9342A /* StubPayloadConversationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubPayloadConversationEvent.swift; sourceTree = "<group>"; };
 		16972DEC2668E699008AF3A2 /* UserProfileRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileRequestStrategyTests.swift; sourceTree = "<group>"; };
 		169BA1CA25E9507600374343 /* Payload+Coding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Payload+Coding.swift"; sourceTree = "<group>"; };
 		16A489192685CECC001F9127 /* ProteusMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProteusMessage.swift; sourceTree = "<group>"; };
@@ -1514,6 +1516,7 @@
 			isa = PBXGroup;
 			children = (
 				E6E59B072B56D04500E90D36 /* StubPayloadConversation.swift */,
+				1695B9D32B87FFF100E9342A /* StubPayloadConversationEvent.swift */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";
@@ -2464,6 +2467,7 @@
 				630D41BC2B07DA3E00633867 /* ProteusConversationParticipantsServiceTests.swift in Sources */,
 				F18401EB2073C26700E9F4CC /* MockOTREntity.swift in Sources */,
 				06474D5E24B30C79002C695D /* PushNotificationStatusTests.swift in Sources */,
+				1695B9D42B87FFF100E9342A /* StubPayloadConversationEvent.swift in Sources */,
 				F18401E52073C26200E9F4CC /* FetchingClientRequestStrategyTests.swift in Sources */,
 				70C781FD2732B0100059DF07 /* UpdateRoleActionHandlerTests.swift in Sources */,
 				EE0DE5082A24D9C20029746C /* DeleteSubgroupActionHandlerTests.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6382" title="WPB-6382" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6382</a>  [iOS] MLS Group creation: After creating group with federated contacts, "You have added" messages is duplicated
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After creating an MLS group, multiple participant added system messages would some times get inserted.

### Causes

MLS groups are created in two steps: first an empty group conversation is created and then the participants are added with an MLS commit. This creates several update events which the creator will process twice if there's no additional activity after the group has been created.

1. Create empty MLS group which  generates `.new-conversation` event
2. Insert participants with commit which generated `member-join` event
3. No further activity
4. App re-connects are process pending events 
5. Processing `new-conversation` event will remove the participants again since the conversation is empty
6. Processing `member-join` event will add the participants again with an additional system message.

### Solutions

Don't process `new-conversation` event if the conversation already exists locally.

### Testing

#### How to Test

1. Create MLS group with user A
2. Put app into background
3. Put app into foreground

This will cause the events to be processed twice and trigger the scenario described above.

### Attachments (Optional)

<img width="331" alt="Screenshot 2024-02-12 at 12 12 08" src="https://github.com/wireapp/wire-ios/assets/7156/1a170864-4049-42a6-b571-403c80d4d9b8">

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
