### PR TITLE
feat: Do not use refresh token for e2ei WPB-6921

### DIFF
--- a/wire-ios-request-strategy/Sources/E2EIdentity/EnrollE2EICertificateUseCase.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/EnrollE2EICertificateUseCase.swift
@@ -30,11 +30,11 @@ public struct OAuthParameters {
 public struct OAuthResponse {
 
     let idToken: String
-    let refreshToken: String
+    let refreshToken: String?
 
     public init(
         idToken: String,
-        refreshToken: String) {
+        refreshToken: String?) {
             self.idToken = idToken
             self.refreshToken = refreshToken
         }
@@ -138,8 +138,6 @@ public final class EnrollE2EICertificateUseCase: EnrollE2EICertificateUseCasePro
             clientId: selfClientId ?? "",
             dpopToken: dpopToken)
 
-        let refreshTokenFromCC = try? await enrollment.getOAuthRefreshToken()
-
         let dpopChallengeResponse = try await enrollment.validateDPoPChallenge(
             accessToken: wireAccessToken.token,
             prevNonce: authorizations.nonce,
@@ -147,7 +145,7 @@ public final class EnrollE2EICertificateUseCase: EnrollE2EICertificateUseCasePro
 
         let oidcChallengeResponse = try await enrollment.validateOIDCChallenge(
             idToken: oAuthResponse.idToken,
-            refreshToken: refreshTokenFromCC ?? oAuthResponse.refreshToken,
+            refreshToken: oAuthResponse.refreshToken ?? " ",
             prevNonce: dpopChallengeResponse.nonce,
             acmeChallenge: oidcAuthorization.challenge)
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
@@ -125,9 +125,7 @@ public class OAuthUseCase: OAuthUseCaseInterface {
                     return continuation.resume(throwing: OAuthError.missingIdToken)
                 }
 
-                guard let refreshToken = authState?.lastTokenResponse?.refreshToken else {
-                    return continuation.resume(throwing: OAuthError.missingRefreshToken)
-                }
+                let refreshToken = authState?.lastTokenResponse?.refreshToken
 
                 return continuation.resume(returning: OAuthResponse(idToken: idToken, refreshToken: refreshToken))
             })
@@ -144,6 +142,5 @@ enum OAuthError: Error {
     case missingServiceConfiguration
     case missingOIDExternalUserAgent
     case missingIdToken
-    case missingRefreshToken
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6921" title="WPB-6921" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-6921</a>  [iOS] Do not use refresh token for E2EI certificate renewal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

The IdP will not send a refresh token (explained in the ticket) and clients should handle the lack of a refresh token.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
