### PR TITLE
fix: prevent crash converting time interval to unsigned integer

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1335,7 +1335,10 @@ public final class MLSService: MLSServiceInterface {
                 await withTaskGroup(of: Void.self) { group in
                     group.addTask { [self] in
                         do {
-                            try await Task.sleep(nanoseconds: timestamp.timeIntervalSinceNow.nanoseconds)
+                            let timeIntervalSinceNow = timestamp.timeIntervalSinceNow
+                            if timeIntervalSinceNow > 0 {
+                                try await Task.sleep(nanoseconds: timeIntervalSinceNow.nanoseconds)
+                            }
                             logger.info("scheduled commit is ready, committing...")
                             try await commitPendingProposals(in: groupID)
                         } catch {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In the playtest a crash resulted in calling timeInterval.nanoseconds, but the timeInterval value was negative.
This PR adds a check before converting.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
