### PR TITLE
fix: display user-consent popup - WPB-6884

### DIFF
--- a/wire-ios-sync-engine/Source/Data Model/ZMUser+Consent.swift
+++ b/wire-ios-sync-engine/Source/Data Model/ZMUser+Consent.swift
@@ -24,8 +24,9 @@ enum ConsentType: Int {
     case marketing = 2
 }
 
-enum ConsentRequestError: Error {
+public enum ConsentRequestError: Error {
     case unknown
+    case notAvailable
 }
 
 extension ZMUser {
@@ -76,6 +77,10 @@ extension ZMUser {
             guard 200 ... 299 ~= response.httpStatus,
                   let payload = response.payload
             else {
+                if response.httpStatus == 404 {
+                    completion(.failure(ConsentRequestError.notAvailable))
+                    return
+                }
                 let error = response.transportSessionError ?? ConsentRequestError.unknown
                 zmLog.debug("Error fetching consent status: \(error)")
                 completion(.failure(error))

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -155,7 +155,6 @@ final class ZMUserConsentTests: DatabaseTest {
         }
 
         let receivedError = customExpectation(description: "received error")
-        // when
 
         selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
             switch result {

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -155,7 +155,7 @@ final class ZMUserConsentTests: DatabaseTest {
         }
 
         let receivedError = customExpectation(description: "received error")
-
+// WHEN
         selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
             switch result {
             case .failure(let error):

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ZMUserConsentTests.swift
@@ -147,7 +147,7 @@ final class ZMUserConsentTests: DatabaseTest {
     }
 
     func testThatItFailsOn404_get() {
-        // given
+        // GIVEN
         mockTransportSession.responseGeneratorBlock = { request in
             guard request.path == "/self/consent" else { return nil }
 
@@ -155,7 +155,7 @@ final class ZMUserConsentTests: DatabaseTest {
         }
 
         let receivedError = customExpectation(description: "received error")
-// WHEN
+        // WHEN
         selfUser.fetchConsent(for: .marketing, on: mockTransportSession) { result in
             switch result {
             case .failure(let error):

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
@@ -146,10 +146,16 @@ extension ConversationListViewController.ViewModel {
 
             selfUser.fetchMarketingConsent(in: userSession, completion: {[weak self] result in
                 switch result {
-                case .failure:
-                    self?.viewController?.showNewsletterSubscriptionDialogIfNeeded(completionHandler: { marketingConsent in
-                        selfUser.setMarketingConsent(to: marketingConsent, in: userSession, completion: { _ in })
-                    })
+                case .failure(let error):
+                    switch error {
+                    case ConsentRequestError.notAvailable:
+                        // don't show the alert there is no consent to show
+                        break
+                    default:
+                        self?.viewController?.showNewsletterSubscriptionDialogIfNeeded(completionHandler: { marketingConsent in
+                            selfUser.setMarketingConsent(to: marketingConsent, in: userSession, completion: { _ in })
+                        })
+                    }
                 case .success:
                     // The user already gave a marketing consent, no need to ask for it again.
                     return


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6884" title="WPB-6884" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6884</a>  [iOS] display consent popup always showing on elna, diya
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

On some environments (Elna) the self/consent endpoint is not available. We treat the 404 as user did not give it's consent and display a popup.

### Solutions

On 404, no popup should show to ask consent

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution
