### PR TITLE
fix: duplicate one-on-one conversation after accepting a connection request WBP-6380

### DIFF
--- a/wire-ios-data-model/Source/Notifications/ConversationListObserverCenter.swift
+++ b/wire-ios-data-model/Source/Notifications/ConversationListObserverCenter.swift
@@ -158,6 +158,7 @@ public class ConversationListObserverCenter: NSObject, ZMConversationObserver, C
             || changes.messagesChanged
             || changes.labelsChanged
             || changes.mlsStatusChanged
+            || changes.oneOnOneUserChanged
 
         guard hasChanged else { return }
 

--- a/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
+++ b/wire-ios-data-model/Source/Notifications/ObjectObserverTokens/ConversationChangeInfo.swift
@@ -50,7 +50,8 @@ extension ZMConversation: ObjectInSnapshot {
             ZMConversation.mlsStatusKey,
             ZMConversation.mlsVerificationStatusKey,
             #keyPath(ZMConversation.isDeletedRemotely),
-            ZMConversation.messageProtocolKey
+            ZMConversation.messageProtocolKey,
+            #keyPath(ZMConversation.oneOnOneUser)
         ]
     }
 
@@ -177,6 +178,10 @@ extension ZMConversation: ObjectInSnapshot {
         changedKeysContain(keys: ZMConversation.messageProtocolKey)
     }
 
+    public var oneOnOneUserChanged: Bool {
+        changedKeysContain(keys: #keyPath(ZMConversation.oneOnOneUser))
+    }
+
     public var conversation: ZMConversation {
         return object as! ZMConversation
     }
@@ -207,7 +212,8 @@ extension ZMConversation: ObjectInSnapshot {
             "legalHoldStatusChanged: \(legalHoldStatusChanged)",
             "labelsChanged: \(labelsChanged)",
             "mlsStatusChanged: \(mlsStatusChanged)",
-            "messageProtocolChanges: \(messageProtocolChanged)"
+            "messageProtocolChanged: \(messageProtocolChanged)",
+            "oneOnOneUserChanged: \(oneOnOneUserChanged)"
         ].joined(separator: ", ")
     }
 

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -56,7 +56,8 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
             "languageChanged",
             "hasReadReceiptsEnabledChanged",
             "externalParticipantsStateChanged",
-            "legalHoldStatusChanged"
+            "legalHoldStatusChanged",
+            "oneOnOneUserChanged"
         ]
     }
 
@@ -553,6 +554,22 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
 
     }
 
+    func testThatItNotifiesTheObserverOfChangeOneOnOneUser() {
+        // given
+        let otherUser = ZMUser.insertNewObject(in: self.uiMOC)
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.conversationType = ZMConversationType.oneOnOne
+        uiMOC.saveOrRollback()
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // when
+        self.checkThatItNotifiesTheObserverOfAChange(conversation,
+                                                     modifier: { conversation, _ in conversation.oneOnOneUser = otherUser },
+                                                     expectedChangedField: "oneOnOneUserChanged",
+                                                     expectedChangedKeys: ["oneOnOneUser"])
+
+    }
+
     func testThatAccessModeChangeIsTriggeringObservation() {
         // given
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
@@ -658,7 +675,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
                 otherUser.connection?.status = ZMConnectionStatus.pending
                 otherUser.oneOnOneConversation = conversation
             },
-            expectedChangedFields: ["connectionStateChanged"],
+            expectedChangedFields: ["connectionStateChanged", "oneOnOneUserChanged"],
             expectedChangedKeys: ["relatedConnectionState"]
         )
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After accepting an incoming connection request when both users support MLS two duplicate 1-1 conversations are shown in the conversation list until the app is put into the background/foreground.

### Causes

We are displaying both the proteus and the MLS 1-1- conversation because when should only display the MLS 1-1- conversation. This happens because the conversation list observer doesn't get updated when the `oneOnOneUser` property gets nil:ed out when the MLS conversation is selected to be the primary 1-1 conversation.

### Solutions

Make the `oneOnOneUser` property an observable property and update the conversation list when it changes.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
