### PR TITLE
fix: move db setup code into ModelHelper [WPB-765]

### DIFF
--- a/wire-ios-data-model/Support/Sources/ModelHelper.swift
+++ b/wire-ios-data-model/Support/Sources/ModelHelper.swift
@@ -23,11 +23,21 @@ import WireDataModel
 
 public struct ModelHelper {
 
-    public init() {
-
-    }
+    public init() {}
 
     // MARK: - Users
+
+    @discardableResult
+    public func createSelfUser(
+        id: UUID = .init(),
+        domain: String? = nil,
+        in context: NSManagedObjectContext
+    ) -> ZMUser {
+        let selfUser = ZMUser.selfUser(in: context)
+        selfUser.remoteIdentifier = id
+        selfUser.domain = domain
+        return selfUser
+    }
 
     @discardableResult
     public func createUser(
@@ -39,6 +49,32 @@ public struct ModelHelper {
         user.remoteIdentifier = id
         user.domain = domain
         return user
+    }
+
+    // MARK: - Clients
+
+    @discardableResult
+    public func createSelfClient(
+        id: UUID = .init(),
+        in context: NSManagedObjectContext
+    ) -> UserClient {
+        let selfClient = UserClient.insertNewObject(in: context)
+        selfClient.remoteIdentifier = id.transportString()
+        selfClient.user = .selfUser(in: context)
+        context.setPersistentStoreMetadata(selfClient.remoteIdentifier, key: ZMPersistedClientIdKey)
+        return selfClient
+    }
+
+    @discardableResult
+    public func createClient(
+        id: UUID = .init(),
+        for user: ZMUser
+    ) -> UserClient {
+        let context = user.managedObjectContext!
+        let otherClient = UserClient.insertNewObject(in: context)
+        otherClient.remoteIdentifier = id.transportString()
+        otherClient.user = user
+        return otherClient
     }
 
     // MARK: - Teams
@@ -126,4 +162,18 @@ public struct ModelHelper {
         return conversation
     }
 
+    @discardableResult
+    public func createMLSSelfConversation(
+        id: UUID = .init(),
+        mlsGroupID: MLSGroupID? = nil,
+        in context: NSManagedObjectContext
+    ) -> ZMConversation {
+        let conversation = ZMConversation.insertNewObject(in: context)
+        conversation.remoteIdentifier = id
+        conversation.mlsGroupID = mlsGroupID
+        conversation.messageProtocol = .mls
+        conversation.mlsStatus = .ready
+        conversation.conversationType = .`self`
+        return conversation
+    }
 }

--- a/wire-ios-data-model/Tests/UseCases/IsSelfUserE2EICertifiedUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/IsSelfUserE2EICertifiedUseCaseTests.swift
@@ -120,36 +120,20 @@ final class IsSelfUserE2EICertifiedUseCaseTests: ZMBaseManagedObjectTest {
 
     private func setupUsersClientsAndConversation() {
         context.performAndWait {
-            setupMLSSelfConversation()
-            setupSelfUser()
-            setupClients()
+            let helper = ModelHelper()
+            helper.createMLSSelfConversation(
+                id: .init(uuidString: "11AE029E-AFFA-4B81-9095-497797C0C0FA")!,
+                mlsGroupID: .init(base64Encoded: "qE4EdglNFI53Cm4soIFZ/rUMVL4JfCgcE4eo86QVxSc="),
+                in: context
+            )
+            helper.createSelfUser(
+                id: .init(uuidString: "36DFE52F-157D-452B-A9C1-98F7D9C1815D")!,
+                domain: "example.com",
+                in: context
+            )
+            helper.createSelfClient(in: context)
+            helper.createClient(for: .selfUser(in: context))
         }
-    }
-
-    private func setupMLSSelfConversation() {
-        let conversation = ZMConversation.insertNewObject(in: context)
-        conversation.remoteIdentifier = .init(uuidString: "11AE029E-AFFA-4B81-9095-497797C0C0FA")
-        conversation.mlsGroupID = .init(base64Encoded: "qE4EdglNFI53Cm4soIFZ/rUMVL4JfCgcE4eo86QVxSc=")
-        conversation.messageProtocol = .mls
-        conversation.mlsStatus = .ready
-        conversation.conversationType = .`self`
-    }
-
-    private func setupSelfUser() {
-        let selfUser = ZMUser.selfUser(in: context)
-        selfUser.remoteIdentifier = .init(uuidString: "36DFE52F-157D-452B-A9C1-98F7D9C1815D")
-        selfUser.domain = "example.com"
-    }
-
-    private func setupClients() {
-        let selfClient = UserClient.insertNewObject(in: context)
-        selfClient.remoteIdentifier = UUID.create().uuidString
-        selfClient.user = .selfUser(in: context)
-        context.setPersistentStoreMetadata(selfClient.remoteIdentifier, key: ZMPersistedClientIdKey)
-
-        let otherClient = UserClient.insertNewObject(in: context)
-        otherClient.remoteIdentifier = UUID.create().uuidString
-        otherClient.user = .selfUser(in: context)
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-765" title="WPB-765" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-765</a>  [iOS] 5.3.16 Indicate verified user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Extends the `WireDataModel.ModelHelper` type so that more code can be shared between unit tests.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
