### PR TITLE
fix: proteus to mls migration fails to start and finish WPB-6799

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncUsersActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/SyncUsersActionHandler.swift
@@ -35,7 +35,7 @@ class SyncUsersActionHandler: ActionHandler<SyncUsersAction> {
 
     struct RequestPayload: Codable, Equatable {
 
-        let qualified_users: [QualifiedID]
+        let qualified_ids: [QualifiedID]
 
     }
 
@@ -62,7 +62,7 @@ class SyncUsersActionHandler: ActionHandler<SyncUsersAction> {
 
         case .v4, .v5, .v6:
             guard
-                let payloadData = RequestPayload(qualified_users: action.qualifiedIDs).payloadString()
+                let payloadData = RequestPayload(qualified_ids: action.qualifiedIDs).payloadString()
             else {
                 action.fail(with: .failedToEncodeRequestPayload)
                 return nil

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -144,7 +144,8 @@ public class ConversationRequestStrategy: AbstractRequestStrategy, ZMRequestGene
             CreateGroupConversationActionHandler(
                 context: managedObjectContext,
                 removeLocalConversationUseCase: removeLocalConversation
-            )
+            ),
+            UpdateConversationProtocolActionHandler(context: managedObjectContext)
         ])
 
         super.init(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6799" title="WPB-6799" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6799</a>  [iOS] unable to start or finish proteus to mls migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The migration from proteus to mls for any conversation can neither start nor be finalized.

### Causes

Starting the migration depends on successfully updating the conversation message protocol. The action to do this is `UpdateConversationProtocolAction`, which is sent, but never handled because its handler was never initialized.

Finalizing the migration depends on `SyncUsersAction` which always failed because the handler was posting an invalid request payload.

### Solutions

- Add the `UpdateConversationProtocolActionHandler` to the `ConversationRequestStrategy`
- Fix the request payload in the `SyncUsersActionHandler`

### Testing

#### How to Test

1. Start a migration, assert that it has started for all participants.
2. Finalize the migration, assert it has finalized for all participants.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
