### PR TITLE
fix: flaky conversation observer test

### DIFF
--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -682,13 +682,15 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
 
     func testThatItNotifiesTheObserverOfChangedConnectionStatusWhenUpdatingAConnection() {
         // given
-        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
-        conversation.conversationType = ZMConversationType.oneOnOne
-
         let otherUser = ZMUser.insertNewObject(in: self.uiMOC)
         otherUser.connection = ZMConnection.insertNewObject(in: self.uiMOC)
         otherUser.connection?.status = .pending
-        otherUser.oneOnOneConversation = conversation
+        self.uiMOC.saveOrRollback()
+
+        let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
+        conversation.conversationType = ZMConversationType.oneOnOne
+        conversation.oneOnOneUser = otherUser
+        self.uiMOC.saveOrRollback()
 
         self.uiMOC.saveOrRollback()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`testThatItNotifiesTheObserverOfChangedConnectionStatusWhenUpdatingAConnection` is flaky

### Causes

Depending on the order which in core data changes gets processed it sometimes happens that a  `Conversation` snapshot object gets saved with the `oneOneOneUser` relationship pointing to a user with a temporary object ID. This will later trigger a change detected for this relationship when the user has a permanent object ID.

### Solutions

Explicit save the user before assigning it to the `oneOneOneUser` relationship so we are sure it has permanent object ID from the beginning.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
