### PR TITLE
fix: supported protocols doesn't include mls when more than 1 client WPB-6532

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -395,9 +395,12 @@ public extension UserClient {
     ) -> UserClient? {
         WireLogger.userClient.info("create or update self user client")
 
-        guard let id = payloadData["id"] as? String,
-              let type = payloadData["type"] as? String
-        else { return nil }
+        guard
+            let id = payloadData["id"] as? String,
+            let type = payloadData["type"] as? String
+        else {
+            return nil
+        }
 
         let payloadAsDictionary = payloadData as NSDictionary
 
@@ -406,6 +409,7 @@ public extension UserClient {
         let deviceClass = payloadAsDictionary.optionalString(forKey: "class")
         let activationDate = payloadAsDictionary.date(for: "time")
         let lastActiveDate = payloadAsDictionary.optionalDate(forKey: "last_active")
+        let mlsPublicKeys = payloadAsDictionary.optionalDictionary(forKey: "mls_public_keys")
 
         let result = fetchOrCreateUserClient(with: id, in: context)
         let client = result.client
@@ -421,6 +425,10 @@ public extension UserClient {
 
         let selfUser = ZMUser.selfUser(in: context)
         client.user = client.user ?? selfUser
+
+        if let ed22519Key = mlsPublicKeys?["ed25519"] as? String {
+            client.mlsPublicKeys.ed25519 = ed22519Key
+        }
 
         if isNewClient {
             client.needsSessionMigration = selfUser.domain == nil

--- a/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserClient/UserClientTests.swift
@@ -608,9 +608,13 @@ extension UserClientTests {
     func testThatItSetsTheUserWhenInsertingANewSelfUserClient() {
         // given
         _ = createSelfClient()
-        let newClientPayload: [String: AnyObject] = ["id": UUID().transportString() as AnyObject,
-                                                     "type": "permanent" as AnyObject,
-                                                     "time": Date().transportString() as AnyObject]
+        let newClientPayload: [String: AnyObject] = [
+            "id": UUID().transportString() as AnyObject,
+            "type": "permanent" as AnyObject,
+            "time": Date().transportString() as AnyObject,
+            "mls_public_keys": ["ed25519": "some key"] as AnyObject
+        ]
+
         // when
         var newClient: UserClient!
         self.performPretendingUiMocIsSyncMoc {
@@ -623,6 +627,7 @@ extension UserClientTests {
         XCTAssertNotNil(newClient.user)
         XCTAssertEqual(newClient.user, ZMUser.selfUser(in: uiMOC))
         XCTAssertNotNil(newClient.sessionIdentifier)
+        XCTAssertEqual(newClient.mlsPublicKeys.ed25519, "some key")
     }
 
     func testThatItSetsTheUserWhenInsertingANewSelfUserClient_NoExistingSelfClient() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6532" title="WPB-6532" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6532</a>  [iOS] Unable to register 2 MLS devices to same user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When a user adds a second MLS capable client, their supported protocols no longer contains 'mls'.

### Causes

One of the conditions for including 'mls' in the supported protocols of a user is that all of their clients are mls ready: each client is recently active and has mls public keys. When fetching the self client metadata from the backend, we weren't parsing the `mls_public_keys` field and storing it on the `UserClient` object in the database. Therefore, all self user clients except the self client were erroneously consider not ready for mls.

### Solutions

Store the mls public key for all self clients.

### Testing

#### Test Coverage

- Updated existing test

#### How to Test

1. Log in with an mls capable client. Assert 'mls' is included in supported protocols.
2. Log in with a second mls capable client. Assert that 'mls' is still included in the supported protocols.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
