### PR TITLE
fix: restore assert memoryleaks

### DIFF
--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -23,6 +23,7 @@ extension ZMTBaseTest {
     public static func checkForMemoryLeaksAfterTestClassCompletes() {
         if MemoryReferenceDebugger.aliveObjects.count > 0 {
             print("Leaked: \(MemoryReferenceDebugger.aliveObjectsDescription)")
+            assert(false)
         }
     }
 


### PR DESCRIPTION
# What's new in this PR?

### Issues

During submission last friday, some security tests was triggering the assert in memory leaks. The assert was removed temporary.

This restores the assert.