### PR TITLE
fix: 1-1 conversation is erroneously marked read-only WPB-6920

### DIFF
--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
@@ -92,7 +92,7 @@ public final class OneOnOneResolver: OneOnOneResolverInterface {
     ) async throws -> OneOnOneConversationResolution {
         WireLogger.conversation.debug("resolving 1-1 conversation with user: \(userID)")
 
-        let messageProtocol = await protocolSelector.getProtocolForUser(
+        let messageProtocol = try await protocolSelector.getProtocolForUser(
             with: userID,
             in: context
         )

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4426,14 +4426,19 @@ public class MockOneOnOneProtocolSelectorInterface: OneOnOneProtocolSelectorInte
     // MARK: - getProtocolForUser
 
     public var getProtocolForUserWithIn_Invocations: [(id: QualifiedID, context: NSManagedObjectContext)] = []
-    public var getProtocolForUserWithIn_MockMethod: ((QualifiedID, NSManagedObjectContext) async -> MessageProtocol?)?
+    public var getProtocolForUserWithIn_MockError: Error?
+    public var getProtocolForUserWithIn_MockMethod: ((QualifiedID, NSManagedObjectContext) async throws -> MessageProtocol?)?
     public var getProtocolForUserWithIn_MockValue: MessageProtocol??
 
-    public func getProtocolForUser(with id: QualifiedID, in context: NSManagedObjectContext) async -> MessageProtocol? {
+    public func getProtocolForUser(with id: QualifiedID, in context: NSManagedObjectContext) async throws -> MessageProtocol? {
         getProtocolForUserWithIn_Invocations.append((id: id, context: context))
 
+        if let error = getProtocolForUserWithIn_MockError {
+            throw error
+        }
+
         if let mock = getProtocolForUserWithIn_MockMethod {
-            return await mock(id, context)
+            return try await mock(id, context)
         } else if let mock = getProtocolForUserWithIn_MockValue {
             return mock
         } else {

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneProtocolSelectorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneProtocolSelectorTests.swift
@@ -48,7 +48,7 @@ final class OneOnOneProtocolSelectorTests: ZMBaseManagedObjectTest {
         }
 
         // When
-        let result = await sut.getProtocolForUser(
+        let result = try await sut.getProtocolForUser(
             with: userID,
             in: uiMOC
         )
@@ -70,7 +70,7 @@ final class OneOnOneProtocolSelectorTests: ZMBaseManagedObjectTest {
         }
 
         // When
-        let result = await sut.getProtocolForUser(
+        let result = try await sut.getProtocolForUser(
             with: userID,
             in: uiMOC
         )
@@ -92,13 +92,35 @@ final class OneOnOneProtocolSelectorTests: ZMBaseManagedObjectTest {
         }
 
         // When
-        let result = await sut.getProtocolForUser(
+        let result = try await sut.getProtocolForUser(
             with: userID,
             in: uiMOC
         )
 
         // Then
         XCTAssertNil(result)
+    }
+
+    func test_GetProtocolForUser_DefaultsToProteus() async throws {
+        // Given
+        let userID = QualifiedID.random()
+
+        await uiMOC.perform { [self] in
+            let user = createUser(id: userID, in: uiMOC)
+            user.supportedProtocols = []
+
+            let selfUser = ZMUser.selfUser(in: uiMOC)
+            selfUser.supportedProtocols = [.proteus, .mls]
+        }
+
+        // When
+        let result = try await sut.getProtocolForUser(
+            with: userID,
+            in: uiMOC
+        )
+
+        // Then
+        XCTAssertEqual(result, .proteus)
     }
 
 }

--- a/wire-ios-sync-engine/Source/Use cases/CreateTeamOneOnOneConversationUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/CreateTeamOneOnOneConversationUseCase.swift
@@ -83,7 +83,7 @@ struct CreateTeamOneOnOneConversationUseCase: CreateTeamOneOnOneConversationUseC
             )
         }
 
-        switch await protocolSelector.getProtocolForUser(
+        switch try await protocolSelector.getProtocolForUser(
             with: userID,
             in: syncContext
         ) {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
1-1 conversations are marked as read only when they shouldn't be.


### Causes

Depending on the versions of the app on either side of a 1-1, it could be that one person has a build that can resolve 1-1 conversations using the supported protocols of the other user, but the other user is on an old version that has no concept of supported protocols. For the person resolving the one to one, it appears that the other user doesn't have any supported protocols, so the conversation is marked read only.

### Solutions

If another user doesn't have any supported protocols set, then default to `proteus`. 

### Testing

#### Test Coverage

- Unit test asserting we fall back to proteus.

#### How to Test

1. Be on a build that supports MLS 1-1s (e.g 3.112)
2. Open the 1-1 conversation with a user who is on a build that doesn't support MLS 1-1s (e.g 3.111)
3. Assert that the conversation is proteus and messages can be sent.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
