### PR TITLE
feat: Periodically evaluate all 1:1 conversations - WPB-5814

### DIFF
--- a/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
@@ -61,9 +61,13 @@ final class SupportedProtocolsService: SupportedProtocolsServiceInterface {
 
     func updateSupportedProtocols() {
         let selfUser = userRepository.selfUser()
+        let previousProtocols = selfUser.supportedProtocols
+
         selfUser.supportedProtocols = calculateSupportedProtocols()
 
-        delegate?.supportedProtocolsServiceDidCalculateNewProtocols(self)
+        if previousProtocols != selfUser.supportedProtocols {
+            delegate?.supportedProtocolsServiceDidCalculateNewProtocols(self)
+        }
     }
 
     func calculateSupportedProtocols() -> Set<MessageProtocol> {

--- a/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
@@ -24,6 +24,12 @@ protocol SupportedProtocolsServiceInterface {
 
 }
 
+protocol SupportedProtocolsServiceDelegate: AnyObject {
+
+    func supportedProtocolsServiceDidCalculateNewProtocols(_ service: SupportedProtocolsService)
+
+}
+
 final class SupportedProtocolsService: SupportedProtocolsServiceInterface {
 
     // MARK: - Properties
@@ -31,6 +37,8 @@ final class SupportedProtocolsService: SupportedProtocolsServiceInterface {
     private let featureRepository: FeatureRepositoryInterface
     private let userRepository: UserRepositoryInterface
     private let logger = WireLogger(tag: "supported-protocols")
+
+    weak var delegate: SupportedProtocolsServiceDelegate?
 
     // MARK: - Life cycle
 

--- a/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
@@ -62,6 +62,8 @@ final class SupportedProtocolsService: SupportedProtocolsServiceInterface {
     func updateSupportedProtocols() {
         let selfUser = userRepository.selfUser()
         selfUser.supportedProtocols = calculateSupportedProtocols()
+
+        delegate?.supportedProtocolsServiceDidCalculateNewProtocols(self)
     }
 
     func calculateSupportedProtocols() -> Set<MessageProtocol> {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SupportedProtocolsServiceDelegate.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SupportedProtocolsServiceDelegate.swift
@@ -21,7 +21,8 @@ import Foundation
 extension ZMUserSession: SupportedProtocolsServiceDelegate {
 
     func supportedProtocolsServiceDidCalculateNewProtocols(_ service: SupportedProtocolsService) {
-
+        // TBD as soon as https://github.com/wireapp/wire-ios/pull/974 is merged
+        // we need to call a method here  
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SupportedProtocolsServiceDelegate.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+SupportedProtocolsServiceDelegate.swift
@@ -1,0 +1,27 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension ZMUserSession: SupportedProtocolsServiceDelegate {
+
+    func supportedProtocolsServiceDidCalculateNewProtocols(_ service: SupportedProtocolsService) {
+
+    }
+
+}

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -520,6 +520,7 @@
 		E666EDEC2B74EA5000C03E2B /* SessionManagerTests+MultiUserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E666EDEB2B74EA5000C03E2B /* SessionManagerTests+MultiUserSession.swift */; };
 		E666EDEE2B74EAC300C03E2B /* SessionManagerTests+AppLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E666EDED2B74EAC300C03E2B /* SessionManagerTests+AppLock.swift */; };
 		E666EDF22B74ED2F00C03E2B /* MockSessionManagerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E666EDF12B74ED2F00C03E2B /* MockSessionManagerObserver.swift */; };
+		E959C7D52B7A2654005F3945 /* ZMUserSession+SupportedProtocolsServiceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E959C7D42B7A2654005F3945 /* ZMUserSession+SupportedProtocolsServiceDelegate.swift */; };
 		EE01E0371F90DD67001AA33C /* audio.m4a in Resources */ = {isa = PBXBuildFile; fileRef = EE01E0361F90DABC001AA33C /* audio.m4a */; };
 		EE01E0391F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE01E0381F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift */; };
 		EE0BA29029D5DBD6004E93B5 /* MockCryptoboxMigrationManagerInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0BA28F29D5DBD6004E93B5 /* MockCryptoboxMigrationManagerInterface.swift */; };
@@ -1264,6 +1265,7 @@
 		E666EDEB2B74EA5000C03E2B /* SessionManagerTests+MultiUserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManagerTests+MultiUserSession.swift"; sourceTree = "<group>"; };
 		E666EDED2B74EAC300C03E2B /* SessionManagerTests+AppLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionManagerTests+AppLock.swift"; sourceTree = "<group>"; };
 		E666EDF12B74ED2F00C03E2B /* MockSessionManagerObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionManagerObserver.swift; sourceTree = "<group>"; };
+		E959C7D42B7A2654005F3945 /* ZMUserSession+SupportedProtocolsServiceDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+SupportedProtocolsServiceDelegate.swift"; sourceTree = "<group>"; };
 		EBD7B55754FDA4E74F1006FD /* ZMOperationLoopTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMOperationLoopTests.h; sourceTree = "<group>"; };
 		EE01E0361F90DABC001AA33C /* audio.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = audio.m4a; sourceTree = "<group>"; };
 		EE01E0381F90FEC1001AA33C /* ZMLocalNotificationTests_ExpiredMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMLocalNotificationTests_ExpiredMessage.swift; sourceTree = "<group>"; };
@@ -2174,6 +2176,7 @@
 				549710071F6FF5C100026EDD /* NotificationInContext+UserSession.swift */,
 				5458AF831F7021B800E45977 /* PreLoginAuthenticationNotification.swift */,
 				70355A7227AAE62D00F02C76 /* ZMUserSession+SecurityClassification.swift */,
+				E959C7D42B7A2654005F3945 /* ZMUserSession+SupportedProtocolsServiceDelegate.swift */,
 			);
 			path = UserSession;
 			sourceTree = "<group>";
@@ -3597,6 +3600,7 @@
 				1672A64523473EA100380537 /* LabelDownstreamRequestStrategy.swift in Sources */,
 				09BCDB8F1BCE7F000020DCC7 /* ZMAPSMessageDecoder.m in Sources */,
 				546392721D79D5210094EC66 /* Application.swift in Sources */,
+				E959C7D52B7A2654005F3945 /* ZMUserSession+SupportedProtocolsServiceDelegate.swift in Sources */,
 				EFC8281C1FB343B600E27E21 /* RegistationCredentialVerificationStrategy.swift in Sources */,
 				874A16902052BE5E001C6760 /* ZMUserSession+OpenConversation.swift in Sources */,
 				EE1DEBC423D5F1970087EE1F /* Conversation+TypingUsers.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5814" title="WPB-5814" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5814</a>  [iOS] Periodically evaluate all 1:1 conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

We periodically evaluate all 1:1 conversations. In this case we do so specifically after updating protocols if needed. More in depth:

- Added a protocol **SupportedProtocolsServiceDelegate** with a method `supportedProtocolsServiceDidCalculateNewProtocols(_:)`. This method will be called whenever the **SupportedProtocolsService** calculates new protocols.
- Within **SupportedProtocolsService**, a `weak var delegate of type SupportedProtocolsServiceDelegate`? is introduced to hold a reference to the delegate instance.
- `updateSupportedProtocols()` function is updated to call the `calculateSupportedProtocols()` and notify the delegate if there is a change in the supported protocols.
- An extension of **ZMUserSession** is added conforming to **SupportedProtocolsServiceDelegate**, with an implementation of the `supportedProtocolsServiceDidCalculateNewProtocols(_:)` method. Currently, it contains a placeholder comment to call a method once a related pull request is merged on GitHub.
- **ZMUserSession** is now set as the delegate of SupportedProtocolsService.









----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
