### PR TITLE
feat: handle establishing MLS 1-1 when other is out of key packages WPB-6966

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -32,7 +32,7 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// Join group after creating it if needed
     func joinNewGroup(with groupID: MLSGroupID) async throws
 
-    func createGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws
+    func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws
 
     func createGroup(for groupID: MLSGroupID, parentGroupID: MLSGroupID?) async throws
 
@@ -434,7 +434,7 @@ public final class MLSService: MLSServiceInterface {
         case failedToCreateGroup
     }
 
-    /// Create an MLS group with the given group id.
+    /// Establish an MLS group with the given group id.
     ///
     /// - Parameters:
     ///   - groupID the id representing the MLS group.
@@ -442,7 +442,7 @@ public final class MLSService: MLSServiceInterface {
     /// - Throws:
     ///   - MLSGroupCreationError if the group could not be created.
 
-    public func createGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws {
+    public func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws {
         guard let context else { return }
 
         do {

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -100,7 +100,7 @@ public final class OneOnOneMigrator: OneOnOneMigratorInterface {
         }
 
         do {
-            try await mlsService.createGroup(
+            try await mlsService.establishGroup(
                 for: mlsGroupID,
                 with: [MLSUser(userID)]
             )

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -3893,21 +3893,21 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock(groupID)
     }
 
-    // MARK: - createGroup
+    // MARK: - establishGroup
 
-    public var createGroupForWith_Invocations: [(groupID: MLSGroupID, users: [MLSUser])] = []
-    public var createGroupForWith_MockError: Error?
-    public var createGroupForWith_MockMethod: ((MLSGroupID, [MLSUser]) async throws -> Void)?
+    public var establishGroupForWith_Invocations: [(groupID: MLSGroupID, users: [MLSUser])] = []
+    public var establishGroupForWith_MockError: Error?
+    public var establishGroupForWith_MockMethod: ((MLSGroupID, [MLSUser]) async throws -> Void)?
 
-    public func createGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws {
-        createGroupForWith_Invocations.append((groupID: groupID, users: users))
+    public func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws {
+        establishGroupForWith_Invocations.append((groupID: groupID, users: users))
 
-        if let error = createGroupForWith_MockError {
+        if let error = establishGroupForWith_MockError {
             throw error
         }
 
-        guard let mock = createGroupForWith_MockMethod else {
-            fatalError("no mock for `createGroupForWith`")
+        guard let mock = establishGroupForWith_MockMethod else {
+            fatalError("no mock for `establishGroupForWith`")
         }
 
         try await mock(groupID, users)

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -48,7 +48,7 @@ final class OneOnOneMigratorTests: XCTestCase {
     func test_migrateToMLS() async throws {
         // Given
         let mockMLSService = MockMLSServiceInterface()
-        mockMLSService.createGroupForWith_MockMethod = { _, _ in }
+        mockMLSService.establishGroupForWith_MockMethod = { _, _ in }
 
         let sut = OneOnOneMigrator(mlsService: mockMLSService)
         let userID = QualifiedID.random()
@@ -80,8 +80,8 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         // Then
-        XCTAssertEqual(mockMLSService.createGroupForWith_Invocations.count, 1)
-        let createGroupInvocation = try XCTUnwrap(mockMLSService.createGroupForWith_Invocations.first)
+        XCTAssertEqual(mockMLSService.establishGroupForWith_Invocations.count, 1)
+        let createGroupInvocation = try XCTUnwrap(mockMLSService.establishGroupForWith_Invocations.first)
         XCTAssertEqual(createGroupInvocation.groupID, mlsGroupID)
         XCTAssertEqual(createGroupInvocation.users, [MLSUser(userID)])
 
@@ -125,7 +125,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         // Then
-        XCTAssertTrue(mockMLSService.createGroupForWith_Invocations.isEmpty)
+        XCTAssertTrue(mockMLSService.establishGroupForWith_Invocations.isEmpty)
         XCTAssertTrue(mockMLSService.addMembersToConversationWithFor_Invocations.isEmpty)
 
         await uiMOC.perform {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If the other user doesn't have any key packages when we attempt to establish an MLS 1-1 we would fail and the conversation would remain broken until the re-installs the app.

### Causes

After failing establish the 1-1 we would have local MLS group which prevent us from trying establish the group again and CoreCrypto would fail processing an incoming welcome message with `CryptoError.ConversationAlreadyExists`.

### Solutions

Delete the local MLS group when we fail to establish it.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

1. Create user A & B
2. Deplete the key packages for user B
3. User A opens 1-1 with B, which will fail
4. Login with user B and open 1-1 with A and send a message

User A should now receive the messages in the 1-1

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
