### PR TITLE
chore: remove 3rd party library to decode E2EI certificate [WPB-6766]

### DIFF
--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "ASN1Decoder",
-        "repositoryURL": "https://github.com/wireapp/ASN1Decoder",
-        "state": {
-          "branch": "master",
-          "revision": "d30708c89cbbf8f0f27122a53fbd98d0cda079fd",
-          "version": null
-        }
-      },
-      {
         "package": "DifferenceKit",
         "repositoryURL": "https://github.com/wireapp/DifferenceKit",
         "state": {

--- a/wire-ios-sync-engine/Source/Use cases/GetE2eIdentityCertificatesUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/GetE2eIdentityCertificatesUseCase.swift
@@ -46,7 +46,6 @@ final public class GetE2eIdentityCertificatesUseCase: GetE2eIdentityCertificates
         let identities = try await getWireIdentity(coreCrypto: coreCrypto,
                                                    conversationId: mlsGroupId.data,
                                                    clientIDs: clientIds)
-
         let identitiesAndStatus = await validateUserHandleAndName(for: identities)
 
         return identitiesAndStatus.map { identity, status in

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -284,7 +284,6 @@
 		16FF474C1F0D54B20044C491 /* SessionManager+Logs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16FF474B1F0D54B20044C491 /* SessionManager+Logs.swift */; };
 		1836188BC0E48C1AC1671FC2 /* ZMSyncStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6B0837E10BD4D5E88805E3 /* ZMSyncStrategyTests.swift */; };
 		25A9B7BA2B5EA36D00FD43FB /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25A9B7B92B5EA36D00FD43FB /* Security.framework */; };
-		25A9B7C02B5EB57300FD43FB /* ASN1Decoder in Frameworks */ = {isa = PBXBuildFile; productRef = 25A9B7BF2B5EB57300FD43FB /* ASN1Decoder */; };
 		25E11B0B2B56A15F005D51FA /* GetE2eIdentityCertificatesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E11B0A2B56A15F005D51FA /* GetE2eIdentityCertificatesUseCase.swift */; };
 		25E11B0D2B56B497005D51FA /* GetIsE2EIdentityEnabledUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E11B0C2B56B497005D51FA /* GetIsE2EIdentityEnabledUseCase.swift */; };
 		2B15596A295093360069AE34 /* HotfixPatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B155969295093360069AE34 /* HotfixPatch.swift */; };
@@ -1519,7 +1518,6 @@
 			files = (
 				EE67F6CC296F0622001D7C88 /* avs.xcframework in Frameworks */,
 				25A9B7BA2B5EA36D00FD43FB /* Security.framework in Frameworks */,
-				25A9B7C02B5EB57300FD43FB /* ASN1Decoder in Frameworks */,
 				EE668BB62954AA7F00D939E7 /* WireRequestStrategy.framework in Frameworks */,
 				EE67F6C8296F0622001D7C88 /* libPhoneNumberiOS.xcframework in Frameworks */,
 				EE67F6CA296F0622001D7C88 /* ZipArchive.xcframework in Frameworks */,
@@ -2977,7 +2975,6 @@
 			);
 			name = "WireSyncEngine-ios";
 			packageProductDependencies = (
-				25A9B7BF2B5EB57300FD43FB /* ASN1Decoder */,
 			);
 			productName = "WireSyncEngine-ios";
 			productReference = 549815931A43232400A7CE2E /* WireSyncEngine.framework */;
@@ -3056,7 +3053,6 @@
 			);
 			mainGroup = 540029AA1918CA8500578793;
 			packageReferences = (
-				25A9B7BE2B5EB57300FD43FB /* XCRemoteSwiftPackageReference "ASN1Decoder" */,
 			);
 			productRefGroup = 540029B51918CA8500578793 /* Products */;
 			projectDirPath = "";
@@ -4345,25 +4341,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		25A9B7BE2B5EB57300FD43FB /* XCRemoteSwiftPackageReference "ASN1Decoder" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/wireapp/ASN1Decoder";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		25A9B7BF2B5EB57300FD43FB /* ASN1Decoder */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 25A9B7BE2B5EB57300FD43FB /* XCRemoteSwiftPackageReference "ASN1Decoder" */;
-			productName = ASN1Decoder;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 540029AB1918CA8500578793 /* Project object */;
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6766" title="WPB-6766" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6766</a>  [iOS] Remove 3rd part libs deps for Cert Decoding
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?


### Solutions

Removed ASN1Decoder to decode E2EI certificate as WireIdentity from Core cypto now provides all the necessary details

Needs releases with:

- [ ] GitHub link to other pull request

#### How to Test

E2EI certificates must be displayed as before in Device details .


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
