### PR TITLE
fix: crash after enrollment 

### DIFF
--- a/wire-ios-data-model/Source/E2EIdentity/E2eISetupService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2eISetupService.swift
@@ -46,6 +46,10 @@ public protocol E2eISetupServiceInterface {
 /// This class setups e2eIdentity object from CoreCrypto.
 public final class E2eISetupService: E2eISetupServiceInterface {
 
+    // TODO: temporary workaround for a crash WPB-6761
+    // The E2eiEnrollment cause a memory corruption when it deinits so we hold on to it forever.
+    private static var enrollment: E2eiEnrollment?
+
     // MARK: - Properties
 
     private let coreCryptoProvider: CoreCryptoProviderProtocol
@@ -83,13 +87,15 @@ public final class E2eISetupService: E2eISetupServiceInterface {
         isUpgradingClient: Bool
     ) async throws -> E2eiEnrollment {
         do {
-            return try await setupNewActivationOrRotate(
+            let enrollment = try await setupNewActivationOrRotate(
                 clientID: clientID,
                 userName: userName,
                 handle: handle,
                 teamId: teamId,
                 isUpgradingClient: isUpgradingClient
             )
+            Self.enrollment = enrollment
+            return enrollment
         } catch {
             throw Failure.failedToSetupE2eIClient(error)
         }

--- a/wire-ios-data-model/Source/E2EIdentity/E2eISetupService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2eISetupService.swift
@@ -46,7 +46,7 @@ public protocol E2eISetupServiceInterface {
 /// This class setups e2eIdentity object from CoreCrypto.
 public final class E2eISetupService: E2eISetupServiceInterface {
 
-    // TODO: temporary workaround for a crash WPB-6761
+    // TODO: [WPB-6761] temporary workaround for a crash 
     // The E2eiEnrollment cause a memory corruption when it deinits so we hold on to it forever.
     private static var enrollment: E2eiEnrollment?
 

--- a/wire-ios-data-model/Tests/UseCases/IsSelfUserE2EICertifiedUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/IsSelfUserE2EICertifiedUseCaseTests.swift
@@ -163,7 +163,10 @@ extension WireIdentity {
             domain: "D",
             certificate: "E",
             status: status,
-            thumbprint: "F"
+            thumbprint: "F",
+            serialNumber: "G",
+            notBefore: 0,
+            notAfter: 0
         )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The app crashes after enrolling into e2ei

### Causes

Something corrupts the memory when the `E2eiEnrollment` gets deinited

### Solutions

As temporary work-around we hold on to the `E2eiEnrollment` forever thus avoid the crash.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
