### PR TITLE
feat: restore fetch members - WPB-6485

### DIFF
--- a/wire-ios-request-strategy/Sources/Protocols/SyncProgress.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/SyncProgress.swift
@@ -22,6 +22,7 @@ import Foundation
 
     case fetchingLastUpdateEventID
     case fetchingTeams
+    case fetchingTeamMembers
     case fetchingTeamRoles
     case fetchingConnections
     case fetchingConversations
@@ -58,6 +59,8 @@ import Foundation
             return "fetchingConversations"
         case .fetchingTeams:
             return "fetchingTeams"
+        case .fetchingTeamMembers:
+            return "fetchingTeamMembers"
         case .fetchingTeamRoles:
             return "fetchingTeamRoles"
         case .fetchingUsers:

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -66,10 +66,10 @@ public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, 
             return
         }
 
-        if !payload.hasMore {
-            payload.members.forEach { (membershipPayload) in
-                membershipPayload.createOrUpdateMember(team: team, in: managedObjectContext)
-            }
+        // as per WPB-6485 we ignore the hasMore and download only the first page
+        // hence the ZMSingleRequestSync
+        payload.members.forEach { (membershipPayload) in
+            membershipPayload.createOrUpdateMember(team: team, in: managedObjectContext)
         }
 
         completeSyncPhase()

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategy.swift
@@ -1,0 +1,81 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Downloads all team members during the slow sync.
+
+public final class TeamMembersDownloadRequestStrategy: AbstractRequestStrategy, ZMSingleRequestTranscoder {
+
+    let syncStatus: SyncStatus
+    var sync: ZMSingleRequestSync!
+
+    public init(withManagedObjectContext managedObjectContext: NSManagedObjectContext,
+                applicationStatus: ApplicationStatus,
+                syncStatus: SyncStatus) {
+
+        self.syncStatus = syncStatus
+
+        super.init(withManagedObjectContext: managedObjectContext,
+                   applicationStatus: applicationStatus)
+
+        configuration = [.allowsRequestsDuringSlowSync]
+        sync = ZMSingleRequestSync(singleRequestTranscoder: self, groupQueue: managedObjectContext)
+    }
+
+    override public func nextRequestIfAllowed(for apiVersion: APIVersion) -> ZMTransportRequest? {
+        guard syncStatus.currentSyncPhase == .fetchingTeamMembers else { return nil }
+
+        sync.readyForNextRequestIfNotBusy()
+
+        return sync.nextRequest(for: apiVersion)
+    }
+
+// MARK: - ZMSingleRequestTranscoder
+
+    public func request(for sync: ZMSingleRequestSync, apiVersion: APIVersion) -> ZMTransportRequest? {
+        guard let teamID = ZMUser.selfUser(in: managedObjectContext).teamIdentifier else {
+            completeSyncPhase() // Skip sync phase if user doesn't belong to a team
+            return nil
+        }
+        return ZMTransportRequest(getFromPath: "/teams/\(teamID.transportString())/members", apiVersion: apiVersion.rawValue)
+    }
+
+    public func didReceive(_ response: ZMTransportResponse, forSingleRequest sync: ZMSingleRequestSync) {
+        guard
+            response.result == .success,
+            let team = ZMUser.selfUser(in: managedObjectContext).team,
+            let rawData = response.rawData,
+            let payload = MembershipListPayload(rawData)
+        else {
+            return
+        }
+
+        if !payload.hasMore {
+            payload.members.forEach { (membershipPayload) in
+                membershipPayload.createOrUpdateMember(team: team, in: managedObjectContext)
+            }
+        }
+
+        completeSyncPhase()
+    }
+
+    func completeSyncPhase() {
+        syncStatus.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
+    }
+}

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -265,6 +265,10 @@ mlsService: mlsService,
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,
                 syncStatus: applicationStatusDirectory.syncStatus),
+            TeamMembersDownloadRequestStrategy(
+                withManagedObjectContext: syncMOC,
+                applicationStatus: applicationStatusDirectory,
+                syncStatus: applicationStatusDirectory.syncStatus),
             PermissionsDownloadRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory),

--- a/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
@@ -289,10 +289,10 @@ extension SyncStatus {
             let data = try JSONEncoder().encode(info)
             let jsonString = String(data: data, encoding: .utf8)
             let message = "SYNC_STATUS: \(jsonString ?? self.description)"
-            RemoteMonitoring.remoteLogger?.log(message: message, error: nil, attributes: nil, level: .debug)
+            WireLogger.sync.info(message)
         } catch {
             let message = "SYNC_STATUS: \(self.description)"
-            RemoteMonitoring.remoteLogger?.log(message: message, error: nil, attributes: nil, level: .error)
+            WireLogger.sync.error(message)
         }
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategyTests.swift
@@ -124,7 +124,6 @@ class TeamMembersDownloadRequestStrategyTests: MessagingTest {
     }
 
     func testThatItFinishSyncStep_OnSuccessfulResponse() {
-//        var team: Team!
 
         syncMOC.performGroupedBlockAndWait {
             // given

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamMembersDownloadRequestStrategyTests.swift
@@ -103,7 +103,7 @@ class TeamMembersDownloadRequestStrategyTests: MessagingTest {
 
             // then
             XCTAssertNotNil(request)
-            XCTAssertEqual(request?.path, "/teams/\(teamID.transportString())/members")
+            XCTAssertEqual(request?.path, "/teams/\(teamID.transportString())/members?maxResults=2000")
         }
     }
 
@@ -171,14 +171,15 @@ class TeamMembersDownloadRequestStrategyTests: MessagingTest {
         }
     }
 
-    func testThatItDoesNotCreateTeamMembers_WhenHasMoreIsTrue() {
+    func testThatItCreatesTeamMembers_WhenHasMoreIsTrue() {
         var team: Team!
-
+        var initialTeamMembersCount = 0
         syncMOC.performGroupedBlockAndWait {
             // given
             self.mockApplicationStatus.mockSynchronizationState = .slowSyncing
             self.mockSyncStatus.mockPhase = .fetchingTeamMembers
             team = self.createTeam()
+            initialTeamMembersCount = team.members.count
 
             guard let request = self.sut.nextRequest(for: .v0) else { return XCTFail("No request generated") }
 
@@ -191,7 +192,7 @@ class TeamMembersDownloadRequestStrategyTests: MessagingTest {
 
         syncMOC.performGroupedBlockAndWait {
             // then
-            XCTAssertEqual(team.members.count, 1)
+            XCTAssertEqual(team.members.count, initialTeamMembersCount + 1)
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
@@ -70,6 +70,7 @@ final class SyncStatusTests: MessagingTest {
     private var syncPhases: [SyncPhase] {
         return [.fetchingLastUpdateEventID,
                 .fetchingTeams,
+                .fetchingTeamMembers,
                 .fetchingTeamRoles,
                 .fetchingConnections,
                 .fetchingConversations,
@@ -109,6 +110,8 @@ final class SyncStatusTests: MessagingTest {
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertNil(lastEventIDRepository.fetchLastEventID())
+        // then
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
         // then
         XCTAssertNil(lastEventIDRepository.fetchLastEventID())
         // when
@@ -160,6 +163,10 @@ final class SyncStatusTests: MessagingTest {
         // when
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingTeamMembers)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
+        // then
         XCTAssertEqual(sut.currentSyncPhase, .fetchingTeamRoles)
         // when
         sut.finishCurrentSyncPhase(phase: .fetchingTeamRoles)
@@ -198,6 +205,8 @@ final class SyncStatusTests: MessagingTest {
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishQuickSync)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
         // then
         XCTAssertFalse(mockSyncDelegate.didCallFinishQuickSync)
         // when
@@ -461,6 +470,8 @@ extension SyncStatusTests {
         sut.finishCurrentSyncPhase(phase: .fetchingTeams)
         // then
         XCTAssertNotEqual(lastEventIDRepository.fetchLastEventID(), newID)
+        // when
+        sut.finishCurrentSyncPhase(phase: .fetchingTeamMembers)
         // then
         XCTAssertNotEqual(lastEventIDRepository.fetchLastEventID(), newID)
         // when

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0145AE892B11551C0097E3B8 /* AutoMockable.manual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BA78702B04D98A006D8CCF /* AutoMockable.manual.swift */; };
 		0145AE8B2B1155690097E3B8 /* WireSyncEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 549815931A43232400A7CE2E /* WireSyncEngine.framework */; };
 		0145AE902B1155760097E3B8 /* WireSyncEngineSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0145AE812B1154010097E3B8 /* WireSyncEngineSupport.framework */; };
+		0153CA9E2B8651FD000000CA /* TeamMembersDownloadRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0153CA9D2B8651FD000000CA /* TeamMembersDownloadRequestStrategy.swift */; };
+		0153CAA02B86550E000000CA /* TeamMembersDownloadRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0153CA9F2B86550E000000CA /* TeamMembersDownloadRequestStrategyTests.swift */; };
 		017ABBB62995278C0004C243 /* SlowSyncTests+NotificationsV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017ABBB52995278C0004C243 /* SlowSyncTests+NotificationsV3.swift */; };
 		018A3DBC2B07998400EB3D6B /* GetUserClientFingerprintUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018A3DBB2B07998400EB3D6B /* GetUserClientFingerprintUseCase.swift */; };
 		018A3DBF2B0799CA00EB3D6B /* GetUserClientFingerprintUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018A3DBE2B0799CA00EB3D6B /* GetUserClientFingerprintUseCaseTests.swift */; };
@@ -737,6 +739,8 @@
 		0145AE812B1154010097E3B8 /* WireSyncEngineSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireSyncEngineSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0145AE832B1154010097E3B8 /* WireSyncEngineSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WireSyncEngineSupport.h; sourceTree = "<group>"; };
 		014C7AA42ADD4DEA00CDEC45 /* AutoMockable.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
+		0153CA9D2B8651FD000000CA /* TeamMembersDownloadRequestStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamMembersDownloadRequestStrategy.swift; sourceTree = "<group>"; };
+		0153CA9F2B86550E000000CA /* TeamMembersDownloadRequestStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamMembersDownloadRequestStrategyTests.swift; sourceTree = "<group>"; };
 		017ABBB52995278C0004C243 /* SlowSyncTests+NotificationsV3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SlowSyncTests+NotificationsV3.swift"; sourceTree = "<group>"; };
 		018A3DBB2B07998400EB3D6B /* GetUserClientFingerprintUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetUserClientFingerprintUseCase.swift; sourceTree = "<group>"; };
 		018A3DBE2B0799CA00EB3D6B /* GetUserClientFingerprintUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetUserClientFingerprintUseCaseTests.swift; sourceTree = "<group>"; };
@@ -2049,6 +2053,7 @@
 			children = (
 				BF491CD01F03D7CF0055EE44 /* PermissionsDownloadRequestStrategy.swift */,
 				F9ABE84B1EFD568B00D83214 /* TeamDownloadRequestStrategy.swift */,
+				0153CA9D2B8651FD000000CA /* TeamMembersDownloadRequestStrategy.swift */,
 				A913C02123A7EDFA0048CE74 /* TeamRolesDownloadRequestStrategy.swift */,
 				F9ABE84D1EFD568B00D83214 /* TeamRequestFactory.swift */,
 				16D9E8B922BCD39200FA463F /* LegalHoldRequestStrategy.swift */,
@@ -2094,6 +2099,7 @@
 				EF2CB12822D5E5BB00350B0A /* TeamImageAssetUpdateStrategyTests.swift */,
 				F148F66A1FBAFAF600BD6909 /* RegistrationStatusTestHelper.swift */,
 				EFC8281D1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift */,
+				0153CA9F2B86550E000000CA /* TeamMembersDownloadRequestStrategyTests.swift */,
 				EFC828211FB356CE00E27E21 /* RegistrationStatusTests.swift */,
 				F148F6681FBAF55800BD6909 /* TeamRegistrationStrategyTests.swift */,
 				168CF42C2007BCA0009FCB89 /* TeamInvitationRequestStrategyTests.swift */,
@@ -3405,6 +3411,7 @@
 				54DE9BEF1DE760A900EFFB9C /* RandomHandleGeneratorTests.swift in Sources */,
 				F9C598AD1A0947B300B1F760 /* ZMBlacklistDownloaderTest.m in Sources */,
 				1672A653234784B500380537 /* LabelDownstreamRequestStrategyTests.swift in Sources */,
+				0153CAA02B86550E000000CA /* TeamMembersDownloadRequestStrategyTests.swift in Sources */,
 				874A16942052C64B001C6760 /* UserExpirationObserverTests.swift in Sources */,
 				16A702D01E92998100B8410D /* ApplicationStatusDirectoryTests.swift in Sources */,
 				093694451BA9633300F36B3A /* UserClientRequestFactoryTests.swift in Sources */,
@@ -3495,6 +3502,7 @@
 				06025664248E5BC700E060E1 /* (null) in Sources */,
 				EE5FEF0521E8948F00E24F7F /* ZMUserSession+DarwinNotificationCenter.swift in Sources */,
 				549815DC1A432BC700A7CE2E /* NSError+ZMUserSession.m in Sources */,
+				0153CA9E2B8651FD000000CA /* TeamMembersDownloadRequestStrategy.swift in Sources */,
 				1662B0F723D9B29C00B8C7C5 /* UnauthenticatedSession+DomainLookup.swift in Sources */,
 				63C5322027FDB4C4009DFFF4 /* BuildType.swift in Sources */,
 				5E9D326F2109C1740032FB06 /* CompanyLoginErrorCode.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6485" title="WPB-6485" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-6485</a>  [iOS] Fetch first page of team members during slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

Restore fetching team members during slow sync. For more details, see ticket.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

Also log sync phase on device when datadog is off