### PR TITLE
fix: team users not filtered with search query WPB-6663

### DIFF
--- a/wire-ios-data-model/Support/Sources/ModelHelper.swift
+++ b/wire-ios-data-model/Support/Sources/ModelHelper.swift
@@ -163,6 +163,24 @@ public struct ModelHelper {
     }
 
     @discardableResult
+    public func createProteusTeamOneOnOne(
+        with user: ZMUser,
+        team: Team,
+        in context: NSManagedObjectContext
+    ) -> ZMConversation {
+        let selfUser = ZMUser.selfUser(in: context)
+        let conversation = ZMConversation.insertNewObject(in: context)
+        conversation.remoteIdentifier = UUID()
+        conversation.team = team
+        conversation.conversationType = .group
+        conversation.messageProtocol = .proteus
+        conversation.addParticipantAndUpdateConversationState(user: user, role: nil)
+        conversation.addParticipantAndUpdateConversationState(user: selfUser, role: nil)
+        conversation.oneOnOneUser = user
+        return conversation
+    }
+
+    @discardableResult
     public func createSelfMLSConversation(
         id: UUID = .init(),
         mlsGroupID: MLSGroupID? = nil,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6663" title="WPB-6663" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6663</a>  [iOS] When I search, search results should be at the top
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When entering a search query, all team members are shown and not filtered out with the query.

### Causes

When collecting all users of team one on ones, we weren't filtering them out with the search query.

### Solutions

Apply the filter.


### Testing

#### Test Coverage

- Added unit test that we search team one on one users

#### How to Test

1. Be in a team
2. Search for users in the contacts tab
3. Assert that also the team users in the "contacts" section are filtered according to the query

### Notes

I also fixed the local user lookup where we weren't filtering team users with the remote id.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
