### PR TITLE
fix: not updating verification status for 1-1 conversations

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -443,7 +443,7 @@ final class ConversationViewController: UIViewController {
 
     private func updateVerificationStatusIfNeeded() {
         guard
-            conversation.conversationType == .group,
+            conversation.conversationType.isOne(of: .group, .oneOnOne),
             conversation.messageProtocol == .mls
         else {
             return


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A 1-1 MLS conversation with a user with an invalid certificate is shown as verified

### Causes

The default `mlsVerificationStatus` value (0) is verified and the verifications status is only updated for group conversations.

### Solutions

Also update the mls verification status for 1-1 conversations

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
