### PR TITLE
fix: system message when added to group WPB-7094

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -224,11 +224,10 @@ struct ConversationEventPayloadProcessor {
                 in: context
             )!
         }) {
-            let selfUser = ZMUser.selfUser(in: context)
             let users = Set(usersAndRoles.map { $0.0 })
             let newUsers = !users.subtracting(conversation.localParticipants).isEmpty
 
-            if (users.contains(selfUser) || newUsers) && conversation.conversationType == .group {
+            if newUsers && conversation.conversationType == .group {
                 // TODO jacob refactor to append method on conversation
                 _ = ZMSystemMessage.createOrUpdate(from: originalEvent, in: context)
             }

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -143,7 +143,7 @@ public class MLSEventProcessor: MLSEventProcessing {
         do {
             let groupID = try await mlsService.processWelcomeMessage(welcomeMessage: welcomeMessage)
             await mlsService.uploadKeyPackagesIfNeeded()
-            await conversationService.syncConversation(qualifiedID: conversationID)
+            await conversationService.syncConversationIfMissing(qualifiedID: conversationID)
 
             let conversation: ZMConversation? = await context.perform {
                 guard let conversation = ZMConversation.fetch(

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandlerTests.swift
@@ -48,7 +48,7 @@ final class AddParticipantActionHandlerTests: MessagingTestBase {
         }
 
         mockConversationService = MockConversationServiceInterface()
-
+        mockConversationService.syncConversationIfMissingQualifiedID_MockMethod = { _ in }
         mockConversationService.syncConversationQualifiedID_MockMethod = { _ in }
         mockConversationService.syncConversationQualifiedIDCompletion_MockMethod = { _, completion in
             completion()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -31,6 +31,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
         super.setUp()
         conversationService = MockConversationServiceInterface()
         conversationService.syncConversationQualifiedID_MockMethod = { _ in }
+        conversationService.syncConversationIfMissingQualifiedID_MockMethod = { _ in }
 
         conversationService.syncConversationQualifiedIDCompletion_MockMethod = { _, completion in
             completion()
@@ -79,6 +80,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
 
             let selfUser = ZMUser.selfUser(in: syncMOC)
             let selfMember = Payload.ConversationMember(qualifiedID: selfUser.qualifiedID)
+            groupConversation.removeParticipantAndUpdateConversationState(user: selfUser)
 
             let payload = ConversationEventProcessor.MemberJoinPayload(
                 id: groupConversation.remoteIdentifier,
@@ -104,10 +106,9 @@ final class ConversationEventProcessorTests: MessagingTestBase {
         await sut.processConversationEvents([event])
 
         // Then
-        let updateConversationCalls = mockMLSEventProcessor.updateConversationIfNeededConversationFallbackGroupIDContext_Invocations
-        XCTAssertEqual(updateConversationCalls.count, 1)
-        XCTAssertEqual(updateConversationCalls.first?.conversation, groupConversation)
-
+        await syncMOC.perform {
+            XCTAssertTrue(self.groupConversation.isSelfAnActiveMember)
+        }
     }
 
     // MARK: - MLS: Welcome Message

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationService.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationService.swift
@@ -46,6 +46,10 @@ public protocol ConversationServiceInterface {
         qualifiedID: QualifiedID
     ) async
 
+    func syncConversationIfMissing(
+        qualifiedID: QualifiedID
+    ) async
+
 }
 
 public enum ConversationCreationFailure: Error {
@@ -393,6 +397,17 @@ public final class ConversationService: ConversationServiceInterface {
         action.perform(in: context.notificationContext) { _ in
             completion()
         }
+    }
+
+    public func syncConversationIfMissing(
+        qualifiedID: QualifiedID
+    ) async {
+        guard await context.perform({
+            ZMConversation.fetch(with: qualifiedID.uuid, domain: qualifiedID.domain, in: self.context)
+        }) == nil else {
+            return
+        }
+        await syncConversation(qualifiedID: qualifiedID)
     }
 
     public func syncConversation(

--- a/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -402,6 +402,21 @@ public class MockConversationServiceInterface: ConversationServiceInterface {
         await mock(qualifiedID)
     }
 
+    // MARK: - syncConversationIfMissing
+
+    public var syncConversationIfMissingQualifiedID_Invocations: [QualifiedID] = []
+    public var syncConversationIfMissingQualifiedID_MockMethod: ((QualifiedID) async -> Void)?
+
+    public func syncConversationIfMissing(qualifiedID: QualifiedID) async {
+        syncConversationIfMissingQualifiedID_Invocations.append(qualifiedID)
+
+        guard let mock = syncConversationIfMissingQualifiedID_MockMethod else {
+            fatalError("no mock for `syncConversationIfMissingQualifiedID`")
+        }
+
+        await mock(qualifiedID)
+    }
+
 }
 public class MockE2EIKeyPackageRotating: E2EIKeyPackageRotating {
 

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
@@ -48,6 +48,7 @@ class MLSEventProcessorTests: MessagingTestBase {
 
         conversationServiceMock = .init()
         conversationServiceMock.syncConversationQualifiedID_MockMethod = { _ in }
+        conversationServiceMock.syncConversationIfMissingQualifiedID_MockMethod = { _ in }
 
         syncMOC.performGroupedBlockAndWait {
             self.syncMOC.mlsService = self.mlsServiceMock
@@ -96,7 +97,7 @@ class MLSEventProcessorTests: MessagingTestBase {
         // Then
         XCTAssertEqual(mlsServiceMock.processWelcomeMessageWelcomeMessage_Invocations, [message])
         XCTAssertEqual(mlsServiceMock.uploadKeyPackagesIfNeeded_Invocations.count, 1)
-        XCTAssertEqual(conversationServiceMock.syncConversationQualifiedID_Invocations, [qualifiedID])
+        XCTAssertEqual(conversationServiceMock.syncConversationIfMissingQualifiedID_Invocations, [qualifiedID])
         XCTAssertTrue(oneOnOneResolverMock.resolveOneOnOneConversationWithIn_Invocations.isEmpty)
 
         await syncMOC.perform {
@@ -144,7 +145,7 @@ class MLSEventProcessorTests: MessagingTestBase {
 
         XCTAssertEqual(mlsServiceMock.processWelcomeMessageWelcomeMessage_Invocations, [message])
         XCTAssertEqual(mlsServiceMock.uploadKeyPackagesIfNeeded_Invocations.count, 1)
-        XCTAssertEqual(conversationServiceMock.syncConversationQualifiedID_Invocations, [qualifiedID])
+        XCTAssertEqual(conversationServiceMock.syncConversationIfMissingQualifiedID_Invocations, [qualifiedID])
         XCTAssertEqual(oneOnOneResolverMock.resolveOneOnOneConversationWithIn_Invocations.count, 1)
         XCTAssertEqual(oneOnOneResolverMock.resolveOneOnOneConversationWithIn_Invocations.first?.userID, otherUserID)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7094" title="WPB-7094" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7094</a>  [iOS] Missing Added to Group System Messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There's an incorrect system message about MLS migration when you're added an MLS group and there's no "memberJoined" or "newConversation" system message.

### Causes

1, The MLS migration message gets inserted because when processing the memberJoin event we insert an incomplete conversation which assigns proteus as the message protocol. Afterwards we sync the conversation metadata from the backend which thinks conversation was migration since message protocol is then updated to MLS.
2. The "newConversation" system message is missing because with MLS we don't get any `conversation.create` events and by the time we fetch metadata the conversation is not considered new since a incomplete conversation by the memberJoin event.
3. The "memberJoined" system message doesn't get inserted but are missing then necessary metadata when processing it `conversationType`.

### Solutions

Fetch conversation metadata on `memberJoined` and "welcomeMessage" if and only if we don't already know about it.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
