### PR TITLE
fix: MLS groups getting stuck with pending commits WPB-6553

### DIFF
--- a/wire-ios-data-model/Source/MLS/CommitSender.swift
+++ b/wire-ios-data-model/Source/MLS/CommitSender.swift
@@ -208,7 +208,7 @@ private extension CommitError.RecoveryStrategy {
         case .mlsClientMismatch:
             self = .retryAfterQuickSync
         case .mlsCommitMissingReferences:
-            self = .commitPendingProposalsAfterQuickSync
+            self = .retryAfterQuickSync
         case .mlsStaleMessage:
             self = .retryAfterRepairingGroup
         default:

--- a/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
@@ -117,7 +117,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(receivedEvents, [event])
     }
 
-    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_RetryAfterQuickSync() async {
+    func test_SendCommitBundleMlsClientMismatch_ThrowsWithRecoveryStrategy_RetryAfterQuickSync() async {
         await assertSendCommitBundleThrows(
             withRecovery: .retryAfterQuickSync,
             for: .mlsClientMismatch,
@@ -125,15 +125,15 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         )
     }
 
-    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_CommitPendingProposalsAfterQuickSync() async {
+    func test_SendCommitBundleMlsCommitMissingReferences_ThrowsWithRecoveryStrategy_RetryAfterQuickSync() async {
         await assertSendCommitBundleThrows(
-            withRecovery: .commitPendingProposalsAfterQuickSync,
+            withRecovery: .retryAfterQuickSync,
             for: .mlsCommitMissingReferences,
-            shouldClearPendingCommit: false
+            shouldClearPendingCommit: true
         )
     }
 
-    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_RetryAfterRepairingGroup() async {
+    func test_SendCommitBundleMlsStaleMessage_ThrowsWithRecoveryStrategy_RetryAfterRepairingGroup() async {
         await assertSendCommitBundleThrows(
             withRecovery: .retryAfterRepairingGroup,
             for: .mlsStaleMessage,
@@ -141,7 +141,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         )
     }
 
-    func test_SendCommitBundle_ThrowsWithRecoveryStrategy_GiveUp() async {
+    func test_SendCommitBundleUnknownError_ThrowsWithRecoveryStrategy_GiveUp() async {
         await assertSendCommitBundleThrows(
             withRecovery: .giveUp,
             for: .unknown(status: 400, label: "", message: ""),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6553" title="WPB-6553" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6553</a>  MLS operation sometimes get stuck due to pending commits
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes a MLS group with get stuck in state where it had a pending commit, which prevents any further operations to be performed in a that group.

### Causes

A client could  into this state by:
1. Crashing while sending before it has accepted a pending commit
2. Backend responds with `mls-commit-missing-references` (not all pending commits are included in the commit). 

### Solutions

1. Clear any pending commit when `commitPendingProposals` fails, this allows us to re-generate the commit and try again.
2. Clear the pending in this case since CC migrating the pending commit doesn't work in all cases.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
