### PR TITLE
fix: crash after logout WPB-7136

### DIFF
--- a/wire-ios-request-strategy/Sources/E2EIdentity/CRL/CRLsDistributionPointsObserver.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/CRL/CRLsDistributionPointsObserver.swift
@@ -39,9 +39,10 @@ public class CRLsDistributionPointsObserver: CRLsDistributionPointsObserving {
     public func startObservingNewCRLsDistributionPoints(
         from publisher: AnyPublisher<CRLsDistributionPoints, Never>
     ) {
-        publisher.sink { distributionPoints in
+        publisher.sink { [weak self] distributionPoints in
+            let cRLsChecker = self?.cRLsChecker
             Task {
-                await self.cRLsChecker.checkNewCRLs(from: distributionPoints)
+                await cRLsChecker?.checkNewCRLs(from: distributionPoints)
             }
         }
         .store(in: &cancellables)

--- a/wire-ios/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
+++ b/wire-ios/Wire-iOS/Sources/Analytics/AnalyticsCountlyProvider.swift
@@ -79,7 +79,7 @@ final class AnalyticsCountlyProvider: AnalyticsProvider {
         }
     }
 
-    var selfUser: UserType? {
+    weak var selfUser: UserType? {
         didSet {
             endCountly()
             guard let user = selfUser as? ZMUser else { return }

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -402,7 +402,6 @@ extension AppRootRouter {
 
     private func setupAnalyticsSharing() {
         guard
-            appStateCalculator.wasUnauthenticated,
             let selfUser = SelfUser.provider?.providedSelfUser,
             selfUser.isTeamMember
         else {

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -77,19 +77,17 @@ final class AppStateCalculator {
 
     // MARK: - Public Property
     weak var delegate: AppStateCalculatorDelegate?
-    var wasUnauthenticated: Bool {
-        guard case .unauthenticated = previousAppState else {
-            return false
-        }
-        return true
-    }
+    var wasUnauthenticated: Bool = false
 
     // MARK: - Private Set Property
-    private(set) var previousAppState: AppState = .headless
     private(set) var pendingAppState: AppState?
     private(set) var appState: AppState = .headless {
         willSet {
-            previousAppState = appState
+            if case .unauthenticated = appState {
+                wasUnauthenticated = true
+            } else {
+                wasUnauthenticated = false
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/CellDescription/MLSMigrationCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/CellDescription/MLSMigrationCellDescription.swift
@@ -41,9 +41,9 @@ final class MLSMigrationCellDescription: ConversationMessageCellDescription {
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String?
 
-    var message: WireDataModel.ZMConversationMessage?
-    var delegate: ConversationMessageCellDelegate?
-    var actionController: ConversationMessageActionController?
+    weak var message: WireDataModel.ZMConversationMessage?
+    weak var delegate: ConversationMessageCellDelegate?
+    weak var actionController: ConversationMessageActionController?
 
     init(messageType: ZMSystemMessageType) {
         let icon = Asset.Images.attention.image.withTintColor(SemanticColors.Icon.backgroundDefault)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -241,8 +241,6 @@ final class ConversationListTopBarViewController: UIViewController {
         let keyboardAvoidingViewController = KeyboardAvoidingViewController(viewController: settingsViewController)
 
         if wr_splitViewController?.layoutSize == .compact {
-            keyboardAvoidingViewController.modalPresentationStyle = .currentContext
-            keyboardAvoidingViewController.transitioningDelegate = self
             present(keyboardAvoidingViewController, animated: true)
         } else {
             keyboardAvoidingViewController.modalPresentationStyle = .formSheet


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7136" title="WPB-7136" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7136</a>  iOS: crash on login screen using notification center
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App crashes after logout when app becomes inactive/active

### Causes

The `ConversationListViewController` and all its child objects are not deallocated on logout, this causes the `IsUserE2EICertifiedUseCase` to run from the `ProfileHeaderViewController` when the application becomes active resulting in a crash since the core data stack has been torn down.

### Solutions

Fix the retain cycles which causes the `ConversationListViewController` to stay alive.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
