### PR TITLE
fix: performGroupedAndWait - WPB-6628

### DIFF
--- a/wire-ios-utilities/Source/NSManagedObjectContext+PerformGrouped.swift
+++ b/wire-ios-utilities/Source/NSManagedObjectContext+PerformGrouped.swift
@@ -59,6 +59,9 @@ public extension NSManagedObjectContext {
         }
 
         if let error = thrownError {
+            groups.apply {
+                dispatchGroupContext?.leave($0)
+            }
             throw error
         } else {
             return result

--- a/wire-ios-utilities/Tests/NSManagedObjectContext+SwiftTests.swift
+++ b/wire-ios-utilities/Tests/NSManagedObjectContext+SwiftTests.swift
@@ -83,11 +83,13 @@ final class NSManagedObjectContext_SwiftTests: XCTestCase {
 
     func testThatItReturnsNonOptionalValue_Throwing() throws {
         // given
+        sut.dispatchGroup.enter()
         let expectation = self.expectation(description: "wait for group to be left on error")
         let group = try XCTUnwrap(sut.dispatchGroup)
         group.notify(on: DispatchQueue.main) {
             expectation.fulfill()
         }
+
         let closure: () throws -> Int = {
             throw TestError()
         }
@@ -102,8 +104,9 @@ final class NSManagedObjectContext_SwiftTests: XCTestCase {
             // then
             XCTAssert(error is TestError)
         }
+        sut.dispatchGroup.leave()
 
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testThatItReturnsOptionalValue_Throwing() {

--- a/wire-ios-utilities/Tests/NSManagedObjectContext+SwiftTests.swift
+++ b/wire-ios-utilities/Tests/NSManagedObjectContext+SwiftTests.swift
@@ -81,8 +81,13 @@ final class NSManagedObjectContext_SwiftTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func testThatItReturnsNonOptionalValue_Throwing() {
+    func testThatItReturnsNonOptionalValue_Throwing() throws {
         // given
+        let expectation = self.expectation(description: "wait for group to be left on error")
+        let group = try XCTUnwrap(sut.dispatchGroup)
+        group.notify(on: DispatchQueue.main) {
+            expectation.fulfill()
+        }
         let closure: () throws -> Int = {
             throw TestError()
         }
@@ -97,6 +102,8 @@ final class NSManagedObjectContext_SwiftTests: XCTestCase {
             // then
             XCTAssert(error is TestError)
         }
+
+        wait(for: [expectation])
     }
 
     func testThatItReturnsOptionalValue_Throwing() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6628" title="WPB-6628" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6628</a>  [iOS] Crash on C3 during playtest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----

# What's new in this PR?

### Issues

Looking into the crash referencing EventDecoder.filterInvalidEvents(from:), I tried to look at all callstack ending up to that line: `EventDecoder.filterInvalidEvents -> processBatch -> process(with:consumeBlock:firstCall:callEventsOnly:) -> processStoredEvents ->  processStoredUpdateEvents -> processEvents(callEventsOnly: -> processPendingCallEvents -> performGroupedAndWait`

```
Thread 15 name:
Thread 15:
0 Foundation 0x00000001aa9b6710 static
UUID._unconditionallyBridgeFromObjectiveC(_:) + 256 (UUID_Wrappers.swift:51)
1 WireDataModel 0x0000000102f07700 @objc static
ZMManagedObject.fetch(with:in:) + 100 (<compiler-generated>:0)
2 WireDataModel 0x0000000102d6d920 +[ZMConversation(Internal)
selfConversationInContext:] + 76 (ZMConversation.m:677)
3 WireRequestStrategy 0x00000001021d1e28 closure #1 in
EventDecoder.filterInvalidEvents(from:) + 96
4 WireRequestStrategy 0x00000001021d27a4 partial apply for closure #1
in EventDecoder.filterInvalidEvents(from:) + 44 (<compiler-generated>:0)
5 CoreData 0x00000001b3bfe704 closure #1 in closure #1 in
NSManagedObjectContext._rethrowsHelper_perform_enqueued<A>(_:rescue:) + 356
(NSManagedObjectContext.swift:180)
6 CoreData 0x00000001b3bfe580 thunk for @escaping
@callee_guaranteed () -> () + 36 (<compiler-generated>:0)
7 CoreData 0x00000001b3b7f74c
developerSubmittedBlockToNSManagedObjectContextPerform + 156
(NSManagedObjectContext.m:3983)
8 libdispatch.dylib 0x00000001b3949300 _dispatch_client_callout +
20 (object.m:561)
9 libdispatch.dylib 0x00000001b3950894 _dispatch_lane_serial_drain
+ 748 (queue.c:3885)
10 libdispatch.dylib 0x00000001b39513c4 _dispatch_lane_invoke + 380
(queue.c:3976)
11 libdispatch.dylib 0x00000001b395c004
_dispatch_root_queue_drain_deferred_wlh + 288 (queue.c:6913)
12 libdispatch.dylib 0x00000001b395b878
_dispatch_workloop_worker_thread + 404 (queue.c:6507)
13 libsystem_pthread.dylib 0x000000021593b964 _pthread_wqthread + 288
(pthread.c:2629)
14 libsystem_pthread.dylib 0x000000021593ba04 start_wqthread + 8 (:-1)
```

I found an issue where we don't exit dispatchGroup in performGroupAndWait that would explain we stay waiting forever on mainThread.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

### Notes (Optional)

I am not 100% this is the reason for the crash but for sure a bug lays here in `performGroupAndWait`
