### PR TITLE
fix: remove conformance of UIControl.State to Hashable [WPB-6969]

### DIFF
--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
+++ b/wire-ios/Wire-iOS Share Extension/ShareExtensionAnalytics.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2017 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios/Wire-iOS Share Extension/UnlockViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/UnlockViewController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireDataModel
 import WireCommonComponents
@@ -208,7 +207,7 @@ extension UnlockViewController {
         let attributedString = NSMutableAttributedString(string: L10n.ShareExtension.Unlock.errorLabel)
         attributedString.addAttributes([.font: hintFont], range: NSRange(location: 0, length: attributedString.length))
         attributedString.insert(.init(attachment: textAttachment), at: 0)
-        errorLabel.attributedText = attributedString
+        errorLabel.attributedText = .init(attributedString)
         unlockButton.isEnabled = false
     }
 

--- a/wire-ios/Wire-iOS Share Extension/UnlockViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/UnlockViewController.swift
@@ -205,9 +205,10 @@ extension UnlockViewController {
     func showWrongPasscodeMessage() {
         let textAttachment = NSTextAttachment.textAttachment(for: .exclamationMarkCircle, with: SemanticColors.Label.textErrorDefault, iconSize: StyleKitIcon.Size.CreatePasscode.errorIconSize, verticalCorrection: -1, insets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 4))
 
-        let attributedString = NSAttributedString(string: L10n.ShareExtension.Unlock.errorLabel) && hintFont
-
-        errorLabel.attributedText = NSAttributedString(attachment: textAttachment) + attributedString
+        let attributedString = NSMutableAttributedString(string: L10n.ShareExtension.Unlock.errorLabel)
+        attributedString.addAttributes([.font: hintFont], range: NSRange(location: 0, length: attributedString.length))
+        attributedString.insert(.init(attachment: textAttachment), at: 0)
+        errorLabel.attributedText = attributedString
         unlockButton.isEnabled = false
     }
 

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 		06E89AFE25C82C51008E3846 /* UnlockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E89AFD25C82C50008E3846 /* UnlockViewController.swift */; };
 		06E89B0025C82CA9008E3846 /* PasscodeTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E89AFF25C82CA9008E3846 /* PasscodeTextField.swift */; };
 		06F2664223881A0D006BD21F /* LabelIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F2664123881A0D006BD21F /* LabelIndicator.swift */; };
-		06F9864125CBD9C7005572C5 /* AttributedStringOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870534001DD6265100A7F822 /* AttributedStringOperators.swift */; };
 		06F9864225CBEEE6005572C5 /* StyleKitIcon+Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CBBEB924CED5C9006543D4 /* StyleKitIcon+Const.swift */; };
 		06F9864425CBFA6E005572C5 /* UIButton+SetIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F9864325CBFA6E005572C5 /* UIButton+SetIcon.swift */; };
 		06F9864525CC1440005572C5 /* UIStackView+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58191FF2091CEBF003BA7EC /* UIStackView+Helper.swift */; };
@@ -9083,7 +9082,6 @@
 				06717E5E2865188000AF442C /* SemanticColors.swift in Sources */,
 				06F9864525CC1440005572C5 /* UIStackView+Helper.swift in Sources */,
 				BF6EC90A1EB1FD0C009D9A69 /* ExtensionBackupExcluder.swift in Sources */,
-				06F9864125CBD9C7005572C5 /* AttributedStringOperators.swift in Sources */,
 				A955D3D923F5791100304851 /* String+URL.swift in Sources */,
 				D3095761283CEB1C00CEC620 /* MediaShareRestrictionManager.swift in Sources */,
 				06E89B0025C82CA9008E3846 /* PasscodeTextField.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -77,9 +77,9 @@ class IconButton: ButtonWithLargerHitArea {
     var adjustsBorderColorWhenHighlighted = false
     var adjustBackgroundImageWhenHighlighted = false
 
-    private var iconColorsByState: [UIControl.State: UIColor] = [:]
-    private var borderColorByState: [UIControl.State: UIColor] = [:]
-    private var iconDefinitionsByState: [UIControl.State: IconDefinition] = [:]
+    private var iconColorsByState: [UIControl.State.RawValue: UIColor] = [:]
+    private var borderColorByState: [UIControl.State.RawValue: UIColor] = [:]
+    private var iconDefinitionsByState: [UIControl.State.RawValue: IconDefinition] = [:]
     private var priorState: UIControl.State?
 
     override init(fontSpec: FontSpec = .smallLightFont) {
@@ -218,11 +218,11 @@ class IconButton: ButtonWithLargerHitArea {
 
         let newIcon = IconDefinition(type: iconType, size: iconSize, renderingMode: renderingMode)
 
-        guard force || newIcon != iconDefinitionsByState[state] else {
+        guard force || newIcon != iconDefinitionsByState[state.rawValue] else {
             return
         }
 
-        iconDefinitionsByState[state] = newIcon
+        iconDefinitionsByState[state.rawValue] = newIcon
 
         let color: UIColor
         if renderingMode == .alwaysOriginal,
@@ -238,19 +238,19 @@ class IconButton: ButtonWithLargerHitArea {
     }
 
     func removeIcon(for state: UIControl.State) {
-        iconDefinitionsByState[state] = nil
+        iconDefinitionsByState[state.rawValue] = nil
         setImage(nil, for: state)
     }
 
     func setIconColor(_ color: UIColor?,
                       for state: UIControl.State) {
         if nil != color {
-            iconColorsByState[state] = color
+            iconColorsByState[state.rawValue] = color
         } else {
-            iconColorsByState.removeValue(forKey: state)
+            iconColorsByState.removeValue(forKey: state.rawValue)
         }
 
-        if let currentIcon = iconDefinitionsByState[state],
+        if let currentIcon = iconDefinitionsByState[state.rawValue],
            currentIcon.renderingMode == .alwaysOriginal {
             setIcon(currentIcon.type,
                     iconSize: currentIcon.size,
@@ -263,15 +263,15 @@ class IconButton: ButtonWithLargerHitArea {
     }
 
     func iconDefinition(for state: UIControl.State) -> IconDefinition? {
-        return iconDefinitionsByState[state]
+        return iconDefinitionsByState[state.rawValue]
     }
 
     func iconColor(for state: UIControl.State) -> UIColor? {
-        return iconColorsByState[state] ?? iconColorsByState[.normal]
+        return iconColorsByState[state.rawValue] ?? iconColorsByState[UIControl.State.normal.rawValue]
     }
 
     func borderColor(for state: UIControl.State) -> UIColor? {
-        return borderColorByState[state] ?? borderColorByState[.normal]
+        return borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
     private func updateBorderColor() {
@@ -322,11 +322,11 @@ class IconButton: ButtonWithLargerHitArea {
     func setBorderColor(_ color: UIColor?, for state: UIControl.State) {
         state.expanded.forEach { expandedState in
             if color != nil {
-                borderColorByState[expandedState] = color
+                borderColorByState[expandedState.rawValue] = color
 
                 if adjustsBorderColorWhenHighlighted &&
                     expandedState == .normal {
-                    borderColorByState[.highlighted] = color?.mix(.black, amount: 0.4)
+                    borderColorByState[UIControl.State.highlighted.rawValue] = color?.mix(.black, amount: 0.4)
                 }
             }
         }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/LegacyButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/LegacyButton.swift
@@ -85,9 +85,8 @@ class LegacyButton: ButtonWithLargerHitArea {
 
     var textTransform: TextTransform = .none {
         didSet {
-            for(state, title) in originalTitles {
-                let state = UIControl.State(rawValue: state)
-                setTitle(title, for: state)
+            for (state, title) in originalTitles {
+                setTitle(title, for: .init(rawValue: state))
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/LegacyButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/LegacyButton.swift
@@ -86,6 +86,7 @@ class LegacyButton: ButtonWithLargerHitArea {
     var textTransform: TextTransform = .none {
         didSet {
             for(state, title) in originalTitles {
+                let state = UIControl.State(rawValue: state)
                 setTitle(title, for: state)
             }
         }
@@ -99,9 +100,9 @@ class LegacyButton: ButtonWithLargerHitArea {
 
     private(set) var variant: ColorSchemeVariant = ColorScheme.default.variant
 
-    private var originalTitles: [UIControl.State: String] = [:]
+    private var originalTitles: [UIControl.State.RawValue: String] = [:]
 
-    private var borderColorByState: [UIControl.State: UIColor] = [:]
+    private var borderColorByState: [UIControl.State.RawValue: UIColor] = [:]
 
     override init(fontSpec: FontSpec = .normalRegularFont) {
         super.init(fontSpec: fontSpec)
@@ -180,7 +181,7 @@ class LegacyButton: ButtonWithLargerHitArea {
     }
 
     func borderColor(for state: UIControl.State) -> UIColor? {
-        return borderColorByState[state] ?? borderColorByState[.normal]
+        return borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
     private func updateBorderColor() {
@@ -228,9 +229,9 @@ class LegacyButton: ButtonWithLargerHitArea {
         var title = title
         state.expanded.forEach { expandedState in
             if title != nil {
-                originalTitles[expandedState] = title
+                originalTitles[expandedState.rawValue] = title
             } else {
-                originalTitles[expandedState] = nil
+                originalTitles[expandedState.rawValue] = nil
             }
         }
 
@@ -244,7 +245,7 @@ class LegacyButton: ButtonWithLargerHitArea {
     func setBorderColor(_ color: UIColor?, for state: UIControl.State) {
         state.expanded.forEach { expandedState in
             if color != nil {
-                borderColorByState[expandedState] = color
+                borderColorByState[expandedState.rawValue] = color
             }
         }
 

--- a/wire-ios/Wire-iOS/Sources/Helpers/UIAlertController/UIAlertController+Permissions.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/UIAlertController/UIAlertController+Permissions.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireCommonComponents
 

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/UserType+Helpers.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/UserType+Helpers.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import WireCommonComponents
 import WireSyncEngine
 
 typealias ConversationCreatedBlock = (Result<ZMConversation, Error>) -> Void

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
@@ -78,13 +78,11 @@ extension IconButton {
         translatesAutoresizingMaskIntoConstraints = false
 
         for (state, color) in backgroundColor {
-            let state = UIControl.State(rawValue: state)
-            setBackgroundImageColor(color, for: state)
+            setBackgroundImageColor(color, for: .init(rawValue: state))
         }
 
         for (state, color) in iconColor {
-            let state = UIControl.State(rawValue: state)
-            setIconColor(color, for: state)
+            setIconColor(color, for: .init(rawValue: state))
         }
 
         borderWidth = 0

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
@@ -28,8 +28,8 @@ extension IconButton {
         return .init(
             icon: .phone,
             accessibilityId: "AcceptButton",
-            backgroundColor: [.normal: SemanticColors.Button.backgroundPickUp],
-            iconColor: [.normal: .white],
+            backgroundColor: [UIControl.State.normal.rawValue: SemanticColors.Button.backgroundPickUp],
+            iconColor: [UIControl.State.normal.rawValue: .white],
             width: IconButton.width
         )
     }
@@ -39,8 +39,8 @@ extension IconButton {
             icon: .endCall,
             size: .small,
             accessibilityId: "LeaveCallButton",
-            backgroundColor: [.normal: SemanticColors.Button.backgroundHangUp],
-            iconColor: [.normal: .white],
+            backgroundColor: [UIControl.State.normal.rawValue: SemanticColors.Button.backgroundHangUp],
+            iconColor: [UIControl.State.normal.rawValue: .white],
             width: IconButton.width
         )
     }
@@ -52,12 +52,12 @@ extension IconButton {
         let sendButton = IconButton(
             icon: .send,
             accessibilityId: "sendButton",
-            backgroundColor: [.normal: UIColor.accent(),
-                              .highlighted: UIColor.accentDarken,
-                              .disabled: SemanticColors.Button.backgroundSendDisabled],
-            iconColor: [.normal: sendButtonIconColor,
-                        .highlighted: sendButtonIconColor,
-                        .disabled: sendButtonIconColor]
+            backgroundColor: [UIControl.State.normal.rawValue: UIColor.accent(),
+                              UIControl.State.highlighted.rawValue: UIColor.accentDarken,
+                              UIControl.State.disabled.rawValue: SemanticColors.Button.backgroundSendDisabled],
+            iconColor: [UIControl.State.normal.rawValue: sendButtonIconColor,
+                        UIControl.State.highlighted.rawValue: sendButtonIconColor,
+                        UIControl.State.disabled.rawValue: sendButtonIconColor]
         )
 
         return sendButton
@@ -67,8 +67,8 @@ extension IconButton {
         icon: StyleKitIcon,
         size: StyleKitIcon.Size = .tiny,
         accessibilityId: String,
-        backgroundColor: [UIControl.State: UIColor],
-        iconColor: [UIControl.State: UIColor],
+        backgroundColor: [UIControl.State.RawValue: UIColor],
+        iconColor: [UIControl.State.RawValue: UIColor],
         width: CGFloat? = nil
     ) {
         self.init(fontSpec: .smallLightFont)
@@ -78,10 +78,12 @@ extension IconButton {
         translatesAutoresizingMaskIntoConstraints = false
 
         for (state, color) in backgroundColor {
+            let state = UIControl.State(rawValue: state)
             setBackgroundImageColor(color, for: state)
         }
 
         for (state, color) in iconColor {
+            let state = UIControl.State(rawValue: state)
             setIconColor(color, for: state)
         }
 
@@ -93,10 +95,4 @@ extension IconButton {
         }
     }
 
-}
-
-extension UIControl.State: Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.rawValue)
-    }
 }

--- a/wire-ios/WireCommonComponents/UIColor+AccentColor.swift
+++ b/wire-ios/WireCommonComponents/UIColor+AccentColor.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6969" title="WPB-6969" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6969</a>  One on One call and video fails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

By using its raw value there is no reason that `UIControl.State` conforms to `Hashable`.
This PR removes the extension.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
