### PR TITLE
fix: attempt to present on DeveloperMenu

### DIFF
--- a/wire-ios/Wire-iOS/Sources/WireApplication.swift
+++ b/wire-ios/Wire-iOS/Sources/WireApplication.swift
@@ -23,27 +23,31 @@ import SwiftUI
 
 final class WireApplication: UIApplication {
 
+    private var displayedDeveloperTools = false
+
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        guard motion == .motionShake else { return }
-
-        if Bundle.developerModeEnabled {
-            let developerTools = UIHostingController(
-                rootView: NavigationView {
-                    DeveloperToolsView(viewModel: DeveloperToolsViewModel(
-                        router: AppDelegate.shared.appRootRouter,
-                        onDismiss: { [weak self] in
-                            self?.topmostViewController()?.dismissIfNeeded()
-                        }
-                    ))
-                }
-            )
-
-            topmostViewController()?.present(developerTools, animated: true)
-        } else {
-            DebugAlert.showSendLogsMessage(
-                message: "You have performed a shake motion, please confirm sending debug logs."
-            )
+        guard Bundle.developerModeEnabled else {
+            return
         }
+
+        guard motion == .motionShake, !displayedDeveloperTools else { return }
+
+        let developerTools = UIHostingController(
+            rootView: NavigationView {
+                DeveloperToolsView(viewModel: DeveloperToolsViewModel(
+                    router: AppDelegate.shared.appRootRouter,
+                    onDismiss: { [weak self] in
+
+                        self?.topmostViewController()?.dismissIfNeeded()
+                        self?.displayedDeveloperTools = false
+                    }
+                ))
+            }
+        )
+
+        topmostViewController()?.present(developerTools, animated: true, completion: { [weak self] in
+            self?.displayedDeveloperTools = true
+        })
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If you shake your phone while developer tools is displayed you'll get :

```
Attempt to present <_TtGC7SwiftUI19UIHostingControllerGVS_14NavigationViewV4Wire18DeveloperToolsView__: 0x112808200> on <Wire.RootViewController: 0x108504fb0> (from <Wire.RootViewController: 0x108504fb0>) which is already presenting <_TtGC7SwiftUI19UIHostingControllerGVS_14NavigationViewV4Wire18DeveloperToolsView__: 0x11100d800>.
```

### Solutions

Check if DeveloperTools was presented before trying to present.

Also remove logic to fallback to DebugAlert as it will never happen (check on Bundle.developerModeEnabled)
