### PR TITLE
fix: it's possible escape E2EI enrollment on login WPB-7011

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -297,6 +297,13 @@ public class ZMClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
         needsToVerifySelfClient = !needsToRegisterClient
         needsToFetchFeatureConfigs = needsToRegisterClient
         needsRefreshSelfUser = needsToRegisterClient
+
+        if !needsToRegisterClient && needsToRegisterMLSCLient {
+            guard let client = ZMUser.selfUser(in: managedObjectContext).selfClient() else {
+                fatal("Expected a self user client to exist")
+            }
+            createMLSClient(client: client)
+        }
     }
 
     func observeProfileUpdates() {
@@ -453,28 +460,32 @@ public class ZMClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
         lastResortPrekey = nil
 
         if needsToRegisterMLSCLient {
-            if needsToEnrollE2EI {
-                isWaitingForE2EIEnrollment = true
-                notifyE2EIEnrollmentNecessary()
-            } else {
-                guard let mlsClientID = MLSClientID(userClient: client) else {
-                    fatalError("Needs to register MLS client but can't retrieve qualified client ID")
-                }
-
-                WaitingGroupTask(context: managedObjectContext) {
-                    do {
-                        try await self.coreCryptoProvider.initialiseMLSWithBasicCredentials(mlsClientID: mlsClientID)
-                    } catch {
-                        WireLogger.mls.error("Failed to initialise mls client: \(error)")
-                    }
-                }
-                isWaitingForMLSClientToBeRegistered = true
-            }
+            createMLSClient(client: client)
         } else {
             registrationStatusDelegate?.didRegisterSelfUserClient(client)
         }
 
         WireLogger.authentication.debug("current phase: \(currentPhase)")
+    }
+
+    private func createMLSClient(client: UserClient) {
+        if needsToEnrollE2EI {
+            isWaitingForE2EIEnrollment = true
+            notifyE2EIEnrollmentNecessary()
+        } else {
+            guard let mlsClientID = MLSClientID(userClient: client) else {
+                fatalError("Needs to register MLS client but can't retrieve qualified client ID")
+            }
+
+            WaitingGroupTask(context: managedObjectContext) {
+                do {
+                    try await self.coreCryptoProvider.initialiseMLSWithBasicCredentials(mlsClientID: mlsClientID)
+                } catch {
+                    WireLogger.mls.error("Failed to initialise mls client: \(error)")
+                }
+            }
+            isWaitingForMLSClientToBeRegistered = true
+        }
     }
 
     private func fetchExistingSelfClientsAfterRegisteringClient(_ selfClient: UserClient) {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -679,22 +679,6 @@ public final class ZMUserSession: NSObject {
         }
     }
 
-    func createMLSClientIfNeeded() {
-        // TODO: [WPB-6198] refactor out - [jacob]
-        if applicationStatusDirectory.clientRegistrationStatus.needsToRegisterMLSCLient {
-            guard let mlsClientID = MLSClientID(user: ZMUser.selfUser(in: syncContext)) else {
-                fatal("Needs to register MLS client but can't retrieve qualified client ID")
-            }
-            WaitingGroupTask(context: syncContext) { [self] in
-                do {
-                    _ = try await coreCryptoProvider.initialiseMLSWithBasicCredentials(mlsClientID: mlsClientID)
-                } catch {
-                    WireLogger.mls.error("Failed to create MLS client: \(error)")
-                }
-            }
-        }
-    }
-
     // MARK: - Network
 
     public func requestResyncResources() {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -517,8 +517,6 @@ public final class ZMUserSession: NSObject {
             self.applicationStatusDirectory.clientRegistrationStatus.determineInitialRegistrationStatus()
             self.hasCompletedInitialSync = self.applicationStatusDirectory.syncStatus.isSlowSyncing == false
 
-            createMLSClientIfNeeded()
-
             if e2eiFeature.isEnabled {
                 self.observeMLSGroupVerificationStatus.invoke()
                 self.cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMClientRegistrationStatusTests.swift
@@ -65,6 +65,54 @@ class ZMClientRegistrationStatusTests: MessagingTest {
         super.tearDown()
     }
 
+    // MARK: Initialisation
+
+    func testThatItRequestsE2EIEnrollment_whenRequiredOnInitialisation() {
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            let client  = UserClient.insertNewObject(in: self.syncMOC)
+            client.user = selfUser
+            client.remoteIdentifier = "identifier"
+            self.syncMOC.setPersistentStoreMetadata(client.remoteIdentifier, key: ZMPersistedClientIdKey)
+
+            enableMLS()
+            enableE2EI()
+
+            // when
+            sut.determineInitialRegistrationStatus()
+
+            // then
+            XCTAssertTrue(mockClientRegistationDelegate.didCallFailRegisterSelfUserClient)
+            XCTAssertEqual(mockClientRegistationDelegate.currentError as? NSError, needToToEnrollE2EIToRegisterClientError())
+        }
+    }
+
+    func testThatItCreatesBasicMLSClient_whenIfThereIsNoneOnInitialisation() {
+        syncMOC.performAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.remoteIdentifier = UUID()
+            let client  = UserClient.insertNewObject(in: self.syncMOC)
+            client.user = selfUser
+            client.remoteIdentifier = "identifier"
+            selfUser.domain = "example.com"
+            self.syncMOC.setPersistentStoreMetadata(client.remoteIdentifier, key: ZMPersistedClientIdKey)
+            mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_MockMethod = { _ in }
+
+            enableMLS()
+
+            // when
+            sut.determineInitialRegistrationStatus()
+            XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+            // then
+            XCTAssertEqual(self.sut.currentPhase, .registeringMLSClient)
+            XCTAssertEqual(mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_Invocations.count, 1)
+        }
+    }
+
     func testThatItInsertsANewClientIfThereIsNoneWaitingToBeSynced() {
         syncMOC.performAndWait {
             // given
@@ -101,6 +149,8 @@ class ZMClientRegistrationStatusTests: MessagingTest {
             XCTAssertEqual(selfUser.clients.count, 1)
         }
     }
+
+    // MARK: State machine
 
     func testThatItReturns_WaitingForSelfUser_IfSelfUserDoesNotHaveRemoteID() {
         syncMOC.performAndWait {

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		168A16AF1D9597C2005CFA6C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 168A16AD1D9597C2005CFA6C /* MainInterface.storyboard */; };
 		1695B9D62B912E8D00E9342A /* ConversationDegradedSystemMessageSectionDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1695B9D52B912E8D00E9342A /* ConversationDegradedSystemMessageSectionDescription.swift */; };
 		1695B9D82B91307600E9342A /* ConversationSecureSystemMessageSectionDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1695B9D72B91307600E9342A /* ConversationSecureSystemMessageSectionDescription.swift */; };
+		1695B9DC2BA1C15000E9342A /* AuthenticationStartE2EIdentityMissingErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1695B9DB2BA1C15000E9342A /* AuthenticationStartE2EIdentityMissingErrorHandler.swift */; };
 		169FF9331C57CB2100C5BF90 /* VideoToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 169FF9321C57CB2100C5BF90 /* VideoToolbox.framework */; };
 		16A293DA1F5FFA2E00B4EB16 /* SkeletonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A293D91F5FFA2E00B4EB16 /* SkeletonViewController.swift */; };
 		16A5FDC52154F53F00AEEBBD /* NSAttributedString+MessageFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A5FDC42154F53F00AEEBBD /* NSAttributedString+MessageFormatting.swift */; };
@@ -2242,6 +2243,7 @@
 		1693D9661CEDB26200D1F13C /* UIApplication+Permissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+Permissions.swift"; sourceTree = "<group>"; };
 		1695B9D52B912E8D00E9342A /* ConversationDegradedSystemMessageSectionDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDegradedSystemMessageSectionDescription.swift; sourceTree = "<group>"; };
 		1695B9D72B91307600E9342A /* ConversationSecureSystemMessageSectionDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSecureSystemMessageSectionDescription.swift; sourceTree = "<group>"; };
+		1695B9DB2BA1C15000E9342A /* AuthenticationStartE2EIdentityMissingErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStartE2EIdentityMissingErrorHandler.swift; sourceTree = "<group>"; };
 		169FF9321C57CB2100C5BF90 /* VideoToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VideoToolbox.framework; path = System/Library/Frameworks/VideoToolbox.framework; sourceTree = SDKROOT; };
 		16A293D91F5FFA2E00B4EB16 /* SkeletonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkeletonViewController.swift; sourceTree = "<group>"; };
 		16A5FDC42154F53F00AEEBBD /* NSAttributedString+MessageFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+MessageFormatting.swift"; sourceTree = "<group>"; };
@@ -5064,6 +5066,7 @@
 				5E1314C022097BEF000FAFC5 /* AuthenticationStartCompanyLoginLinkEventHandler.swift */,
 				5EE73BE52122C6DC0032986D /* AuthenticationStartAddAccountEventHandler.swift */,
 				16D74BEB2B59203C00160298 /* AuthenticationStartMissingUsernameErrorHandler.swift */,
+				1695B9DB2BA1C15000E9342A /* AuthenticationStartE2EIdentityMissingErrorHandler.swift */,
 			);
 			path = "Flow Start";
 			sourceTree = "<group>";
@@ -10137,6 +10140,7 @@
 				EE8E9267202496C2000F4752 /* NSAttributedString+Down.swift in Sources */,
 				A9C9D35E23E84EA20098CACC /* MediaPlayerDelegate.swift in Sources */,
 				16CB8DB91DC0F777000C5F47 /* DefaultNavigationBar.swift in Sources */,
+				1695B9DC2BA1C15000E9342A /* AuthenticationStartE2EIdentityMissingErrorHandler.swift in Sources */,
 				BF1743742123060E008851CA /* AdditionalMenuItem.swift in Sources */,
 				F15E9BFD1E4878AC00EA207F /* UINavigationController+Additions.swift in Sources */,
 				A96E802824C828070010CD80 /* WipeDatabaseViewController.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -115,6 +115,7 @@ final class AuthenticationEventResponderChain {
 
     fileprivate func registerDefaultEventHandlers() {
         // flowStartHandlers
+        registerHandler(AuthenticationStartE2EIdentityMissingErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartMissingUsernameErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartMissingCredentialsErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartReauthenticateErrorHandler(), to: &flowStartHandlers)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Flow Start/AuthenticationStartE2EIdentityMissingErrorHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Flow Start/AuthenticationStartE2EIdentityMissingErrorHandler.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/**
+ * Handles client registration errors related to the lack of a e2e identity enrollment on launch
+ */
+
+final class AuthenticationStartE2EIdentityMissingErrorHandler: AuthenticationEventHandler {
+
+    weak var statusProvider: AuthenticationStatusProvider?
+
+    func handleEvent(currentStep: AuthenticationFlowStep, context: (NSError?, Int)) -> [AuthenticationCoordinatorAction]? {
+        let (error, _) = context
+
+        // Only handle errors on start
+        guard case .start = currentStep else {
+            return nil
+        }
+
+        // Only handle needsToHandleToRegisterClient errors
+        guard error?.userSessionErrorCode == .needsToEnrollE2EIToRegisterClient else {
+            return nil
+        }
+
+        // Verify the state
+        guard statusProvider?.selfUser != nil && statusProvider?.selfUserProfile != nil else {
+            return nil
+        }
+
+        return [.startPostLoginFlow, .transition(.enrollE2EIdentity, mode: .reset)]
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7011" title="WPB-7011" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7011</a>  [iOS] Able to bypass the E2EI enrollment by closing app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

it's possible escape E2EI enrollment on login by restarting the app on the "get certificate" screen.

### Causes

We don't check the enrollment requirement on a fresh launch when a user client has already been registered.

### Solutions

Check if we need to enrollment into E2EI or create an MLS client when launching the app

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

1. Login into an account where E2EI is enabled
2. Restart the app on the "Get Certificate" screen

The app should now re-launch into the "Get Certificate" screen.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
