### PR TITLE
chore: enable verbose shell output to cherry pick action [WPB-6956]

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -307,7 +307,6 @@ jobs:
             build/reports/*.junit
           compare_to_earlier_commit: false
             
-            
       - name: Archiving DerivedData Logs
         uses: actions/upload-artifact@v2
         if: always()

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -102,6 +102,7 @@ jobs:
               if: env.shouldCherryPick == 'true'
               run: |
                   set -vx
+                  echo We are at commit `git rev-parse HEAD`
                   if [[ -n "${{ env.SUBMODULE_NAME }}" && "${{ env.SUBMODULE_TRACK }}" == "true" ]]; then
                     # If SUBMODULE_NAME is set
                     git reset --soft HEAD~2

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -54,7 +54,6 @@ jobs:
             - name: Append -cherry-pick to branch name
               id: extract
               run: |
-                  set -vx
                   PR_BRANCH="${{ github.event.pull_request.head.ref }}"
                   NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
                   echo "New branch name: $NEW_BRANCH_NAME"
@@ -63,7 +62,6 @@ jobs:
             - name: Check for changes excluding submodule
               id: check_changes
               run: |
-                  set -vx
                   if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
                     # If SUBMODULE_NAME is set
                     NUM_CHANGES=$(git diff origin/${{ env.TARGET_BRANCH }} --name-only | grep -v "^${{ env.SUBMODULE_NAME }}/" | wc -l)
@@ -85,7 +83,7 @@ jobs:
             - name: Update submodule
               if: env.SUBMODULE_NAME && env.SUBMODULE_TRACK == 'true' && env.shouldCherryPick == 'true'
               run: |
-                  set -vx
+                  set -x
                   git submodule update --init --recursive || true
                   # Create a temporary branch and get the last commit message
                   git checkout -b temp-branch-for-cherry-pick
@@ -120,7 +118,6 @@ jobs:
               id: get-author
               if: env.shouldCherryPick == 'true'
               run: |
-                  set -vx
                   ORIGINAL_AUTHOR=$(git log -1 --pretty=format:'%an <%ae>' ${{ github.event.pull_request.merge_commit_sha }})
                   echo "Original author: $ORIGINAL_AUTHOR"
                   echo "originalAuthor=$ORIGINAL_AUTHOR" >> $GITHUB_ENV
@@ -129,7 +126,6 @@ jobs:
               id: commit-cherry-pick
               if: env.shouldCherryPick == 'true'
               run: |
-                  set -vx
                   # Checkout the desired branch and cherry-pick the commit
                   git checkout ${{ env.TARGET_BRANCH }}
                   git checkout -b ${{ env.newBranchName }}
@@ -160,6 +156,5 @@ jobs:
                   PR_BRANCH: ${{ env.newBranchName }}
                   PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
               run: |
-                  set -vx
                   PR_BODY=$(echo -e "Cherry pick from the original PR: \n- #${{ github.event.pull_request.number }}\n\n---- \n\n ⚠️ Conflicts during cherry-pick:\n${{ env.conflictedFiles }}\n\n${{ github.event.pull_request.body }}")
                   gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base ${{ env.TARGET_BRANCH }} --head "$PR_BRANCH" --label "cherry-pick" --assignee "$PR_ASSIGNEE"

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -54,6 +54,7 @@ jobs:
             - name: Append -cherry-pick to branch name
               id: extract
               run: |
+                  set -vx
                   PR_BRANCH="${{ github.event.pull_request.head.ref }}"
                   NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
                   echo "New branch name: $NEW_BRANCH_NAME"
@@ -62,6 +63,7 @@ jobs:
             - name: Check for changes excluding submodule
               id: check_changes
               run: |
+                  set -vx
                   if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
                     # If SUBMODULE_NAME is set
                     NUM_CHANGES=$(git diff origin/${{ env.TARGET_BRANCH }} --name-only | grep -v "^${{ env.SUBMODULE_NAME }}/" | wc -l)
@@ -83,7 +85,7 @@ jobs:
             - name: Update submodule
               if: env.SUBMODULE_NAME && env.SUBMODULE_TRACK == 'true' && env.shouldCherryPick == 'true'
               run: |
-                  set -x
+                  set -vx
                   git submodule update --init --recursive || true
                   # Create a temporary branch and get the last commit message
                   git checkout -b temp-branch-for-cherry-pick
@@ -101,6 +103,7 @@ jobs:
               id: get-cherry
               if: env.shouldCherryPick == 'true'
               run: |
+                  set -vx
                   if [[ -n "${{ env.SUBMODULE_NAME }}" && "${{ env.SUBMODULE_TRACK }}" == "true" ]]; then
                     # If SUBMODULE_NAME is set
                     git reset --soft HEAD~2
@@ -117,6 +120,7 @@ jobs:
               id: get-author
               if: env.shouldCherryPick == 'true'
               run: |
+                  set -vx
                   ORIGINAL_AUTHOR=$(git log -1 --pretty=format:'%an <%ae>' ${{ github.event.pull_request.merge_commit_sha }})
                   echo "Original author: $ORIGINAL_AUTHOR"
                   echo "originalAuthor=$ORIGINAL_AUTHOR" >> $GITHUB_ENV
@@ -125,6 +129,7 @@ jobs:
               id: commit-cherry-pick
               if: env.shouldCherryPick == 'true'
               run: |
+                  set -vx
                   # Checkout the desired branch and cherry-pick the commit
                   git checkout ${{ env.TARGET_BRANCH }}
                   git checkout -b ${{ env.newBranchName }}
@@ -155,5 +160,6 @@ jobs:
                   PR_BRANCH: ${{ env.newBranchName }}
                   PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
               run: |
+                  set -vx
                   PR_BODY=$(echo -e "Cherry pick from the original PR: \n- #${{ github.event.pull_request.number }}\n\n---- \n\n ⚠️ Conflicts during cherry-pick:\n${{ env.conflictedFiles }}\n\n${{ github.event.pull_request.body }}")
                   gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base ${{ env.TARGET_BRANCH }} --head "$PR_BRANCH" --label "cherry-pick" --assignee "$PR_ASSIGNEE"

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -34,7 +34,6 @@ jobs:
       wire-ios-link-preview : ${{ steps.filter.outputs.wire-ios-link-preview }}
       wire-ios-utilities: ${{ steps.filter.outputs.wire-ios-utilities }}
       wire-ios-testing: ${{ steps.filter.outputs.wire-ios-testing }}
-      any: ${{ steps.filter.outputs.carthage == 'true' || steps.filter.outputs.wire-ios == 'true' || steps.filter.outputs.wire-ios-sync-engine == 'true' || steps.filter.outputs.wire-ios-data-model == 'true' || steps.filter.outputs.wire-ios-system == 'true' || steps.filter.outputs.wire-ios-request-strategy == 'true' || steps.filter.outputs.wire-ios-transport == 'true' || steps.filter.outputs.wire-ios-share-engine == 'true' || steps.filter.outputs.wire-ios-cryptobox == 'true' || steps.filter.outputs.wire-ios-mocktransport == 'true' || steps.filter.outputs.wire-ios-notification-engine == 'true' || steps.filter.outputs.wire-ios-protos == 'true' || steps.filter.outputs.wire-ios-images == 'true' || steps.filter.outputs.wire-ios-link-preview == 'true' || steps.filter.outputs.wire-ios-utilities == 'true' || steps.filter.outputs.wire-ios-testing == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +76,6 @@ jobs:
 
   trigger_tests_pr:
     needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.any == 'true' }}
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:
       wire-ios: ${{ needs.detect-changes.outputs.wire-ios == 'true' }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6956" title="WPB-6956" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6956</a>  [iOS] cherry-pick action broken for 3.112
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Enables verbose logging, in order to make it easier to debug the cherry-pick action.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
