### PR TITLE
fix: request loop when committing proposals when someone leaves an MLS group WPB-6610

### DIFF
--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -3221,24 +3221,19 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock(groupID)
     }
 
-    // MARK: - commitPendingProposals
+    // MARK: - commitPendingProposalsIfNeeded
 
-    public var commitPendingProposals_Invocations: [Void] = []
-    public var commitPendingProposals_MockError: Error?
-    public var commitPendingProposals_MockMethod: (() async throws -> Void)?
+    public var commitPendingProposalsIfNeeded_Invocations: [Void] = []
+    public var commitPendingProposalsIfNeeded_MockMethod: (() -> Void)?
 
-    public func commitPendingProposals() async throws {
-        commitPendingProposals_Invocations.append(())
+    public func commitPendingProposalsIfNeeded() {
+        commitPendingProposalsIfNeeded_Invocations.append(())
 
-        if let error = commitPendingProposals_MockError {
-            throw error
+        guard let mock = commitPendingProposalsIfNeeded_MockMethod else {
+            fatalError("no mock for `commitPendingProposalsIfNeeded`")
         }
 
-        guard let mock = commitPendingProposals_MockMethod else {
-            fatalError("no mock for `commitPendingProposals`")
-        }
-
-        try await mock()
+        mock()
     }
 
     // MARK: - commitPendingProposals

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -84,16 +84,7 @@ extension EventDecoder {
                     }
 
                     if let mlsService, updateEvent.source == .webSocket {
-                        // It's not uncommon to receive multiple proposals in a row for a group, and attempting to
-                        // commit only one of them will result in mls-commit-missing-references and uncessary re-tries
-                        // so we defer committing them for later.
-                        WaitingGroupTask(context: context) {
-                            do {
-                                try await mlsService.commitPendingProposals()
-                            } catch {
-                                WireLogger.mls.error("failed to commit pending proposals: \(String(describing: error))")
-                            }
-                        }
+                        mlsService.commitPendingProposalsIfNeeded()
                     }
 
                     return nil

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -84,12 +84,16 @@ extension EventDecoder {
                     }
 
                     if let mlsService, updateEvent.source == .webSocket {
-                        do {
-                            try await mlsService.commitPendingProposals()
-                        } catch {
-                            WireLogger.mls.error("failed to commit pending proposals: \(String(describing: error))")
+                        // It's not uncommon to receive multiple proposals in a row for a group, and attempting to
+                        // commit only one of them will result in mls-commit-missing-references and uncessary re-tries
+                        // so we defer committing them for later.
+                        WaitingGroupTask(context: context) {
+                            do {
+                                try await mlsService.commitPendingProposals()
+                            } catch {
+                                WireLogger.mls.error("failed to commit pending proposals: \(String(describing: error))")
+                            }
                         }
-
                     }
 
                     return nil

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -38,7 +38,7 @@ class EventDecoderTest: MessagingTestBase {
         sut = EventDecoder(eventMOC: eventMOC, syncMOC: syncMOC)
 
         syncMOC.performGroupedBlockAndWait {
-            self.mockMLSService.commitPendingProposals_MockMethod = {}
+            self.mockMLSService.commitPendingProposalsIfNeeded_MockMethod = {}
             self.syncMOC.mlsService = self.mockMLSService
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             selfUser.remoteIdentifier = self.accountIdentifier
@@ -564,10 +564,10 @@ extension EventDecoderTest {
         // Then
         XCTAssertTrue(decryptedEvents.isEmpty)
         XCTAssertTrue(wait(withTimeout: 3.0) { [self] in
-            !mockMLSService.commitPendingProposals_Invocations.isEmpty
+            !mockMLSService.commitPendingProposalsIfNeeded_Invocations.isEmpty
         })
 
-        XCTAssertEqual(1, mockMLSService.commitPendingProposals_Invocations.count)
+        XCTAssertEqual(1, mockMLSService.commitPendingProposalsIfNeeded_Invocations.count)
     }
 
     func test_DecryptMLSMessage_CommitsPendingsProposalsIsNotCalled_WhenReceivingProposalViaDownload() async {
@@ -591,7 +591,7 @@ extension EventDecoderTest {
         // Then
         XCTAssertTrue(decryptedEvents.isEmpty)
         spinMainQueue(withTimeout: 1)
-        XCTAssertTrue(mockMLSService.commitPendingProposals_Invocations.isEmpty)
+        XCTAssertTrue(mockMLSService.commitPendingProposalsIfNeeded_Invocations.isEmpty)
     }
 
     func test_DecryptMLSMessage_ReturnsNoEvent_WhenPayloadIsInvalid() async {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -755,17 +755,12 @@ extension ZMUserSession: ZMSyncStateDelegate {
                 } catch {
                     WireLogger.mls.error("Failed to performPendingJoins: \(String(reflecting: error))")
                 }
-
-                do {
-                    try await mlsService.commitPendingProposals()
-                } catch {
-                    WireLogger.mls.error("Failed to commit pending proposals: \(String(reflecting: error))")
-                }
                 await mlsService.uploadKeyPackagesIfNeeded()
                 await mlsService.updateKeyMaterialForAllStaleGroupsIfNeeded()
             }
         }
 
+        mlsService.commitPendingProposalsIfNeeded()
         fetchFeatureConfigs()
         recurringActionService.performActionsIfNeeded()
 
@@ -817,19 +812,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
                 }
             } catch {
                 WireLogger.mls.error("Failed to process pending call events: \(String(reflecting: error))")
-            }
-        }
-    }
-
-    // swiftlint:disable todo_requires_jira_link
-    // FIXME: [jacob] move commitPendingProposalsIfNeeded to MLSService?
-    // swiftlint:enable todo_requires_jira_link
-    private func commitPendingProposalsIfNeeded() {
-        Task {
-            do {
-                try await mlsService.commitPendingProposals()
-            } catch {
-                WireLogger.mls.error("Failed to commit pending proposals: \(String(describing: error))")
             }
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -515,7 +515,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
     func test_itPerformsPeriodicMLSUpdates_AfterQuickSync() {
         // given
         mockMLSService.performPendingJoins_MockMethod = {}
-        mockMLSService.commitPendingProposals_MockMethod = {}
+        mockMLSService.commitPendingProposalsIfNeeded_MockMethod = {}
         mockMLSService.uploadKeyPackagesIfNeeded_MockMethod = {}
         mockMLSService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
 
@@ -535,5 +535,6 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertFalse(mockMLSService.performPendingJoins_Invocations.isEmpty)
         XCTAssertFalse(mockMLSService.uploadKeyPackagesIfNeeded_Invocations.isEmpty)
         XCTAssertFalse(mockMLSService.updateKeyMaterialForAllStaleGroupsIfNeeded_Invocations.isEmpty)
+        XCTAssertFalse(mockMLSService.commitPendingProposalsIfNeeded_Invocations.isEmpty)
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -95,6 +95,7 @@ class ZMUserSessionTestsBase: MessagingTest {
         let mockUpdateEventProcessor = MockUpdateEventProcessor()
         let mockCryptoboxMigrationManager = MockCryptoboxMigrationManagerInterface()
         mockMLSService = MockMLSServiceInterface()
+        mockMLSService.commitPendingProposalsIfNeeded_MockMethod = {}
         mockCryptoboxMigrationManager.isMigrationNeededAccountDirectory_MockValue = false
         sut = ZMUserSession(
             userId: coreDataStack.account.userIdentifier,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6610" title="WPB-6610" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6610</a>  Getting into request loop when someone else leaves an MLS group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App gets stuck in request loop when someone else leaves an MLS group

### Causes (Optional)

When a user leaves an MLS group backend will send remove proposal for all clients of that user. If the proposals arrive on the websocket we will attempt to commit only the first proposal which backend will reject (mls-commit-missing-references) because they require us to commit all proposals at once. 
This will cause the client to do a quick sync but it won’t decrypt the incoming events before it tries to commit the proposals so it will fail with the same reason.

### Solutions

Defer committing proposals outside of the event processing flow so that we can allow all proposals to be consumed before attempt to commit proposals in the group.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

1. Be in a group with User A (iOS) and B  which has two clients but only one is online (web)
2. User B leaves

iOS client gets stuck in request loop

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
