### PR TITLE
chore: version bump to 3.113.0

### DIFF
--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,4 +16,4 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.112
+WIRE_SHORT_VERSION = 3.113.0


### PR DESCRIPTION
# What's new in this PR?

### Issues

Distinguish develop and release 3.112.1.
Bump version on develop