### PR TITLE
fix: calculate certification status based on all clients count [WPB-765]

### DIFF
--- a/wire-ios-data-model/Source/UseCases/IsSelfUserE2EICertifiedUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/IsSelfUserE2EICertifiedUseCase.swift
@@ -43,7 +43,7 @@ public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProt
     }
 
     public func invoke() async throws -> Bool {
-        let (conversationID, userID) = try await context.perform(schedule: schedule) {
+        let (conversationID, userID, clientCount) = try await context.perform(schedule: schedule) {
             // conversationID
             guard let selfConversation = ZMConversation.fetchSelfMLSConversation(in: context) else {
                 throw Error.couldNotFetchMLSSelfConversation
@@ -60,7 +60,7 @@ public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProt
             else {
                 throw Error.failedToGetSelfUserID
             }
-            return (mlsGroupID, userID)
+            return (mlsGroupID, userID, selfUser.allClients.count)
         }
 
         let coreCrypto = try await coreCryptoProvider.coreCrypto(requireMLS: true)
@@ -76,7 +76,7 @@ public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProt
             return identities
         }
 
-        return !identities.isEmpty && identities.allSatisfy { $0.status == .valid }
+        return !identities.isEmpty && identities.count == clientCount && identities.allSatisfy { $0.status == .valid }
     }
 }
 

--- a/wire-ios-sync-engine/Source/Use cases/GetE2eIdentityCertificatesUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/GetE2eIdentityCertificatesUseCase.swift
@@ -38,11 +38,11 @@ final public class GetE2eIdentityCertificatesUseCase: GetE2eIdentityCertificates
                        clientIds: [MLSClientID]) async throws -> [E2eIdentityCertificate] {
 
         let coreCrypto = try await coreCryptoProvider.coreCrypto(requireMLS: true)
-        let clientIds = clientIds.compactMap({$0.rawValue.data(using: .utf8)})
+        let clientIds = clientIds.compactMap { $0.rawValue.data(using: .utf8) }
         let wireIdentities = try await getWireIdentity(coreCrypto: coreCrypto,
                                                        conversationId: mlsGroupId.data,
                                                        clientIDs: clientIds)
-        return try wireIdentities.compactMap({try $0.toE2eIdenityCertificate()})
+        return try wireIdentities.compactMap { try $0.toE2eIdenityCertificate() }
     }
 
     @MainActor
@@ -94,10 +94,11 @@ extension X509Certificate {
         certificateStatus: E2EIdentityCertificateStatus,
         mlsThumbprint: String
     ) -> E2eIdentityCertificate? {
-        guard let notValidBefore = notBefore,
-              let notValidAfter = notAfter,
-              let theSerialNumber = serialNumber?.bytes.map({String($0, radix: 16).uppercased()}).joined(separator: "")
-        else {
+        let serialNumber = serialNumber
+            .map { [UInt8]($0) }?
+            .map { String($0, radix: 16).uppercased() }
+            .joined(separator: "")
+        guard let notValidBefore = notBefore, let notValidAfter = notAfter, let serialNumber else {
             return nil
         }
         return .init(
@@ -107,6 +108,7 @@ extension X509Certificate {
             notValidBefore: notValidBefore,
             expiryDate: notValidAfter,
             certificateStatus: certificateStatus,
-            serialNumber: theSerialNumber)
+            serialNumber: serialNumber
+        )
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/E2eIdentity/DeveloperDeviceDetailsSettingsSelectionViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/E2eIdentity/DeveloperDeviceDetailsSettingsSelectionViewModel.swift
@@ -82,13 +82,15 @@ class DeveloperDeviceDetailsSettingsSelectionViewModel: ObservableObject {
             )
         ]
         selectedItemID = UUID()
-        guard let status = E2EIdentityCertificateStatus.allCases
-                                                        .first(where: {$0.title == Self.selectedE2eIdentiyStatus ?? ""}),
-              let selectedItem = sections.flatMap(\.items).first(where: {
-            $0.value == status.title
-        }) else {
-            return
-        }
+
+        let status = E2EIdentityCertificateStatus
+            .allCases
+            .first { $0.title == Self.selectedE2eIdentiyStatus ?? "" }
+        let selectedItem = sections
+            .flatMap(\.items)
+            .first { $0.value == status?.title }
+        guard let status, let selectedItem else { return }
+
         // Initial selection
         selectedItemID = selectedItem.id
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -511,7 +511,7 @@ final class ClientListViewController: UIViewController,
                     nil
                 }
             })
-            let mlsClienIds = mlsClients.values.map({$0})
+            let mlsClienIds = Array(mlsClients.values)
             do {
                 let isE2eIEnabledForSelfClient = try await userSession.getIsE2eIdentityEnabled.invoke()
                 let certificates = try await userSession.getE2eIdentityCertificates.invoke(mlsGroupId: mlsGroupID,
@@ -519,7 +519,7 @@ final class ClientListViewController: UIViewController,
                 if certificates.isNonEmpty {
                     for client in userClients {
                         let mlsClientIdRawValue = mlsClients[client.clientId.hashValue]?.rawValue
-                        client.e2eIdentityCertificate = certificates.first(where: {$0.clientId == mlsClientIdRawValue})
+                        client.e2eIdentityCertificate = certificates.first { $0.clientId == mlsClientIdRawValue }
                         if client.e2eIdentityCertificate == nil && client.mlsPublicKeys.ed25519 != nil {
                             client.e2eIdentityCertificate = client.notActivatedE2EIdenityCertificate()
                         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-765" title="WPB-765" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-765</a>  [iOS] 5.3.16 Indicate verified user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If Core Crypto returns fewer client certificates than a user actually has clients, the user might be shown as certified even if he isn't.

### Causes (Optional)

The condition `.allSatisfies` alone is wrong, it needs to be checked if the total count is equal.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
