### PR TITLE
fix(e2ei): CRL renewal timeout

### DIFF
--- a/wire-ios-data-model/Source/E2EIdentity/CRL/CRLExpirationDatesRepository.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/CRL/CRLExpirationDatesRepository.swift
@@ -69,9 +69,9 @@ public class CRLExpirationDatesRepository: CRLExpirationDatesRepositoryProtocol 
 
         storeDistributionPointIfNeeded(dpString)
 
-        if DeveloperFlag.forceCRLExpiryAfterThirtyMinutes.isOn {
+        if DeveloperFlag.forceCRLExpiryAfterOneMinute.isOn {
             storage.set(
-                Calendar.current.date(byAdding: .minute, value: 30, to: .now)!,
+                Calendar.current.date(byAdding: .minute, value: 1, to: .now)!,
                 forKey: expirationDateKey
             )
         } else {

--- a/wire-ios-data-model/Source/E2EIdentity/CRL/CertificateRevocationListsChecker.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/CRL/CertificateRevocationListsChecker.swift
@@ -29,7 +29,7 @@ public protocol CertificateRevocationListAPIProtocol {
 // sourcery: AutoMockable
 public protocol CertificateRevocationListsChecking {
     func checkNewCRLs(from distributionPoints: CRLsDistributionPoints) async
-    func checkExpiringCRLs() async
+    func checkExpiredCRLs() async
 }
 
 public class CertificateRevocationListsChecker: CertificateRevocationListsChecking {
@@ -92,9 +92,9 @@ public class CertificateRevocationListsChecker: CertificateRevocationListsChecki
         await checkCertificateRevocationLists(from: newDistributionPoints)
     }
 
-    public func checkExpiringCRLs() async {
+    public func checkExpiredCRLs() async {
 
-        WireLogger.e2ei.info("checking expiring CRLs")
+        WireLogger.e2ei.info("checking expired CRLs")
 
         let distributionPointsOfExpiringCRLs = crlExpirationDatesRepository
             .fetchAllCRLExpirationDates()

--- a/wire-ios-data-model/Source/E2EIdentity/CRL/CertificateRevocationListsChecker.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/CRL/CertificateRevocationListsChecker.swift
@@ -100,6 +100,7 @@ public class CertificateRevocationListsChecker: CertificateRevocationListsChecki
             .fetchAllCRLExpirationDates()
             .filter {
                 // We give 10 seconds delay to allow time for the certificate to be renewed by the server
+                // see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/950010018/Use+case+revocation+expiration+of+an+E2EI+certificate
                 hasCRLExpiredAtLeastTenSecondsAgo(expirationDate: $0.value)
             }
             .keys
@@ -139,13 +140,11 @@ public class CertificateRevocationListsChecker: CertificateRevocationListsChecki
     }
 
     private func hasCRLExpiredAtLeastTenSecondsAgo(expirationDate: Date) -> Bool {
-        let now = Date.now
-
         guard let tenSecondsAfterExpiration = tenSecondsAfter(date: expirationDate) else {
-            return now > expirationDate
+            return expirationDate.isInThePast
         }
 
-        return now > tenSecondsAfterExpiration
+        return tenSecondsAfterExpiration.isInThePast
     }
 
     private func tenSecondsAfter(date: Date) -> Date? {

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -171,16 +171,16 @@ public class MockCertificateRevocationListsChecking: CertificateRevocationListsC
         await mock(distributionPoints)
     }
 
-    // MARK: - checkExpiringCRLs
+    // MARK: - checkExpiredCRLs
 
-    public var checkExpiringCRLs_Invocations: [Void] = []
-    public var checkExpiringCRLs_MockMethod: (() async -> Void)?
+    public var checkExpiredCRLs_Invocations: [Void] = []
+    public var checkExpiredCRLs_MockMethod: (() async -> Void)?
 
-    public func checkExpiringCRLs() async {
-        checkExpiringCRLs_Invocations.append(())
+    public func checkExpiredCRLs() async {
+        checkExpiredCRLs_Invocations.append(())
 
-        guard let mock = checkExpiringCRLs_MockMethod else {
-            fatalError("no mock for `checkExpiringCRLs`")
+        guard let mock = checkExpiredCRLs_MockMethod else {
+            fatalError("no mock for `checkExpiredCRLs`")
         }
 
         await mock()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession.swift
@@ -893,7 +893,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
         recurringActionService.performActionsIfNeeded()
 
         Task {
-            await self.cRLsChecker.checkExpiringCRLs()
+            await self.cRLsChecker.checkExpiredCRLs()
         }
 
         managedObjectContext.performGroupedBlock { [weak self] in

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -29,7 +29,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case forceDatabaseLoadingFailure
     case ignoreIncomingEvents
     case debugDuplicateObjects
-    case forceCRLExpiryAfterThirtyMinutes
+    case forceCRLExpiryAfterOneMinute
 
     public var description: String {
         switch self {
@@ -54,8 +54,8 @@ public enum DeveloperFlag: String, CaseIterable {
         case .debugDuplicateObjects:
             return "Turn on to have actions to insert duplicate users, conversations, teams"
 
-        case .forceCRLExpiryAfterThirtyMinutes:
-            return "Turn on to force CRLs to expire after 30 minutes"
+        case .forceCRLExpiryAfterOneMinute:
+            return "Turn on to force CRLs to expire after 1 minute"
         }
     }
 
@@ -92,7 +92,7 @@ public enum DeveloperFlag: String, CaseIterable {
             return "ProteusByCoreCryptoEnabled"
         case .forceDatabaseLoadingFailure:
             return "ForceDatabaseLoadingFailure"
-        case .nseV2, .debugDuplicateObjects, .forceCRLExpiryAfterThirtyMinutes:
+        case .nseV2, .debugDuplicateObjects, .forceCRLExpiryAfterOneMinute:
             return nil
         case .ignoreIncomingEvents:
             return "IgnoreIncomingEventsEnabled"

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperE2ei/DeveloperE2eiView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperE2ei/DeveloperE2eiView.swift
@@ -35,9 +35,9 @@ struct DeveloperE2eiView: View {
 
             Section("Certificate Revocation Lists") {
                 toggleRow(
-                    title: "Force CRL expiry after 30 minutes",
-                    description: "Sets the CRL expiration time to 30 minutes. Enable to force refresh the CRLs when the app comes to the foreground.",
-                    binding: binding(for: .forceCRLExpiryAfterThirtyMinutes)
+                    title: "Force CRL expiry after 1 minute",
+                    description: "Sets the CRL expiration time to 1 minute. Enable to force refresh the CRLs when the app comes to the foreground (at least one minute after the CRL has been fetched the 1st time).",
+                    binding: binding(for: .forceCRLExpiryAfterOneMinute)
                 )
                 VStack(alignment: .leading) {
                     SwiftUI.Button("Clear CRL expiration dates", action: { viewModel.removeAllExpirationDates() })


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Small fix of the logic for renewing CRLs. We need to renew the CRL only after it has expired (+10s delay for the server to have time to renew it), contrary to the previous implementation that was renewing it at least an hour before it's expiration date, leading to continuously refetching the same CRL until it's expiration date had passed.


