### PR TITLE
fix: handle user cancelling auth gracefully [WPB-7130]

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser.m
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.m
@@ -749,7 +749,7 @@ static NSString *const PrimaryKey = @"primaryKey";
 @end
 
 
-@implementation  ZMUser (Utilities)
+@implementation ZMUser (Utilities)
 
 + (ZMUser<ZMEditableUser> *)selfUserInUserSession:(id<ContextProvider>)session
 {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -855,31 +855,25 @@ extension AuthenticationCoordinator {
         }
         let oauthUseCase = OAuthUseCase(targetViewController: topmostViewController)
 
-        Task {
+        Task { @MainActor in
             do {
                 let certificateChain = try await e2eiCertificateUseCase.invoke(authenticate: oauthUseCase.invoke)
-                await MainActor.run {
-                    executeActions([
-                        .hideLoadingView,
-                        .transition(.enrollE2EIdentitySuccess(certificateChain), mode: .reset)
-                    ])
-                }
+                executeActions([
+                    .hideLoadingView,
+                    .transition(.enrollE2EIdentitySuccess(certificateChain), mode: .reset)
+                ])
             } catch OAuthError.userCancelled {
-                await MainActor.run {
-                    executeActions([
-                        .hideLoadingView
-                    ])
-                }
+                executeActions([
+                    .hideLoadingView
+                ])
             } catch {
-                await MainActor.run {
-                    executeActions([
-                        .hideLoadingView,
-                        .presentAlert(
-                            .init(title: E2ei.Error.Alert.title,
-                                  message: E2ei.Error.Alert.message,
-                                  actions: [.ok]))
-                    ])
-                }
+                executeActions([
+                    .hideLoadingView,
+                    .presentAlert(
+                        .init(title: E2ei.Error.Alert.title,
+                              message: E2ei.Error.Alert.message,
+                              actions: [.ok]))
+                ])
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -864,6 +864,12 @@ extension AuthenticationCoordinator {
                         .transition(.enrollE2EIdentitySuccess(certificateChain), mode: .reset)
                     ])
                 }
+            } catch OAuthError.userCancelled {
+                await MainActor.run {
+                    executeActions([
+                        .hideLoadingView
+                    ])
+                }
             } catch {
                 await MainActor.run {
                     executeActions([

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -206,9 +206,19 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
 
         setupMentionsResultsView()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(UIApplicationDelegate.applicationDidBecomeActive(_:)), name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive(_:)),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
 
-        NotificationCenter.default.addObserver(self, selector: #selector(showErrorAlertToSendMessage), name: ZMConversation.failedToSendMessageNotificationName, object: .none)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showErrorAlertToSendMessage),
+            name: ZMConversation.failedToSendMessageNotificationName,
+            object: .none
+        )
     }
 
     @objc
@@ -222,7 +232,7 @@ final class ConversationContentViewController: UIViewController, PopoverPresente
     }
 
     @objc
-    private func showErrorAlertToSendMessage() {
+    private func showErrorAlertToSendMessage(_ notification: Notification) {
         typealias MessageSendError = L10n.Localizable.Error.Message.Send
         UIAlertController.showErrorAlertWithLink(title: MessageSendError.title,
                                                  message: MessageSendError.missingLegalholdConsent)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/OAuthUseCase.swift
@@ -119,8 +119,12 @@ public class OAuthUseCase: OAuthUseCaseInterface {
             self?.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: authorizationRequest,
                                                                     externalUserAgent: userAgent,
                                                                     callback: { authState, error in
-                if let error = error {
-                    return continuation.resume(throwing: OAuthError.failedToSendAuthorizationRequest(error))
+                if let error = error as NSError? {
+                    if error.domain == OIDGeneralErrorDomain, error.code == OIDErrorCode.userCanceledAuthorizationFlow.rawValue {
+                        return continuation.resume(throwing: OAuthError.userCancelled)
+                    } else {
+                        return continuation.resume(throwing: OAuthError.failedToSendAuthorizationRequest(error))
+                    }
                 }
 
                 guard let idToken = authState?.lastTokenResponse?.idToken else {
@@ -144,5 +148,6 @@ enum OAuthError: Error {
     case missingServiceConfiguration
     case missingOIDExternalUserAgent
     case missingIdToken
+    case userCancelled
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -337,10 +337,7 @@ final class ProfileHeaderViewController: UIViewController {
     }
 
     private func updateE2EICertifiedStatus() {
-        guard
-            let contextProvider = userSession as? ContextProvider,
-            let user = user as? ZMUser
-        else { return }
+        guard let user = user as? ZMUser else { return }
 
         Task { @MainActor [conversation] in
             do {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7130" title="WPB-7130" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7130</a>  [iOS] App crash when attempting getting keycloak certificate 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

A "Something went wrong" error is presented after pressing Cancel on the authentication (web view) screen.
This PR adds a check for the cancelled error in order to skip the alert.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
