### PR TITLE
fix: use x509 credentials when e2ei is enabled

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -253,10 +253,11 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
 
             case .joinGroup(let groupInfo):
                 let conversationInitBundle = try await coreCrypto.perform {
-                    try await $0.joinByExternalCommit(
+                    let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: CiphersuiteName.default.rawValue)
+                    return try await $0.joinByExternalCommit(
                         groupInfo: groupInfo,
                         customConfiguration: .init(keyRotationSpan: nil, wirePolicy: nil),
-                        credentialType: .basic
+                        credentialType: e2eiIsEnabled ? .x509 : .basic
                     )
                 }
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -460,9 +460,10 @@ public final class MLSService: MLSServiceInterface {
             )
 
             try await coreCrypto.perform {
+                let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: CiphersuiteName.default.rawValue)
                 try await $0.createConversation(
                     conversationId: groupID.data,
-                    creatorCredentialType: .basic,
+                    creatorCredentialType: e2eiIsEnabled ? .x509 : .basic,
                     config: config
                 )
             }
@@ -726,7 +727,13 @@ public final class MLSService: MLSServiceInterface {
         var keyPackages = [Data]()
 
         do {
-            keyPackages = try await coreCrypto.perform { try await $0.clientKeypackages(ciphersuite: CiphersuiteName.default.rawValue, credentialType: .basic, amountRequested: amountRequested) }
+            keyPackages = try await coreCrypto.perform {
+                let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: CiphersuiteName.default.rawValue)
+                return try await $0.clientKeypackages(
+                    ciphersuite: CiphersuiteName.default.rawValue,
+                    credentialType: e2eiIsEnabled ? .x509 : .basic,
+                    amountRequested: amountRequested
+                ) }
 
         } catch let error {
             logger.warn("failed to generate new key packages: \(String(describing: error))")

--- a/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
@@ -35,6 +35,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
     override func setUp() {
         super.setUp()
         mockCoreCrypto = MockCoreCryptoProtocol()
+        mockCoreCrypto.e2eiIsEnabledCiphersuite_MockValue = false
         mockSafeCoreCrypto = MockSafeCoreCrypto(coreCrypto: mockCoreCrypto)
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
         mockCoreCryptoProvider.coreCrypto_MockValue = mockSafeCoreCrypto

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -65,6 +65,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         privateUserDefaults = PrivateUserDefaults(userID: userIdentifier, storage: userDefaultsTestSuite)
         mockSubconversationGroupIDRepository = MockSubconversationGroupIDRepositoryInterface()
 
+        mockCoreCrypto.e2eiIsEnabledCiphersuite_MockValue = false
         mockCoreCrypto.clientValidKeypackagesCountCiphersuiteCredentialType_MockMethod = { _, _ in
             return 100
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After enrolling our certificate are still not valid

### Causes (Optional)

We are still uploading key packages and joining existing conversations using basic credentials

### Solutions

Use x509 credentials if e2ei is enabled

### Notes

Ideally we should test both variants, but that's very clunky right now without introducing an abstraction layer above CC where logic like this could live.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
