### PR TITLE
fix: Tint Color for attention icon in ConversationWarningSystemMessageCell

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
@@ -50,7 +50,8 @@ final class ConversationWarningSystemMessageCell: ConversationIconBasedCell, Con
         bottomContentView.addSubview(sensitiveInfoLabel)
 
         lineView.isHidden = true
-        imageView.image =  Asset.Images.attention.image.withTintColor(IconColors.backgroundDefault)
+        imageView.image =  Asset.Images.attention.image
+        imageView.tintColor = IconColors.backgroundDefault
     }
 
     override func configureConstraints() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
@@ -50,7 +50,7 @@ final class ConversationWarningSystemMessageCell: ConversationIconBasedCell, Con
         bottomContentView.addSubview(sensitiveInfoLabel)
 
         lineView.isHidden = true
-        imageView.image =  Asset.Images.attention.image
+        imageView.image = Asset.Images.attention.image
         imageView.tintColor = IconColors.backgroundDefault
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This pull request introduces an enhancement to the way we handle tint colors for icons within our ConversationWarningSystemMessageCell. Previously, the tint color was applied by creating a new image with a tint color directly baked into it using withTintColor. This approach has been replaced with a two-step process where we set the icon and the tint color separately. This change brings our approach in line with best practices for UI adaptability and theming.

# Changes Made

Removed the direct application of tint color using withTintColor from the imageView assignment.
Assigned the attention icon directly to imageView.image without a predefined tint color.
Separately set imageView.tintColor to IconColors.backgroundDefault, which allows dynamic changes to the tint color based on different states or themes.

## Benefits

- Dynamic Theming: This change allows for dynamic theming across the app, enabling the icons to react to theme changes in real-time.
- State Responsiveness: Icons can now respond to state changes with the appropriate tint color, improving visual feedback in interactive components.
- Code Clarity: Separating the icon image assignment from the tint color application clarifies the intention of the code and increases maintainability.

## Testing

- Visual inspection and manual testing were carried out to ensure the icon correctly reflects the tintColor when the cell is in different states.
- Tested against different themes to confirm that the icon updates its tint color in response to theme changes.

| BEFORE |  AFTER  |
|---|---|
| ![IMG_0034](https://github.com/wireapp/wire-ios/assets/10944108/a976a492-783e-4ebe-8dee-a349f5956d8f) |  ![Screenshot 2024-03-01 at 14 14 16](https://github.com/wireapp/wire-ios/assets/10944108/cfba1a18-5fb3-4475-a7e3-c9f5c4011f35) |


----




##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
