### PR TITLE
fix: taskGroup inside for loop of commitPendingProposals

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1324,26 +1324,28 @@ public final class MLSService: MLSServiceInterface {
 
         logger.info("\(groupsWithPendingCommits.count) groups with scheduled pending proposals")
 
-        for (groupID, timestamp) in groupsWithPendingCommits {
-            if timestamp.isInThePast {
-                logger.info("commit scheduled in the past, committing...")
-                try await commitPendingProposals(in: groupID)
-            } else {
-                logger.info("commit scheduled in the future, waiting...")
-                // Committing proposals for each group is independent and should not wait for
-                // each other.
-                await withTaskGroup(of: Void.self) { group in
-                    group.addTask { [self] in
-                        do {
+        // Committing proposals for each group is independent and should not wait for
+        // each other.
+        await withTaskGroup(of: Void.self) { taskGroup in
+            for (groupID, timestamp) in groupsWithPendingCommits {
+                taskGroup.addTask { [self] in
+                    do {
+                        if timestamp.isInThePast {
+                            logger.info("commit scheduled in the past, committing...")
+                            try await commitPendingProposals(in: groupID)
+                        } else {
+                            logger.info("commit scheduled in the future, waiting...")
+
                             let timeIntervalSinceNow = timestamp.timeIntervalSinceNow
                             if timeIntervalSinceNow > 0 {
                                 try await Task.sleep(nanoseconds: timeIntervalSinceNow.nanoseconds)
                             }
                             logger.info("scheduled commit is ready, committing...")
                             try await commitPendingProposals(in: groupID)
-                        } catch {
-                            logger.error("failed to commit pending proposals: \(String(describing: error))")
                         }
+
+                    } catch {
+                        logger.error("failed to commit pending proposals: \(String(describing: error))")
                     }
                 }
             }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1077,14 +1077,18 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertEqual(subgroupInvocations.first?.type, .conference)
         XCTAssertEqual(subgroupInvocations.first?.parentGroupID, parentGroupdID)
 
-        // Then we try to commit pending propsoals twice, once for the subgroup, once for the parent
+        // Then we try to commit pending proposals twice, once for the subgroup, once for the parent
         XCTAssertEqual(mockCommitPendingProposalArguments.count, 2)
         let (id1, commitTime1) = try XCTUnwrap(mockCommitPendingProposalArguments.first)
-        XCTAssertEqual(id1, subgroupID)
+
+        // there is no guarantee which proposal is finished first
+        XCTAssertTrue([subgroupID, parentGroupdID].contains(id1))
         XCTAssertEqual(commitTime1.timeIntervalSinceNow, Date().timeIntervalSinceNow, accuracy: 0.1)
 
         let (id2, commitTime2) = try XCTUnwrap(mockCommitPendingProposalArguments.last)
-        XCTAssertEqual(id2, parentGroupdID)
+
+        // there is no guarantee which proposal is finished first
+        XCTAssertTrue([subgroupID, parentGroupdID].contains(id2))
         XCTAssertEqual(commitTime2.timeIntervalSinceNow, Date().timeIntervalSinceNow, accuracy: 0.1)
 
         await uiMOC.perform {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The taskGroup inside the commitPendingProposals was created inside the for loop so it was one taskGroup per MLS group instead of having N tasks for N groups inside one taskGroup.

### Solutions

Move the taskGroup outside the for-loop
