### PR TITLE
fix(mls-migration): start time check

### DIFF
--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
@@ -157,6 +157,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
         if (BackendInfo.apiVersion ?? .v0) < .v5 {
             return .cannotStart(reason: .unsupportedAPIVersion)
         }
+
         if !DeveloperFlag.enableMLSSupport.isOn {
             return .cannotStart(reason: .clientDoesntSupportMLS)
         }
@@ -175,7 +176,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
             return .cannotStart(reason: .mlsMigrationIsNotEnabled)
         }
 
-        if let startTime = features.mlsMigration.config.startTime, startTime.isInTheFuture {
+        guard let startTime = features.mlsMigration.config.startTime, startTime.isInThePast else {
             return .cannotStart(reason: .startTimeHasNotBeenReached)
         }
 

--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
@@ -175,7 +175,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
             return .cannotStart(reason: .mlsMigrationIsNotEnabled)
         }
 
-        if let startTime = features.mlsMigration.config.startTime, startTime.isInThePast {
+        if let startTime = features.mlsMigration.config.startTime, startTime.isInTheFuture {
             return .cannotStart(reason: .startTimeHasNotBeenReached)
         }
 

--- a/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
+++ b/wire-ios-data-model/Source/MLS/Migration/ProteusToMLSMigrationCoordinator.swift
@@ -175,7 +175,7 @@ public class ProteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
             return .cannotStart(reason: .mlsMigrationIsNotEnabled)
         }
 
-        if features.mlsMigration.config.startTime > .now {
+        if let startTime = features.mlsMigration.config.startTime, startTime.isInThePast {
             return .cannotStart(reason: .startTimeHasNotBeenReached)
         }
 

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -166,6 +166,62 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
         XCTAssertFalse(startedMigration)
     }
 
+    func test_ItDoesntStartMigration_IfStartTimeIsInTheFuture() async throws {
+        // GIVEN
+        await createUserAndGroupConversation()
+
+        setMockValues(
+            isAPIV5Supported: true,
+            isClientSupportingMLS: true,
+            isBackendSupportingMLS: true,
+            isMLSProtocolSupported: true,
+            isMLSMigrationFeatureEnabled: true,
+            startTime: .distantFuture
+        )
+
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        var startedMigration = false
+        mockMLSService.startProteusToMLSMigration_MockMethod = {
+            startedMigration = true
+        }
+
+        // WHEN
+        try await sut.updateMigrationStatus()
+
+        // THEN
+        XCTAssertEqual(mockStorage.underlyingMigrationStatus, .notStarted)
+        XCTAssertFalse(startedMigration)
+    }
+
+    func test_ItStartsMigration_IfStartTimeIsInThePast() async throws {
+        // GIVEN
+        await createUserAndGroupConversation()
+
+        setMockValues(
+            isAPIV5Supported: true,
+            isClientSupportingMLS: true,
+            isBackendSupportingMLS: true,
+            isMLSProtocolSupported: true,
+            isMLSMigrationFeatureEnabled: true,
+            startTime: .distantPast
+        )
+
+        mockStorage.underlyingMigrationStatus = .notStarted
+
+        var startedMigration = false
+        mockMLSService.startProteusToMLSMigration_MockMethod = {
+            startedMigration = true
+        }
+
+        // WHEN
+        try await sut.updateMigrationStatus()
+
+        // THEN
+        XCTAssertEqual(mockStorage.underlyingMigrationStatus, .started)
+        XCTAssertTrue(startedMigration)
+    }
+
     func test_UpdateMigrationStatusDoesntFetchFeaturesConfig_IfAPIV5NotSupported() async throws {
         try await internalTest_updateMigrationStatusDoesntFetchFeaturesConfig(isAPIV5Supported: false)
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Migration starts even when the MLS migration config has no migration start time 

### Causes

The migration config has an optional startTime. We compare the `startTime` to `.now` and somehow the compiler allows us to compare `nil` to `.now`

### Solutions

Do not migrate if `startTime` is `nil` 
