### PR TITLE
fix: wait for dismissal completion before presenting alert [WPB-7154]

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeepLinks/DeepLinksView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeepLinks/DeepLinksView.swift
@@ -34,7 +34,7 @@ struct DeepLinksView: View {
         List {
             Section("Open deeplink") {
                 TextField("Link", text: $urlString, prompt: Text("Enter deeplink"))
-                SwiftUI.Button("Go") {
+                Button("Go") {
                     viewModel.openLink(urlString: urlString)
                 }
                 .disabled(urlString.isEmpty)

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeepLinks/DeepLinksViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeepLinks/DeepLinksViewModel.swift
@@ -35,7 +35,7 @@ final class DeepLinksViewModel: ObservableObject {
     }
 
     let router: AppRootRouter?
-    let onDismiss: (() -> Void)?
+    let onDismiss: (_ completion: @escaping () -> Void) -> Void
 
     @Published
     var isShowingAlert = false
@@ -47,7 +47,7 @@ final class DeepLinksViewModel: ObservableObject {
 
     init(
         router: AppRootRouter? = nil,
-        onDismiss: (() -> Void)? = nil
+        onDismiss: @escaping (_ completion: @escaping () -> Void) -> Void = { $0() }
     ) {
         self.router = router
         self.onDismiss = onDismiss
@@ -65,7 +65,8 @@ final class DeepLinksViewModel: ObservableObject {
             return
         }
 
-        onDismiss?()
-        _ = router?.openDeepLinkURL(url)
+        onDismiss {
+            _ = self.router?.openDeepLinkURL(url)
+        }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -93,7 +93,7 @@ final class DeveloperToolsViewModel: ObservableObject {
     // MARK: - Properties
 
     let router: AppRootRouter?
-    var onDismiss: (() -> Void)?
+    let onDismiss: (_ completion: @escaping () -> Void) -> Void
 
     // MARK: - State
 
@@ -109,7 +109,7 @@ final class DeveloperToolsViewModel: ObservableObject {
 
     init(
         router: AppRootRouter? = nil,
-        onDismiss: (() -> Void)? = nil
+        onDismiss: @escaping (_ completion: @escaping () -> Void) -> Void = { $0() }
     ) {
         self.router = router
         self.onDismiss = onDismiss
@@ -134,7 +134,7 @@ final class DeveloperToolsViewModel: ObservableObject {
                 .destination(DestinationItem(title: "Deep links", makeView: { [weak self] in
                     AnyView(DeepLinksView(viewModel: DeepLinksViewModel(
                         router: self?.router,
-                        onDismiss: self?.onDismiss
+                        onDismiss: self?.onDismiss ?? { $0() }
                     )))
                 }))
             ]
@@ -229,7 +229,7 @@ final class DeveloperToolsViewModel: ObservableObject {
     func handleEvent(_ event: Event) {
         switch event {
         case .dismissButtonTapped:
-            onDismiss?()
+            onDismiss {}
 
         case let .itemCopyRequested(.text(textItem)):
             UIPasteboard.general.string = textItem.value

--- a/wire-ios/Wire-iOS/Sources/WireApplication.swift
+++ b/wire-ios/Wire-iOS/Sources/WireApplication.swift
@@ -31,13 +31,15 @@ final class WireApplication: UIApplication {
                     DeveloperToolsView(viewModel: DeveloperToolsViewModel(
                         router: AppDelegate.shared.appRootRouter,
                         onDismiss: { [weak self] completion in
-                            guard let topmostViewController = self?.topmostViewController() else { return completion() }
-                            topmostViewController.dismissIfNeeded(animated: true, completion: completion)
+                            if let topmostViewController = self?.topmostViewController() {
+                                topmostViewController.dismissIfNeeded(completion: completion)
+                            } else {
+                                completion()
+                            }
                         }
                     ))
                 }
             )
-
             topmostViewController()?.present(developerTools, animated: true)
         } else {
             DebugAlert.showSendLogsMessage(
@@ -48,6 +50,7 @@ final class WireApplication: UIApplication {
 }
 
 extension WireApplication: NotificationSettingsRegistrable {
+
     var shouldRegisterUserNotificationSettings: Bool {
         return !(AutomationHelper.sharedHelper.skipFirstLoginAlerts || AutomationHelper.sharedHelper.disablePushNotificationAlert)
     }

--- a/wire-ios/Wire-iOS/Sources/WireApplication.swift
+++ b/wire-ios/Wire-iOS/Sources/WireApplication.swift
@@ -16,10 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import UIKit
+import SwiftUI
 import WireCommonComponents
 import WireSyncEngine
-import SwiftUI
 
 final class WireApplication: UIApplication {
 
@@ -31,8 +30,9 @@ final class WireApplication: UIApplication {
                 rootView: NavigationView {
                     DeveloperToolsView(viewModel: DeveloperToolsViewModel(
                         router: AppDelegate.shared.appRootRouter,
-                        onDismiss: { [weak self] in
-                            self?.topmostViewController()?.dismissIfNeeded()
+                        onDismiss: { [weak self] completion in
+                            guard let topmostViewController = self?.topmostViewController() else { return completion() }
+                            topmostViewController.dismissIfNeeded(animated: true, completion: completion)
                         }
                     ))
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7154" title="WPB-7154" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7154</a>  Issues on logout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

When opening a deep link via debug menu, the view is dismissed, however, there is also an alert presented immediately.

This PR adds a completion closure to the `dismiss` closure.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
