### PR TITLE
fix: added participant not appearing WPB-7225

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/AddParticipantActionHandler.swift
@@ -153,6 +153,7 @@ class AddParticipantActionHandler: ActionHandler<AddParticipantAction> {
             }
             Task {
                 await eventProcessor.processConversationEvents([updateEvent])
+                await context.perform { _ = self.context.saveOrRollback() }
                 success()
             }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7225" title="WPB-7225" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7225</a>  [iOS] It takes two tries to add federated users to groups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User is not appearing after adding a participant to a proteus group conversation 

### Causes (Optional)

Server response is processed in a Task so implicit save of the context is done for the `conversation.member-join` event is processed, therefore the change is not visible to the UI until something else saves the context.

### Solutions

Enqueue a save after processing the event.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
