### PR TITLE
chore: restore C1 C3 workflows for release 3.111 cycle

### DIFF
--- a/.github/workflows/c1_c3_app_release_production.yml
+++ b/.github/workflows/c1_c3_app_release_production.yml
@@ -1,0 +1,19 @@
+name: C1 C3 Production
+
+on: workflow_dispatch
+
+permissions: 
+  checks: write
+
+jobs:
+  column_1_production:
+    uses: ./.github/workflows/_reusable_app_release.yml
+    with:
+      fastlane_action: appstore_col_1_prod
+    secrets: inherit
+
+  column_3_production:
+    uses: ./.github/workflows/_reusable_app_release.yml
+    with:
+      fastlane_action: appstore_col_3_prod
+    secrets: inherit

--- a/.github/workflows/c1_c3_app_release_restricted.yml
+++ b/.github/workflows/c1_c3_app_release_restricted.yml
@@ -1,0 +1,19 @@
+name: C1 C3 Restricted
+
+on: workflow_dispatch
+
+permissions: 
+  checks: write
+
+jobs:
+  column_1_restricted:
+    uses: ./.github/workflows/_reusable_app_release.yml
+    with:
+      fastlane_action: appstore_col_1_restricted
+    secrets: inherit
+
+  column_3_restricted:
+    uses: ./.github/workflows/_reusable_app_release.yml
+    with:
+      fastlane_action: appstore_col_3_restricted
+    secrets: inherit


### PR DESCRIPTION
# What's new in this PR?

### Issues

We can't push C1 and C3 on release cycle 3.111 branch because the workflows have been renamed on develop to C1,C2,C3.

### Solutions

Add same workflows of release/cycle-3.111 on develop so they can be triggered.
