### PR TITLE
feat: Use topmostViewController for Keycloak auth

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -850,10 +850,10 @@ extension AuthenticationCoordinator {
 
         guard let session = statusProvider.sharedUserSession else { return }
         let e2eiCertificateUseCase = session.enrollE2EICertificate
-        guard let rootViewController = AppDelegate.shared.window?.rootViewController else {
+        guard let topmostViewController = UIApplication.shared.topmostViewController() else {
             return
         }
-        let oauthUseCase = OAuthUseCase(rootViewController: rootViewController)
+        let oauthUseCase = OAuthUseCase(targetViewController: topmostViewController)
 
         Task {
             do {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -850,7 +850,7 @@ extension AuthenticationCoordinator {
 
         guard let session = statusProvider.sharedUserSession else { return }
         let e2eiCertificateUseCase = session.enrollE2EICertificate
-        guard let topmostViewController = UIApplication.shared.topmostViewController() else {
+        guard let topmostViewController = UIApplication.shared.topmostViewController(onlyFullScreen: false) else {
             return
         }
         let oauthUseCase = OAuthUseCase(targetViewController: topmostViewController)

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperE2ei/DeveloperE2eiViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperE2ei/DeveloperE2eiViewModel.swift
@@ -51,11 +51,11 @@ final class DeveloperE2eiViewModel: ObservableObject {
     func enrollCertificate() {
         guard
             let session = userSession,
-            let rootViewController = AppDelegate.shared.window?.rootViewController
+            let topmostViewController = UIApplication.shared.topmostViewController()
         else { return }
 
         let e2eiCertificateUseCase = session.enrollE2EICertificate as? EnrollE2EICertificateUseCase
-        let oauthUseCase = OAuthUseCase(rootViewController: rootViewController)
+        let oauthUseCase = OAuthUseCase(targetViewController: topmostViewController)
         let crlExpirationDatesRepository = CRLExpirationDatesRepository(userID: session.selfUser.remoteIdentifier)
 
         Task {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceDetailsViewActionsHandler.swift
@@ -134,12 +134,12 @@ final class DeviceDetailsViewActionsHandler: DeviceDetailsViewActions, Observabl
 
     @MainActor
     private func startE2EIdentityEnrollment() async throws -> String {
-        guard let rootViewController = AppDelegate.shared.window?.rootViewController else {
+        guard let topmostViewController = UIApplication.shared.topmostViewController() else {
             let errorDescription = "Failed to fetch RootViewController instance"
             logger.error(errorDescription)
             throw DeviceDetailsActionsError.failedAction(errorDescription)
         }
-        let oauthUseCase = OAuthUseCase(rootViewController: rootViewController)
+        let oauthUseCase = OAuthUseCase(targetViewController: topmostViewController)
         return try await e2eiCertificateEnrollment.invoke(
             authenticate: oauthUseCase.invoke
         )

--- a/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/E2EINotificationActionsHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/E2EINotificationActionsHandler.swift
@@ -54,7 +54,7 @@ final class E2EINotificationActionsHandler: E2EINotificationActions {
         }
 
     public func getCertificate() async {
-        let oauthUseCase = OAuthUseCase(rootViewController: targetVC)
+        let oauthUseCase = OAuthUseCase(targetViewController: targetVC)
         do {
             let certificateDetails = try await enrollCertificateUseCase.invoke(authenticate: oauthUseCase.invoke)
             await confirmSuccessfulEnrollment(certificateDetails)
@@ -88,7 +88,7 @@ final class E2EINotificationActionsHandler: E2EINotificationActions {
     // MARK: - Helpers
 
     private func showGetCertificateErrorAlert(canCancel: Bool) async {
-        let oauthUseCase = OAuthUseCase(rootViewController: targetVC)
+        let oauthUseCase = OAuthUseCase(targetViewController: targetVC)
         let alert = await UIAlertController.getCertificateFailed(canCancel: canCancel) {
             Task {
                 do {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
@@ -32,10 +32,10 @@ public class OAuthUseCase: OAuthUseCaseInterface {
 
     private let logger = WireLogger.e2ei
     private var currentAuthorizationFlow: OIDExternalUserAgentSession?
-    private var rootViewController: UIViewController
+    private var targetViewController: UIViewController
 
-    init(rootViewController: UIViewController) {
-        self.rootViewController = rootViewController
+    init(targetViewController: UIViewController) {
+        self.targetViewController = targetViewController
     }
 
     public func invoke(parameters: OAuthParameters) async throws -> OAuthResponse {
@@ -109,7 +109,7 @@ public class OAuthUseCase: OAuthUseCaseInterface {
 
     @MainActor
     private func execute(authorizationRequest: OIDAuthorizationRequest) async throws -> OAuthResponse {
-        guard let userAgent = OIDExternalUserAgentIOS(presenting: rootViewController) else {
+        guard let userAgent = OIDExternalUserAgentIOS(presenting: targetViewController) else {
             throw OAuthError.missingOIDExternalUserAgent
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
@@ -114,7 +114,7 @@ public class OAuthUseCase: OAuthUseCaseInterface {
         ) else {
             throw OAuthError.missingOIDExternalUserAgent
         }
-        
+
         return try await withCheckedThrowingContinuation { [weak self] continuation in
             self?.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: authorizationRequest,
                                                                     externalUserAgent: userAgent,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

I don't think this is a bug, just an improvement.
It makes more sense to use topmostViewController to display the web view for Keycloak.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
