### PR TITLE
fix: snapshot tests of ProfileDetailsViewController [WPB-765]

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
@@ -49,8 +49,8 @@ final class TwoLineTitleView: UIView {
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 4),
-            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
             subtitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             subtitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             subtitleLabel.bottomAnchor.constraint(equalTo: bottomAnchor)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/UserImageView/BadgeUserImageView.swift
@@ -16,13 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-/**
- * A user image view that can display a badge on top for different connection states.
- */
 import UIKit
 import WireCommonComponents
 import WireSyncEngine
 
+/// A user image view that can display a badge on top for different connection states.
 final class BadgeUserImageView: UserImageView {
 
     /// The color of the badge.
@@ -76,6 +74,12 @@ final class BadgeUserImageView: UserImageView {
         badgeShadow.translatesAutoresizingMaskIntoConstraints = false
         badgeImageView.translatesAutoresizingMaskIntoConstraints = false
 
+        // default size if no image is set
+        let badgeImageViewWidthConstraint = badgeImageView.widthAnchor.constraint(equalToConstant: 0)
+        badgeImageViewWidthConstraint.priority = .defaultLow
+        let badgeImageViewHeightConstraint = badgeImageView.heightAnchor.constraint(equalToConstant: 0)
+        badgeImageViewHeightConstraint.priority = .defaultLow
+
         NSLayoutConstraint.activate([
             // badgeShadow
             badgeShadow.leadingAnchor.constraint(equalTo: container.leadingAnchor),
@@ -83,6 +87,8 @@ final class BadgeUserImageView: UserImageView {
             badgeShadow.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             badgeShadow.bottomAnchor.constraint(equalTo: container.bottomAnchor),
             // badgeImageView
+            badgeImageViewWidthConstraint,
+            badgeImageViewHeightConstraint,
             badgeImageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             badgeImageView.centerYAnchor.constraint(equalTo: container.centerYAnchor)
         ])
@@ -127,7 +133,7 @@ final class BadgeUserImageView: UserImageView {
      * - parameter animated: Whether to animate the change.
      */
 
-    func updateIconView(with icon: StyleKitIcon?, animated: Bool) {
+    private func updateIconView(with icon: StyleKitIcon?, animated: Bool) {
         badgeImageView.image = nil
 
         if let icon = icon {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -34,7 +34,12 @@ final class ProfileHeaderViewController: UIViewController {
     private let user: UserType
 
     private var userStatus: UserStatus {
-        didSet { updateNameAndVerificationStatus() }
+        didSet {
+            nameLabel.text = userStatus.name
+            userStatusViewController.userStatus = userStatus
+            e2eiCertifiedImageView.isHidden = !userStatus.isCertified
+            proteusVerifiedImageView.isHidden = !userStatus.isVerified
+        }
     }
 
     private let userSession: UserSession
@@ -205,7 +210,6 @@ final class ProfileHeaderViewController: UIViewController {
         updateGroupRoleIndicator()
         updateHandleLabel()
         updateTeamLabel()
-        updateNameAndVerificationStatus()
 
         addChild(userStatusViewController)
 
@@ -312,12 +316,6 @@ final class ProfileHeaderViewController: UIViewController {
         updateImageButton()
         updateAvailabilityVisibility()
         warningView.update(withUser: user)
-    }
-
-    private func updateNameAndVerificationStatus() {
-        userStatusViewController.userStatus = userStatus
-        e2eiCertifiedImageView.isHidden = !userStatus.isCertified
-        proteusVerifiedImageView.isHidden = !userStatus.isVerified
     }
 
     private func updateHandleLabel() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-765" title="WPB-765" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-765</a>  [iOS] 5.3.16 Indicate verified user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The name of the user was not set after resolving merge conflicts. This PR fixes it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
