### PR TITLE
fix: crash on invalid range - WPB-6629

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Timestamps.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Timestamps.swift
@@ -289,6 +289,8 @@ extension ZMConversation {
     public func savePendingLastRead() {
         guard let upperBound = pendingLastReadServerTimestamp else { return }
         let lowerBound = previousLastReadServerTimestamp ?? lastReadServerTimeStamp ?? .distantPast
+        guard lowerBound <= upperBound else { return }
+
         performMarkAsReadUpdate(in: lowerBound...upperBound)
         pendingLastReadServerTimestamp = nil
         previousLastReadServerTimestamp = nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6629" title="WPB-6629" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6629</a>  [iOS] crash savePendingLastRead()
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

# What's new in this PR?

### Issues

The crash reported is because we got an invalid range.

### Causes (Optional)

I think it happened at the same time when CC was returning negative timestamps to retry pending commits. But it's likely a side effect that won't happen again.

### Solutions

add guard on the range.