### PR TITLE
fix: add learn more link to the E2EI enrollment screen

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -4930,8 +4930,12 @@ internal enum L10n {
         internal enum E2ei {
           /// Your team now uses end-to-end identity to make Wire's usage more secure.
           /// 
-          ///  Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device.
-          internal static let subtitle = L10n.tr("Localizable", "registration.signin.e2ei.subtitle", fallback: "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device.")
+          ///  Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device. 
+          /// 
+          ///  [Learn more about end-to-end identity](%@)
+          internal static func subtitle(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "registration.signin.e2ei.subtitle", String(describing: p1), fallback: "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device. \n\n [Learn more about end-to-end identity](%@)")
+          }
           /// End-to-end identity certificate
           internal static let title = L10n.tr("Localizable", "registration.signin.e2ei.title", fallback: "End-to-end identity certificate")
           internal enum Error {

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1608,7 +1608,7 @@
 "registration.signin.alert.password_needed.message" = "Please enter your Password in order to log in.";
 
 "registration.signin.e2ei.title" = "End-to-end identity certificate";
-"registration.signin.e2ei.subtitle" = "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device.";
+"registration.signin.e2ei.subtitle" = "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device. \n\n [Learn more about end-to-end identity](%@)";
 "registration.signin.e2ei.get_certificate_button.title" = "Get Certificate";
 "registration.signin.e2ei.error.alert.title" = "Something went wrong";
 "registration.signin.e2ei.error.alert.message" = "Failed to retrieve certificate";

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/AuthenticationStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/AuthenticationStepDescription.swift
@@ -50,7 +50,7 @@ protocol AuthenticationStepDescription {
     var backButton: BackButtonDescription? { get }
     var mainView: ViewDescriptor & ValueSubmission { get }
     var headline: String { get }
-    var subtext: String? { get }
+    var subtext: NSAttributedString? { get }
     var secondaryView: AuthenticationSecondaryViewDescription? { get }
     var footerView: AuthenticationFooterViewDescription? { get }
     func shouldSkipFromNavigation() -> Bool

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/AddEmailPasswordStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/AddEmailPasswordStepDescription.swift
@@ -27,7 +27,7 @@ final class AddEmailPasswordStepDescription: DefaultValidatingStepDescription {
         emailPasswordFieldDescription
     }
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let initialValidation: ValueValidation
     let footerView: AuthenticationFooterViewDescription?
@@ -37,7 +37,7 @@ final class AddEmailPasswordStepDescription: DefaultValidatingStepDescription {
     init() {
         backButton = BackButtonDescription()
         headline = L10n.Localizable.Registration.AddEmailPassword.Hero.title
-        subtext = L10n.Localizable.Registration.AddEmailPassword.Hero.paragraph
+        subtext = .markdown(from: L10n.Localizable.Registration.AddEmailPassword.Hero.paragraph, style: .login)
         initialValidation = .info(PasswordRuleSet.localizedErrorMessage)
         footerView = nil
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/AddUsernameStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/AddUsernameStepDescription.swift
@@ -26,7 +26,7 @@ final class AddUsernameStepDescription: DefaultValidatingStepDescription {
     let backButton: BackButtonDescription?
     var mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription? = nil
     let initialValidation: ValueValidation
     let footerView: AuthenticationFooterViewDescription? = nil
@@ -40,7 +40,7 @@ final class AddUsernameStepDescription: DefaultValidatingStepDescription {
         mainView = textField
         backButton = BackButtonDescription()
         headline = Username.title
-        subtext = Username.message
+        subtext = .markdown(from: Username.message, style: .login)
         initialValidation = .info(HandleChange.footer)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/BackupRestoreStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/BackupRestoreStepDescription.swift
@@ -48,7 +48,7 @@ final class BackupRestoreStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
@@ -59,10 +59,10 @@ final class BackupRestoreStepDescription: AuthenticationStepDescription {
         switch context {
         case .newDevice:
             headline = L10n.Localizable.Registration.NoHistory.hero
-            subtext = L10n.Localizable.Registration.NoHistory.subtitle
+            subtext = .markdown(from: L10n.Localizable.Registration.NoHistory.subtitle, style: .login)
         case .loggedOut:
             headline = L10n.Localizable.Registration.NoHistory.LoggedOut.hero
-            subtext = L10n.Localizable.Registration.NoHistory.LoggedOut.subtitle
+            subtext = .markdown(from: L10n.Localizable.Registration.NoHistory.LoggedOut.subtitle, style: .login)
         }
 
         guard SecurityFlags.backup.isEnabled else {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/ClientUnregisterInvitationStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/ClientUnregisterInvitationStepDescription.swift
@@ -27,7 +27,7 @@ final class ClientUnregisterInvitationStepDescription: AuthenticationStepDescrip
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
@@ -36,7 +36,7 @@ final class ClientUnregisterInvitationStepDescription: AuthenticationStepDescrip
     init() {
         backButton = BackButtonDescription()
         headline = TooManyDevices.title
-        subtext = TooManyDevices.subtitle
+        subtext = .markdown(from: TooManyDevices.subtitle, style: .login)
 
         mainView = SolidButtonDescription(title: TooManyDevices.ManageButton.title.capitalized, accessibilityIdentifier: "manage_devices")
         secondaryView = nil

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/EmailLinkVerificationStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/EmailLinkVerificationStepDescription.swift
@@ -24,7 +24,7 @@ final class EmailLinkVerificationStepDescription: AuthenticationStepDescription 
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
@@ -32,7 +32,7 @@ final class EmailLinkVerificationStepDescription: AuthenticationStepDescription 
         backButton = BackButtonDescription()
         mainView = EmailLinkVerificationMainView()
         headline = L10n.Localizable.Team.ActivationCode.headline
-        subtext = L10n.Localizable.Registration.VerifyEmail.instructions(emailAddress)
+        subtext = .markdown(from: L10n.Localizable.Registration.VerifyEmail.instructions(emailAddress), style: .login)
         secondaryView = nil
         footerView = VerifyEmailStepSecondaryView(canResend: false)
     }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/EnrollE2EIdentityStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/EnrollE2EIdentityStepDescription.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import UIKit
 
 typealias E2ei = L10n.Localizable.Registration.Signin.E2ei
 
@@ -28,7 +29,7 @@ class EnrollE2EIdentityStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription? = nil
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription? = nil
 
@@ -39,7 +40,7 @@ class EnrollE2EIdentityStepDescription: AuthenticationStepDescription {
         )
         secondaryView = nil
         headline = E2ei.title
-        subtext = E2ei.subtitle
+        subtext = .markdown(from: E2ei.subtitle(URL.wr_e2eiLearnMore), style: .login)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/LogInStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/LogInStepDescription.swift
@@ -43,7 +43,7 @@ final class LogInStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/ReauthenticateStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/ReauthenticateStepDescription.swift
@@ -27,7 +27,7 @@ final class ReauthenticateStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
@@ -39,18 +39,18 @@ final class ReauthenticateStepDescription: AuthenticationStepDescription {
         switch prefilledCredentials?.primaryCredentialsType {
         case .email?:
             if prefilledCredentials?.isExpired == true {
-                subtext = L10n.Localizable.SigninLogout.Email.subheadline
+                subtext = .markdown(from: L10n.Localizable.SigninLogout.Email.subheadline, style: .login)
             } else {
-                subtext = L10n.Localizable.Signin.Email.MissingPassword.subtitle
+                subtext = .markdown(from: L10n.Localizable.Signin.Email.MissingPassword.subtitle, style: .login)
             }
         case .phone?:
             if prefilledCredentials?.isExpired == true {
-                subtext = L10n.Localizable.SigninLogout.Phone.subheadline
+                subtext = .markdown(from: L10n.Localizable.SigninLogout.Phone.subheadline, style: .login)
             } else {
-                subtext = L10n.Localizable.Signin.Phone.MissingPassword.subtitle
+                subtext = .markdown(from: L10n.Localizable.Signin.Phone.MissingPassword.subtitle, style: .login)
             }
         case .none:
-            subtext = L10n.Localizable.SigninLogout.subheadline
+            subtext = .markdown(from: L10n.Localizable.SigninLogout.subheadline, style: .login)
         }
 
         secondaryView = nil

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/ReauthenticateWithCompanyLoginStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/ReauthenticateWithCompanyLoginStepDescription.swift
@@ -23,14 +23,14 @@ final class ReauthenticateWithCompanyLoginStepDescription: AuthenticationStepDes
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
     init() {
         backButton = BackButtonDescription()
         headline = L10n.Localizable.Registration.Signin.title
-        subtext = L10n.Localizable.SigninLogout.Sso.subheadline
+        subtext = .markdown(from: L10n.Localizable.SigninLogout.Sso.subheadline, style: .login)
 
         mainView = SolidButtonDescription(title: L10n.Localizable.SigninLogout.Sso.buton, accessibilityIdentifier: "company_login")
         secondaryView = nil

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/PersonalRegistrationStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/PersonalRegistrationStepDescription.swift
@@ -27,7 +27,7 @@ final class PersonalRegistrationStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/SetFullNameStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/SetFullNameStepDescription.swift
@@ -25,7 +25,7 @@ final class SetFullNameStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/SetPasswordStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/SetPasswordStepDescription.swift
@@ -24,7 +24,7 @@ final class SetPasswordStepDescription: DefaultValidatingStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let initialValidation: ValueValidation
     let footerView: AuthenticationFooterViewDescription?

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/VerifyEmailStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/VerifyEmailStepDescription.swift
@@ -54,7 +54,7 @@ final class VerifyEmailStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
@@ -63,7 +63,7 @@ final class VerifyEmailStepDescription: AuthenticationStepDescription {
         backButton = nil
         mainView = VerificationCodeFieldDescription()
         headline = L10n.Localizable.Team.ActivationCode.headline
-        subtext = L10n.Localizable.Team.ActivationCode.subheadline(email)
+        subtext = .markdown(from: L10n.Localizable.Team.ActivationCode.subheadline(email), style: .login)
         secondaryView = nil
         footerView = VerifyEmailStepSecondaryView(canChangeEmail: canChangeEmail)
     }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/VerifyPhoneStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Registration/VerifyPhoneStepDescription.swift
@@ -44,7 +44,7 @@ final class VerifyPhoneStepDescription: AuthenticationStepDescription {
     let backButton: BackButtonDescription?
     let mainView: ViewDescriptor & ValueSubmission
     let headline: String
-    let subtext: String?
+    let subtext: NSAttributedString?
     let secondaryView: AuthenticationSecondaryViewDescription?
     let footerView: AuthenticationFooterViewDescription?
 
@@ -53,7 +53,7 @@ final class VerifyPhoneStepDescription: AuthenticationStepDescription {
         backButton = nil
         mainView = VerificationCodeFieldDescription()
         headline = L10n.Localizable.Team.PhoneActivationCode.headline
-        subtext = L10n.Localizable.Team.ActivationCode.subheadline(phoneNumber)
+        subtext = .markdown(from: L10n.Localizable.Team.ActivationCode.subheadline(phoneNumber), style: .login)
         secondaryView = nil
         footerView = VerifyPhoneStepSecondaryView(phoneNumber: phoneNumber, allowChange: allowChange)
     }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -52,7 +52,7 @@ class AuthenticationStepController: AuthenticationStepViewController {
 
     private var headlineLabel: DynamicFontLabel!
     private var headlineLabelContainer: ContentInsetView!
-    private var subtextLabel: UILabel!
+    private var subtextLabel: WebLinkTextView!
     private var subtextLabelContainer: ContentInsetView!
     private var mainView: UIView!
     private var errorLabel: UILabel!
@@ -146,14 +146,15 @@ class AuthenticationStepController: AuthenticationStepViewController {
         headlineLabel.accessibilityTraits.insert(.header)
 
         if stepDescription.subtext != nil {
-            subtextLabel = DynamicFontLabel(fontSpec: .normalRegularFont,
-                                            color: labelColor)
+            subtextLabel = WebLinkTextView()
             subtextLabelContainer = ContentInsetView(subtextLabel, inset: textPadding)
+            subtextLabel.tintColor = labelColor
             subtextLabel.textAlignment = .center
-            subtextLabel.text = stepDescription.subtext
+            subtextLabel.attributedText = stepDescription.subtext
             subtextLabel.font = AuthenticationStepController.subtextFont
-            subtextLabel.numberOfLines = 0
-            subtextLabel.lineBreakMode = .byWordWrapping
+            subtextLabel.linkTextAttributes = [
+                NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue
+            ]
             subtextLabelContainer.isHidden = stepDescription.subtext == nil
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/MarkdownTextView.swift
@@ -698,6 +698,23 @@ extension DownStyle {
         style.h3Size = style.h1Size
         return style
     }()
+
+    /// The style used during the login flow
+    static var login: DownStyle = {
+        let paragraphStyle = NSParagraphStyle.default.mutableCopy() as! NSMutableParagraphStyle
+        paragraphStyle.alignment = .center
+        paragraphStyle.paragraphSpacing = 8
+        paragraphStyle.paragraphSpacingBefore = 8
+
+        let style = DownStyle()
+        style.baseFont = FontSpec.normalLightFont.font!
+        style.baseFontColor = SemanticColors.Label.textDefault
+        style.codeFont = UIFont(name: "Menlo", size: style.baseFont.pointSize) ?? style.baseFont
+        style.codeColor = SemanticColors.Label.textDefault
+        style.baseParagraphStyle = paragraphStyle
+        style.listItemPrefixSpacing = 8
+        return style
+    }()
 }
 
 // MARK: - Helper Extensions


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Add missing "learn more" link to the E2EI enrollment screen

### Attachments

![Simulator Screenshot - iPhone 15 Pro - 2024-03-07 at 00 33 25](https://github.com/wireapp/wire-ios/assets/7156/e19ff126-52fd-48c1-84c9-58612951f6d7)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
