### PR TITLE
fix: init MLS with basic

### DIFF
--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -77,7 +77,7 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         WireLogger.mls.info("Initialising MLS client with basic credentials")
         _ = try await coreCrypto().perform { coreCrypto in
             try await coreCrypto.mlsInit(
-                clientId: Data(mlsClientID.clientID.utf8),
+                clientId: Data(mlsClientID.rawValue.utf8),
                 ciphersuites: [CiphersuiteName.default.rawValue],
                 nbKeyPackage: nil
             )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Logging in with without E2EI is broken

### Causes

We pass bad client ID when Initialising MLS with basic credentials.

### Solutions

Pass correct client ID 

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
