### PR TITLE
fix: prevent E2eiEnrollment deallocation [WPB-7130]

### DIFF
--- a/wire-ios-data-model/Source/E2EIdentity/E2EISetupService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2EISetupService.swift
@@ -50,7 +50,7 @@ public final class E2EISetupService: E2EISetupServiceInterface {
 
     // TODO: [WPB-6761] temporary workaround for a crash 
     // The E2eiEnrollment cause a memory corruption when it deinits so we hold on to it forever.
-    private static var enrollment: E2eiEnrollment?
+    private static var enrollments = [E2eiEnrollment]()
 
     // MARK: - Properties
 
@@ -98,7 +98,7 @@ public final class E2EISetupService: E2EISetupServiceInterface {
                 isUpgradingClient: isUpgradingClient,
                 expirySec: expirySec
             )
-            Self.enrollment = enrollment
+            Self.enrollments += [enrollment]
             return enrollment
         } catch {
             throw Failure.failedToSetupE2eIClient(error)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusView.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireCommonComponents
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireSyncEngine
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Convenience.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Convenience.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 
 extension UIViewController {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7130" title="WPB-7130" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7130</a>  [iOS] App crash when attempting getting keycloak certificate 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

In rare cases the deallocation of `E2eiEnrollment` instances throw an error.
This PR extends the current workaround so that multiple instances of `E2eiEnrollment` are kept alive.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
