### PR TITLE
refactor: evaluate all oneonone conversations protocol [WPB-5812]

### DIFF
--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -459,7 +459,6 @@
 		D5FA30D12063FD3A00716618 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FA30D02063FD3A00716618 /* VersionTests.swift */; };
 		E608F4B22B5EACE000FF98A1 /* OneOnOneResolvedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E608F4B12B5EACE000FF98A1 /* OneOnOneResolvedState.swift */; };
 		E62EE7F82B3447E9002A54EF /* RemoveZombieParticipantRolesMigrationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62EE7F72B3447E9002A54EF /* RemoveZombieParticipantRolesMigrationPolicy.swift */; };
-		E62F31C92B711FEE0095777A /* CoreDataStackHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62B972A2B680AB20099D5DC /* CoreDataStackHelper.swift */; };
 		E68D9FF12B0F595100EFE04F /* store2-108-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = E68D9FF02B0F594600EFE04F /* store2-108-0.wiredatabase */; };
 		E68D9FF32B0F5B4600EFE04F /* store2-105-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = E68D9FF22B0F5B4600EFE04F /* store2-105-0.wiredatabase */; };
 		E6A5BBA62B0E33DB00ACC236 /* CoreDataMessagingMigrationVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A5BBA52B0E33DB00ACC236 /* CoreDataMessagingMigrationVersion.swift */; };
@@ -1997,13 +1996,6 @@
 			path = Availability;
 			sourceTree = "<group>";
 		};
-		597A3BB82B641EA20020E337 /* UserStatus */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = UserStatus;
-			sourceTree = "<group>";
-		};
 		59D1C3012B1DE6FF0016F6B2 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -2272,14 +2264,6 @@
 				E62EE7F72B3447E9002A54EF /* RemoveZombieParticipantRolesMigrationPolicy.swift */,
 			);
 			path = "2.106-2.107";
-			sourceTree = "<group>";
-		};
-		E62F31C82B711F280095777A /* CoreData */ = {
-			isa = PBXGroup;
-			children = (
-				E62B972A2B680AB20099D5DC /* CoreDataStackHelper.swift */,
-			);
-			path = CoreData;
 			sourceTree = "<group>";
 		};
 		E6A5BBA22B0E329800ACC236 /* Migration */ = {
@@ -2738,7 +2722,6 @@
 			isa = PBXGroup;
 			children = (
 				597A3BB52B6418090020E337 /* Availability */,
-				597A3BB82B641EA20020E337 /* UserStatus */,
 				1687ABAB20EBE0770007C240 /* UserType.swift */,
 				EEF4010623A9213B007B1A97 /* UserType+Team.swift */,
 				1607AAF1243768D200A93D29 /* UserType+Materialize.swift */,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Connection/ConnectionRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Connection/ConnectionRequestStrategyTests.swift
@@ -17,6 +17,7 @@
 
 import XCTest
 import WireDataModelSupport
+import WireRequestStrategySupport
 @testable import WireRequestStrategy
 
 final class ConnectionRequestStrategyTests: MessagingTestBase {
@@ -37,7 +38,12 @@ final class ConnectionRequestStrategyTests: MessagingTestBase {
 
         mockApplicationStatus = MockApplicationStatus()
         mockApplicationStatus.mockSynchronizationState = .online
+
         mockSyncProgress = MockSyncProgress()
+        mockSyncProgress.currentSyncPhase = .done
+        mockSyncProgress.finishCurrentSyncPhasePhase_MockMethod = { _ in }
+        mockSyncProgress.failCurrentSyncPhasePhase_MockMethod = { _ in }
+
         mockOneOnOneResolver = MockOneOnOneResolverInterface()
 
         sut = ConnectionRequestStrategy(withManagedObjectContext: syncMOC,
@@ -148,7 +154,7 @@ final class ConnectionRequestStrategyTests: MessagingTestBase {
         fetchConnectionsDuringSlowSync(connections: [createConnectionPayload()])
 
         // then
-        XCTAssertEqual(mockSyncProgress.didFinishCurrentSyncPhase, .fetchingConnections)
+        XCTAssertEqual(mockSyncProgress.finishCurrentSyncPhasePhase_Invocations, [.fetchingConnections])
     }
 
     func testThatFetchingConnectionsSyncPhaseIsFinished_WhenThereIsNoConnectionsToFetch() {
@@ -160,7 +166,7 @@ final class ConnectionRequestStrategyTests: MessagingTestBase {
         fetchConnectionsDuringSlowSync(connections: [])
 
         // then
-        XCTAssertEqual(mockSyncProgress.didFinishCurrentSyncPhase, .fetchingConnections)
+        XCTAssertEqual(mockSyncProgress.finishCurrentSyncPhasePhase_Invocations, [.fetchingConnections])
     }
 
     func testThatFetchingConnectionsSyncPhaseIsFailed_WhenReceivingAPermanentError() {
@@ -172,7 +178,7 @@ final class ConnectionRequestStrategyTests: MessagingTestBase {
         fetchConnectionsDuringSlowSyncWithPermanentError()
 
         // then
-        XCTAssertEqual(mockSyncProgress.didFailCurrentSyncPhase, .fetchingConnections)
+        XCTAssertEqual(mockSyncProgress.failCurrentSyncPhasePhase_Invocations, [.fetchingConnections])
     }
 
     // MARK: Response processing

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategyTests.swift
@@ -19,6 +19,7 @@ import Foundation
 import XCTest
 import WireDataModel
 import WireDataModelSupport
+import WireRequestStrategySupport
 @testable import WireRequestStrategy
 
 class ConversationRequestStrategyTests: MessagingTestBase {
@@ -40,9 +41,13 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
         mockApplicationStatus = MockApplicationStatus()
         mockApplicationStatus.mockSynchronizationState = .online
-        mockSyncProgress = MockSyncProgress()
         mockRemoveLocalConversation = MockLocalConversationRemovalUseCase()
         mockMLSService = MockMLSServiceInterface()
+
+        mockSyncProgress = MockSyncProgress()
+        mockSyncProgress.currentSyncPhase = .done
+        mockSyncProgress.finishCurrentSyncPhasePhase_MockMethod = { _ in }
+        mockSyncProgress.failCurrentSyncPhasePhase_MockMethod = { _ in }
 
         sut = ConversationRequestStrategy(
             withManagedObjectContext: syncMOC,
@@ -231,7 +236,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
         // then
         syncMOC.performGroupedBlockAndWait {
-            XCTAssertEqual(self.mockSyncProgress.didFinishCurrentSyncPhase, .fetchingConversations)
+            XCTAssertEqual(self.mockSyncProgress.finishCurrentSyncPhasePhase_Invocations, [.fetchingConversations])
         }
     }
 
@@ -245,7 +250,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
         // then
         syncMOC.performGroupedBlockAndWait {
-            XCTAssertEqual(self.mockSyncProgress.didFinishCurrentSyncPhase, .fetchingConversations)
+            XCTAssertEqual(self.mockSyncProgress.finishCurrentSyncPhasePhase_Invocations, [.fetchingConversations])
         }
     }
 
@@ -259,7 +264,7 @@ class ConversationRequestStrategyTests: MessagingTestBase {
 
         // then
         syncMOC.performGroupedBlockAndWait {
-            XCTAssertEqual(self.mockSyncProgress.didFailCurrentSyncPhase, .fetchingConversations)
+            XCTAssertEqual(self.mockSyncProgress.failCurrentSyncPhasePhase_Invocations, [.fetchingConversations])
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
@@ -17,6 +17,7 @@
 //
 
 import XCTest
+import WireRequestStrategySupport
 @testable import WireRequestStrategy
 
 class FeatureConfigRequestStrategyTests: MessagingTestBase {
@@ -36,7 +37,8 @@ class FeatureConfigRequestStrategyTests: MessagingTestBase {
 
         sut = FeatureConfigRequestStrategy(
             withManagedObjectContext: syncMOC,
-            applicationStatus: mockApplicationStatus
+            applicationStatus: mockApplicationStatus,
+            syncStatus: MockSyncProgress()
         )
 
         featureRepository = .init(context: syncMOC)

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
@@ -37,8 +37,7 @@ class FeatureConfigRequestStrategyTests: MessagingTestBase {
 
         sut = FeatureConfigRequestStrategy(
             withManagedObjectContext: syncMOC,
-            applicationStatus: mockApplicationStatus,
-            syncStatus: MockSyncProgress()
+            applicationStatus: mockApplicationStatus
         )
 
         featureRepository = .init(context: syncMOC)

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserProfileRequestStrategyTests.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import XCTest
+import WireRequestStrategySupport
 @testable import WireRequestStrategy
 
 class UserProfileRequestStrategyTests: MessagingTestBase {
@@ -36,11 +37,16 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
 
         mockApplicationStatus = MockApplicationStatus()
         mockApplicationStatus.mockSynchronizationState = .online
-        mockSyncProgress = MockSyncProgress()
 
-        sut = UserProfileRequestStrategy(managedObjectContext: syncMOC,
-                                         applicationStatus: mockApplicationStatus,
-                                         syncProgress: mockSyncProgress)
+        mockSyncProgress = MockSyncProgress()
+        mockSyncProgress.currentSyncPhase = .done
+        mockSyncProgress.finishCurrentSyncPhasePhase_MockMethod = { _ in }
+
+        sut = UserProfileRequestStrategy(
+            managedObjectContext: syncMOC,
+            applicationStatus: mockApplicationStatus,
+            syncProgress: mockSyncProgress
+        )
 
         apiVersion = .v0
     }
@@ -197,7 +203,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
 
         syncMOC.performGroupedBlockAndWait {
             // then
-            XCTAssertEqual(self.mockSyncProgress.didFinishCurrentSyncPhase, .fetchingUsers)
+            XCTAssertEqual(self.mockSyncProgress.finishCurrentSyncPhasePhase_Invocations, [.fetchingUsers])
             XCTAssertFalse(self.sut.isFetchingAllConnectedUsers)
         }
     }
@@ -214,7 +220,7 @@ class UserProfileRequestStrategyTests: MessagingTestBase {
             _ = self.sut.nextRequest(for: self.apiVersion)
 
             // then
-            XCTAssertEqual(self.mockSyncProgress.didFinishCurrentSyncPhase, .fetchingUsers)
+            XCTAssertEqual(self.mockSyncProgress.finishCurrentSyncPhasePhase_Invocations, [.fetchingUsers])
             XCTAssertFalse(self.sut.isFetchingAllConnectedUsers)
         }
     }

--- a/wire-ios-request-strategy/Sources/Synchronization/SyncProgress.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/SyncProgress.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public protocol SyncProgress {
+public protocol SyncProgress: AnyObject {
 
     var currentSyncPhase: SyncPhase { get }
 

--- a/wire-ios-request-strategy/Sources/Synchronization/SyncProgress.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/SyncProgress.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 
+// sourcery: AutoMockable
 public protocol SyncProgress: AnyObject {
 
     var currentSyncPhase: SyncPhase { get }

--- a/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -649,6 +649,53 @@ public class MockSessionEstablisherInterface: SessionEstablisherInterface {
     }
 
 }
+public class MockSyncProgress: SyncProgress {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+    // MARK: - currentSyncPhase
+
+    public var currentSyncPhase: SyncPhase {
+        get { return underlyingCurrentSyncPhase }
+        set(value) { underlyingCurrentSyncPhase = value }
+    }
+
+    public var underlyingCurrentSyncPhase: SyncPhase!
+
+
+    // MARK: - finishCurrentSyncPhase
+
+    public var finishCurrentSyncPhasePhase_Invocations: [SyncPhase] = []
+    public var finishCurrentSyncPhasePhase_MockMethod: ((SyncPhase) -> Void)?
+
+    public func finishCurrentSyncPhase(phase: SyncPhase) {
+        finishCurrentSyncPhasePhase_Invocations.append(phase)
+
+        guard let mock = finishCurrentSyncPhasePhase_MockMethod else {
+            fatalError("no mock for `finishCurrentSyncPhasePhase`")
+        }
+
+        mock(phase)
+    }
+
+    // MARK: - failCurrentSyncPhase
+
+    public var failCurrentSyncPhasePhase_Invocations: [SyncPhase] = []
+    public var failCurrentSyncPhasePhase_MockMethod: ((SyncPhase) -> Void)?
+
+    public func failCurrentSyncPhase(phase: SyncPhase) {
+        failCurrentSyncPhasePhase_Invocations.append(phase)
+
+        guard let mock = failCurrentSyncPhasePhase_MockMethod else {
+            fatalError("no mock for `failCurrentSyncPhasePhase`")
+        }
+
+        mock(phase)
+    }
+
+}
 class MockUserProfilePayloadProcessing: UserProfilePayloadProcessing {
 
     // MARK: - Life cycle

--- a/wire-ios-request-strategy/Tests/Helpers/MockObjects.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MockObjects.swift
@@ -89,19 +89,3 @@ class MockPushMessageHandler: NSObject, PushMessageHandler {
 
     fileprivate(set) var failedToSend: [ZMMessage] = []
 }
-
-class MockSyncProgress: NSObject, SyncProgress {
-
-    var currentSyncPhase: SyncPhase = .done
-
-    var didFinishCurrentSyncPhase: SyncPhase?
-    func finishCurrentSyncPhase(phase: SyncPhase) {
-        didFinishCurrentSyncPhase = phase
-    }
-
-    var didFailCurrentSyncPhase: SyncPhase?
-    func failCurrentSyncPhase(phase: SyncPhase) {
-        didFailCurrentSyncPhase = phase
-    }
-
-}

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
@@ -29,8 +29,6 @@ final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
 
     private var task: Task<Void, Never>?
 
-    var taskCompletion: (() -> Void)?
-
     public init(
         withManagedObjectContext managedObjectContext: NSManagedObjectContext,
         applicationStatus: ApplicationStatus,
@@ -76,7 +74,6 @@ final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
             }
 
             self.task = nil
-            self.taskCompletion?()
         }
 
         return nil

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
@@ -23,18 +23,18 @@ final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
 
     let syncPhase: SyncPhase = .evaluate1on1ConversationsForMLS
 
-    private unowned var syncStatus: SyncProgress
+    private unowned var syncProgress: SyncProgress
 
-    private var isSyncing: Bool { syncStatus.currentSyncPhase == syncPhase }
+    private var isSyncing: Bool { syncProgress.currentSyncPhase == syncPhase }
 
     private var task: Task<Void, Never>?
 
     public init(
         withManagedObjectContext managedObjectContext: NSManagedObjectContext,
         applicationStatus: ApplicationStatus,
-        syncStatus: SyncProgress
+        syncProgress: SyncProgress
     ) {
-        self.syncStatus = syncStatus
+        self.syncProgress = syncProgress
 
         super.init(withManagedObjectContext: managedObjectContext, applicationStatus: applicationStatus)
     }
@@ -81,11 +81,11 @@ final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
 
     private func failCurrentSyncPhase(errorMessage: String) {
         WireLogger.conversation.error("EvaluateOneOnOneConversationsStrategy: \(errorMessage)!")
-        syncStatus.failCurrentSyncPhase(phase: syncPhase)
+        syncProgress.failCurrentSyncPhase(phase: syncPhase)
     }
 
     private func finishCurrentSyncPhase() {
         WireLogger.conversation.error("EvaluateOneOnOneConversationsStrategy: finishCurrentSyncPhase!")
-        syncStatus.finishCurrentSyncPhase(phase: syncPhase)
+        syncProgress.finishCurrentSyncPhase(phase: syncPhase)
     }
 }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
@@ -17,12 +17,13 @@
 //
 
 import Foundation
+import WireRequestStrategy
 
 final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
 
     let syncPhase: SyncPhase = .evaluate1on1ConversationsForMLS
 
-    private unowned var syncStatus: SyncStatus
+    private unowned var syncStatus: SyncProgress
 
     private var isSyncing: Bool { syncStatus.currentSyncPhase == syncPhase }
 
@@ -33,7 +34,7 @@ final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
     public init(
         withManagedObjectContext managedObjectContext: NSManagedObjectContext,
         applicationStatus: ApplicationStatus,
-        syncStatus: SyncStatus
+        syncStatus: SyncProgress
     ) {
         self.syncStatus = syncStatus
 

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -324,7 +324,7 @@ mlsService: mlsService,
             EvaluateOneOnOneConversationsStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,
-                syncStatus: applicationStatusDirectory.syncStatus
+                syncProgress: applicationStatusDirectory.syncStatus
             )
         ]
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategyTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 import WireDataModelSupport
+import WireRequestStrategySupport
 @testable import WireSyncEngine
 
 final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
@@ -29,8 +30,7 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
 
     private var mockApplicationStatus: MockApplicationStatus!
     private var mockCoreDataStack: CoreDataStack!
-    private var mockLastEventIDRepository: LastEventIDRepository!
-    private var mockSyncStatus: MockSyncStatus!
+    private var mockSyncStatus: MockSyncProgress!
 
     private var syncContext: NSManagedObjectContext { mockCoreDataStack.syncContext }
 
@@ -41,18 +41,10 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
         mockCoreDataStack = try await coreDataHelper.createStack()
 
         mockApplicationStatus = MockApplicationStatus()
-        mockLastEventIDRepository = LastEventIDRepository(
-            userID: UUID(),
-            sharedUserDefaults: .temporary()
-        )
-        mockSyncStatus = MockSyncStatus(
-            managedObjectContext: syncContext,
-            lastEventIDRepository: mockLastEventIDRepository
-        )
+        mockSyncStatus = MockSyncProgress()
     }
 
     override func tearDown() async throws {
-        mockLastEventIDRepository = nil
         mockSyncStatus = nil
         mockApplicationStatus = nil
 
@@ -65,11 +57,7 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
 
     func testInitialState() {
         // given
-        let strategy = EvaluateOneOnOneConversationsStrategy(
-            withManagedObjectContext: syncContext,
-            applicationStatus: mockApplicationStatus,
-            syncStatus: mockSyncStatus
-        )
+        let strategy = makeStrategy()
 
         // when
         // then
@@ -78,15 +66,14 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
 
     func testNextRequest_givenSyncPhaseEvaluate1on1ConversationsForMLS_thenCallFinishSync() async {
         // given
-        mockSyncStatus.mockPhase = .evaluate1on1ConversationsForMLS
-
         let expectation = self.expectation(description: "EvaluateOneOnOneConversationsStrategy")
-        let strategy = EvaluateOneOnOneConversationsStrategy(
-            withManagedObjectContext: syncContext,
-            applicationStatus: mockApplicationStatus,
-            syncStatus: mockSyncStatus
-        )
-        strategy.taskCompletion = { expectation.fulfill() }
+
+        mockSyncStatus.currentSyncPhase = .evaluate1on1ConversationsForMLS
+        mockSyncStatus.finishCurrentSyncPhasePhase_MockMethod = { _ in
+            expectation.fulfill()
+        }
+
+        let strategy = makeStrategy()
 
         // when
         XCTAssertNil(strategy.nextRequest(for: apiVersion))
@@ -94,21 +81,20 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
         // then
         await fulfillment(of: [expectation], timeout: 0.1)
 
-        XCTAssertTrue(mockSyncStatus.didCallFinishCurrentSyncPhase)
+        XCTAssertEqual(mockSyncStatus.finishCurrentSyncPhasePhase_Invocations.count, 1)
     }
 
     func testNextRequest_givenOtherSyncPhase_thenDoNotCallFinishSync() async {
         // given
-        mockSyncStatus.mockPhase = .fetchingLastUpdateEventID
-
         let expectation = self.expectation(description: "EvaluateOneOnOneConversationsStrategy")
         expectation.isInverted = true
-        let strategy = EvaluateOneOnOneConversationsStrategy(
-            withManagedObjectContext: syncContext,
-            applicationStatus: mockApplicationStatus,
-            syncStatus: mockSyncStatus
-        )
-        strategy.taskCompletion = { expectation.fulfill() }
+
+        mockSyncStatus.currentSyncPhase = .fetchingLastUpdateEventID
+        mockSyncStatus.finishCurrentSyncPhasePhase_MockMethod = { _ in
+            expectation.fulfill()
+        }
+
+        let strategy = makeStrategy()
 
         // when
         XCTAssertNil(strategy.nextRequest(for: apiVersion))
@@ -116,6 +102,16 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
         // then
         await fulfillment(of: [expectation], timeout: 0.1)
 
-        XCTAssertFalse(mockSyncStatus.didCallFinishCurrentSyncPhase)
+        XCTAssert(mockSyncStatus.finishCurrentSyncPhasePhase_Invocations.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeStrategy() -> EvaluateOneOnOneConversationsStrategy {
+        EvaluateOneOnOneConversationsStrategy(
+            withManagedObjectContext: syncContext,
+            applicationStatus: mockApplicationStatus,
+            syncStatus: mockSyncStatus
+        )
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategyTests.swift
@@ -111,7 +111,7 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
         EvaluateOneOnOneConversationsStrategy(
             withManagedObjectContext: syncContext,
             applicationStatus: mockApplicationStatus,
-            syncStatus: mockSyncStatus
+            syncProgress: mockSyncStatus
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-5812" title="WPB-5812" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />WPB-5812</a>  [iOS] Implement the logic for evaluating all 1:1 conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----


# What's new in this PR?

### Issues

💡 merges in epic branch #944 

Recognised that we should use the protocol `SyncProgress` instead of `SyncStatus` class. Then we can use sorcery to build mocks and delete the custom ones.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Run test suite.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
