### PR TITLE
fix: self certificate was always shown as invalid

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession+Clients.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession+Clients.swift
@@ -43,7 +43,7 @@ extension ZMUserSession {
     @objc
     public func fetchAllClients() {
         syncManagedObjectContext.performGroupedBlock {
-            self.applicationStatusDirectory.clientUpdateStatus.needsToFetchClients(andVerifySelfClient: true)
+            self.applicationStatusDirectory.clientUpdateStatus.needsToFetchClients(andVerifySelfClient: false)
             RequestAvailableNotification.notifyNewRequestsAvailable(self)
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Integration/ClientManagementTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/ClientManagementTests.m
@@ -124,8 +124,7 @@
     NSArray *fetchedClients = self.observer.fetchedClients;
     
     XCTAssertNotEqualObjects(fetchedClients, selfUserClients);
-    XCTAssertEqual(fetchedClients.count, 2u);
-    XCTAssertFalse([fetchedClients containsObject:selfUser.selfClient]);
+    XCTAssertEqual(fetchedClients.count, 3u);
     XCTAssertNil(self.observer.fetchError);
     XCTAssertTrue(self.observer.finishedFetching);
 }
@@ -142,7 +141,7 @@
     WaitForAllGroupsToBeEmpty(0.5);
     
     NSArray *fetchClients = self.observer.fetchedClients;
-    XCTAssertEqual(fetchClients.count, 2u);
+    XCTAssertEqual(fetchClients.count, 3u);
     XCTAssertTrue(self.observer.finishedFetching);
     XCTAssertNil(self.observer.fetchError);
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
@@ -626,6 +626,7 @@ class ZMClientRegistrationStatusTests: MessagingTest {
 
             // when
             sut.didRegisterProteusClient(selfUserClient)
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
             // then
             XCTAssertEqual(self.sut.currentPhase, .registeringMLSClient)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -523,7 +523,7 @@ final class ClientListViewController: UIViewController,
                         selfClient.e2eIdentityCertificate = certificates.first(where: {
                             $0.clientId == mlsResolver.mlsClientId(for: selfClient)?.rawValue
                         })
-                        if certificates.isNonEmpty {
+                        if certificates.isEmpty {
                             selfClient.e2eIdentityCertificate = selfClient.notActivatedE2EIdenityCertificate()
                         }
                         selfClient.mlsThumbPrint = selfClient.e2eIdentityCertificate?.mlsThumbprint ?? selfClient.mlsPublicKeys.ed25519

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -522,10 +522,7 @@ final class ClientListViewController: UIViewController,
                     if let selfClient = selfClient {
                         selfClient.e2eIdentityCertificate = certificates.first(where: {
                             $0.clientId == mlsResolver.mlsClientId(for: selfClient)?.rawValue
-                        })
-                        if certificates.isEmpty {
-                            selfClient.e2eIdentityCertificate = selfClient.notActivatedE2EIdenityCertificate()
-                        }
+                        }) ?? selfClient.notActivatedE2EIdenityCertificate()
                         selfClient.mlsThumbPrint = selfClient.e2eIdentityCertificate?.mlsThumbprint ?? selfClient.mlsPublicKeys.ed25519
                     }
                     return updatedUserClients


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Self certificate is always shown as invalid

### Causes

1. We don't include self client retrieving certificates
2. Inverted logic which set certificate as invalid if the certificate is available

### Solutions

1. Calling `needsToFetchClients` with  `andVerifySelfClient = false` will include the self client. We don't need to verify self client every time we list the self devices.
2. Fix inverted logic

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
