### PR TITLE
fix: add spinner after accepting E2EI enrollment WPB-6793

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -901,6 +901,7 @@ extension AuthenticationCoordinator {
     }
 
     private func completeE2EIdentityEnrollment() {
+        executeActions([.showLoadingView])
         guard let session = statusProvider.sharedUserSession else { return }
         session.reportEndToEndIdentityEnrollmentSuccess()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6793" title="WPB-6793" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6793</a>  [iOS] - Inject certificate enrolment success screen at login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The OK button on the E2EI enrollment success screen seems unresponsive.

### Causes

After pressing the button we don't transition away until the slow sync is completed which may take awhile.

### Solutions

Show a spinner after pressing the button.

### Attachments

![Simulator Screenshot - iPhone 15 Pro - 2024-02-26 at 16 31 08](https://github.com/wireapp/wire-ios/assets/7156/6e28a601-3d58-419d-8b42-f7de3b8eb704)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
