### PR TITLE
fix: request loop team - WPB-6724

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/Member.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Member.swift
@@ -61,11 +61,9 @@
         precondition(context.zm_isSyncContext)
 
         if let existing = user.membership {
-            existing.team = team
             return existing
         }
         else if let userId = user.remoteIdentifier, let existing = Member.fetch(with: userId, in: context) {
-            existing.team = team
             return existing
         }
 

--- a/wire-ios-data-model/Source/Model/Conversation/Member.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Member.swift
@@ -56,22 +56,25 @@
         }
     }
 
-    @objc(getOrCreateMemberForUser:inTeam:context:)
-    public static func getOrCreateMember(for user: ZMUser, in team: Team, context: NSManagedObjectContext) -> Member {
+    @objc(getOrUpdateMemberForUser:inTeam:context:)
+    public static func getOrUpdateMember(for user: ZMUser, in team: Team, context: NSManagedObjectContext) -> Member {
         precondition(context.zm_isSyncContext)
 
+        var member: Member
         if let existing = user.membership {
-            return existing
+            member = existing
         }
         else if let userId = user.remoteIdentifier, let existing = Member.fetch(with: userId, in: context) {
-            return existing
+            member = existing
+        } else {
+            member = insertNewObject(in: context)
+            member.needsToBeUpdatedFromBackend = true
         }
 
-        let member = insertNewObject(in: context)
         member.team = team
         member.user = user
         member.remoteIdentifier = user.remoteIdentifier
-        member.needsToBeUpdatedFromBackend = true
+
         return member
     }
 
@@ -96,7 +99,7 @@ extension Member {
         let user = ZMUser.fetchOrCreate(with: id, domain: nil, in: context)
         let createdAt = (payload[ResponseKey.createdAt.rawValue] as? String).flatMap(NSDate.init(transport:)) as Date?
         let createdBy = (payload[ResponseKey.createdBy.rawValue] as? String).flatMap(UUID.init)
-        let member = getOrCreateMember(for: user, in: team, context: context)
+        let member = getOrUpdateMember(for: user, in: team, context: context)
 
         member.updatePermissions(with: payload)
         member.createdAt = createdAt

--- a/wire-ios-data-model/Source/Model/Conversation/Member.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/Member.swift
@@ -61,9 +61,11 @@
         precondition(context.zm_isSyncContext)
 
         if let existing = user.membership {
+            existing.team = team
             return existing
         }
         else if let userId = user.remoteIdentifier, let existing = Member.fetch(with: userId, in: context) {
+            existing.team = team
             return existing
         }
 

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
@@ -67,7 +67,7 @@ public extension ZMUser {
     }
 
     private func createMembership(in team: Team, context: NSManagedObjectContext) {
-        _ = Member.getOrCreateMember(for: self, in: team, context: context)
+        _ = Member.getOrUpdateMember(for: self, in: team, context: context)
     }
 
     private func deleteMembership(in context: NSManagedObjectContext) {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SecurityLevel.swift
@@ -524,11 +524,11 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
                                               in: self.syncMOC,
                                               created: nil)!
 
-            _ = Member.getOrCreateMember(for: selfUser, in: mainTeam, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: mainTeam, context: self.syncMOC)
 
             // WHEN
             let user = self.insertUser(conversation: conversation, userIsTrusted: true, moc: self.syncMOC)
-            _ = Member.getOrCreateMember(for: user, in: mainTeam, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: user, in: mainTeam, context: self.syncMOC)
 
             // THEN
             XCTAssertTrue(conversation.allUsersTrusted)
@@ -548,7 +548,7 @@ class ZMConversationTests_SecurityLevel: ZMConversationTestsBase {
                                               in: self.syncMOC,
                                               created: nil)!
 
-            _ = Member.getOrCreateMember(for: selfUser, in: mainTeam, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: mainTeam, context: self.syncMOC)
 
             // WHEN
             _ = self.insertUser(conversation: conversation, userIsTrusted: true, moc: self.syncMOC)

--- a/wire-ios-data-model/Tests/Source/Model/MemberTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/MemberTests.swift
@@ -113,7 +113,7 @@ class MemberTests: ZMConversationTestsBase {
 
         self.performPretendingUiMocIsSyncMoc {
             // when
-            member = Member.getOrCreateMember(for: user, in: team, context: self.uiMOC)
+            member = Member.getOrUpdateMember(for: user, in: team, context: self.uiMOC)
         }
 
         // then
@@ -128,7 +128,7 @@ class MemberTests: ZMConversationTestsBase {
 
         self.performPretendingUiMocIsSyncMoc {
             // when
-            member = Member.getOrCreateMember(for: user, in: team, context: self.uiMOC)
+            member = Member.getOrUpdateMember(for: user, in: team, context: self.uiMOC)
         }
 
         // then
@@ -146,7 +146,7 @@ class MemberTests: ZMConversationTestsBase {
 
         self.performPretendingUiMocIsSyncMoc {
             // when
-            member = Member.getOrCreateMember(for: user, in: team, context: self.uiMOC)
+            member = Member.getOrUpdateMember(for: user, in: team, context: self.uiMOC)
         }
 
         // then
@@ -166,7 +166,7 @@ extension MemberTests {
             let user = ZMUser.insertNewObject(in: self.syncMOC)
             user.remoteIdentifier = .create()
             let team = Team.insertNewObject(in: self.syncMOC)
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             let createdAt = Date(timeIntervalSince1970: 0)
             let createdByUUID = UUID()
 

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -43,7 +43,7 @@ final class ZMUserTests_Permissions: ModelObjectsTests {
         self.performPretendingUiMocIsSyncMoc {
             self.conversation.team = self.team
             self.conversation.teamRemoteIdentifier = self.team.remoteIdentifier
-            let member = Member.getOrCreateMember(for: self.selfUser, in: self.team, context: self.uiMOC)
+            let member = Member.getOrUpdateMember(for: self.selfUser, in: self.team, context: self.uiMOC)
             member.permissions = permissions
         }
     }

--- a/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
@@ -270,7 +270,7 @@ class LegacyPersistedDataPatchesTests: ZMBaseManagedObjectTest {
             teamConversation.team = team
             let user = ZMUser.insertNewObject(in: moc)
             user.remoteIdentifier = .create()
-            let member = Member.getOrCreateMember(for: user, in: team, context: moc)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: moc)
             XCTAssert(moc.saveOrRollback())
 
             // when
@@ -296,9 +296,9 @@ class LegacyPersistedDataPatchesTests: ZMBaseManagedObjectTest {
             user2.remoteIdentifier = userId2
             let team = Team.insertNewObject(in: moc)
 
-            let member1User1 = Member.getOrCreateMember(for: user1, in: team, context: moc)
-            let member2User1 = Member.getOrCreateMember(for: user1, in: team, context: moc)
-            let member1User2 = Member.getOrCreateMember(for: user2, in: team, context: moc)
+            let member1User1 = Member.getOrUpdateMember(for: user1, in: team, context: moc)
+            let member2User1 = Member.getOrUpdateMember(for: user1, in: team, context: moc)
+            let member1User2 = Member.getOrUpdateMember(for: user2, in: team, context: moc)
             XCTAssert(moc.saveOrRollback())
 
             // when

--- a/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactoryTests.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactoryTests.swift
@@ -39,7 +39,7 @@ class AssetRequestFactoryTests: MessagingTestBase {
 
             // when
             let selfUser = ZMUser.selfUser(in: moc)
-            let membership = Member.getOrCreateMember(for: selfUser, in: team, context: moc)
+            let membership = Member.getOrUpdateMember(for: selfUser, in: team, context: moc)
             XCTAssertNotNil(membership.team)
             XCTAssertTrue(selfUser.hasTeam)
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
@@ -181,8 +181,8 @@ class AddParticipantActionHandlerTests: MessagingTestBase {
             nonTeamUser.remoteIdentifier = UUID()
             nonTeamUser.needsToBeUpdatedFromBackend = false
 
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.syncMOC)
-            _ = Member.getOrCreateMember(for: teamUser, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: teamUser, in: team, context: self.syncMOC)
 
             let action = AddParticipantAction(users: [teamUser, nonTeamUser], conversation: conversation)
             let response = ZMTransportResponse(payload: nil,

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -501,7 +501,7 @@ class ZMLocalNotificationTests_Message: ZMLocalNotificationTests {
             team.name = "Wire Amazing Team"
             team.remoteIdentifier = UUID.create()
             let user = ZMUser.selfUser(in: self.syncMOC)
-            _ = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             user.teamIdentifier = team.remoteIdentifier
 
             // when
@@ -785,7 +785,7 @@ extension ZMLocalNotificationTests_Message {
             let team = Team.insertNewObject(in: self.syncMOC)
             team.name = "Wire Amazing Team"
             let user = ZMUser.selfUser(in: self.syncMOC)
-            _ = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
 
             // WHEN
             let note = self.textNotification(self.oneOnOneConversation, sender: self.sender, text: "Hello", isEphemeral: false)!
@@ -847,7 +847,7 @@ extension ZMLocalNotificationTests_Message {
             team.name = "Wire Amazing Team"
 
             let user = ZMUser.selfUser(in: self.syncMOC)
-            _ = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
 
             // When
             let note = self.textNotification(self.oneOnOneConversation, sender: self.sender, text: "Hello", isEphemeral: false)!

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/PermissionsDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/PermissionsDownloadRequestStrategy.swift
@@ -56,7 +56,7 @@ extension MembershipPayload {
     @discardableResult
     func createOrUpdateMember(team: Team, in managedObjectContext: NSManagedObjectContext) -> Member? {
         let user = ZMUser.fetchOrCreate(with: userID, domain: nil, in: managedObjectContext)
-        let member = Member.getOrCreateMember(for: user, in: team, context: managedObjectContext)
+        let member = Member.getOrUpdateMember(for: user, in: team, context: managedObjectContext)
 
         if let permissions = permissions.flatMap({ Permissions(rawValue: $0.selfPermissions) }) {
             member.permissions = permissions

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
@@ -58,10 +58,8 @@ extension TeamPayload {
             return nil
         }
 
-        if created {
-            let selfUser = ZMUser.selfUser(in: managedObjectContext)
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: managedObjectContext)
-        }
+        let selfUser = ZMUser.selfUser(in: managedObjectContext)
+        _ = Member.getOrUpdateMember(for: selfUser, in: team, context: managedObjectContext)
 
         updateTeam(team, in: managedObjectContext)
 
@@ -176,7 +174,7 @@ public final class TeamDownloadRequestStrategy: AbstractRequestStrategy, ZMConte
         guard let addedUserId = (data[TeamEventPayloadKey.user.rawValue] as? String).flatMap(UUID.init) else { return }
         let user = ZMUser.fetchOrCreate(with: addedUserId, domain: nil, in: managedObjectContext)
         user.needsToBeUpdatedFromBackend = true
-        _ = Member.getOrCreateMember(for: user, in: team, context: managedObjectContext)
+        _ = Member.getOrUpdateMember(for: user, in: team, context: managedObjectContext)
     }
 
     private func processRemovedMember(with event: ZMUpdateEvent) {

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -63,7 +63,7 @@ public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, 
             let rawData = response.rawData,
             let payload = MembershipListPayload(rawData)
         else {
-            syncStatus.failCurrentSyncPhase(phase: .fetchingTeamMembers)
+            failSyncPhase()
             return
         }
 
@@ -76,8 +76,11 @@ public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, 
         completeSyncPhase()
     }
 
+    func failSyncPhase() {
+        syncStatus.failCurrentSyncPhase(phase: .fetchingTeamMembers)
+    }
+
     func completeSyncPhase() {
         syncStatus.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
     }
-
 }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -63,7 +63,6 @@ public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, 
             let rawData = response.rawData,
             let payload = MembershipListPayload(rawData)
         else {
-            //failed for some reason, should we inform?
             syncStatus.failCurrentSyncPhase(phase: .fetchingTeamMembers)
             return
         }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -63,6 +63,8 @@ public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, 
             let rawData = response.rawData,
             let payload = MembershipListPayload(rawData)
         else {
+            //failed for some reason, should we inform?
+            syncStatus.failCurrentSyncPhase(phase: .fetchingTeamMembers)
             return
         }
 

--- a/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
+++ b/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationForTests_CallState.swift
@@ -194,7 +194,7 @@ class ZMLocalNotificationTests_CallState: MessagingTest {
             let team = Team.insertNewObject(in: self.syncMOC)
             team.name = "Wire Amazing Team"
             let user = ZMUser.selfUser(in: self.syncMOC)
-            _ = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             self.syncMOC.saveOrRollback()
 
             XCTAssertNotNil(user.team)

--- a/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Alerts.swift
+++ b/wire-ios-sync-engine/Tests/Source/Notifications/PushNotifications/ZMLocalNotificationTests_Alerts.swift
@@ -27,7 +27,7 @@ class ZMLocalNotificationTests_Alerts: ZMLocalNotificationTests {
         team.name = "Team-A"
         let user = ZMUser.selfUser(in: self.uiMOC)
         self.performPretendingUiMocIsSyncMoc {
-            _ = Member.getOrCreateMember(for: user, in: team, context: self.uiMOC)
+            _ = Member.getOrUpdateMember(for: user, in: team, context: self.uiMOC)
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/LegalHoldRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/LegalHoldRequestStrategyTests.swift
@@ -115,7 +115,7 @@ class LegalHoldRequestStrategyTests: MessagingTest {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let team = Team.insertNewObject(in: self.syncMOC)
             team.remoteIdentifier = .create()
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: team, context: self.syncMOC)
 
             // WHEN
             guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail() }
@@ -164,7 +164,7 @@ class LegalHoldRequestStrategyTests: MessagingTest {
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let team = Team.insertNewObject(in: self.syncMOC)
             team.remoteIdentifier = .create()
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: team, context: self.syncMOC)
             expectedLegalHoldRequest = type(of: self).legalHoldRequest(for: selfUser)
 
             let payload = type(of: self).payloadForReceivingLegalHoldRequestStatus(request: expectedLegalHoldRequest)
@@ -189,7 +189,7 @@ class LegalHoldRequestStrategyTests: MessagingTest {
 
             let team = Team.insertNewObject(in: self.syncMOC)
             team.remoteIdentifier = .create()
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: team, context: self.syncMOC)
 
             let legalHoldRequest = type(of: self).legalHoldRequest(for: selfUser)
             selfUser.userDidReceiveLegalHoldRequest(legalHoldRequest)
@@ -242,7 +242,7 @@ class LegalHoldRequestStrategyTests: MessagingTest {
 
             let team = Team.insertNewObject(in: self.syncMOC)
             team.remoteIdentifier = .create()
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: team, context: self.syncMOC)
 
             let legalHoldRequest = type(of: self).legalHoldRequest(for: selfUser)
             selfUser.userDidReceiveLegalHoldRequest(legalHoldRequest)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/PermissionsDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/PermissionsDownloadRequestStrategyTests.swift
@@ -65,7 +65,7 @@ class PermissionsDownloadRequestStrategyTests: MessagingTest {
             self.mockApplicationStatus.mockSynchronizationState = .online
             let user = ZMUser.insertNewObject(in: self.syncMOC)
             user.remoteIdentifier = userId
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
 
             // when
             member.needsToBeUpdatedFromBackend = true
@@ -105,7 +105,7 @@ class PermissionsDownloadRequestStrategyTests: MessagingTest {
             team.remoteIdentifier = .create()
             user = ZMUser.insertNewObject(in: self.syncMOC)
             user.remoteIdentifier = .create()
-            member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
 
             member.needsToBeUpdatedFromBackend = true
             self.boostrapChangeTrackers(with: member)
@@ -151,7 +151,7 @@ class PermissionsDownloadRequestStrategyTests: MessagingTest {
             team.remoteIdentifier = .create()
             let user = ZMUser.insertNewObject(in: self.syncMOC)
             user.remoteIdentifier = userid
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             member.needsToBeUpdatedFromBackend = true
 
             self.boostrapChangeTrackers(with: member)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -427,7 +427,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
             user.remoteIdentifier = userId
             let team = Team.insertNewObject(in: self.syncMOC)
             team.remoteIdentifier = teamId
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             XCTAssertNotNil(member)
             XCTAssertEqual(user.membership, member)
             XCTAssert(self.syncMOC.saveOrRollback())
@@ -465,7 +465,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
             userId = user.remoteIdentifier!
             let team = Team.insertNewObject(in: self.syncMOC)
             team.remoteIdentifier = teamId
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             XCTAssertNotNil(member)
             XCTAssertEqual(user.membership, member)
         }
@@ -513,7 +513,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
             teamConversation1.team = team
             let conversation = ZMConversation.insertGroupConversation(moc: self.syncMOC, participants: [user, otherUser])
             conversation?.remoteIdentifier = conversationId
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             XCTAssertNotNil(member)
             XCTAssertEqual(user.membership, member)
         }
@@ -568,7 +568,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
 
             let conversation = ZMConversation.insertGroupConversation(moc: self.syncMOC, participants: [user, otherUser])
             conversation?.remoteIdentifier = conversationId
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             XCTAssertNotNil(member)
             XCTAssertEqual(user.membership, member)
         }
@@ -620,7 +620,7 @@ class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
             let team = Team.fetchOrCreate(with: teamId, create: true, in: self.syncMOC, created: nil)!
             let user = ZMUser.fetchOrCreate(with: userId, domain: nil, in: self.syncMOC)
             user.needsToBeUpdatedFromBackend = false
-            let member = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             member.needsToBeUpdatedFromBackend = false
             XCTAssert(self.syncMOC.saveOrRollback())
         }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
@@ -320,7 +320,7 @@ class TeamDownloadRequestStrategyTests: MessagingTest {
 
             let user = ZMUser.insertNewObject(in: self.syncMOC)
             user.remoteIdentifier = userId
-            _ = Member.getOrCreateMember(for: user, in: team, context: self.syncMOC)
+            _ = Member.getOrUpdateMember(for: user, in: team, context: self.syncMOC)
             self.syncMOC.saveOrRollback()
 
             let payload: [String: Any] = [

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -83,7 +83,7 @@ class TeamMembersDownloadRequestStrategyTests: MessagingTest {
         selfUser.teamIdentifier = teamID
         let team = Team.insertNewObject(in: syncMOC)
         team.remoteIdentifier = teamID
-        _ = Member.getOrCreateMember(for: selfUser, in: team, context: syncMOC)
+        _ = Member.getOrUpdateMember(for: selfUser, in: team, context: syncMOC)
 
         return team
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -135,7 +135,7 @@ class ZMHotFixTests_Integration: MessagingTest {
 
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
             let team = Team.fetchOrCreate(with: UUID(), create: true, in: self.syncMOC, created: nil)!
-            let member = Member.getOrCreateMember(for: selfUser, in: team, context: self.syncMOC)
+            let member = Member.getOrUpdateMember(for: selfUser, in: team, context: self.syncMOC)
             member.needsToBeUpdatedFromBackend = false
 
             // WHEN

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -35,7 +35,7 @@ class SearchTaskTests: DatabaseTest {
             selfUser.remoteIdentifier = UUID()
             selfUser.teamIdentifier = self.teamIdentifier
             guard let team = Team.fetchOrCreate(with: self.teamIdentifier, create: true, in: self.uiMOC, created: nil) else { XCTFail(); return }
-            _ = Member.getOrCreateMember(for: selfUser, in: team, context: self.uiMOC)
+            _ = Member.getOrUpdateMember(for: selfUser, in: team, context: self.uiMOC)
             uiMOC.saveOrRollback()
         }
         BackendInfo.storage = UserDefaults(suiteName: UUID().uuidString)!

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -238,15 +238,21 @@ static NSInteger const DefaultMaximumRequests = 6;
                                                                           group:group
                                                                         backoff:nil
                                                              initialAccessToken:initialAccessToken];
+
+        self.remoteMonitoring = [[RemoteMonitoring alloc] initWithLevel: LevelInfo];
+
         ZM_WEAK(self);
         self.requestLoopDetection = [[RequestLoopDetection alloc] initWithTriggerCallback:^(NSString * _Nonnull path) {
             ZM_STRONG(self);
+
+            [self.remoteMonitoring log:[NSString stringWithFormat:@"Request loop detected for %@", path]
+                                 error:nil];
             if(self.requestLoopDetectionCallback != nil) {
                 self.requestLoopDetectionCallback(path);
             }
         }];
 
-        self.remoteMonitoring = [[RemoteMonitoring alloc] initWithLevel: LevelInfo];
+
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(renewReachabilityObserverToken)

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -239,7 +239,7 @@ static NSInteger const DefaultMaximumRequests = 6;
                                                                         backoff:nil
                                                              initialAccessToken:initialAccessToken];
 
-        self.remoteMonitoring = [[RemoteMonitoring alloc] initWithLevel: LevelInfo];
+        self.remoteMonitoring = [[RemoteMonitoring alloc] initWithLevel:LevelInfo];
 
         ZM_WEAK(self);
         self.requestLoopDetection = [[RequestLoopDetection alloc] initWithTriggerCallback:^(NSString * _Nonnull path) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6724" title="WPB-6724" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6724</a>  request loop on /teams/XXX/members
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

During the playtest, we inserted a duplicate of team and after the migration, the slowsync was looping on the fetching team members phase.

### Causes (Optional)

Deleting the duplicate team deleted the members (which makes the link to User) in cascade and nulling the team relationship on User (here the selfUser).
The TeamDownloadMembers strategy depends on the selfuser team to update the members, as it was nil it was not able to go on.

Note that in the duplicate Team action we moved the members which is in reality not a likely scenario. Also having multiple teams is possible in theory in reality we always have only one.

### Solutions

* Update the method that update or get the team for a user to update properties at the same time. See `getOrUpdateMember(for:in:context:)`
* Report request loops in Datadog

### Testing

#### How to Test

* Restore backup with team duplicate
-> it should not have a request loop
