### PR TITLE
fix: accessing core data instance on the right context

### DIFF
--- a/wire-ios-data-model/Source/Model/FeatureConfig/Feature.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/Feature.swift
@@ -136,9 +136,11 @@ public class Feature: ZMManagedObject {
         fetchRequest.predicate = NSPredicate(format: "nameValue == %@", name.rawValue)
         fetchRequest.fetchLimit = 2
 
-        let results = context.fetchOrAssert(request: fetchRequest)
-        require(results.count <= 1, "More than instance for feature: \(name.rawValue)")
-        return results.first
+        return context.performAndWait {
+            let results = context.fetchOrAssert(request: fetchRequest)
+            require(results.count <= 1, "More than instance for feature: \(name.rawValue)")
+            return results.first
+        }
     }
 
     /// Update the feature instance with the given name.

--- a/wire-ios-data-model/Source/Model/FeatureConfig/Feature.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/Feature.swift
@@ -136,11 +136,9 @@ public class Feature: ZMManagedObject {
         fetchRequest.predicate = NSPredicate(format: "nameValue == %@", name.rawValue)
         fetchRequest.fetchLimit = 2
 
-        return context.performAndWait {
-            let results = context.fetchOrAssert(request: fetchRequest)
-            require(results.count <= 1, "More than instance for feature: \(name.rawValue)")
-            return results.first
-        }
+        let results = context.fetchOrAssert(request: fetchRequest)
+        require(results.count <= 1, "More than instance for feature: \(name.rawValue)")
+        return results.first
     }
 
     /// Update the feature instance with the given name.

--- a/wire-ios-data-model/Source/UseCases/IsSelfUserVerifiedUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/IsSelfUserVerifiedUseCase.swift
@@ -40,9 +40,7 @@ public struct IsSelfUserProteusVerifiedUseCase: IsSelfUserProteusVerifiedUseCase
 
     public func invoke() async -> Bool {
         await context.perform(schedule: schedule) {
-            ZMUser.selfUser(in: context)
-                .allClients
-                .allSatisfy(\.verified)
+            ZMUser.selfUser(in: context).isVerified
         }
     }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+RecurringAction.swift
@@ -84,15 +84,13 @@ extension ZMUserSession {
     var refreshFederationCertificatesAction: RecurringAction {
         .init(id: #function, interval: .oneDay) { [weak self] in
             guard
-                self?.e2eiFeature.isEnabled == true,
-                let e2eiRepository = self?.e2eiRepository
-            else {
-                return
-            }
+                let self,
+                viewContext.performAndWait({ self.e2eiFeature.isEnabled })
+            else { return }
 
             Task {
                 do {
-                    try await e2eiRepository.fetchFederationCertificate()
+                    try await self.e2eiRepository.fetchFederationCertificate()
                 } catch {
                     WireLogger.e2ei.error("Failed to refresh federation certificates: \(error)")
                 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Fixes a bug on app start where `Feature` is accessed from the wrong thread.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
