### PR TITLE
fix: Tint Color for scrollToBottom Button 

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -47,10 +47,13 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
     /// It appears when the user has scrolled up past a certain point in the conversation.
     lazy var scrollToBottomButton: Button = {
         let button = Button(style: .scrollToBottomButtonStyle, cornerRadius: scrollToBottomButtonHeight / 2)
-        let image = Asset.Images.downArrow.image.withTintColor(SemanticColors.Icon.foregroundDefaultWhite)
+        let icon = Asset.Images.downArrow.image
 
-        button.setImage(image, for: .normal)
-        button.setImage(image, for: .highlighted)
+        button.setImage(icon, for: .normal)
+        button.setImage(icon, for: .highlighted)
+
+        button.tintColor = SemanticColors.Icon.foregroundDefaultWhite
+
         button.translatesAutoresizingMaskIntoConstraints = false
 
         button.accessibilityLabel = L10n.Accessibility.Conversation.ScrollToBottomButton.description


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR addresses an issue where the scrollToBottom button's icon did not correctly apply the tint color in all button states. Previously, the tint color was applied directly to the image asset using withTintColor, which resulted in a static image that did not adapt to state changes of the button, such as highlight or disabled states. To ensure consistency and adaptability across different states, we've modified the implementation to dynamically apply the tint color through the button's tintColor property.

# Changes Made

- Removed the direct application of tint color using withTintColor on the scrollToBottom button icon.
- Set the button icon without pre-applying a tint color, allowing the UIButton to control the tint color dynamically.
- Applied the desired tint color (SemanticColors.Icon.foregroundDefaultWhite) to the button's tintColor property, ensuring the icon adapts to state changes correctly.

## Benefits

- Dynamic Tint Application: The icon now correctly reflects the button's tintColor, ensuring that it adapts to different button states (e.g., highlighted).
- Improved Consistency: This change ensures that the icon's appearance remains consistent with the overall design system, especially in response to state changes.
- Increased Flexibility: Modifying the button's tintColor at runtime will now dynamically update the icon's appearance, offering greater flexibility for theme changes or state-based visual cues.

## Testing

- Manual testing was conducted to ensure that the icon correctly changes its appearance in response to button state changes.
- Verified that the icon's tint color dynamically updates when the button's tintColor is changed at runtime.

| BEFORE | AFTER |
|---|---|
| ![IMG_0035](https://github.com/wireapp/wire-ios/assets/10944108/d0a9c59d-c614-4262-a211-82f961e36704) | ![IMG_0034](https://github.com/wireapp/wire-ios/assets/10944108/502eebc9-1bca-46fa-b57d-8654972ab946) |

----

##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
