### PR TITLE
chore: enable SwiftLint closure spacing

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,6 @@
+opt_in_rules:
+  - closure_spacing
+
 disabled_rules:
   - function_body_length
   - type_body_length

--- a/wire-ios-data-model/Source/Model/Conversation/AssetCollection.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/AssetCollection.swift
@@ -124,7 +124,7 @@ public class AssetCollection: NSObject, ZMCollection {
     public func assets(for category: CategoryMatch) -> [ZMConversationMessage] {
         // Remove zombie objects and return remaining
         if let values = assets?[category] {
-            let withoutZombie = values.filter {!$0.isZombieObject}
+            let withoutZombie = values.filter { !$0.isZombieObject }
             assets?[category] = withoutZombie
             return withoutZombie
         }
@@ -207,7 +207,7 @@ public class AssetCollection: NSObject, ZMCollection {
             // Map to ui assets
             var uiAssets = [CategoryMatch: [ZMMessage]]()
             newAssets.forEach { (category, messages) in
-                let uiValues = messages.compactMap { (try? self.uiMOC?.existingObject(with: $0.objectID)) as? ZMMessage}
+                let uiValues = messages.compactMap { (try? self.uiMOC?.existingObject(with: $0.objectID)) as? ZMMessage }
                 uiAssets[category] = uiValues
             }
 

--- a/wire-ios-data-model/Source/Model/Conversation/AssetCollectionBatched.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/AssetCollectionBatched.swift
@@ -110,7 +110,7 @@ public class AssetCollectionBatched: NSObject, ZMCollection {
     public func assets(for category: CategoryMatch) -> [ZMConversationMessage] {
         // Remove zombie objects and return remaining
         if let values = assets?[category] {
-            let withoutZombie = values.filter {!$0.isZombieObject}
+            let withoutZombie = values.filter { !$0.isZombieObject }
             assets?[category] = withoutZombie
             return withoutZombie
         }
@@ -178,7 +178,7 @@ public class AssetCollectionBatched: NSObject, ZMCollection {
             // Map assets to UI assets
             var uiAssets = [CategoryMatch: [ZMMessage]]()
             newAssets.forEach {
-                let uiValues = $1.compactMap { (try? self.uiMOC?.existingObject(with: $0.objectID)) as? ZMMessage}
+                let uiValues = $1.compactMap { (try? self.uiMOC?.existingObject(with: $0.objectID)) as? ZMMessage }
                 uiAssets[$0] = uiValues
             }
 
@@ -258,7 +258,7 @@ extension AssetCollectionBatched {
             sorted[matchPair] = []
         }
 
-        let unionIncluding: MessageCategory = matchingCategories.reduce(.none) {$0.union($1.including)}
+        let unionIncluding: MessageCategory = matchingCategories.reduce(.none) { $0.union($1.including) }
         messages.forEach { message in
             let category = message.cachedCategory
             guard     (category.intersection(unionIncluding) != .none)

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Deletion.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Deletion.swift
@@ -23,7 +23,7 @@ extension ZMConversation {
     open override func prepareForDeletion() {
         super.prepareForDeletion()
 
-        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache?.deleteAssetData($0)})
+        allMessages.forEach({ managedObjectContext?.zm_fileAssetCache?.deleteAssetData($0) })
     }
 
 }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Labels.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Labels.swift
@@ -57,7 +57,7 @@ extension ZMConversation {
         let existingFolders = labels.filter({ $0.kind == .folder })
         labels.subtract(existingFolders)
 
-        for emptyFolder in existingFolders.filter({ $0.conversations.isEmpty}) {
+        for emptyFolder in existingFolders.filter({ $0.conversations.isEmpty }) {
             emptyFolder.markForDeletion()
         }
     }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -165,7 +165,7 @@ extension ZMConversation {
             return (result == .created) ? pr : nil
         }
 
-        let addedSelfUser = doesExistsOnBackend && addedRoles.contains(where: {$0.user?.isSelfUser == true})
+        let addedSelfUser = doesExistsOnBackend && addedRoles.contains(where: { $0.user?.isSelfUser == true })
         if addedSelfUser {
             self.markToDownloadRolesIfNeeded()
             self.needsToBeUpdatedFromBackend = true
@@ -190,7 +190,7 @@ extension ZMConversation {
         guard let moc = self.managedObjectContext else { return nil }
 
         // If the user is already there, just change the role
-        if let current = self.participantRoles.first(where: {$0.user == user}) {
+        if let current = self.participantRoles.first(where: { $0.user == user }) {
             if let role = role {
                 current.role = role
             }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Patches.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Patches.swift
@@ -72,7 +72,7 @@ extension ZMConversation {
 
             if isSelfAnActiveMember {
                 var participantRoleForSelfUser: ParticipantRole
-                let adminRole = conversation.getRoles().first(where: {$0.name == defaultAdminRoleName})
+                let adminRole = conversation.getRoles().first(where: { $0.name == defaultAdminRoleName })
 
                 if let conversationTeam = conversation.team, conversationTeam == selfUser.team, selfUser.isTeamMember {
                     participantRoleForSelfUser = getAParticipantRole(in: moc, adminRole: adminRole, user: selfUser, conversation: conversation, team: conversationTeam)

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -310,7 +310,7 @@ extension ZMConversation {
             return
         }
 
-        zmLog.debug("Sender: \(user.remoteIdentifier?.transportString() ?? "n/a") missing from participant list: \(localParticipants.map { $0.remoteIdentifier})")
+        zmLog.debug("Sender: \(user.remoteIdentifier?.transportString() ?? "n/a") missing from participant list: \(localParticipants.map { $0.remoteIdentifier })")
 
         switch conversationType {
         case .group:

--- a/wire-ios-data-model/Source/Model/Message/Composite/CompositeMessageItemContent.swift
+++ b/wire-ios-data-model/Source/Model/Message/Composite/CompositeMessageItemContent.swift
@@ -135,7 +135,7 @@ extension CompositeMessageItemContent: ButtonMessageData {
 // MARK: - Helpers
 extension CompositeMessageItemContent {
     private var hasSelectedButton: Bool {
-        return parentMessage.buttonStates?.contains(where: {$0.state == .selected}) ?? false
+        return parentMessage.buttonStates?.contains(where: { $0.state == .selected }) ?? false
     }
 
     private var buttonState: ButtonState? {

--- a/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
+++ b/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
@@ -404,5 +404,5 @@ public extension FileAssetCache {
 // Helper function inserted by Swift 4.2 migrator.
 private func convertToOptionalFileAttributeKeyDictionary(_ input: [String: Any]?) -> [FileAttributeKey: Any]? {
 	guard let input = input else { return nil }
-	return Dictionary(uniqueKeysWithValues: input.map { key, value in (FileAttributeKey(rawValue: key), value)})
+	return Dictionary(uniqueKeysWithValues: input.map { key, value in (FileAttributeKey(rawValue: key), value) })
 }

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -23,7 +23,7 @@ extension ZMAssetClientMessage {
     func genericMessageDataFromDataSet(for format: ZMImageFormat) -> ZMGenericMessageData? {
         return self.dataSet.lazy
             .compactMap { $0 as? ZMGenericMessageData }
-            .first(where: {$0.underlyingMessage?.imageAssetData?.imageFormat() == format})
+            .first(where: { $0.underlyingMessage?.imageAssetData?.imageFormat() == format })
     }
 
     public var mediumGenericMessage: GenericMessage? {

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage.swift
@@ -505,11 +505,11 @@ extension ZMAssetClientMessage: AssetMessage {
     public var processingState: AssetProcessingState {
         let assets = self.assets
 
-        if assets.filter({$0.needsPreprocessing && !$0.hasPreprocessed || !$0.isUploaded && !$0.hasEncrypted}).count > 0 {
+        if assets.filter({ $0.needsPreprocessing && !$0.hasPreprocessed || !$0.isUploaded && !$0.hasEncrypted }).count > 0 {
             return .preprocessing
         }
 
-        if assets.filter({!$0.isUploaded}).count > 0 {
+        if assets.filter({ !$0.isUploaded }).count > 0 {
             return .uploading
         }
 

--- a/wire-ios-data-model/Source/Model/Message/ZMClientMessage+Encryption.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMClientMessage+Encryption.swift
@@ -455,7 +455,7 @@ extension GenericMessage {
                 )
             }
 
-            if useQualifiedIdentifiers, let selfDomain = context.performAndWait({ZMUser.selfUser(in: context).domain }) {
+            if useQualifiedIdentifiers, let selfDomain = context.performAndWait({ ZMUser.selfUser(in: context).domain }) {
                 let message = legacyProteusMessage(
                     selfClient,
                     selfDomain: selfDomain,

--- a/wire-ios-data-model/Source/Model/User/PersonName.swift
+++ b/wire-ios-data-model/Source/Model/User/PersonName.swift
@@ -120,7 +120,7 @@
         let nameOrder: NameOrder
         if tags.contains("Arab") {
             nameOrder = .arabicGivenName
-        } else if tags.contains(where: {["Hani", "Jpan", "Deva", "Gurj"].contains($0)}) {
+        } else if tags.contains(where: { ["Hani", "Jpan", "Deva", "Gurj"].contains($0) }) {
             nameOrder = tags.contains("Latn") ? .givenNameFirst : .givenNameLast
         } else {
             nameOrder = .givenNameFirst
@@ -162,7 +162,7 @@
 
     override public var hash: Int {
         var hash = 0
-        components.forEach {hash ^= $0.hash}
+        components.forEach { hash ^= $0.hash }
         return hash
     }
 

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Permissions.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Permissions.swift
@@ -220,6 +220,6 @@ public extension ZMUser {
         guard conversation.isSelfAnActiveMember,
             let role = self.role(in: conversation)
         else { return false }
-        return role.actions.contains(where: {$0.name == actionName})
+        return role.actions.contains(where: { $0.name == actionName })
     }
 }

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Predicates.swift
@@ -59,7 +59,7 @@ extension ZMUser {
         if !query.isEmpty {
             let namePredicate = NSPredicate(formatDictionary: [#keyPath(ZMUser.normalizedName): "%K MATCHES %@"], matchingSearch: query)
             let handlePredicate = NSPredicate(format: "%K BEGINSWITH %@", #keyPath(ZMUser.handle), query.strippingLeadingAtSign())
-            allPredicates.append([namePredicate, handlePredicate].compactMap {$0})
+            allPredicates.append([namePredicate, handlePredicate].compactMap { $0 })
         }
 
         let orPredicates = allPredicates.map { NSCompoundPredicate(orPredicateWithSubpredicates: $0) }

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -197,7 +197,7 @@ public class UserClient: ZMManagedObject, UserClientType {
             fatal("User \(user.safeForLoggingDescription) is not a member of a managed object context (deleted object).")
         }
 
-        let relationClients = user.clients.filter({$0.remoteIdentifier == remoteIdentifier})
+        let relationClients = user.clients.filter({ $0.remoteIdentifier == remoteIdentifier })
 
         if relationClients.count > 1 {
             WireLogger.userClient.error("Detected duplicate clients: \(relationClients.map(\.remoteIdentifier))")
@@ -713,7 +713,7 @@ extension UserClient {
 
     /// Adds to ignored clients, remove from trusted clients, returns the set with the self client excluded
     fileprivate func addIgnoredClients(_ clients: Set<UserClient>) -> Set<UserClient> {
-        let notSelfClients = Set(clients.filter {$0 != self})
+        let notSelfClients = Set(clients.filter { $0 != self })
 
         guard notSelfClients.count > 0 else { return notSelfClients }
 

--- a/wire-ios-data-model/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
+++ b/wire-ios-data-model/Source/Notifications/ChangeCalculation/ChangedIndexes.swift
@@ -156,7 +156,7 @@ public struct ChangedIndexes<T: Hashable> {
         // This way the only items remaining will be inserted objects
         // We need to sort inserted indexes in ascending order to avoid out of bounds inserts
         let ascInsertedIndexes = insertedObjects.values.sorted()
-        ascInsertedIndexes.forEach {intermediateState.insert(end.array[$0], at: $0)}
+        ascInsertedIndexes.forEach { intermediateState.insert(end.array[$0], at: $0) }
 
         return (insertedObjects, deletedObjects, updatedIndexes, intermediateState)
     }

--- a/wire-ios-data-model/Source/Notifications/ConversationListObserverCenter.swift
+++ b/wire-ios-data-model/Source/Notifications/ConversationListObserverCenter.swift
@@ -99,11 +99,11 @@ public class ConversationListObserverCenter: NSObject, ZMConversationObserver, C
         }
 
         if let convChanges = changes[ZMConversation.classIdentifier] as? [ConversationChangeInfo] {
-            convChanges.forEach {conversationDidChange($0)}
+            convChanges.forEach { conversationDidChange($0) }
         } else if let messageChanges = changes[ZMClientMessage.classIdentifier] as? [MessageChangeInfo] {
-            messageChanges.forEach {messagesDidChange($0)}
+            messageChanges.forEach { messagesDidChange($0) }
         } else if let labelChanges = changes[Label.classIdentifier] as? [LabelChangeInfo] {
-            labelChanges.forEach {labelDidChange($0)}
+            labelChanges.forEach { labelDidChange($0) }
         }
 
         let insertedConversations = self.insertedConversations
@@ -150,7 +150,7 @@ public class ConversationListObserverCenter: NSObject, ZMConversationObserver, C
               || changes.messagesChanged          || changes.labelsChanged           || changes.mlsStatusChanged
         else { return }
         zmLog.debug("conversationDidChange with changes \(changes.customDebugDescription)")
-        forwardToSnapshots {$0.processConversationChanges(changes)}
+        forwardToSnapshots { $0.processConversationChanges(changes) }
     }
 
     /// Stores inserted or deleted folders temporarily until save / merge completes
@@ -189,7 +189,7 @@ public class ConversationListObserverCenter: NSObject, ZMConversationObserver, C
         }
 
         // clean up snapshotlist
-        snapshotsToRemove.forEach {listSnapshots.removeValue(forKey: $0)}
+        snapshotsToRemove.forEach { listSnapshots.removeValue(forKey: $0) }
     }
 
     public func stopObserving() {
@@ -272,8 +272,8 @@ class ConversationListSnapshot: NSObject {
     func conversationsChanges(inserted: [ZMConversation], deleted: [ZMConversation]) {
         guard let list = conversationList else { return }
 
-        let conversationsToInsert = Set(inserted.filter { list.predicateMatchesConversation($0)})
-        let conversationsToRemove = Set(deleted.filter { list.contains($0)})
+        let conversationsToInsert = Set(inserted.filter { list.predicateMatchesConversation($0) })
+        let conversationsToRemove = Set(deleted.filter { list.contains($0) })
         zmLog.debug("List \(list.identifier) is inserting \(conversationsToInsert.count) and deletes \(conversationsToRemove.count) conversations")
 
         list.insertConversations(conversationsToInsert)
@@ -298,7 +298,7 @@ class ConversationListSnapshot: NSObject {
             needsToRecalculate = false
         }
 
-        let changedSet = Set(conversationChanges.compactMap {$0.conversation})
+        let changedSet = Set(conversationChanges.compactMap { $0.conversation })
         guard let newStateUpdate = self.state.updatedState(changedSet, observedObject: list, newSet: list.toOrderedSetState())
         else {
             zmLog.debug("Recalculated list \(list.identifier), but old state is same as new state")
@@ -337,7 +337,7 @@ class ConversationListSnapshot: NSObject {
 
     func logMessage(for conversationChanges: [ConversationChangeInfo], listChanges: ConversationListChangeInfo?) -> String {
         var message = "Posting notification for list \(String(describing: conversationList?.identifier)) with conversationChanges: \n"
-        message.append(conversationChanges.map {$0.customDebugDescription}.joined(separator: "\n"))
+        message.append(conversationChanges.map { $0.customDebugDescription }.joined(separator: "\n"))
 
         guard let changeInfo = listChanges else { return message }
         message.append("\n ConversationListChangeInfo: \(changeInfo.description)")

--- a/wire-ios-data-model/Source/Notifications/DependencyKeyStore.swift
+++ b/wire-ios-data-model/Source/Notifications/DependencyKeyStore.swift
@@ -76,10 +76,10 @@ class DependencyKeyStore {
     /// Returns a store mapping observable keys and their affecting keys
     /// @param classIdentifier: Identifiers for each class, e.g. entityName
     init(classIdentifiers: [String]) {
-        let observable = classIdentifiers.mapToDictionary {DependencyKeyStore.setupObservableKeys(classIdentifier: $0)}
-        let affecting = classIdentifiers.mapToDictionary {DependencyKeyStore.setupAffectedKeys(classIdentifier: $0, observableKeys: observable[$0]!)}
-        let all = classIdentifiers.mapToDictionary {DependencyKeyStore.setupAllKeys(observableKeys: observable[$0]!, affectingKeys: affecting[$0]!)}
-        effectedKeys = classIdentifiers.mapToDictionary {DependencyKeyStore.setupEffectedKeys(affectingKeys: affecting[$0]!)}
+        let observable = classIdentifiers.mapToDictionary { DependencyKeyStore.setupObservableKeys(classIdentifier: $0) }
+        let affecting = classIdentifiers.mapToDictionary { DependencyKeyStore.setupAffectedKeys(classIdentifier: $0, observableKeys: observable[$0]!) }
+        let all = classIdentifiers.mapToDictionary { DependencyKeyStore.setupAllKeys(observableKeys: observable[$0]!, affectingKeys: affecting[$0]!) }
+        effectedKeys = classIdentifiers.mapToDictionary { DependencyKeyStore.setupEffectedKeys(affectingKeys: affecting[$0]!) }
 
         self.observableKeys = observable
         self.affectingKeys = affecting
@@ -132,35 +132,35 @@ class DependencyKeyStore {
     private static func setupAffectedKeys(classIdentifier: String, observableKeys: Set<String>) -> [String: Set<String>] {
         switch classIdentifier {
         case ZMConversation.entityName():
-            return observableKeys.mapToDictionary {ZMConversation.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMConversation.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMUser.entityName():
-            return observableKeys.mapToDictionary {ZMUser.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMUser.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMConnection.entityName():
             return [:]
         case UserClient.entityName():
-            return observableKeys.mapToDictionary {UserClient.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { UserClient.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMMessage.entityName():
-            return observableKeys.mapToDictionary {ZMMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMMessage.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMAssetClientMessage.entityName():
-            return observableKeys.mapToDictionary {ZMAssetClientMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMAssetClientMessage.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMSystemMessage.entityName():
-            return observableKeys.mapToDictionary {ZMSystemMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMSystemMessage.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMClientMessage.entityName():
-            return observableKeys.mapToDictionary {ZMClientMessage.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMClientMessage.keyPathsForValuesAffectingValue(forKey: $0) }
         case Reaction.entityName():
-            return observableKeys.mapToDictionary {Reaction.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { Reaction.keyPathsForValuesAffectingValue(forKey: $0) }
         case ZMGenericMessageData.entityName():
-            return observableKeys.mapToDictionary {ZMGenericMessageData.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ZMGenericMessageData.keyPathsForValuesAffectingValue(forKey: $0) }
         case Team.entityName():
-            return observableKeys.mapToDictionary {Team.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { Team.keyPathsForValuesAffectingValue(forKey: $0) }
         case Member.entityName():
             return [:]
         case Label.entityName():
-            return observableKeys.mapToDictionary {Label.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { Label.keyPathsForValuesAffectingValue(forKey: $0) }
         case ParticipantRole.entityName():
-            return observableKeys.mapToDictionary {ParticipantRole.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ParticipantRole.keyPathsForValuesAffectingValue(forKey: $0) }
         case ButtonState.entityName():
-            return observableKeys.mapToDictionary {ButtonState.keyPathsForValuesAffectingValue(forKey: $0)}
+            return observableKeys.mapToDictionary { ButtonState.keyPathsForValuesAffectingValue(forKey: $0) }
         default:
             zmLog.warn("There is no path to affecting keys defined for \(classIdentifier)")
             return [:]
@@ -169,7 +169,7 @@ class DependencyKeyStore {
 
     /// Combines observed keys and all affecting keys in one giant Set
     private static func setupAllKeys(observableKeys: Set<String>, affectingKeys: [String: Set<String>]) -> Set<String> {
-        let allAffectingKeys: Set<String> = affectingKeys.reduce(Set()) {$0.union($1.value)}
+        let allAffectingKeys: Set<String> = affectingKeys.reduce(Set()) { $0.union($1.value) }
         return observableKeys.union(allAffectingKeys)
     }
 

--- a/wire-ios-data-model/Source/Notifications/ManagedObjectObserver.swift
+++ b/wire-ios-data-model/Source/Notifications/ManagedObjectObserver.swift
@@ -37,7 +37,7 @@ import Foundation
             forName: .NSManagedObjectContextObjectsDidChange,
             object: context,
             queue: nil,
-            using: {  [weak self] _ in self?.callback() }
+            using: { [weak self] _ in self?.callback() }
         )
     }
 

--- a/wire-ios-data-model/Source/Notifications/NotificationDispatcher.swift
+++ b/wire-ios-data-model/Source/Notifications/NotificationDispatcher.swift
@@ -78,7 +78,7 @@ import CoreData
     private var changeInfoConsumers = [UnownedNSObject]()
 
     private var allChangeInfoConsumers: [ChangeInfoConsumer] {
-        var consumers = changeInfoConsumers.compactMap {$0.unbox as? ChangeInfoConsumer}
+        var consumers = changeInfoConsumers.compactMap { $0.unbox as? ChangeInfoConsumer }
         consumers.append(searchUserObserverCenter)
         consumers.append(conversationListObserverCenter)
         return consumers

--- a/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/ConversationListChangeInfo.swift
+++ b/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/ConversationListChangeInfo.swift
@@ -24,7 +24,7 @@ private var zmLog = ZMSLog(tag: "ConversationListObserverCenter")
 extension ZMConversationList {
 
     func toOrderedSetState() -> OrderedSetState<ZMConversation> {
-        return OrderedSetState(array: self.map {$0 as! ZMConversation})
+        return OrderedSetState(array: self.map { $0 as! ZMConversation })
     }
 
 }

--- a/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/Helpers/KeySet.swift
+++ b/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/Helpers/KeySet.swift
@@ -139,7 +139,7 @@ extension KeySet {
         return backing.isEmpty
     }
     func filter(_ match: (StringKeyPath) -> Bool) -> KeySet {
-        return KeySet(backing.filter {match($0)})
+        return KeySet(backing.filter { match($0) })
     }
 }
 

--- a/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/Helpers/SetSnapshot.swift
+++ b/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/Helpers/SetSnapshot.swift
@@ -56,7 +56,7 @@ open class SetChangeInfo<T: Hashable>: NSObject {
     open var updatedIndexes: IndexSet { return changeSet.updatedIndexes }
     open var movedIndexPairs: [MovedIndex] { return changeSet.movedIndexes }
     // for temporary objC-compatibility
-    open var zm_movedIndexPairs: [ZMMovedIndex] { return changeSet.movedIndexes.map {ZMMovedIndex(from: UInt($0.from), to: UInt($0.to))}}
+    open var zm_movedIndexPairs: [ZMMovedIndex] { return changeSet.movedIndexes.map { ZMMovedIndex(from: UInt($0.from), to: UInt($0.to)) } }
     convenience init(observedObject: NSObject) {
         let orderSetState = OrderedSetState<T>(array: [])
         self.init(observedObject: observedObject,

--- a/wire-ios-data-model/Source/Notifications/SearchUserObserverCenter.swift
+++ b/wire-ios-data-model/Source/Notifications/SearchUserObserverCenter.swift
@@ -124,10 +124,10 @@ public class SearchUserSnapshot {
     /// Removes all snapshots for searchUsers that are not contained in this set
     /// This should be called when the searchDirectory changes
     public func searchDirectoryDidUpdate(newSearchUsers: [ZMSearchUser]) {
-        let remoteIDs = newSearchUsers.compactMap {$0.remoteIdentifier}
+        let remoteIDs = newSearchUsers.compactMap { $0.remoteIdentifier }
         let currentRemoteIds = Set(snapshots.keys)
         let toRemove = currentRemoteIds.subtracting(remoteIDs)
-        toRemove.forEach {snapshots.removeValue(forKey: $0)}
+        toRemove.forEach { snapshots.removeValue(forKey: $0) }
     }
 
     /// Removes the snapshots for the specified searchUser
@@ -147,7 +147,7 @@ public class SearchUserSnapshot {
 
     public func objectsDidChange(changes: [ClassIdentifier: [ObjectChangeInfo]]) {
         guard let userChanges = changes[ZMUser.entityName()] as? [UserChangeInfo] else { return }
-        userChanges.forEach {usersDidChange(info: $0)}
+        userChanges.forEach { usersDidChange(info: $0) }
     }
 
     /// Matches the userChangeInfo with the searchUser snapshots and updates those if needed

--- a/wire-ios-data-model/Source/Notifications/SideEffectSources.swift
+++ b/wire-ios-data-model/Source/Notifications/SideEffectSources.swift
@@ -117,10 +117,10 @@ extension ZMUser: SideEffectSource {
             keys.formUnion(keyStore.observableKeysAffectedByValue(ZMUser.entityName(), key: changedKey))
         }
 
-        let otherPartKeys = allChangedKeys.map {"\(#keyPath(ZMConversation.participantRoles.user)).\($0)"}
-        let selfUserKeys = allChangedKeys.map {"\(#keyPath(ZMConversation.oneOnOneUser)).\($0)"}
+        let otherPartKeys = allChangedKeys.map { "\(#keyPath(ZMConversation.participantRoles.user)).\($0)" }
+        let selfUserKeys = allChangedKeys.map { "\(#keyPath(ZMConversation.oneOnOneUser)).\($0)" }
         let mappedKeys = otherPartKeys + selfUserKeys
-        var keys = mappedKeys.map {keyStore.observableKeysAffectedByValue(classIdentifier, key: $0)}.reduce(Set()) {$0.union($1)}
+        var keys = mappedKeys.map { keyStore.observableKeysAffectedByValue(classIdentifier, key: $0) }.reduce(Set()) { $0.union($1) }
 
         conversations.forEach {
             if $0.allUsersTrusted {
@@ -212,7 +212,7 @@ extension ZMConnection: SideEffectSource {
 extension UserClient: SideEffectSource {
 
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: user, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: "clientChanges", keyMapping: {"\(#keyPath(ZMUser.clients)).\($0)"})
+        return byUpdateAffectedKeys(for: user, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: "clientChanges", keyMapping: { "\(#keyPath(ZMUser.clients)).\($0)" })
     }
 
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
@@ -223,7 +223,7 @@ extension UserClient: SideEffectSource {
 extension Reaction: SideEffectSource {
 
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: "reactionChanges", keyMapping: {"\(#keyPath(ZMMessage.reactions)).\($0)"})
+        return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: "reactionChanges", keyMapping: { "\(#keyPath(ZMMessage.reactions)).\($0)" })
     }
 
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
@@ -234,7 +234,7 @@ extension Reaction: SideEffectSource {
 extension ButtonState: SideEffectSource {
 
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: MessageChangeInfo.ButtonStateChangeInfoKey, keyMapping: {"\(#keyPath(ZMClientMessage.buttonStates)).\($0)"})
+        return byUpdateAffectedKeys(for: message, knownKeys: knownKeys, keyStore: keyStore, originalChangeKey: MessageChangeInfo.ButtonStateChangeInfoKey, keyMapping: { "\(#keyPath(ZMClientMessage.buttonStates)).\($0)" })
     }
 
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {
@@ -245,7 +245,7 @@ extension ButtonState: SideEffectSource {
 extension ZMGenericMessageData: SideEffectSource {
 
     func affectedObjectsAndKeys(keyStore: DependencyKeyStore, knownKeys: Set<String>) -> ObjectAndChanges {
-        return byUpdateAffectedKeys(for: message ?? asset, knownKeys: knownKeys, keyStore: keyStore, keyMapping: {"\(#keyPath(ZMClientMessage.dataSet)).\($0)"})
+        return byUpdateAffectedKeys(for: message ?? asset, knownKeys: knownKeys, keyStore: keyStore, keyMapping: { "\(#keyPath(ZMClientMessage.dataSet)).\($0)" })
     }
 
     func affectedObjectsForInsertionOrDeletion(keyStore: DependencyKeyStore) -> ObjectAndChanges {

--- a/wire-ios-data-model/Source/Notifications/SnapshotCenter.swift
+++ b/wire-ios-data-model/Source/Notifications/SnapshotCenter.swift
@@ -59,13 +59,13 @@ public class SnapshotCenter {
         let attributes = Array(object.entity.attributesByName.keys)
         let relationships = object.entity.relationshipsByName
 
-        let attributesDict = attributes.mapToDictionaryWithOptionalValue {object.primitiveValue(forKey: $0) as? NSObject}
-        let toManyRelationshipsDict: [String: Int] = relationships.mapKeysAndValues(keysMapping: {$0}, valueMapping: { (key, relationShipDescription) in
+        let attributesDict = attributes.mapToDictionaryWithOptionalValue { object.primitiveValue(forKey: $0) as? NSObject }
+        let toManyRelationshipsDict: [String: Int] = relationships.mapKeysAndValues(keysMapping: { $0 }, valueMapping: { (key, relationShipDescription) in
             guard relationShipDescription.isToMany else { return nil }
             return (object.primitiveValue(forKey: key) as? Countable)?.count
         })
 
-        let toOneRelationshipsDict: [String: NSManagedObjectID] = relationships.mapKeysAndValues(keysMapping: {$0}, valueMapping: { (key, relationshipDescription) in
+        let toOneRelationshipsDict: [String: NSManagedObjectID] = relationships.mapKeysAndValues(keysMapping: { $0 }, valueMapping: { (key, relationshipDescription) in
             guard !relationshipDescription.isToMany else { return nil }
             return (object.primitiveValue(forKey: key) as? NSManagedObject)?.objectID
         })

--- a/wire-ios-data-model/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/wire-ios-data-model/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -213,7 +213,7 @@ extension GenericMessage {
 
 public extension Text {
     func isMentioningSelf(_ selfUser: ZMUser) -> Bool {
-        return mentions.any {$0.userID.uppercased() == selfUser.remoteIdentifier.uuidString }
+        return mentions.any { $0.userID.uppercased() == selfUser.remoteIdentifier.uuidString }
     }
 
     func isQuotingSelf(_ quotedMessage: ZMOTRMessage?) -> Bool {

--- a/wire-ios-data-model/Source/Utilis/ZMUpdateEvent.swift
+++ b/wire-ios-data-model/Source/Utilis/ZMUpdateEvent.swift
@@ -44,7 +44,7 @@ extension ZMUpdateEvent {
             let userIds = dataPayload["user_ids"] as? [String] else {
                 return []
         }
-        return userIds.compactMap({ UUID.init(uuidString: $0)})
+        return userIds.compactMap({ UUID.init(uuidString: $0) })
     }
 
     public var qualifiedUserIDs: [QualifiedID]? {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/AssetCollectionBatchedTests.swift
@@ -197,7 +197,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
 
         // given
         insertAssetMessages(count: 1000)
-        uiMOC.registeredObjects.forEach {uiMOC.refresh($0, mergeChanges: false)}
+        uiMOC.registeredObjects.forEach { uiMOC.refresh($0, mergeChanges: false) }
 
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
 
@@ -211,7 +211,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
             // then
             self.sut.tearDown()
             self.sut = nil
-            self.uiMOC.registeredObjects.forEach {self.uiMOC.refresh($0, mergeChanges: false)}
+            self.uiMOC.registeredObjects.forEach { self.uiMOC.refresh($0, mergeChanges: false) }
         }
     }
 
@@ -220,7 +220,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
         insertAssetMessages(count: 10)
 
         // when
-        conversation.allMessages.forEach {_ = $0.cachedCategory}
+        conversation.allMessages.forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         sut = AssetCollectionBatched(conversation: conversation, matchingCategories: [defaultMatchPair], delegate: delegate)
@@ -234,7 +234,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
     func testThatItGetsPreCategorizedMessagesInTheCorrectOrder() {
         // given
         let messages = insertAssetMessages(count: 10)
-        conversation.allMessages.forEach {_ = $0.cachedCategory}
+        conversation.allMessages.forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         // when
@@ -255,7 +255,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
         uiMOC.saveOrRollback()
 
         // when
-        conversation.allMessages.forEach {_ = $0.cachedCategory}
+        conversation.allMessages.forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
@@ -343,7 +343,7 @@ class AssetColletionBatchedTests: ModelObjectsTests {
     func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects() {
         // given
         let messages = insertAssetMessages(count: 20)
-        messages[0..<10].forEach {_ = $0.cachedCategory}
+        messages[0..<10].forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         // when

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/AssetColletionTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/AssetColletionTests.swift
@@ -45,7 +45,7 @@ class MockAssetCollectionDelegate: NSObject, AssetCollectionDelegate {
     }
 
     func allMessages(for categoryMatch: CategoryMatch) -> [ZMMessage] {
-        return messagesByFilter.reduce([ZMMessage]()) {$0 + ($1[categoryMatch] ?? [])}
+        return messagesByFilter.reduce([ZMMessage]()) { $0 + ($1[categoryMatch] ?? []) }
     }
 }
 
@@ -227,7 +227,7 @@ class AssetColletionTests: ModelObjectsTests {
 
         // given
         insertAssetMessages(count: 1000)
-        uiMOC.registeredObjects.forEach {uiMOC.refresh($0, mergeChanges: false)}
+        uiMOC.registeredObjects.forEach { uiMOC.refresh($0, mergeChanges: false) }
 
         self.measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
 
@@ -241,7 +241,7 @@ class AssetColletionTests: ModelObjectsTests {
             // then
             self.sut.tearDown()
             self.sut = nil
-            self.uiMOC.registeredObjects.forEach {self.uiMOC.refresh($0, mergeChanges: false)}
+            self.uiMOC.registeredObjects.forEach { self.uiMOC.refresh($0, mergeChanges: false) }
         }
     }
 
@@ -250,7 +250,7 @@ class AssetColletionTests: ModelObjectsTests {
         insertAssetMessages(count: 10)
 
         // when
-        conversation.allMessages.forEach {_ = $0.cachedCategory}
+        conversation.allMessages.forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         sut = AssetCollection(conversation: conversation, matchingCategories: [self.defaultMatchPair], delegate: delegate)
@@ -264,7 +264,7 @@ class AssetColletionTests: ModelObjectsTests {
     func testThatItGetsPreCategorizedMessagesInTheCorrectOrder() {
         // given
         let messages = insertAssetMessages(count: 10)
-        conversation.allMessages.forEach {_ = $0.cachedCategory}
+        conversation.allMessages.forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         // when
@@ -284,7 +284,7 @@ class AssetColletionTests: ModelObjectsTests {
         _ = try! conversation.appendImage(from: data) as! ZMAssetClientMessage
 
         // when
-        conversation.allMessages.forEach {_ = $0.cachedCategory}
+        conversation.allMessages.forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
         let excludingGif = CategoryMatch(including: .image, excluding: .GIF)
         sut = AssetCollection(conversation: conversation, matchingCategories: [excludingGif], delegate: delegate)
@@ -370,7 +370,7 @@ class AssetColletionTests: ModelObjectsTests {
     func testThatItFetchesPreAndUncategorizedObjectsAndSavesThemAsUIDObjects() {
         // given
         let messages = insertAssetMessages(count: 20)
-        messages[0..<10].forEach {_ = $0.cachedCategory}
+        messages[0..<10].forEach { _ = $0.cachedCategory }
         uiMOC.saveOrRollback()
 
         // when

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Creation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Creation.swift
@@ -41,7 +41,7 @@ final class ZMConversationTests_Creation: ZMConversationTestsBase {
         )!
 
         // then
-        XCTAssertEqual(conversation.participantRoles.compactMap { $0.role}, [role1, role1, role1])
+        XCTAssertEqual(conversation.participantRoles.compactMap { $0.role }, [role1, role1, role1])
     }
 
     func testThatItCreatesConversationAndIncludesSelfUser() {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Participants.swift
@@ -520,7 +520,7 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
 
         // then
         XCTAssertEqual(conversation.participantRoles.count, 2)
-        XCTAssertEqual(conversation.participantRoles.compactMap { $0.role}, [role1, role1])
+        XCTAssertEqual(conversation.participantRoles.compactMap { $0.role }, [role1, role1])
     }
 
     func testThatItAddsParticipantsWithTheGivenRole() {
@@ -545,8 +545,8 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
 
         // then
         XCTAssertEqual(conversation.participantRoles.count, 2)
-        XCTAssertEqual(conversation.participantRoles.first {$0.user == user1}?.role, role1)
-        XCTAssertEqual(conversation.participantRoles.first {$0.user == user2}?.role, role2)
+        XCTAssertEqual(conversation.participantRoles.first { $0.user == user1 }?.role, role1)
+        XCTAssertEqual(conversation.participantRoles.first { $0.user == user2 }?.role, role2)
     }
 
     func testThatItDoesNotAddDeletedParticipants() {
@@ -571,7 +571,7 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
 
         // then
         XCTAssertEqual(conversation.participantRoles.count, 1)
-        XCTAssertEqual(conversation.participantRoles.first {$0.user == user1}?.role, role1)
+        XCTAssertEqual(conversation.participantRoles.first { $0.user == user1 }?.role, role1)
     }
 
     func testThatItUpdateParticipantWithTheGivenRole() {
@@ -600,8 +600,8 @@ final class ConversationParticipantsTests: ZMConversationTestsBase {
 
         // then
         XCTAssertEqual(conversation.participantRoles.count, 2)
-        XCTAssertEqual(conversation.participantRoles.first {$0.user == user1}?.role, role1)
-        XCTAssertEqual(conversation.participantRoles.first {$0.user == user2}?.role, role2)
+        XCTAssertEqual(conversation.participantRoles.first { $0.user == user1 }?.role, role1)
+        XCTAssertEqual(conversation.participantRoles.first { $0.user == user2 }?.role, role2)
     }
 
     func testThatItRefetchesRolesIfNoRoles() {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Timestamps.swift
@@ -446,9 +446,9 @@ class ZMConversationTests_Timestamps: ZMConversationTestsBase {
 
             // then
             XCTAssertEqual(conversation.unreadMessages.count, 2)
-            XCTAssertTrue(conversation.unreadMessages.contains { $0.nonce == systemMessage1.nonce})
-            XCTAssertFalse(conversation.unreadMessages.contains { $0.nonce == systemMessage2.nonce})
-            XCTAssertTrue(conversation.unreadMessages.contains { $0.nonce == textMessage.nonce})
+            XCTAssertTrue(conversation.unreadMessages.contains { $0.nonce == systemMessage1.nonce })
+            XCTAssertFalse(conversation.unreadMessages.contains { $0.nonce == systemMessage2.nonce })
+            XCTAssertTrue(conversation.unreadMessages.contains { $0.nonce == textMessage.nonce })
         }
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Transport.swift
@@ -30,7 +30,7 @@ class ZMConversationTests_Transport: ZMConversationTestsBase {
             let accessMode = ConversationAccessMode.allowGuests
 
             // when
-            conversation.updateAccessStatus(accessModes: accessMode.stringValue, accessRoles: accessRoles.map({$0.rawValue}))
+            conversation.updateAccessStatus(accessModes: accessMode.stringValue, accessRoles: accessRoles.map({ $0.rawValue }))
 
             // then
             XCTAssertEqual(conversation.accessMode, accessMode)
@@ -166,7 +166,7 @@ class ZMConversationTests_Transport: ZMConversationTestsBase {
             XCTAssertEqual(participant2.role?.team, team)
             XCTAssertEqual(participant1.role?.name, "test_role1")
             XCTAssertEqual(participant2.role?.name, "test_role2")
-            XCTAssertEqual(team.roles, Set([participant1.role, participant2.role].compactMap {$0}))
+            XCTAssertEqual(team.roles, Set([participant1.role, participant2.role].compactMap { $0 }))
         }
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/Messages/Composite/CompositeMessageItemContentTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/Composite/CompositeMessageItemContentTests.swift
@@ -70,7 +70,7 @@ class CompositeMessageItemContentTests: BaseCompositeMessageTests {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
 
         // THEN
-        let buttonState = message.buttonStates?.first(where: {$0.remoteIdentifier == id})
+        let buttonState = message.buttonStates?.first(where: { $0.remoteIdentifier == id })
         XCTAssertNotNil(buttonState)
         XCTAssertEqual(WireDataModel.ButtonState.State.selected, buttonState?.state)
     }
@@ -88,7 +88,7 @@ class CompositeMessageItemContentTests: BaseCompositeMessageTests {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
 
         // THEN
-        let buttonState = message.buttonStates?.first(where: {$0.remoteIdentifier == id})
+        let buttonState = message.buttonStates?.first(where: { $0.remoteIdentifier == id })
         XCTAssertEqual(buttonState?.isExpired, true)
         XCTAssertEqual(buttonState?.state, WireDataModel.ButtonState.State.unselected)
         let lastmessage = conversation.hiddenMessages.first as? ZMClientMessage

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ChangedIndexesTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ChangedIndexesTests.swift
@@ -59,8 +59,8 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(callCount, 1)
 
         var result = ["A", "B", "C", "D", "E"]
-        sut.deletedIndexes.forEach {result.remove(at: $0)}
-        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
+        sut.deletedIndexes.forEach { result.remove(at: $0) }
+        sut.insertedIndexes.forEach { result.insert(endState.array[$0], at: $0) }
         sut.enumerateMovedIndexes { (from, to) in
             let item = startState.array[from]
             result.remove(at: result.firstIndex(of: item)!)
@@ -105,8 +105,8 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(callCount, 3)
 
         var result = ["A", "B", "C", "D", "E"]
-        sut.deletedIndexes.forEach {result.remove(at: $0)}
-        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
+        sut.deletedIndexes.forEach { result.remove(at: $0) }
+        sut.insertedIndexes.forEach { result.insert(endState.array[$0], at: $0) }
         sut.enumerateMovedIndexes { (from, to) in
             let item = startState.array[from]
             result.remove(at: result.firstIndex(of: item)!)
@@ -192,8 +192,8 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(callCount, 1)
 
         var result = ["A", "B", "C", "D", "E"]
-        sut.deletedIndexes.forEach {result.remove(at: $0)}
-        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
+        sut.deletedIndexes.forEach { result.remove(at: $0) }
+        sut.insertedIndexes.forEach { result.insert(endState.array[$0], at: $0) }
         sut.enumerateMovedIndexes { (from, to) in
             let item = result.remove(at: from)
             result.insert(item, at: to)
@@ -237,8 +237,8 @@ class ChangedIndexesTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(callCount, 3)
 
         var result = ["A", "B", "C", "D", "E"]
-        sut.deletedIndexes.forEach {result.remove(at: $0)}
-        sut.insertedIndexes.forEach {result.insert(endState.array[$0], at: $0)}
+        sut.deletedIndexes.forEach { result.remove(at: $0) }
+        sut.insertedIndexes.forEach { result.insert(endState.array[$0], at: $0) }
         sut.enumerateMovedIndexes { (from, to) in
             let item = result.remove(at: from)
             result.insert(item, at: to)

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -66,7 +66,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
     fileprivate func movedIndexes(_ changeSet: ConversationListChangeInfo) -> [MovedIndex] {
         var array: [MovedIndex] = []
-        changeSet.enumerateMovedIndexes {(x: Int, y: Int) in array.append(MovedIndex(from: x, to: y)) }
+        changeSet.enumerateMovedIndexes { (x: Int, y: Int) in array.append(MovedIndex(from: x, to: y)) }
         return array
     }
 
@@ -287,8 +287,8 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
         XCTAssert(uiMOC.saveOrRollback(), file: file, line: line)
 
         let conversationList = ZMConversation.conversationsExcludingArchived(in: uiMOC)
-        XCTAssertEqual(conversationList.map { ($0 as! ZMConversation).objectID},
-                       [conversation3, conversation2, conversation1].map {$0.objectID}, file: file, line: line)
+        XCTAssertEqual(conversationList.map { ($0 as! ZMConversation).objectID },
+                       [conversation3, conversation2, conversation1].map { $0.objectID }, file: file, line: line)
 
         self.token = ConversationListChangeInfo.addListObserver( testObserver, for: conversationList, managedObjectContext: self.uiMOC)
         XCTAssertEqual(conversationList.count, 3, file: file, line: line)
@@ -298,8 +298,8 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
         XCTAssert(uiMOC.saveOrRollback(), file: file, line: line)
 
         // then
-        XCTAssertEqual(conversationList.map { ($0 as! ZMConversation).objectID},
-                       [conversation2, conversation3, conversation1].map {$0.objectID}, file: file, line: line)
+        XCTAssertEqual(conversationList.map { ($0 as! ZMConversation).objectID },
+                       [conversation2, conversation3, conversation1].map { $0.objectID }, file: file, line: line)
         XCTAssertEqual(conversationList.count, 3, file: file, line: line)
         XCTAssertEqual(testObserver.changes.count, 1, file: file, line: line)
         if let first = testObserver.changes.last {

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -111,7 +111,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
 
         // when
         self.checkThatItNotifiesTheObserverOfAChange(conversation,
-                                                     modifier: { conversation, _ in conversation.userDefinedName = "Phil"},
+                                                     modifier: { conversation, _ in conversation.userDefinedName = "Phil" },
                                                      expectedChangedField: "nameChanged",
                                                      expectedChangedKeys: ["displayName"]
         )
@@ -278,7 +278,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
 
         // when
         self.checkThatItNotifiesTheObserverOfAChange(conversation,
-                                                     modifier: { conversation, _ in try! conversation.appendText(content: "foo")},
+                                                     modifier: { conversation, _ in try! conversation.appendText(content: "foo") },
                                                      expectedChangedFields: ["messagesChanged", "lastModifiedDateChanged"],
                                                      expectedChangedKeys: ["allMessages", "lastModifiedDate"])
     }
@@ -344,7 +344,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
 
         // when
         checkThatItNotifiesTheObserverOfAChange(conversation,
-                                                modifier: {conversation, _ in conversation.removeParticipantsAndUpdateConversationState(users: Set([user]), initiatingUser: selfUser) },
+                                                modifier: { conversation, _ in conversation.removeParticipantsAndUpdateConversationState(users: Set([user]), initiatingUser: selfUser) },
                                                 expectedChangedFields: ["participantsChanged",
                                                                         "nameChanged",
                                                                         "activeParticipantsChanged"],

--- a/wire-ios-data-model/Tests/Source/Model/Observer/MessageObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/MessageObserverTests.swift
@@ -193,7 +193,7 @@ class MessageObserverTests: NotificationDispatcherTestBase {
         // when
         self.checkThatItNotifiesTheObserverOfAChange(
             message,
-            modifier: {$0.setReactions(["👻"], forUser: ZMUser.selfUser(in: self.uiMOC))},
+            modifier: { $0.setReactions(["👻"], forUser: ZMUser.selfUser(in: self.uiMOC)) },
             expectedChangedField: #keyPath(MessageChangeInfo.reactionsChanged)
         )
     }
@@ -226,7 +226,7 @@ class MessageObserverTests: NotificationDispatcherTestBase {
         // when
         self.checkThatItNotifiesTheObserverOfAChange(
             message,
-            modifier: {$0.setReactions([], forUser: selfUser)},
+            modifier: { $0.setReactions([], forUser: selfUser) },
             expectedChangedField: #keyPath(MessageChangeInfo.reactionsChanged)
         )
     }

--- a/wire-ios-data-model/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -84,7 +84,7 @@ extension ObjectChangeInfo {
     }
     @discardableResult public func mergeLastChangesWithoutNotifying() -> [NSManagedObjectID] {
         guard let change = mergeNotifications.last else { return [] }
-        let changedObjects = (change.userInfo?[NSUpdatedObjectsKey] as? Set<ZMManagedObject>)?.map {$0.objectID} ?? []
+        let changedObjects = (change.userInfo?[NSUpdatedObjectsKey] as? Set<ZMManagedObject>)?.map { $0.objectID } ?? []
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         self.uiMOC.mergeChanges(fromContextDidSave: change)

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ObjectObserverToken/LabelObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ObjectObserverToken/LabelObserverTests.swift
@@ -86,7 +86,7 @@ final class LabelObserverTests: NotificationDispatcherTestBase {
 
         // when
         self.checkThatItNotifiesTheObserverOfAChange(label,
-                                                     modifier: { $0.name =  "foo"},
+                                                     modifier: { $0.name =  "foo" },
                                                      expectedChangedFields: [#keyPath(LabelChangeInfo.nameChanged)]
         )
 

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ObjectObserverToken/TeamObserverTests.swift
@@ -89,7 +89,7 @@ class TeamObserverTests: NotificationDispatcherTestBase {
 
         // when
         self.checkThatItNotifiesTheObserverOfAChange(team,
-                                                     modifier: { $0.name =  "foo"},
+                                                     modifier: { $0.name =  "foo" },
                                                      expectedChangedFields: [#keyPath(TeamChangeInfo.nameChanged)]
         )
 

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
@@ -115,7 +115,7 @@ final class SearchUserObserverTests: NotificationDispatcherTestBase {
         self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
 
         // when
-        searchUser.connect(completion: {_ in })
+        searchUser.connect(completion: { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then

--- a/wire-ios-data-model/Tests/Source/Model/Observer/UserChangeInfoObservationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/UserChangeInfoObservationTests.swift
@@ -93,8 +93,8 @@ final class UserChangeInfoObservationTests: NotificationDispatcherTestBase {
         XCTAssertEqual(userObserver.notifications.count, changeCount, "Should not have changed further once", file: file, line: line)
 
         guard let changes = userObserver.notifications.first else { return }
-        changes.checkForExpectedChangeFields(userInfoKeys: Set(userInfoChangeKeys.map {$0.rawValue}),
-                                             expectedChangedFields: Set(expectedChangedFields.map {$0.rawValue}))
+        changes.checkForExpectedChangeFields(userInfoKeys: Set(userInfoChangeKeys.map { $0.rawValue }),
+                                             expectedChangedFields: Set(expectedChangedFields.map { $0.rawValue }))
     }
 
     func testThatItNotifiesTheObserverOfANameChange() {
@@ -105,7 +105,7 @@ final class UserChangeInfoObservationTests: NotificationDispatcherTestBase {
 
         // when
         self.checkThatItNotifiesTheObserverOfAChange(user,
-                                                     modifier: { $0.name = "Phil"},
+                                                     modifier: { $0.name = "Phil" },
                                                      expectedChangedField: .name)
 
     }

--- a/wire-ios-data-model/Tests/Source/Model/Utils/PBMessageValidationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Utils/PBMessageValidationTests.swift
@@ -219,13 +219,13 @@ class PBMessageValidationTests: XCTestCase {
     // MARK: User ID
 
     func testThatItCreatesUserIDWithValidFields() {
-        let userId = Proteus_UserId.with({$0.uuid = NSUUID().data()})
+        let userId = Proteus_UserId.with({ $0.uuid = NSUUID().data() })
 
         XCTAssertNotNil(userId.validatingFields())
     }
 
     func testThatItDoesNotCreateUserIDWithInvalidFields() {
-        let userId = Proteus_UserId.with({$0.uuid = Data() })
+        let userId = Proteus_UserId.with({ $0.uuid = Data() })
 
         XCTAssertNil(userId.validatingFields())
     }

--- a/wire-ios-mocktransport/Source/ConversationRoles/MockRole.swift
+++ b/wire-ios-mocktransport/Source/ConversationRoles/MockRole.swift
@@ -49,7 +49,7 @@ extension MockRole {
     var payloadValues: [String: Any?] {
         return [
             "conversation_role": name,
-            "actions": actions.map({$0.payload})
+            "actions": actions.map({ $0.payload })
         ]
     }
 

--- a/wire-ios-mocktransport/Source/Teams/MockTeam.swift
+++ b/wire-ios-mocktransport/Source/Teams/MockTeam.swift
@@ -93,12 +93,12 @@ extension MockTeam {
                  "modify_conversation_access",
                  "modify_other_conversation_member",
                  "leave_conversation",
-                 "delete_conversation"].map {MockAction.insert(in: context, name: $0)})
+                 "delete_conversation"].map { MockAction.insert(in: context, name: $0) })
     }
 
     @objc
     public static func createMemberActions(context: NSManagedObjectContext) -> Set<MockAction> {
 
-        return  Set(["leave_conversation"].map {MockAction.insert(in: context, name: $0)})
+        return  Set(["leave_conversation"].map { MockAction.insert(in: context, name: $0) })
     }
 }

--- a/wire-ios-mocktransport/Source/Teams/MockTransportSession+teams.swift
+++ b/wire-ios-mocktransport/Source/Teams/MockTransportSession+teams.swift
@@ -85,7 +85,7 @@ extension MockTransportSession {
         guard let identifier = identifier else { return nil }
         let predicate = MockTeam.predicateWithIdentifier(identifier: identifier)
         guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate),
-              let selfMemberships = selfUser.memberships, selfMemberships.contains(where: {$0.team == team})
+              let selfMemberships = selfUser.memberships, selfMemberships.contains(where: { $0.team == team })
         else {
             return .teamNotFound(apiVersion: apiVersion)
         }
@@ -96,7 +96,7 @@ extension MockTransportSession {
     }
 
     private func fetchAllTeams(query: [String: Any], apiVersion: APIVersion) -> ZMTransportResponse? {
-        let teams = selfUser.memberships?.map {$0.team} ?? []
+        let teams = selfUser.memberships?.map { $0.team } ?? []
         let payload: [String: Any] = [
             "teams": teams.map { $0.payload },
             "has_more": false
@@ -212,7 +212,7 @@ extension MockTransportSession {
         guard let teamId = teamId, let userId = userId else { return nil }
         let predicate = MockTeam.predicateWithIdentifier(identifier: teamId)
         guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate) else { return .teamNotFound(apiVersion: apiVersion) }
-        guard let member = team.members.first(where: {$0.user.identifier == userId}) else { return .notTeamMember(apiVersion: apiVersion) }
+        guard let member = team.members.first(where: { $0.user.identifier == userId }) else { return .notTeamMember(apiVersion: apiVersion) }
         if let permissionError = ensurePermission(.getMemberPermissions, in: team, apiVersion: apiVersion) {
             return permissionError
         }
@@ -241,7 +241,7 @@ extension MockTransportSession {
         // 2) Check the user in the team
         let predicate = MockTeam.predicateWithIdentifier(identifier: teamId)
         guard let team: MockTeam = MockTeam.fetch(in: managedObjectContext, withPredicate: predicate) else { return .teamNotFound(apiVersion: apiVersion) }
-        guard let member = team.members.first(where: {$0.user.identifier == userId}) else { return .notTeamMember(apiVersion: apiVersion) }
+        guard let member = team.members.first(where: { $0.user.identifier == userId }) else { return .notTeamMember(apiVersion: apiVersion) }
 
         // 3) Check the password
         guard let password = payload?.asDictionary()?["password"] as? String, password == member.user.password else {

--- a/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionConversationsTests.swift
@@ -203,8 +203,8 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
         }
         XCTAssertNil(conversation.team)
         XCTAssertEqual(conversationRoles.count, conversation.nonTeamRoles!.count)
-        let admin = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.admin})
-        XCTAssertEqual((admin?["actions"] as? [String]).map({Set($0)}), Set([
+        let admin = conversationRoles.first(where: { ($0["conversation_role"] as? String) == MockConversation.admin })
+        XCTAssertEqual((admin?["actions"] as? [String]).map({ Set($0) }), Set([
             "add_conversation_member",
             "remove_conversation_member",
             "modify_conversation_name",
@@ -215,7 +215,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
             "leave_conversation", "delete_conversation"
             ]))
 
-        let member = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.member})
+        let member = conversationRoles.first(where: { ($0["conversation_role"] as? String) == MockConversation.member })
         XCTAssertEqual(member?["actions"] as? [String], ["leave_conversation"])
     }
 
@@ -248,8 +248,8 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
         }
         XCTAssertNotNil(conversation.team)
         XCTAssertEqual(conversationRoles.count, team.roles.count)
-        let admin = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.admin})
-        XCTAssertEqual((admin?["actions"] as? [String]).map({Set($0)}), Set([
+        let admin = conversationRoles.first(where: { ($0["conversation_role"] as? String) == MockConversation.admin })
+        XCTAssertEqual((admin?["actions"] as? [String]).map({ Set($0) }), Set([
             "add_conversation_member",
             "remove_conversation_member",
             "modify_conversation_name",
@@ -260,7 +260,7 @@ class MockTransportSessionConversationsTests_Swift: MockTransportSessionTests {
             "leave_conversation", "delete_conversation"
             ]))
 
-        let member = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.member})
+        let member = conversationRoles.first(where: { ($0["conversation_role"] as? String) == MockConversation.member })
         XCTAssertEqual(member?["actions"] as? [String], ["leave_conversation"])
     }
 

--- a/wire-ios-mocktransport/Tests/Source/Teams/MockTransportSessionTeamTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Teams/MockTransportSessionTeamTests.swift
@@ -535,8 +535,8 @@ extension MockTransportSessionTeamTests {
             return
         }
         XCTAssertEqual(conversationRoles.count, team.roles.count)
-        let admin = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.admin})
-        XCTAssertEqual((admin?["actions"] as? [String]).map({Set($0)}), Set([
+        let admin = conversationRoles.first(where: { ($0["conversation_role"] as? String) == MockConversation.admin })
+        XCTAssertEqual((admin?["actions"] as? [String]).map({ Set($0) }), Set([
             "add_conversation_member",
             "remove_conversation_member",
             "modify_conversation_name",
@@ -547,7 +547,7 @@ extension MockTransportSessionTeamTests {
             "leave_conversation", "delete_conversation"
             ]))
 
-        let member = conversationRoles.first(where: {($0["conversation_role"] as? String) == MockConversation.member})
+        let member = conversationRoles.first(where: { ($0["conversation_role"] as? String) == MockConversation.member })
         XCTAssertEqual(member?["actions"] as? [String], ["leave_conversation"])
     }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -125,7 +125,7 @@ public class MessageSender: MessageSenderInterface {
     }
 
     private func attemptToSend(message: any SendableMessage) async throws {
-        let messageProtocol = await context.perform {message.conversation?.messageProtocol }
+        let messageProtocol = await context.perform { message.conversation?.messageProtocol }
 
         guard let apiVersion = BackendInfo.apiVersion else { throw MessageSendError.unresolvedApiVersion }
         guard let messageProtocol else {

--- a/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatus.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatus.swift
@@ -116,7 +116,7 @@ open class PushNotificationStatus: NSObject {
         guard finished else { return }
 
         // We take all events that are older than or equal to lastEventId and add highest ranking event ID
-        for eventId in completionHandlers.keys.filter({  self.lastEventIdIsNewerThan(lastEventId: lastEventId, eventId: $0) || highestRankingEventId == $0 }) {
+        for eventId in completionHandlers.keys.filter({ self.lastEventIdIsNewerThan(lastEventId: lastEventId, eventId: $0) || highestRankingEventId == $0 }) {
             let completionHandler = completionHandlers.removeValue(forKey: eventId)
             completionHandler?(.success(()))
         }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/InsertedObjectSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/InsertedObjectSync.swift
@@ -56,7 +56,7 @@ class InsertedObjectSync<Transcoder: InsertedObjectSyncTranscoder>: NSObject, ZM
     }
 
     func objectsDidChange(_ objects: Set<NSManagedObject>) {
-        var trackedObjects = objects.compactMap({ $0 as? Transcoder.Object})
+        var trackedObjects = objects.compactMap({ $0 as? Transcoder.Object })
         let indexOfSecondPartition = trackedObjects.partition(by: insertPredicate.evaluate)
         let insertedObjects = trackedObjects[indexOfSecondPartition...]
         let removedObjects = trackedObjects[..<indexOfSecondPartition]
@@ -69,7 +69,7 @@ class InsertedObjectSync<Transcoder: InsertedObjectSyncTranscoder>: NSObject, ZM
     }
 
     func addTrackedObjects(_ objects: Set<NSManagedObject>) {
-        let insertedObjects = objects.compactMap({ $0 as? Transcoder.Object})
+        let insertedObjects = objects.compactMap({ $0 as? Transcoder.Object })
 
         addInsertedObjects(insertedObjects)
     }

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ModifiedKeyObjectSync.swift
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ModifiedKeyObjectSync.swift
@@ -58,7 +58,7 @@ class ModifiedKeyObjectSync<Transcoder: ModifiedKeyObjectSyncTranscoder>: NSObje
     }
 
     func objectsDidChange(_ objects: Set<NSManagedObject>) {
-        let trackedObjects = objects.compactMap({ $0 as? Transcoder.Object})
+        let trackedObjects = objects.compactMap({ $0 as? Transcoder.Object })
         let modifiedObjects = trackedObjects.filter({ modifiedPredicate?.evaluate(with: $0) ?? true })
 
         addModifiedObjects(modifiedObjects)
@@ -73,7 +73,7 @@ class ModifiedKeyObjectSync<Transcoder: ModifiedKeyObjectSyncTranscoder>: NSObje
     }
 
     func addTrackedObjects(_ objects: Set<NSManagedObject>) {
-        let trackedObjects = objects.compactMap({ $0 as? Transcoder.Object})
+        let trackedObjects = objects.compactMap({ $0 as? Transcoder.Object })
 
         addModifiedObjects(trackedObjects)
     }

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -223,7 +223,7 @@ struct ConversationEventPayloadProcessor {
             }
 
             conversation.addParticipantsAndUpdateConversationState(usersAndRoles: usersAndRoles)
-        } else if let users = payload.data.userIDs?.map({ ZMUser.fetchOrCreate(with: $0, domain: nil, in: context)}) {
+        } else if let users = payload.data.userIDs?.map({ ZMUser.fetchOrCreate(with: $0, domain: nil, in: context) }) {
             // NOTE: legacy code path for backwards compatibility with servers without role support
 
             let users = Set(users)
@@ -292,7 +292,7 @@ struct ConversationEventPayloadProcessor {
             }
         }
 
-        if let role = payload.data.conversationRole.map({conversation.fetchOrCreateRoleForConversation(name: $0) }) {
+        if let role = payload.data.conversationRole.map({ conversation.fetchOrCreateRoleForConversation(name: $0) }) {
             conversation.addParticipantAndUpdateConversationState(user: targetUser, role: role)
         }
     }

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/UserProfilePayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/UserProfilePayloadProcessor.swift
@@ -159,8 +159,8 @@ final class UserProfilePayloadProcessor: UserProfilePayloadProcessing {
         }
 
         let validAssets = payload.assets?.filter(\.key.isValidAssetID)
-        let previewAssetKey = validAssets?.first(where: {$0.size == .preview }).map(\.key)
-        let completeAssetKey = validAssets?.first(where: {$0.size == .complete }).map(\.key)
+        let previewAssetKey = validAssets?.first(where: { $0.size == .preview }).map(\.key)
+        let completeAssetKey = validAssets?.first(where: { $0.size == .complete }).map(\.key)
 
         if previewAssetKey != nil || authoritative {
             user.previewProfileAssetIdentifier = previewAssetKey

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetV3UploadRequestStrategy.swift
@@ -111,7 +111,7 @@ extension AssetV3UploadRequestStrategy: ZMUpstreamTranscoder {
 
     public func request(forUpdating managedObject: ZMManagedObject, forKeys keys: Set<String>, apiVersion: APIVersion) -> ZMUpstreamRequest? {
         guard let message = managedObject as? AssetMessage else { fatal("Could not cast to ZMAssetClientMessage, it is \(type(of: managedObject)))") }
-        guard let asset = message.assets.first(where: { !$0.isUploaded}) else { return nil } // TODO jacob are we sure we only have one upload per message active?
+        guard let asset = message.assets.first(where: { !$0.isUploaded }) else { return nil } // TODO jacob are we sure we only have one upload per message active?
 
         return requestForUploadingAsset(asset, for: managedObject as! ZMAssetClientMessage, apiVersion: apiVersion)
     }
@@ -159,7 +159,7 @@ extension AssetV3UploadRequestStrategy: ZMUpstreamTranscoder {
 
         guard response.result == .success else { return false }
         guard let message = managedObject as? ZMAssetClientMessage else { return false }
-        guard let asset = message.assets.first(where: { !$0.isUploaded}) else {return false }
+        guard let asset = message.assets.first(where: { !$0.isUploaded }) else {return false }
         guard let payload = response.payload?.asDictionary(),
               let assetId = payload["key"] as? String else {
             fatal("No asset ID present in payload")

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -739,7 +739,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
         await syncMOC.perform {
             // THEN
             guard let participant = self.groupConversation.participantRoles
-                .first(where: {$0.user == user}) else {
+                .first(where: { $0.user == user }) else {
                 return XCTFail("No user in convo")
             }
             XCTAssertEqual(participant.role, newRole)
@@ -783,7 +783,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
         await syncMOC.perform {
             // THEN
             guard let participant = self.groupConversation.participantRoles
-                .first(where: {$0.user == selfUser}) else {
+                .first(where: { $0.user == selfUser }) else {
                 return XCTFail("No user in convo")
             }
             XCTAssertEqual(participant.role, newRole)

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
@@ -457,7 +457,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
                             notFound: [QualifiedID],
                             failed: [QualifiedID]) -> ZMTransportResponse {
 
-        let found = request.qualifiedIDs.map({ conversation(uuid: $0.uuid, domain: $0.domain)})
+        let found = request.qualifiedIDs.map({ conversation(uuid: $0.uuid, domain: $0.domain) })
         let payload = Payload.QualifiedConversationList(found: found, notFound: notFound, failed: failed)
         let payloadData = payload.payloadData()!
         let payloadString = String(bytes: payloadData, encoding: .utf8)!

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/FetchingClientRequestStrategy.swift
@@ -139,13 +139,13 @@ extension FetchingClientRequestStrategy: ZMContextChangeTracker, ZMContextChange
     }
 
     public func addTrackedObjects(_ objects: Set<NSManagedObject>) {
-        let clientsNeedingToBeUpdated = objects.compactMap({ $0 as? UserClient})
+        let clientsNeedingToBeUpdated = objects.compactMap({ $0 as? UserClient })
 
         fetch(userClients: clientsNeedingToBeUpdated)
     }
 
     public func objectsDidChange(_ object: Set<NSManagedObject>) {
-        let clientsNeedingToBeUpdated = object.compactMap({ $0 as? UserClient}).filter(\.needsToBeUpdatedFromBackend)
+        let clientsNeedingToBeUpdated = object.compactMap({ $0 as? UserClient }).filter(\.needsToBeUpdatedFromBackend)
 
         fetch(userClients: clientsNeedingToBeUpdated)
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategy.swift
@@ -53,13 +53,13 @@ extension VerifyLegalHoldRequestStrategy: ZMContextChangeTracker, ZMContextChang
     }
 
     public func addTrackedObjects(_ objects: Set<NSManagedObject>) {
-        let conversationsNeedingToVerifyClients = objects.compactMap({ $0 as? ZMConversation})
+        let conversationsNeedingToVerifyClients = objects.compactMap({ $0 as? ZMConversation })
 
         conversationSync.sync(identifiers: conversationsNeedingToVerifyClients)
     }
 
     public func objectsDidChange(_ object: Set<NSManagedObject>) {
-        let conversationsNeedingToVerifyClients = object.compactMap({ $0 as? ZMConversation}).filter(\.needsToVerifyLegalHold)
+        let conversationsNeedingToVerifyClients = object.compactMap({ $0 as? ZMConversation }).filter(\.needsToVerifyLegalHold)
 
         if !conversationsNeedingToVerifyClients.isEmpty {
             conversationSync.sync(identifiers: conversationsNeedingToVerifyClients)

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategy.swift
@@ -136,7 +136,7 @@ extension UserProfileRequestStrategy: ZMContextChangeTracker {
         guard let apiVersion = BackendInfo.apiVersion else { return }
 
         let usersNeedingToBeUpdated = objects
-            .compactMap { $0 as? ZMUser}
+            .compactMap { $0 as? ZMUser }
             .filter(\.needsToBeUpdatedFromBackend)
 
         fetch(users: Set(usersNeedingToBeUpdated), for: apiVersion)

--- a/wire-ios-sync-engine/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
+++ b/wire-ios-sync-engine/Source/Notifications/Push notifications/LocalNotificationDispatcher.swift
@@ -45,7 +45,7 @@ import UserNotifications
         observers.append(
             NotificationInContext.addObserver(name: ZMConversation.lastReadDidChangeNotificationName,
                                               context: managedObjectContext.notificationContext,
-                                              using: { [weak self] in self?.cancelNotificationForLastReadChanged(notification: $0)})
+                                              using: { [weak self] in self?.cancelNotificationForLastReadChanged(notification: $0) })
         )
     }
 

--- a/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
@@ -55,7 +55,7 @@ final class APIVersionResolver {
         sendRequest(completion: completion)
     }
 
-    private func sendRequest(completion: @escaping (Error?) -> Void = {_ in }) {
+    private func sendRequest(completion: @escaping (Error?) -> Void = { _ in }) {
         // This is endpoint isn't versioned, so it always version 0.
         let request = ZMTransportRequest(getFromPath: "/api-version", apiVersion: APIVersion.v0.rawValue)
         let completionHandler = ZMCompletionHandler(on: queue) { [weak self] response in

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -22,7 +22,7 @@ private let log = ZMSLog(tag: "APIVersion")
 
 extension SessionManager: APIVersionResolverDelegate {
 
-    public func resolveAPIVersion(completion: @escaping (Error?) -> Void = {_ in }) {
+    public func resolveAPIVersion(completion: @escaping (Error?) -> Void = { _ in }) {
         if apiVersionResolver == nil {
             apiVersionResolver = createAPIVersionResolver()
         }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/SearchUserImageStrategy.swift
@@ -237,7 +237,7 @@ public class SearchUserImageStrategy: AbstractRequestStrategy {
     }
 
     public static func requestForFetchingFullProfile(for usersWithIDs: Set<UUID>, apiVersion: APIVersion, completionHandler: ZMCompletionHandler) -> ZMTransportRequest {
-        let usersList = usersWithIDs.map {$0.transportString()}.joined(separator: ",")
+        let usersList = usersWithIDs.map { $0.transportString() }.joined(separator: ",")
         let request = ZMTransportRequest(getFromPath: userPath + usersList, apiVersion: apiVersion.rawValue)
         request.add(completionHandler)
         return request

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TypingStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TypingStrategy.swift
@@ -134,19 +134,19 @@ public class TypingStrategy: AbstractRequestStrategy, TearDownCapable, ZMEventCo
         observers.append(
             NotificationInContext.addObserver(name: ZMConversation.typingNotificationName,
                                               context: self.managedObjectContext.notificationContext,
-                                              using: { [weak self] in self?.addConversationForNextRequest(note: $0)})
+                                              using: { [weak self] in self?.addConversationForNextRequest(note: $0) })
             )
 
         observers.append(
             NotificationInContext.addObserver(name: ZMConversation.typingChangeNotificationName,
                                               context: self.managedObjectContext.notificationContext,
-                                              using: { [weak self] in self?.addConversationForNextRequest(note: $0)})
+                                              using: { [weak self] in self?.addConversationForNextRequest(note: $0) })
         )
 
         observers.append(
             NotificationInContext.addObserver(name: ZMConversation.clearTypingNotificationName,
                                               context: self.managedObjectContext.notificationContext,
-                                              using: { [weak self] in self?.shouldClearTypingForConversation(note: $0)})
+                                              using: { [weak self] in self?.shouldClearTypingForConversation(note: $0) })
         )
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -71,7 +71,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             coreCryptoProvider: coreCryptoProvider
         )
 
-        self.requestStrategies = strategies.compactMap({ $0 as? RequestStrategy})
+        self.requestStrategies = strategies.compactMap({ $0 as? RequestStrategy })
         self.eventConsumers = strategies.compactMap({ $0 as? ZMEventConsumer })
         self.eventAsyncConsumers = strategies.compactMap({ $0 as? ZMEventAsyncConsumer })
         self.contextChangeTrackers = strategies.flatMap({ (object: Any) -> [ZMContextChangeTracker] in

--- a/wire-ios-sync-engine/Source/Synchronization/ZMOperationLoop+PushChannel.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMOperationLoop+PushChannel.swift
@@ -23,7 +23,7 @@ extension ZMOperationLoop: ZMPushChannelConsumer {
     public func pushChannelDidReceive(_ data: ZMTransportData) {
         if let events = ZMUpdateEvent.eventsArray(fromPushChannelData: data), !events.isEmpty {
             Logging.eventProcessing.info("Received \(events.count) events from push channel")
-            events.forEach({ $0.appendDebugInformation("from push channel (web socket)")})
+            events.forEach({ $0.appendDebugInformation("from push channel (web socket)") })
 
             if syncStatus.isSyncing {
                 WaitingGroupTask(context: syncMOC) {

--- a/wire-ios-sync-engine/Source/UserSession/ClientUpdateStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ClientUpdateStatus.swift
@@ -198,7 +198,7 @@ public enum ClientUpdateError: NSInteger {
     var selfUserClientsExcludingSelfClient: [UserClient] {
         let selfUser = ZMUser.selfUser(in: self.syncManagedObjectContext)
         let selfClient = selfUser.selfClient()
-        let remainingClients = selfUser.clients.filter {$0 != selfClient && !$0.isZombieObject}
+        let remainingClients = selfUser.clients.filter { $0 != selfClient && !$0.isZombieObject }
         return Array(remainingClients)
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/PushNotificationStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/PushNotificationStatus.swift
@@ -82,7 +82,7 @@ open class PushNotificationStatus: NSObject {
         Logging.eventProcessing.info("Finished to fetching all available events")
 
         // We take all events that are older than or equal to lastEventId and add highest ranking event ID
-        for eventId in completionHandlers.keys.filter({  self.lastEventIdIsNewerThan(lastEventId: lastEventId, eventId: $0) || highestRankingEventId == $0 }) {
+        for eventId in completionHandlers.keys.filter({ self.lastEventIdIsNewerThan(lastEventId: lastEventId, eventId: $0) || highestRankingEventId == $0 }) {
             let completionHandler = completionHandlers.removeValue(forKey: eventId)
             completionHandler?()
         }

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchResult+AddressBook.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchResult+AddressBook.swift
@@ -46,7 +46,7 @@ extension SearchResult {
 
         let (additionalUsersFromAddressBook, addressBookContactsWithoutUser) = contactsThatAreAlsoUsers(contacts: allMatchingAddressBookContacts,
                                                                                                         managedObjectContext: contextProvider.viewContext)
-        let searchUsersFromAddressBook = addressBookContactsWithoutUser.compactMap {  ZMSearchUser(contextProvider: contextProvider, contact: $0) }
+        let searchUsersFromAddressBook = addressBookContactsWithoutUser.compactMap { ZMSearchUser(contextProvider: contextProvider, contact: $0) }
 
         // of those users, which one are connected and which one are not?
         let additionalConnectedUsers = additionalUsersFromAddressBook

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -142,8 +142,8 @@ extension SearchTask {
                 let copiedConnectedUsers = connectedUsers.compactMap { contextProvider.viewContext.object(with: $0.objectID) as? ZMUser }
 
                 let result = SearchResult(
-                    contacts: copiedConnectedUsers.map { ZMSearchUser(contextProvider: contextProvider, user: $0)},
-                    teamMembers: copiedOne2oneConversationUsers.map { ZMSearchUser(contextProvider: contextProvider, user: $0)},
+                    contacts: copiedConnectedUsers.map { ZMSearchUser(contextProvider: contextProvider, user: $0) },
+                    teamMembers: copiedOne2oneConversationUsers.map { ZMSearchUser(contextProvider: contextProvider, user: $0) },
                     addressBook: [],
                     directory: [],
                     conversations: [],

--- a/wire-ios-sync-engine/Source/UserSession/Search/TopConversationsDirectory.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/TopConversationsDirectory.swift
@@ -50,7 +50,7 @@ private let topConversationsObjectIDKey = "WireTopConversationsObjectIDKey"
 
             // Mapping from conversation to message count in the last month
             let countByConversation = conversations.mapToDictionary { $0.lastMonthMessageCount() }
-            let sorted = countByConversation.filter { $0.1 > 0 }.sorted {  $0.1 > $1.1 }.prefix(TopConversationsDirectory.topConversationSize)
+            let sorted = countByConversation.filter { $0.1 > 0 }.sorted { $0.1 > $1.1 }.prefix(TopConversationsDirectory.topConversationSize)
             let identifiers = sorted.compactMap { $0.0.objectID }
             self.updateUIList(with: identifiers)
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -200,7 +200,7 @@ extension ZMClientRegistrationStatus {
     }
 
     public func didGeneratePrekeys(_ prekeys: [IdPrekeyTuple], lastResortPrekey: IdPrekeyTuple) {
-        self.prekeys = prekeys.map { [NSNumber(value: Int($0.id)): $0.prekey]}
+        self.prekeys = prekeys.map { [NSNumber(value: Int($0.id)): $0.prekey] }
         self.lastResortPrekey = lastResortPrekey.prekey
         self.isGeneratingPrekeys = false
         RequestAvailableNotification.notifyNewRequestsAvailable(self)

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -908,7 +908,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
 
 extension ZMUserSession: URLActionProcessor {
     func process(urlAction: URLAction, delegate: PresentationDelegate?) {
-        urlActionProcessors?.forEach({ $0.process(urlAction: urlAction, delegate: delegate)})
+        urlActionProcessors?.forEach({ $0.process(urlAction: urlAction, delegate: delegate) })
     }
 }
 

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientEventConsumerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientEventConsumerTests.swift
@@ -118,7 +118,7 @@ final class UserClientEventConsumerTests: RequestStrategyTestBase {
         syncMOC.performGroupedBlockAndWait {
             // then
             XCTAssertEqual(selfUser.clients.count, 2)
-            guard let newClient = selfUser.clients.filter({ $0 != selfClient}).first else {
+            guard let newClient = selfUser.clients.filter({ $0 != selfClient }).first else {
                 XCTFail()
                 return
             }

--- a/wire-ios-sync-engine/Tests/Source/Integration/CallingV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/CallingV3Tests.swift
@@ -127,7 +127,7 @@ final class CallingV3Tests: IntegrationTest {
     }
 
     func participantsChanged(members: [(user: ZMUser, establishedFlow: Bool)]) {
-        let mappedMembers = members.map {AVSCallMember(userId: $0.user.remoteIdentifier!, audioEstablished: $0.establishedFlow)}
+        let mappedMembers = members.map { AVSCallMember(userId: $0.user.remoteIdentifier!, audioEstablished: $0.establishedFlow) }
         (userSession!.managedObjectContext.zm_callCenter as! WireCallCenterV3IntegrationMock).mockAVSWrapper.mockMembers = mappedMembers
 
         WireSyncEngine.groupMemberHandler(conversationIdRef: conversationIdRef, contextRef: wireCallCenterRef)

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+ClearingHistory.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+ClearingHistory.swift
@@ -89,7 +89,7 @@ class ConversationTests_ClearingHistory: ConversationTestsBase {
         conversation = self.conversation(for: self.groupConversation!)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        let objectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation}.map { $0.objectID }
+        let objectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation }.map { $0.objectID }
         XCTAssertTrue(objectIDs!.contains(conversationID!))
     }
 
@@ -129,9 +129,9 @@ class ConversationTests_ClearingHistory: ConversationTestsBase {
         conversation = self.conversation(for: self.groupConversation!)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
-        let conversationsIncludingArchivedObjectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation}.map { $0.objectID }
-        let archivedConversationsObjectIDs = conversationDirectory?.archivedConversations.compactMap { $0 as? ZMConversation}.map { $0.objectID }
-        let clearedConversationsObjectIDs = conversationDirectory?.clearedConversations.compactMap { $0 as? ZMConversation}.map { $0.objectID }
+        let conversationsIncludingArchivedObjectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation }.map { $0.objectID }
+        let archivedConversationsObjectIDs = conversationDirectory?.archivedConversations.compactMap { $0 as? ZMConversation }.map { $0.objectID }
+        let clearedConversationsObjectIDs = conversationDirectory?.clearedConversations.compactMap { $0 as? ZMConversation }.map { $0.objectID }
         XCTAssertFalse(conversationsIncludingArchivedObjectIDs!.contains(conversationID!))
         XCTAssertFalse(archivedConversationsObjectIDs!.contains(conversationID!))
         XCTAssertTrue(clearedConversationsObjectIDs!.contains(conversationID!))
@@ -155,7 +155,7 @@ class ConversationTests_ClearingHistory: ConversationTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        let objectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation}.map { $0.objectID }
+        let objectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation }.map { $0.objectID }
         XCTAssertFalse(objectIDs!.contains(conversationID!))
     }
 
@@ -177,7 +177,7 @@ class ConversationTests_ClearingHistory: ConversationTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        let objectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation}.map { $0.objectID }
+        let objectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation }.map { $0.objectID }
         XCTAssertFalse(objectIDs!.contains(conversationID!))
     }
 
@@ -225,9 +225,9 @@ class ConversationTests_ClearingHistory: ConversationTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        let conversationsIncludingArchivedObjectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation}.map { $0.objectID }
-        let archivedConversationsObjectIDs = conversationDirectory?.archivedConversations.compactMap { $0 as? ZMConversation}.map { $0.objectID }
-        let clearedConversationsObjectIDs = conversationDirectory?.clearedConversations.compactMap { $0 as? ZMConversation}.map { $0.objectID }
+        let conversationsIncludingArchivedObjectIDs = conversationDirectory?.conversationsIncludingArchived.compactMap { $0 as? ZMConversation }.map { $0.objectID }
+        let archivedConversationsObjectIDs = conversationDirectory?.archivedConversations.compactMap { $0 as? ZMConversation }.map { $0.objectID }
+        let clearedConversationsObjectIDs = conversationDirectory?.clearedConversations.compactMap { $0 as? ZMConversation }.map { $0.objectID }
         XCTAssertTrue(conversationsIncludingArchivedObjectIDs!.contains(conversationID!))
         XCTAssertTrue(archivedConversationsObjectIDs!.contains(conversationID!))
         XCTAssertFalse(clearedConversationsObjectIDs!.contains(conversationID!))

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+OTR.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+OTR.swift
@@ -320,8 +320,8 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
 
         // THEN
-        let changes: [ConversationChangeInfo]? = observer?.notifications.compactMap({ $0 as? ConversationChangeInfo})
-        let note = changes?.first(where: { $0.messagesChanged == true})
+        let changes: [ConversationChangeInfo]? = observer?.notifications.compactMap({ $0 as? ConversationChangeInfo })
+        let note = changes?.first(where: { $0.messagesChanged == true })
 
         XCTAssertNotNil(note)
         XCTAssertTrue(note?.messagesChanged ?? false)
@@ -343,8 +343,8 @@ class ConversationTestsOTR_Swift: ConversationTestsBase {
         try remotelyInsertOTRImage(into: groupConversation, imageFormat: format)
 
         // THEN
-        let changes: [ConversationChangeInfo]? = observer?.notifications.compactMap({ $0 as? ConversationChangeInfo})
-        let note = changes?.first(where: { $0.messagesChanged == true})
+        let changes: [ConversationChangeInfo]? = observer?.notifications.compactMap({ $0 as? ConversationChangeInfo })
+        let note = changes?.first(where: { $0.messagesChanged == true })
 
         XCTAssertTrue(note?.messagesChanged ?? false)
         XCTAssertTrue(note?.lastModifiedDateChanged ?? false)

--- a/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Reactions.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ConversationTests+Reactions.swift
@@ -310,7 +310,7 @@ class ConversationTests_Reactions: ConversationTestsBase {
         let conversation = self.conversation(for: mockConversation!)
 
         let blockedUser = self.user(for: self.user1)
-        blockedUser?.block(completion: {_ in })
+        blockedUser?.block(completion: { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         var message: ZMMessage?

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest+Search.swift
@@ -113,7 +113,7 @@ extension IntegrationTest {
 
     @objc
     public func connect(withUser user: UserType) {
-        user.connect(completion: {_ in })
+        user.connect(completion: { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -104,7 +104,7 @@ class CallingRequestStrategyTests: MessagingTest {
     func testThatItGeneratesOnlyOneCallConfigRequest() {
 
         // given
-        sut.requestCallConfig { (_, _) in}
+        sut.requestCallConfig { (_, _) in }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -119,7 +119,7 @@ class CallingRequestStrategyTests: MessagingTest {
     func testThatItGeneratesCompressedCallConfigRequest() {
 
         // given
-        sut.requestCallConfig { (_, _) in}
+        sut.requestCallConfig { (_, _) in }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
@@ -520,7 +520,7 @@ class CallingRequestStrategyTests: MessagingTest {
 
             XCTAssertEqual(targetRecipients.count, 2)
 
-            guard let recipient1 = targetRecipients.first(where: {  $0.key == user1 }) else {
+            guard let recipient1 = targetRecipients.first(where: { $0.key == user1 }) else {
                 return XCTFail("Expected user1 to be recipient")
             }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ConversationRoleDownstreamRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ConversationRoleDownstreamRequestStrategyTests.swift
@@ -91,7 +91,7 @@ final class ConversationRoleDownstreamRequestStrategyTests: MessagingTest {
             self.mockApplicationStatus.mockSynchronizationState = .online
 
             // when
-            let objs: [ZMConversation] = self.sut.contextChangeTrackers.compactMap({$0.fetchRequestForTrackedObjects()}).flatMap({self.syncMOC.executeFetchRequestOrAssert($0) as! [ZMConversation] })
+            let objs: [ZMConversation] = self.sut.contextChangeTrackers.compactMap({ $0.fetchRequestForTrackedObjects() }).flatMap({ self.syncMOC.executeFetchRequestOrAssert($0) as! [ZMConversation] })
 
             // then            
             XCTAssertEqual(objs, [convo1])
@@ -135,8 +135,8 @@ final class ConversationRoleDownstreamRequestStrategyTests: MessagingTest {
         syncMOC.performGroupedBlockAndWait {
             // then
             XCTAssertEqual(convo1!.nonTeamRoles.count, 2)
-            guard let admin = convo1!.nonTeamRoles.first(where: {$0.name == "wire_admin"}),
-                let member = convo1!.nonTeamRoles.first(where: {$0.name == "wire_member" }) else {
+            guard let admin = convo1!.nonTeamRoles.first(where: { $0.name == "wire_admin" }),
+                let member = convo1!.nonTeamRoles.first(where: { $0.name == "wire_member" }) else {
                     return XCTFail()
             }
             XCTAssertEqual(Set(admin.actions.map { $0.name }), Set(["leave_conversation", "delete_conversation"]))

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamInvitationRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamInvitationRequestStrategyTests.swift
@@ -130,7 +130,7 @@ class TeamInvitationRequestStrategyTests: MessagingTest {
             return ZMTransportResponse(payload: payload as ZMTransportData, httpStatus: httpStatus, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
         }
 
-        let inviteResults = responses.map({ InviteResult.init(response: $0, email: "")})
+        let inviteResults = responses.map({ InviteResult.init(response: $0, email: "") })
         let expectedResults: [InviteResult] = [.success(email: ""),
                                                 .failure(email: "", error: .tooManyTeamInvitations),
                                                 .failure(email: "", error: .blacklistedEmail),

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRolesDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRolesDownloadRequestStrategyTests.swift
@@ -150,16 +150,16 @@ class TeamRolesDownloadRequestStrategyTests: MessagingTest {
         syncMOC.performGroupedBlockAndWait {
             // then
             XCTAssertEqual(team.roles.count, 2)
-            guard let adminRole = team.roles.first(where: {$0.name == "superuser" }),
-                let memberRole = team.roles.first(where: {$0.name == "weakling"}) else {
+            guard let adminRole = team.roles.first(where: { $0.name == "superuser" }),
+                let memberRole = team.roles.first(where: { $0.name == "weakling" }) else {
                     return XCTFail()
             }
             XCTAssertEqual(
-                Set(adminRole.actions.compactMap { $0.name}),
+                Set(adminRole.actions.compactMap { $0.name }),
                 Set(["leave_conversation", "delete_conversation"])
             )
             XCTAssertEqual(
-                Set(memberRole.actions.compactMap { $0.name}),
+                Set(memberRole.actions.compactMap { $0.name }),
                 Set(["leave_conversation"])
             )
             XCTAssertFalse(team.needsToDownloadRoles)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+SSO.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UnauthenticatedSessionTests+SSO.swift
@@ -55,7 +55,7 @@ public final class UnauthenticatedSessionTests_SSO: ZMTBaseTest {
 
     func testThatItGeneratesCorrectRequest() {
         // when
-        sut.fetchSSOSettings(completion: {_ in })
+        sut.fetchSSOSettings(completion: { _ in })
 
         // then
         XCTAssertNotNil(transportSession.lastEnqueuedRequest)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+Authentication.swift
@@ -59,7 +59,7 @@ final class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
 
         // when
-        sut.logout(credentials: credentials, {_ in })
+        sut.logout(credentials: credentials, { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -76,7 +76,7 @@ final class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "")
 
         // when
-        sut.logout(credentials: credentials, {_ in })
+        sut.logout(credentials: credentials, { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
@@ -94,7 +94,7 @@ final class ZMUserSessionTests_Authentication: ZMUserSessionTestsBase {
         let credentials = ZMEmailCredentials(email: "john.doe@domain.com", password: "123456")
 
         // when
-        sut.logout(credentials: credentials, {_ in })
+        sut.logout(credentials: credentials, { _ in })
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         transportSession.lastEnqueuedRequest?.complete(with: ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue))
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/wire-ios-system/Source/SafeForLoggingStringConvertible.swift
+++ b/wire-ios-system/Source/SafeForLoggingStringConvertible.swift
@@ -37,7 +37,7 @@ public struct SafeValueForLogging<T: CustomStringConvertible>: SafeForLoggingStr
 
 extension Array: SafeForLoggingStringConvertible where Array.Element: SafeForLoggingStringConvertible {
     public var safeForLoggingDescription: String {
-        return String(describing: map { $0.safeForLoggingDescription})
+        return String(describing: map { $0.safeForLoggingDescription })
     }
 }
 

--- a/wire-ios-system/Source/ZMSLog+Recording.swift
+++ b/wire-ios-system/Source/ZMSLog+Recording.swift
@@ -28,7 +28,7 @@ extension ZMSLog {
             if recordingToken == nil {
                 recordingToken = self.nonLockingAddEntryHook(logHook: { level, tag, entry, isSafe in
                     guard isInternal || isSafe else { return }
-                    let tagString = tag.flatMap { "[\($0)] "} ?? ""
+                    let tagString = tag.flatMap { "[\($0)] " } ?? ""
                     let date = dateFormatter.string(from: entry.timestamp)
                     // Add newline if it does not have it yet
                     let text = entry.text.hasSuffix("\n") ? entry.text : entry.text + "\n"

--- a/wire-ios-testing/Source/Public/XCTestCase+Helpers.swift
+++ b/wire-ios-testing/Source/Public/XCTestCase+Helpers.swift
@@ -161,7 +161,7 @@ extension XCTestCase {
 
     public func assertSuccess<Value, Failure>(
         result: Result<Value, Failure>,
-        message: (Failure) -> String = { "Expected to be a success but got a failure with \($0) "},
+        message: (Failure) -> String = { "Expected to be a success but got a failure with \($0) " },
         file: StaticString = #filePath,
         line: UInt = #line) {
             switch result {

--- a/wire-ios-testing/Source/Public/ZMTSwiftHelpers.swift
+++ b/wire-ios-testing/Source/Public/ZMTSwiftHelpers.swift
@@ -33,7 +33,7 @@ public func AssertOptionalEqual<T: Equatable>(_ expression1: @autoclosure () -> 
     }
 }
 
-public func AssertOptionalNotNil<T>(_ expression: @autoclosure () -> T?, _ message: String = "", file: StaticString = #file, line: UInt = #line, block: (T) -> Void = {_ in}) {
+public func AssertOptionalNotNil<T>(_ expression: @autoclosure () -> T?, _ message: String = "", file: StaticString = #file, line: UInt = #line, block: (T) -> Void = { _ in }) {
     if let v = expression() {
         block(v)
     } else {

--- a/wire-ios-transport/Source/Public/Collections+ZMSafeTypes.swift
+++ b/wire-ios-transport/Source/Public/Collections+ZMSafeTypes.swift
@@ -92,11 +92,11 @@ extension NSDictionary {
     }
 
     @objc public func uuid(forKey key: String) -> UUID? {
-        return requiredObjectWhichIsKindOfClass(dictionary: self, key: key) {UUID(uuidString: $0)}
+        return requiredObjectWhichIsKindOfClass(dictionary: self, key: key) { UUID(uuidString: $0) }
     }
 
     @objc public func optionalUuid(forKey key: String) -> UUID? {
-        return optionalObjectWhichIsKindOfClass(dictionary: self, key: key) {UUID(uuidString: $0)}
+        return optionalObjectWhichIsKindOfClass(dictionary: self, key: key) { UUID(uuidString: $0) }
     }
 
     @objc

--- a/wire-ios-transport/Source/PushChannel/NativePushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/NativePushChannel.swift
@@ -252,7 +252,7 @@ extension NativePushChannel: URLSessionWebSocketDelegate {
 extension NativePushChannel: URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        Logging.pushChannel.debug("Websocket open connection task did fail: \(error.map({ String(describing: $0)}) ?? "n/a" )")
+        Logging.pushChannel.debug("Websocket open connection task did fail: \(error.map({ String(describing: $0) }) ?? "n/a" )")
 
         websocketTask = nil
     }

--- a/wire-ios-utilities/Source/DispatchGroupContext.swift
+++ b/wire-ios-utilities/Source/DispatchGroupContext.swift
@@ -49,7 +49,7 @@ public final class DispatchGroupContext: NSObject {
 
     @objc(enterAllExcept:)
     func enterAll(except group: ZMSDispatchGroup? = nil) -> [ZMSDispatchGroup] {
-        let groups = self.groups.filter { $0 != group}
+        let groups = self.groups.filter { $0 != group }
 
         groups.forEach {
             $0.enter()

--- a/wire-ios-utilities/Tests/DictionaryTests.swift
+++ b/wire-ios-utilities/Tests/DictionaryTests.swift
@@ -65,7 +65,7 @@ class DictionaryTests: XCTestCase {
         let input = [1: "foo1", 2: "foo2", 3: "foo3"]
 
         // when
-        let dictionary: [Int: String] = input.mapKeysAndValues(keysMapping: ({$0*2}), valueMapping: ({$1 + "bar"}))
+        let dictionary: [Int: String] = input.mapKeysAndValues(keysMapping: ({ $0*2 }), valueMapping: ({ $1 + "bar" }))
 
         // then
         XCTAssertEqual(dictionary, [2: "foo1bar", 4: "foo2bar", 6: "foo3bar"])
@@ -76,8 +76,8 @@ class DictionaryTests: XCTestCase {
         let input = [1: "foo1", 2: "foo2", 3: "foo3"]
 
         // when
-        let dictionary: [Int: String] = input.mapKeysAndValues(keysMapping: ({$0*2}),
-                                                                 valueMapping: ({ $0 == 1 ? nil : $1 + "bar"}))
+        let dictionary: [Int: String] = input.mapKeysAndValues(keysMapping: ({ $0*2 }),
+                                                                 valueMapping: ({ $0 == 1 ? nil : $1 + "bar" }))
 
         // then
         XCTAssertEqual(dictionary, [4: "foo2bar", 6: "foo3bar"])

--- a/wire-ios/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
+++ b/wire-ios/Wire-iOS Tests/Analytics/AnalyticsCountlyProviderTests.swift
@@ -40,7 +40,7 @@ final class AnalyticsCountlyProviderTests: XCTestCase, CoreDataFixtureTestHelper
     }
 
     func testThatLogRoundedConvertNumberIntoBuckets() {
-        XCTAssertEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 50, 100].map({$0.logRound()}), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 46, 91])
+        XCTAssertEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 50, 100].map({ $0.logRound() }), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 46, 91])
     }
 
     func testThatCountlyAttributesFromConverationIsGenerated() {

--- a/wire-ios/Wire-iOS Tests/Calling/VoiceChannelStreamArrangmentTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/VoiceChannelStreamArrangmentTests.swift
@@ -93,8 +93,8 @@ class VoiceChannelStreamArrangementTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(streams.count, 2)
-        XCTAssertTrue(streams.contains(where: {$0.streamId.avsIdentifier == avsId1}))
-        XCTAssertTrue(streams.contains(where: {$0.streamId.avsIdentifier == avsId2}))
+        XCTAssertTrue(streams.contains(where: { $0.streamId.avsIdentifier == avsId1 }))
+        XCTAssertTrue(streams.contains(where: { $0.streamId.avsIdentifier == avsId2 }))
     }
 
     func testThatActiveStreams_ReturnsVideoStreams_ForParticipantsWithVideo() {

--- a/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -136,7 +136,7 @@ final class ConversationAvatarViewTests: XCTestCase {
         // GIVEN
 
         let conversation = MockStableRandomParticipantsConversation()
-        conversation.stableRandomParticipants = MockUserType.usernames.map {MockUserType.createConnectedUser(name: $0)}
+        conversation.stableRandomParticipants = MockUserType.usernames.map { MockUserType.createConnectedUser(name: $0) }
 
         (conversation.stableRandomParticipants[0] as! MockUserType).accentColorValue = .vividRed
         (conversation.stableRandomParticipants[1] as! MockUserType).accentColorValue = .brightOrange

--- a/wire-ios/Wire-iOS Tests/ConversationCell/StartedConversationCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/StartedConversationCellTests.swift
@@ -186,7 +186,7 @@ final class StartedConversationCellTests: ConversationMessageSnapshotTestCase {
         data.text = text
         data.userTypes = {
             // We add the sender to ensure it is removed
-            let users: [MockUserType] = MockUserType.usernames.map {MockUserType.createUser(name: $0)}
+            let users: [MockUserType] = MockUserType.usernames.map { MockUserType.createUser(name: $0) }
 
             let additionalUsers: [MockUserType] = [mockSelfUser, mockOtherUser]
             switch fillUsers {

--- a/wire-ios/Wire-iOS Tests/RequestPasswordViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/RequestPasswordViewControllerSnapshotTests.swift
@@ -38,7 +38,7 @@ final class RequestPasswordControllerSnapshotTests: XCTestCase, CoreDataFixtureT
     }
 
     func testForRemoveDeviceContextPasswordEntered() throws {
-        sut = RequestPasswordController(context: .removeDevice, callback: {_ in })
+        sut = RequestPasswordController(context: .removeDevice, callback: { _ in })
         sut.passwordTextField?.text = "12345678"
         sut.passwordTextFieldChanged(sut.passwordTextField!)
 
@@ -46,7 +46,7 @@ final class RequestPasswordControllerSnapshotTests: XCTestCase, CoreDataFixtureT
     }
 
     func testForRemoveDeviceContext() throws {
-        sut = RequestPasswordController(context: .removeDevice, callback: {_ in })
+        sut = RequestPasswordController(context: .removeDevice, callback: { _ in })
 
         try verify(matching: sut.alertController)
     }

--- a/wire-ios/Wire-iOS Tests/UIAlertViewController+CompanyLoginTests.swift
+++ b/wire-ios/Wire-iOS Tests/UIAlertViewController+CompanyLoginTests.swift
@@ -29,17 +29,17 @@ final class UIAlertControllerCompanyLoginSnapshotTests: XCTestCase {
     }
 
     func testForSSOAndEmailAlert() throws {
-        sut = UIAlertController.companyLogin(ssoOnly: false, completion: {_  in})
+        sut = UIAlertController.companyLogin(ssoOnly: false, completion: { _  in })
         try verify(matching: sut)
     }
 
     func testForSSOOnlyAlert() throws {
-        sut = UIAlertController.companyLogin(ssoOnly: true, completion: {_  in})
+        sut = UIAlertController.companyLogin(ssoOnly: true, completion: { _  in })
         try verify(matching: sut)
     }
 
     func testForAlertWithError() throws {
-        sut = UIAlertController.companyLogin(error: .unknown) {_  in}
+        sut = UIAlertController.companyLogin(error: .unknown) { _  in }
         try verify(matching: sut)
     }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -203,7 +203,7 @@ extension AuthenticationCoordinator: AuthenticationStateControllerDelegate {
             var viewControllers = presenter.viewControllers
             let rewindedController = viewControllers.first { milestone.shouldRewind(to: $0) }
             if let rewindedController = rewindedController {
-                viewControllers = [viewControllers.prefix { !milestone.shouldRewind(to: $0)}, [rewindedController], [stepViewController]].flatMap { $0 }
+                viewControllers = [viewControllers.prefix { !milestone.shouldRewind(to: $0) }, [rewindedController], [stepViewController]].flatMap { $0 }
                 presenter.setViewControllers(viewControllers, animated: true)
             } else {
                 presenter.setViewControllers([stepViewController], animated: true)

--- a/wire-ios/Wire-iOS/Sources/Components/TokenField/TokenField.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/TokenField/TokenField.swift
@@ -319,7 +319,7 @@ final class TokenField: UIView {
 
     // searches by isEqual:
     func token(forRepresentedObject object: NSObjectProtocol) -> Token<NSObjectProtocol>? {
-        return tokens.first(where: { $0.representedObject == HashBox(value: object)})
+        return tokens.first(where: { $0.representedObject == HashBox(value: object) })
     }
 
     private func scrollToBottomOfInputField() {

--- a/wire-ios/Wire-iOS/Sources/Helpers/UIUserInterfaceSizeClass+Constraint.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/UIUserInterfaceSizeClass+Constraint.swift
@@ -24,11 +24,11 @@ extension UIUserInterfaceSizeClass {
                 regularConstraints: [NSLayoutConstraint]) {
         switch self {
         case .regular:
-            compactConstraints.forEach {$0.isActive = false}
-            regularConstraints.forEach {$0.isActive = true}
+            compactConstraints.forEach { $0.isActive = false }
+            regularConstraints.forEach { $0.isActive = true }
         case .compact:
-            regularConstraints.forEach {$0.isActive = false}
-            compactConstraints.forEach {$0.isActive = true}
+            regularConstraints.forEach { $0.isActive = false }
+            compactConstraints.forEach { $0.isActive = true }
         case .unspecified:
             break
         @unknown default:

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Additions.swift
@@ -27,7 +27,7 @@ extension ZMConversation {
             return localParticipants.first
         }
 
-        return localParticipants.first(where: {$0 != selfUser})
+        return localParticipants.first(where: { $0 != selfUser })
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
+++ b/wire-ios/Wire-iOS/Sources/LaunchSequenceOperation.swift
@@ -173,7 +173,7 @@ extension AppCenterOperation: DistributeDelegate {
             })
         }
 
-        alertController.addAction(UIAlertAction(title: "Cancel", style: .default) {_ in })
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .default) { _ in })
 
         window.endEditing(true)
         rootViewController.present(alertController, animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Haptic Feedback/CallHapticsController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/Haptic Feedback/CallHapticsController.swift
@@ -85,7 +85,7 @@ final class CallHapticsController {
         let newVideoStates = createVideoStateMap(using: newParticipants)
         Log.haptics.debug("updating video state map: \(newVideoStates), old: \(videoStates)")
 
-        let mappedNewVideoStates = newVideoStates.mapKeys({$0.hashValue})
+        let mappedNewVideoStates = newVideoStates.mapKeys({ $0.hashValue })
         for (participant, wasSending) in videoStates {
 
             if let isSending = mappedNewVideoStates[participant.hashValue], isSending != wasSending {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration+ConversationOptions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/CellConfiguration+ConversationOptions.swift
@@ -85,7 +85,7 @@ extension CellConfiguration {
             title: L10n.Localizable.GuestRoom.Actions.copiedLink,
             icon: .checkmark,
             color: nil,
-            action: {_ in }
+            action: { _ in }
         )
 
     static func shareLink(action: @escaping Action) -> CellConfiguration {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationServicesOptionsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationServicesOptionsViewModel.swift
@@ -68,7 +68,7 @@ final class ConversationServicesOptionsViewModel {
     }
     private func updateRows() {
         state.rows = [.allowServicesToggle(
-            get: { [unowned self] in return self.configuration.allowServices},
+            get: { [unowned self] in return self.configuration.allowServices },
             set: { [unowned self] in self.setAllowServices($0, view: $1) }
         )]
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationNewDeviceSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationNewDeviceSystemMessageCellDescription.swift
@@ -114,7 +114,7 @@ final class ConversationNewDeviceSystemMessageCellDescription: ConversationMessa
         attributes: TextAttributes
     ) -> View.Configuration {
 
-        let displayNamesOfOthers = users.filter {!$0.isSelfUser }.compactMap { $0.name }
+        let displayNamesOfOthers = users.filter { !$0.isSelfUser }.compactMap { $0.name }
         let firstTwoNames = displayNamesOfOthers.prefix(2)
         let senderNames = firstTwoNames.joined(separator: ", ")
         let additionalSenderCount = max(displayNamesOfOthers.count - 1, 1)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/NSAttributedString+MessageFormatting.swift
@@ -119,7 +119,7 @@ extension NSAttributedString {
 
         // Do emoji substition (but not inside link or mentions)
         let linkAttachmentRanges = links.compactMap { Range<Int>($0.range) }
-        let mentionRanges = mentionTextObjects.compactMap { $0.range(in: markdownText.string as String)}
+        let mentionRanges = mentionTextObjects.compactMap { $0.range(in: markdownText.string as String) }
         markdownText.replaceEmoticons(excluding: linkAttachmentRanges + mentionRanges)
         markdownText.removeTrailingWhitespace()
 
@@ -161,7 +161,7 @@ extension NSAttributedString {
         // Do emoji substition (but not inside link or mentions)
         let links = markdownText.links()
         let linkAttachmentRanges = links.compactMap { Range<Int>($0.range) }
-        let mentionRanges = mentionTextObjects.compactMap { $0.range(in: markdownText.string as String)}
+        let mentionRanges = mentionTextObjects.compactMap { $0.range(in: markdownText.string as String) }
         let codeBlockRanges =  markdownText.ranges(of: .code).compactMap { Range<Int>($0) }
         markdownText.replaceEmoticons(excluding: linkAttachmentRanges + mentionRanges + codeBlockRanges)
 
@@ -185,7 +185,7 @@ extension NSMutableAttributedString {
         let allowedIndexSet = IndexSet(integersIn: Range<Int>(wholeRange)!, excluding: excludedRanges)
 
         // Reverse the order of replacing, if we start replace from the beginning, the string may be shorten and other ranges may be invalid.
-        for range in allowedIndexSet.rangeView.sorted(by: {$0.lowerBound > $1.lowerBound}) {
+        for range in allowedIndexSet.rangeView.sorted(by: { $0.lowerBound > $1.lowerBound }) {
             let convertedRange = NSRange(location: range.lowerBound, length: range.upperBound - range.lowerBound)
             mutableString.resolveEmoticonShortcuts(in: convertedRange)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Constraints.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+Constraints.swift
@@ -53,7 +53,7 @@ extension ConversationViewController {
     func createConstraints() {
         [conversationBarController.view,
          contentViewController.view,
-         inputBarController.view].forEach {$0?.translatesAutoresizingMaskIntoConstraints = false}
+         inputBarController.view].forEach { $0?.translatesAutoresizingMaskIntoConstraints = false }
 
         NSLayoutConstraint.activate([
             conversationBarController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -423,7 +423,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
                 duration: 0.35,
                 options: [.curveEaseIn],
                 animations: changes,
-                completion: { _ in picker.didMove(toParent: self)}
+                completion: { _ in picker.didMove(toParent: self) }
             )
 
             self.effectPickerViewController = picker

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/URLs+zip.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/URLs+zip.swift
@@ -22,7 +22,7 @@ extension Array where Element == URL {
     func zipFiles(filename: String = "archive.zip") -> URL? {
         let archiveURL = URL(fileURLWithPath: NSTemporaryDirectory() + filename)
 
-        let paths = map {$0.path}
+        let paths = map { $0.path }
 
         let zipSucceded = SSZipArchive.createZipFile(atPath: archiveURL.path, withFilesAtPaths: paths)
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/AnimatedListMenuView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/AnimatedListMenuView.swift
@@ -98,7 +98,7 @@ final class AnimatedListMenuView: UIView {
 
         let dotViews = [leftDotView, centerDotView, rightDotView]
 
-        dotViews.forEach {$0.translatesAutoresizingMaskIntoConstraints = false}
+        dotViews.forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
         translatesAutoresizingMaskIntoConstraints = false
 
         centerToRightDistanceConstraint = centerDotView.rightAnchor.constraint(equalTo: rightDotView.leftAnchor, constant: centerToRightDistance(forProgress: progress))

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
@@ -43,7 +43,7 @@ extension ZMConversation {
     }
 
     var detailActions: [Action] {
-        return actions.filter({ $0 != .configureNotifications})
+        return actions.filter({ $0 != .configureNotifications })
     }
 
     private var actions: [Action] {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -134,8 +134,8 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
 
         if !participants.isEmpty {
 
-            let admins = participants.filter({$0.isGroupAdmin(in: conversation)})
-            let members = participants.filter({!$0.isGroupAdmin(in: conversation)})
+            let admins = participants.filter({ $0.isGroupAdmin(in: conversation) })
+            let members = participants.filter({ !$0.isGroupAdmin(in: conversation) })
 
             let maxNumberOfDisplayed = Int.ConversationParticipants.maxNumberOfDisplayed
             let maxNumberWithoutTruncation = Int.ConversationParticipants.maxNumberWithoutTruncation

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewModel.swift
@@ -84,8 +84,8 @@ final class GroupParticipantsDetailViewModel: NSObject, SearchHeaderViewControll
     }
 
     private func computeParticipantGroups() {
-        admins = participants.filter({$0.isGroupAdmin(in: conversation)})
-        members = participants.filter({!$0.isGroupAdmin(in: conversation)})
+        admins = participants.filter({ $0.isGroupAdmin(in: conversation) })
+        members = participants.filter({ !$0.isGroupAdmin(in: conversation) })
     }
 
     private func filterPredicate(for query: String) -> NSPredicate {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -263,7 +263,7 @@ final class ZClientViewController: UIViewController {
 
     // MARK: - Singleton
     static var shared: ZClientViewController? {
-        return AppDelegate.shared.appRootRouter?.rootViewController.children.first(where: {$0 is ZClientViewController}) as? ZClientViewController
+        return AppDelegate.shared.appRootRouter?.rootViewController.children.first(where: { $0 is ZClientViewController }) as? ZClientViewController
     }
 
     /// Select the connection inbox and optionally move focus to it.

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -140,7 +140,7 @@ class SettingsSectionDescriptor: SettingsSectionDescriptorType {
     let footerGenerator: () -> String?
 
     convenience init(cellDescriptors: [SettingsCellDescriptorType], header: String? = .none, footer: String? = .none, visibilityAction: ((SettingsSectionDescriptorType) -> (Bool))? = .none) {
-        self.init(cellDescriptors: cellDescriptors, headerGenerator: { return header }, footerGenerator: { return footer}, visibilityAction: visibilityAction)
+        self.init(cellDescriptors: cellDescriptors, headerGenerator: { return header }, footerGenerator: { return footer }, visibilityAction: visibilityAction)
     }
 
     init(cellDescriptors: [SettingsCellDescriptorType], headerGenerator: @escaping () -> String?, footerGenerator: @escaping () -> String?, visibilityAction: ((SettingsSectionDescriptorType) -> (Bool))? = .none) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Developer.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Developer.swift
@@ -95,7 +95,7 @@ extension SettingsCellDescriptorFactory {
             ExternalScreen(title: "Show database statistics",
                            isDestructive: false,
                            presentationStyle: .navigation,
-                           presentationAction: {  DatabaseStatisticsController() })
+                           presentationAction: { DatabaseStatisticsController() })
         )
 
         if !Analytics.shared.isOptedOut && !TrackingManager.shared.disableAnalyticsSharing {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCopyButtonCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCopyButtonCellDescriptor.swift
@@ -49,13 +49,13 @@ final class SettingsCopyButtonCellDescriptor: SettingsCellDescriptorType {
     let copiedLink: CellConfiguration = .iconAction(title: Actions.copiedLink,
                                                     icon: .checkmark,
                                                     color: nil,
-                                                    action: {_ in }
+                                                    action: { _ in }
     )
 
     let copyLink: CellConfiguration = .iconAction(title: Actions.copyLink,
                                                   icon: .copy,
                                                   color: nil,
-                                                  action: {_ in }
+                                                  action: { _ in }
     )
 
     // MARK: - SettingsCellDescriptorType

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/UserSelection.swift
@@ -50,13 +50,13 @@ final class UserSelection: NSObject {
     }
 
     func add(observer: UserSelectionObserver) {
-        guard !observers.contains(where: { $0.unbox === observer}) else { return }
+        guard !observers.contains(where: { $0.unbox === observer }) else { return }
 
         observers.append(UnownedObject(observer))
     }
 
     func remove(observer: UserSelectionObserver) {
-        guard let index = observers.firstIndex(where: { $0.unbox === observer}) else { return }
+        guard let index = observers.firstIndex(where: { $0.unbox === observer }) else { return }
 
         observers.remove(at: index)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The motivation is to have an aligned way to format closures. The rule supports autocorrection, so that developers don't have extra work.

Documentation of SwiftLint rule `closure_spacing`: https://realm.github.io/SwiftLint/closure_spacing.html.

### Testing

#### How to Test

- No testing required, it just builds.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
