### PR TITLE
fix: download & decrypt messages when performing quick sync

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -154,7 +154,9 @@ public class ConversationRequestStrategy: AbstractRequestStrategy, ZMRequestGene
         )
 
         self.configuration = [.allowsRequestsWhileOnline,
-                              .allowsRequestsDuringSlowSync]
+                              .allowsRequestsDuringSlowSync,
+                              .allowsRequestsDuringQuickSync,
+                              .allowsRequestsWhileWaitingForWebsocket]
 
         self.updateSync.transcoder = self
         self.conversationByIDListSync.delegate = self

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/MLSRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/MLSRequestStrategy.swift
@@ -53,7 +53,12 @@ public final class MLSRequestStrategy: AbstractRequestStrategy {
             applicationStatus: applicationStatus
         )
 
-        configuration = [.allowsRequestsDuringSlowSync, .allowsRequestsWhileOnline]
+        configuration = [
+            .allowsRequestsDuringSlowSync,
+            .allowsRequestsWhileOnline,
+            .allowsRequestsDuringQuickSync,
+            .allowsRequestsWhileWaitingForWebsocket
+        ]
     }
 
     // MARK: - Requests

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -44,6 +44,7 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
 @property (nonatomic) NotificationsTracker *notificationsTracker;
 @property (nonatomic) BOOL useLegacyPushNotifications;
 @property (nonatomic) id<LastEventIDRepositoryInterface> lastEventIDRepository;
+@property (nonatomic) BOOL isProcessingEvents;
 
 
 - (void)appendPotentialGapSystemMessageIfNeededWithResponse:(ZMTransportResponse *)response;
@@ -159,11 +160,11 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
     return [payload.asDictionary optionalArrayForKey:@"notifications"].asDictionaries;
 }
 
-- (NSUUID *)processUpdateEventsAndReturnLastNotificationIDFromPayload:(id<ZMTransportData>)payload
+- (NSUUID *)processUpdateEventsAndReturnLastNotificationIDFromResponse:(ZMTransportResponse *)response
 {
     ZMSTimePoint *tp = [ZMSTimePoint timePointWithInterval:10 label:NSStringFromClass(self.class)];
-    NSArray *eventsDictionaries = [self.class eventDictionariesFromPayload:payload];
-    
+    NSArray *eventsDictionaries = [self.class eventDictionariesFromPayload:response.payload];
+
     NSMutableArray<ZMUpdateEvent *> *parsedEvents = [NSMutableArray array];
     NSMutableArray<NSUUID *> *eventIds = [NSMutableArray array];
     NSUUID *latestEventId = nil;
@@ -185,12 +186,26 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
     ZMLogWithLevelAndTag(ZMLogLevelInfo, ZMTAG_EVENT_PROCESSING, @"Downloaded %lu event(s)", (unsigned long)parsedEvents.count);
 
     BOOL finished = !self.listPaginator.hasMoreToFetch;
+    NSDate *fetchDate = self.listPaginator.lastResetFetchDate;
     NSArray<ZMSDispatchGroup *> *groups = [self.managedObjectContext enterAllGroupsExceptSecondary];
+    self.isProcessingEvents = YES;
 
+    NSLog(@"ZMMissingUpdateEventsTranscoder process %lu events", (unsigned long)parsedEvents.count);
     [self.eventProcessor processEvents:parsedEvents completionHandler:^(NSError * _Nullable error) {
         NOT_USED(error);
         [self.managedObjectContext performBlock:^{
             [self.pushNotificationStatus didFetchEventIds:eventIds lastEventId:latestEventId finished:finished];
+            
+            if (finished) {
+                [self.syncStatus completedFetchingNotificationStreamFetchBeganAt:fetchDate];
+
+                if (self.operationStatus.operationState == SyncEngineOperationStateBackgroundFetch) {
+                    [self updateBackgroundFetchResultWithResponse:response];
+                }
+
+                self.isProcessingEvents = NO;
+            }
+
             [self.managedObjectContext leaveAllGroups:groups];
         }];
     }];
@@ -259,10 +274,14 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
     // We want to create a new request if we are either currently fetching the paginated stream
     // or if we have a new notification ID that requires a pingback.
    
-    if ((self.isFetchingStreamForAPNS && self.useLegacyPushNotifications) || self.isFetchingStreamInBackground || self.isSyncing) {
-        
+    if ((self.isFetchingStreamForAPNS && self.useLegacyPushNotifications) || self.isFetchingStreamInBackground || 
+        self.isSyncing) {
+
         // We only reset the paginator if it is neither in progress nor has more pages to fetch.
-        if (self.listPaginator.status != ZMSingleRequestInProgress && !self.listPaginator.hasMoreToFetch) {
+        if (self.listPaginator.status != ZMSingleRequestInProgress &&
+            !self.listPaginator.hasMoreToFetch &&
+            !self.isProcessingEvents
+        ) {
             [self.listPaginator resetFetching];
         }
 
@@ -302,31 +321,22 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
 
     NOT_USED(paginator);
     SyncStatus *syncStatus = self.syncStatus;
-    OperationStatus *operationStatus = self.operationStatus;
     
     NSString *timestamp = ((NSString *) response.payload.asDictionary[@"time"]);
     if (timestamp) {
         [self updateServerTimeDeltaWithTimestamp:timestamp];
     }
 
-    NSUUID *latestEventId = [self processUpdateEventsAndReturnLastNotificationIDFromPayload:response.payload];
-
-    if (operationStatus.operationState == SyncEngineOperationStateBackgroundFetch) {
-        // This call affects the `isFetchingStreamInBackground` property and should never preceed
-        // the call to `processUpdateEventsAndReturnLastNotificationIDFromPayload:syncStrategy`.
-        [self updateBackgroundFetchResultWithResponse:response];
-    }
+    NSUUID *latestEventId = [self processUpdateEventsAndReturnLastNotificationIDFromResponse:response];
 
     if (!self.listPaginator.hasMoreToFetch) {
         [self.previouslyReceivedEventIDsCollection discardListOfAlreadyReceivedPushEventIDs];
     }
     
     [self appendPotentialGapSystemMessageIfNeededWithResponse:response];
-    
+
     if (response.result == ZMTransportResponseStatusPermanentError) {
         [syncStatus failedFetchingNotificationStream];
-    } else if (!self.listPaginator.hasMoreToFetch) {
-        [syncStatus completedFetchingNotificationStreamFetchBeganAt:self.listPaginator.lastResetFetchDate];
     }
     
     return latestEventId;

--- a/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
@@ -181,12 +181,11 @@ extension SyncStatus {
                 currentSyncPhase = .fetchingMissedEvents
                 needsToRestartQuickSync = false
                 zmLog.debug("restarting quick sync since push channel was closed")
-                return
+            } else {
+                zmLog.debug("sync complete")
+                notifyQuickSyncDidFinish()
+                isForceQuickSync = false
             }
-
-            zmLog.debug("sync complete")
-            notifyQuickSyncDidFinish()
-            isForceQuickSync = false
         }
         RequestAvailableNotification.notifyNewRequestsAvailable(self)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When initiating a quick sync when resolving an MLS backend error we only download the new events but we don't await the events to be decrypted which defeats the purpose of doing the quick sync since we want be sure that we are on the latest epoch.

### Causes

A quick is considered done after all events have been downloaded 

### Solutions

Consider quick sync to be done after all events have been downloaded & processed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
