### PR TITLE
fix: ConversationServiceTests and retain cycle

### DIFF
--- a/wire-ios-data-model/Source/E2EIdentity/CRL/CertificateRevocationListsChecker.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/CRL/CertificateRevocationListsChecker.swift
@@ -131,7 +131,6 @@ public class CertificateRevocationListsChecker: CertificateRevocationListsChecki
                 }
             } catch {
                 logger.warn("failed to check certificate revocation list: (error: \(error), distributionPoint: \(distributionPoint))")
-                continue
             }
         }
     }

--- a/wire-ios-data-model/Source/Model/EntityAction.swift
+++ b/wire-ios-data-model/Source/Model/EntityAction.swift
@@ -20,7 +20,7 @@ import Foundation
 
 /// An EntityActionHandler is responsible for performing actions requested by an EntityAction.
 ///
-public protocol EntityActionHandler {
+public protocol EntityActionHandler: AnyObject {
     associatedtype Action
 
     /// Perform the action represented by Action
@@ -85,22 +85,21 @@ public extension EntityAction {
     ///   - handler: action handler
     ///   - context: context in which to listen for actions
     ///   - queue: queue on which the `performAction()` will be called
-    static func registerHandler<Handler: EntityActionHandler>(_ handler: Handler,
-                                                              context: NotificationContext,
-                                                              queue: OperationQueue? = nil) -> Any where Handler.Action == Self {
-        return NotificationInContext.addObserver(name: notificationName,
-                                          context: context,
-                                          object: nil,
-                                          queue: queue) { (note) in
-
-            guard let action = note.userInfo[userInfoKey] as? Handler.Action else {
-                return
-            }
-
-            handler.performAction(action)
+    static func registerHandler<Handler: EntityActionHandler>(
+        _ handler: Handler,
+        context: NotificationContext,
+        queue: OperationQueue? = nil
+    ) -> NSObjectProtocol where Handler.Action == Self {
+        NotificationInContext.addObserver(
+            name: notificationName,
+            context: context,
+            object: nil,
+            queue: queue
+        ) { [weak handler] notification in
+            guard let action = notification.userInfo[userInfoKey] as? Handler.Action else { return }
+            handler?.performAction(action)
         }
     }
-
 }
 
 public extension EntityAction {

--- a/wire-ios-data-model/Source/Notifications/NotificationInContext.swift
+++ b/wire-ios-data-model/Source/Notifications/NotificationInContext.swift
@@ -86,7 +86,7 @@ import WireUtilities
         context: NotificationContext,
         object: AnyObject? = nil,
         queue: OperationQueue? = nil,
-        using: @escaping (NotificationInContext) -> Void) -> Any {
+        using: @escaping (NotificationInContext) -> Void) -> NSObjectProtocol {
         return addUnboundedObserver(name: name, context: context, object: object, queue: queue, using: using)
     }
 
@@ -95,7 +95,7 @@ import WireUtilities
         context: NotificationContext?,
         object: AnyObject? = nil,
         queue: OperationQueue? = nil,
-        using: @escaping (NotificationInContext) -> Void) -> Any {
+        using: @escaping (NotificationInContext) -> Void) -> NSObjectProtocol {
         return SelfUnregisteringNotificationCenterToken(NotificationCenter.default.addObserver(forName: name,
                                                                                                object: context,
                                                                                                queue: queue) { note in

--- a/wire-ios-data-model/Support/Sources/MockActionHandler.swift
+++ b/wire-ios-data-model/Support/Sources/MockActionHandler.swift
@@ -24,7 +24,7 @@ public class MockActionHandler<T: EntityAction>: EntityActionHandler {
     public typealias Action = T
 
     var results: [Result<Action.Result, Action.Failure>]
-    var token: Any?
+    var token: NSObjectProtocol?
     public var didPerformAction: Bool {
         return results.isEmpty
     }

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -61,7 +61,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         // Mock
-        _ = MockActionHandler<SyncMLSOneToOneConversationAction>(
+        let handler = MockActionHandler<SyncMLSOneToOneConversationAction>(
             result: .success(mlsGroupID),
             context: uiMOC.notificationContext
         )
@@ -89,6 +89,7 @@ final class OneOnOneMigratorTests: XCTestCase {
             XCTAssertEqual(mlsConversation.oneOnOneUser, connection.to)
             XCTAssertNil(proteusConversation.oneOnOneUser)
         }
+        withExtendedLifetime(handler) {}
     }
 
     func test_migrateToMLS_conversationAlreadyExists() async throws {
@@ -107,7 +108,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         // Mock
-        _ = MockActionHandler<SyncMLSOneToOneConversationAction>(
+        let handler = MockActionHandler<SyncMLSOneToOneConversationAction>(
             result: .success(mlsGroupID),
             context: uiMOC.notificationContext
         )
@@ -131,6 +132,7 @@ final class OneOnOneMigratorTests: XCTestCase {
             XCTAssertEqual(mlsConversation.oneOnOneUser, connection.to)
             XCTAssertNil(proteusConversation.oneOnOneUser)
         }
+        withExtendedLifetime(handler) {}
     }
 
     func test_migrateToMLS_moveMessages() async throws {
@@ -149,7 +151,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         // Mock
-        _ = MockActionHandler<SyncMLSOneToOneConversationAction>(
+        let handler = MockActionHandler<SyncMLSOneToOneConversationAction>(
             result: .success(mlsGroupID),
             context: uiMOC.notificationContext
         )
@@ -189,6 +191,7 @@ final class OneOnOneMigratorTests: XCTestCase {
 
             XCTAssertNil(proteusConversation.lastMessage)
         }
+        withExtendedLifetime(handler) {}
     }
 
     // MARK: - Core Data Objects

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Swift.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Swift.swift
@@ -1070,7 +1070,7 @@ extension ZMUserTests_Swift {
         let proteusConversation = try XCTUnwrap(ZMConversation.fetch(with: proteusConversationID, in: uiMOC))
 
         // Mock successful connection updates.
-        _ = MockActionHandler<UpdateConnectionAction>(
+        let handler = MockActionHandler<UpdateConnectionAction>(
             result: .success(()),
             context: uiMOC.notificationContext
         )
@@ -1092,9 +1092,11 @@ extension ZMUserTests_Swift {
 
         // Then
         wait(for: [didSucceed], timeout: 0.5)
-        XCTAssertEqual(oneOneOneResolver.resolveOneOnOneConversationWithIn_Invocations.count, 1)
-        let invocation = try XCTUnwrap(oneOneOneResolver.resolveOneOnOneConversationWithIn_Invocations.first)
-        XCTAssertEqual(invocation.userID, userID)
+        try withExtendedLifetime(handler) {
+            XCTAssertEqual(oneOneOneResolver.resolveOneOnOneConversationWithIn_Invocations.count, 1)
+            let invocation = try XCTUnwrap(oneOneOneResolver.resolveOneOnOneConversationWithIn_Invocations.first)
+            XCTAssertEqual(invocation.userID, userID)
+        }
     }
 
     func testThatBlockSendsAUpdateConnectionAction() {

--- a/wire-ios-request-strategy/Sources/Entity Actions/ActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Entity Actions/ActionHandler.swift
@@ -24,7 +24,7 @@ class ActionHandler<T: EntityAction>: NSObject, EntityActionHandler, ZMRequestGe
     let context: NSManagedObjectContext
 
     private var pendingActions: [Action] = []
-    private var token: Any?
+    private var token: NSObjectProtocol?
 
     init(context: NSManagedObjectContext) {
         self.context = context

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
@@ -615,7 +615,7 @@ final class ConversationServiceTests: MessagingTestBase {
         let didSync = customExpectation(description: "didSync")
 
         // Mock
-        _ = MockActionHandler<SyncConversationAction>(
+        let handler = MockActionHandler<SyncConversationAction>(
             result: .success(()),
             context: uiMOC.notificationContext
         )
@@ -626,7 +626,9 @@ final class ConversationServiceTests: MessagingTestBase {
         }
 
         // Then
-        XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+        withExtendedLifetime(handler) {
+            XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
+        }
     }
 
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ProteusConversationParticipantsServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ProteusConversationParticipantsServiceTests.swift
@@ -69,7 +69,7 @@ class ProteusConversationParticipantsServiceTests: MessagingTestBase {
 
     func test_AddParticipants_Fails() async {
         // GIVEN
-        _ = MockActionHandler<AddParticipantAction>(
+        let handler = MockActionHandler<AddParticipantAction>(
             result: .failure(.unknown),
             context: uiMOC.notificationContext
         )
@@ -79,13 +79,14 @@ class ProteusConversationParticipantsServiceTests: MessagingTestBase {
             // WHEN
             try await sut.addParticipants([user], to: conversation)
         }
+        withExtendedLifetime(handler) {}
     }
 
     func test_AddParticipants_MapsFederationErrors_UnreachableDomains() async {
         // GIVEN
         let domains = Set(["domain.com"])
 
-        _ = MockActionHandler<AddParticipantAction>(
+        let handler = MockActionHandler<AddParticipantAction>(
             result: .failure(.unreachableDomains(domains)),
             context: uiMOC.notificationContext
         )
@@ -95,13 +96,14 @@ class ProteusConversationParticipantsServiceTests: MessagingTestBase {
             // WHEN
             try await sut.addParticipants([user], to: conversation)
         }
+        withExtendedLifetime(handler) {}
     }
 
     func test_AddParticipants_MapsFederationErrors_NonFederatingDomains() async {
         // GIVEN
         let domains = Set(["domain.com"])
 
-        _ = MockActionHandler<AddParticipantAction>(
+        let handler = MockActionHandler<AddParticipantAction>(
             result: .failure(.nonFederatingDomains(domains)),
             context: uiMOC.notificationContext
         )
@@ -111,6 +113,7 @@ class ProteusConversationParticipantsServiceTests: MessagingTestBase {
             // WHEN
             try await sut.addParticipants([user], to: conversation)
         }
+        withExtendedLifetime(handler) {}
     }
 
     // MARK: - Remove Participant
@@ -131,7 +134,7 @@ class ProteusConversationParticipantsServiceTests: MessagingTestBase {
 
     func test_RemoveParticipant_Fails() async {
         // GIVEN
-        _ = MockActionHandler<RemoveParticipantAction>(
+        let handler = MockActionHandler<RemoveParticipantAction>(
             result: .failure(.unknown),
             context: uiMOC.notificationContext
         )
@@ -141,6 +144,7 @@ class ProteusConversationParticipantsServiceTests: MessagingTestBase {
             // WHEN
             try await sut.removeParticipant(user, from: conversation)
         }
+        withExtendedLifetime(handler) {}
     }
 
 }

--- a/wire-ios-request-strategy/Tests/Sources/Synchronization/Decoding/EventPayloadDecoderTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Synchronization/Decoding/EventPayloadDecoderTests.swift
@@ -30,7 +30,21 @@ final class EventPayloadDecoderTests: XCTestCase {
 
         // then
         XCTAssertEqual(book.title, "Hello World!")
-        XCTAssertEqual(book.published.description, "2024-01-04 10:34:56 +0000")
+        let expectedPublished = try XCTUnwrap(
+            Calendar.current.date(
+                from: .init(
+                    timeZone: .init(secondsFromGMT: 0),
+                    year: 2024,
+                    month: 1,
+                    day: 4,
+                    hour: 10,
+                    minute: 34,
+                    second: 56,
+                    nanosecond: 780_000_000
+                )
+            )
+        )
+        XCTAssertEqual(book.published.timeIntervalSince1970, expectedPublished.timeIntervalSince1970, accuracy: 0.0001)
     }
 
     func testDecodeDataFails() throws {
@@ -54,7 +68,21 @@ final class EventPayloadDecoderTests: XCTestCase {
 
         // then
         XCTAssertEqual(book.title, "Hello World!")
-        XCTAssertEqual(book.published.description, "2024-01-04 10:34:56 +0000")
+        let expectedPublished = try XCTUnwrap(
+            Calendar.current.date(
+                from: .init(
+                    timeZone: .init(secondsFromGMT: 0),
+                    year: 2024,
+                    month: 1,
+                    day: 4,
+                    hour: 10,
+                    minute: 34,
+                    second: 56,
+                    nanosecond: 780_000_000
+                )
+            )
+        )
+        XCTAssertEqual(book.published.timeIntervalSince1970, expectedPublished.timeIntervalSince1970, accuracy: 0.0001)
     }
 
     func testDecodeDictionaryFails() throws {

--- a/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PushTokenService.swift
@@ -195,7 +195,7 @@ extension EntityAction {
     ///   The action's error.
 
     mutating func perform(in context: NotificationContext) async throws -> Result {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             perform(in: context, resultHandler: continuation.resume(with:))
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -314,24 +314,24 @@ extension ZMUserSessionTests_PushNotifications {
         XCTAssertTrue(containsReadConfirmation, "expected read confirmation for message with nonce = \(nonce)", file: file, line: line)
     }
 
-    func handle(conversationAction: ConversationAction?, category: Category, userInfo: NotificationUserInfo, userText: String? = nil) {
-        handle(action: conversationAction?.rawValue ?? "", category: category.rawValue, userInfo: userInfo, userText: userText)
+    func handle(conversationAction: ConversationAction?, category: Category, userInfo: NotificationUserInfo, userText: String? = nil, file: StaticString = #filePath, line: UInt = #line) {
+        handle(action: conversationAction?.rawValue ?? "", category: category.rawValue, userInfo: userInfo, userText: userText, file: file, line: line)
     }
 
-    func handle(callAction: CallAction, category: Category, userInfo: NotificationUserInfo) {
-        handle(action: callAction.rawValue, category: category.rawValue, userInfo: userInfo)
+    func handle(callAction: CallAction, category: Category, userInfo: NotificationUserInfo, file: StaticString = #filePath, line: UInt = #line) {
+        handle(action: callAction.rawValue, category: category.rawValue, userInfo: userInfo, file: file, line: line)
     }
 
-    func handle(action: String, category: String, userInfo: NotificationUserInfo, userText: String? = nil) {
+    func handle(action: String, category: String, userInfo: NotificationUserInfo, userText: String? = nil, file: StaticString = #filePath, line: UInt = #line) {
         uiMOC.performAndWait {
             sut.handleNotificationResponse(actionIdentifier: action, categoryIdentifier: category, userInfo: userInfo, userText: userText) {}
         }
 
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
         syncMOC.performAndWait {
             sut.didFinishQuickSync()
         }
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
     }
 
     func userInfoWithConversation(hasMessage: Bool = false) -> NotificationUserInfo {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -28,18 +28,6 @@ final class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
     typealias ConversationAction = WireSyncEngine.ConversationNotificationAction
     typealias CallAction = WireSyncEngine.CallNotificationAction
 
-    private var getFeatureConfigsActionHandler: MockActionHandler<GetFeatureConfigsAction>!
-
-    override func setUp() {
-        super.setUp()
-        getFeatureConfigsActionHandler = .init(result: .success(()), context: syncMOC.notificationContext)
-    }
-
-    override func tearDown() {
-        getFeatureConfigsActionHandler = nil
-        super.tearDown()
-    }
-
     func testThatItCallsShowConversationList_ForPushNotificationCategoryConversationWithoutConversation() {
         // when
         handle(conversationAction: nil, category: .conversation, userInfo: NotificationUserInfo())

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -16,7 +16,10 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireDataModelSupport
 import XCTest
+
+@testable import WireRequestStrategy
 @testable import WireSyncEngine
 
 final class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
@@ -24,6 +27,18 @@ final class ZMUserSessionTests_PushNotifications: ZMUserSessionTestsBase {
     typealias Category = WireSyncEngine.PushNotificationCategory
     typealias ConversationAction = WireSyncEngine.ConversationNotificationAction
     typealias CallAction = WireSyncEngine.CallNotificationAction
+
+    private var getFeatureConfigsActionHandler: MockActionHandler<GetFeatureConfigsAction>!
+
+    override func setUp() {
+        super.setUp()
+        getFeatureConfigsActionHandler = .init(result: .success(()), context: syncMOC.notificationContext)
+    }
+
+    override func tearDown() {
+        getFeatureConfigsActionHandler = nil
+        super.tearDown()
+    }
 
     func testThatItCallsShowConversationList_ForPushNotificationCategoryConversationWithoutConversation() {
         // when

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -289,7 +289,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         // GIVEN
         XCTAssertEqual(thirdPartyServices.uploadCount, 0)
 
-        _ = MockActionHandler<GetFeatureConfigsAction>(
+        let handler = MockActionHandler<GetFeatureConfigsAction>(
             result: .success(()),
             context: syncMOC.notificationContext
         )
@@ -302,7 +302,9 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
-        XCTAssertEqual(thirdPartyServices.uploadCount, 1)
+        withExtendedLifetime(handler) {
+            XCTAssertEqual(thirdPartyServices.uploadCount, 1)
+        }
     }
 
     func testThatItOnlyNotifiesThirdPartyServicesOnce() {
@@ -543,7 +545,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         mockMLSService.uploadKeyPackagesIfNeeded_MockMethod = {}
         mockMLSService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
 
-        _ = MockActionHandler<GetFeatureConfigsAction>(
+        let handler = MockActionHandler<GetFeatureConfigsAction>(
             result: .success(()),
             context: syncMOC.notificationContext
         )
@@ -562,9 +564,11 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
-        XCTAssertFalse(mockMLSService.performPendingJoins_Invocations.isEmpty)
-        XCTAssertFalse(mockMLSService.uploadKeyPackagesIfNeeded_Invocations.isEmpty)
-        XCTAssertFalse(mockMLSService.updateKeyMaterialForAllStaleGroupsIfNeeded_Invocations.isEmpty)
-        XCTAssertFalse(mockMLSService.commitPendingProposalsIfNeeded_Invocations.isEmpty)
+        withExtendedLifetime(handler) {
+            XCTAssertFalse(mockMLSService.performPendingJoins_Invocations.isEmpty)
+            XCTAssertFalse(mockMLSService.uploadKeyPackagesIfNeeded_Invocations.isEmpty)
+            XCTAssertFalse(mockMLSService.updateKeyMaterialForAllStaleGroupsIfNeeded_Invocations.isEmpty)
+            XCTAssertFalse(mockMLSService.commitPendingProposalsIfNeeded_Invocations.isEmpty)
+        }
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -311,7 +311,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         // GIVEN
         XCTAssertEqual(thirdPartyServices.uploadCount, 0)
 
-        var mock = MockActionHandler<GetFeatureConfigsAction>(
+        mockGetFeatureConfigsActionHandler = MockActionHandler<GetFeatureConfigsAction>(
             results: [.success(()), .success(())],
             context: syncMOC.notificationContext
         )
@@ -358,7 +358,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         // GIVEN
         XCTAssertEqual(thirdPartyServices.uploadCount, 0)
 
-        var mock = MockActionHandler<GetFeatureConfigsAction>(
+        mockGetFeatureConfigsActionHandler = MockActionHandler<GetFeatureConfigsAction>(
             results: [.success(()), .success(())],
             context: syncMOC.notificationContext
         )
@@ -390,7 +390,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         // WHEN
         sut.didGoOffline()
 
-        var mock = MockActionHandler<GetFeatureConfigsAction>(
+        mockGetFeatureConfigsActionHandler = MockActionHandler<GetFeatureConfigsAction>(
             results: [.success(())],
             context: syncMOC.notificationContext
         )
@@ -456,14 +456,15 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(sut.networkState, .offline)
 
         // WHEN
-        var token: Any? = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
+        let token = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
         sut.didReceiveData()
 
         // THEN
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertEqual(stateRecorder.stateChanges.count, 1)
-        XCTAssertEqual(stateRecorder.stateChanges.first, .onlineSynchronizing)
-        token = nil
+        withExtendedLifetime(token) {
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+            XCTAssertEqual(stateRecorder.stateChanges.count, 1)
+            XCTAssertEqual(stateRecorder.stateChanges.first, .onlineSynchronizing)
+        }
     }
 
     func testThatItDoesNotNotifiesObserversWhenTheNetworkStatusWasAlreadyOnline() {
@@ -471,13 +472,14 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         let stateRecorder = NetworkStateRecorder()
 
         // WHEN
-        var token: Any? = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
+        let token = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
         sut.didReceiveData()
 
         // THEN
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertEqual(stateRecorder.stateChanges.count, 0)
-        token = nil
+        withExtendedLifetime(token) {
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+            XCTAssertEqual(stateRecorder.stateChanges.count, 0)
+        }
     }
 
     func testThatItNotifiesObserversWhenTheNetworkStatusBecomesOffline() {
@@ -485,14 +487,15 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         let stateRecorder = NetworkStateRecorder()
 
         // WHEN
-        var token: Any? = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
+        let token = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
         sut.didGoOffline()
 
         // THEN
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertEqual(stateRecorder.stateChanges.count, 1)
-        XCTAssertEqual(stateRecorder.stateChanges.first, .offline)
-        token = nil
+        withExtendedLifetime(token) {
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+            XCTAssertEqual(stateRecorder.stateChanges.count, 1)
+            XCTAssertEqual(stateRecorder.stateChanges.first, .offline)
+        }
     }
 
     func testThatItDoesNotNotifiesObserversWhenTheNetworkStatusWasAlreadyOffline() {
@@ -503,13 +506,14 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertTrue(waitForOfflineStatus())
 
         // WHEN
-        var token: Any? = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
+        let token = ZMNetworkAvailabilityChangeNotification.addNetworkAvailabilityObserver(stateRecorder, userSession: sut)
         sut.didGoOffline()
 
         // THEN
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertEqual(stateRecorder.stateChanges.count, 0)
-        token = nil
+        withExtendedLifetime(token) {
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+            XCTAssertEqual(stateRecorder.stateChanges.count, 0)
+        }
     }
 
     func testThatItSetsTheMinimumBackgroundFetchInterval() {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -46,11 +46,14 @@ class ZMUserSessionTestsBase: MessagingTest {
     var mockSyncStateDelegate: MockSyncStateDelegate!
     var mockUseCaseFactory: MockUseCaseFactoryProtocol!
     var mockResolveOneOnOneConversationUseCase: MockResolveOneOnOneConversationsUseCaseProtocol!
+    var mockGetFeatureConfigsActionHandler: MockActionHandler<GetFeatureConfigsAction>!
 
     override func setUp() {
         super.setUp()
 
         WireCallCenterV3Factory.wireCallCenterClass = WireCallCenterV3Mock.self
+
+        mockGetFeatureConfigsActionHandler = .init(result: .success(()), context: syncMOC.notificationContext)
 
         self.thirdPartyServices = ThirdPartyServices()
         self.dataChangeNotificationsCount = 0
@@ -90,6 +93,7 @@ class ZMUserSessionTestsBase: MessagingTest {
         self.mockResolveOneOnOneConversationUseCase = nil
         let sut = self.sut
         self.sut = nil
+        mockGetFeatureConfigsActionHandler = nil
         sut?.tearDown()
 
         super.tearDown()

--- a/wire-ios-utilities/Source/Public/SelfUnregisteringNotificationCenterToken.swift
+++ b/wire-ios-utilities/Source/Public/SelfUnregisteringNotificationCenterToken.swift
@@ -21,14 +21,13 @@ import Foundation
 @objcMembers
 public final class SelfUnregisteringNotificationCenterToken: NSObject {
 
-    private let token: Any
+    private let token: NSObjectProtocol
+
+    public init(_ token: NSObjectProtocol) {
+        self.token = token
+    }
 
     deinit {
         NotificationCenter.default.removeObserver(token)
     }
-
-    public init(_ token: Any) {
-        self.token = token
-    }
-
 }

--- a/wire-ios/Wire-iOS/Sources/SwitchingAccountRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/SwitchingAccountRouter.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR fixes a retain cycle and the ConversationServiceTests.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
