### PR TITLE
fix: Avoid E2Ei certificate check for proteus clients WPB-7252

### DIFF
--- a/wire-ios-data-model/Source/UseCases/IsSelfUserE2EICertifiedUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/IsSelfUserE2EICertifiedUseCase.swift
@@ -26,6 +26,10 @@ public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProt
 
     private let context: NSManagedObjectContext
     private let featureRepository: FeatureRepositoryInterface
+    /// The `featureRepository` operates on a context, so every operation must be dispatched
+    /// on that context's queue. Since `FeatureRepositoryInterface` doesn't contain any
+    /// `context` property, we inject the context here.
+    private let featureRepositoryContext: NSManagedObjectContext
     private let isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol
 
     /// - Parameters:
@@ -34,15 +38,18 @@ public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProt
     public init(
         context: NSManagedObjectContext,
         featureRepository: FeatureRepositoryInterface,
+        featureRepositoryContext: NSManagedObjectContext,
         isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol
     ) {
         self.context = context
         self.featureRepository = featureRepository
+        self.featureRepositoryContext = featureRepositoryContext
         self.isUserE2EICertifiedUseCase = isUserE2EICertifiedUseCase
     }
 
     public func invoke() async throws -> Bool {
-        let isE2EIEnabled = await context.perform {
+
+        let isE2EIEnabled = await featureRepositoryContext.perform {
             featureRepository.fetchE2EI().isEnabled
         }
         guard isE2EIEnabled else { return false }

--- a/wire-ios-data-model/Source/UseCases/IsSelfUserE2EICertifiedUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/IsSelfUserE2EICertifiedUseCase.swift
@@ -25,6 +25,7 @@ import WireCoreCrypto
 public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol {
 
     private let context: NSManagedObjectContext
+    private let featureRepository: FeatureRepositoryInterface
     private let isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol
 
     /// - Parameters:
@@ -32,13 +33,19 @@ public struct IsSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProt
     ///   - isUserE2EICertifiedUseCase: The use case which contains the actual business logic.
     public init(
         context: NSManagedObjectContext,
+        featureRepository: FeatureRepositoryInterface,
         isUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol
     ) {
         self.context = context
+        self.featureRepository = featureRepository
         self.isUserE2EICertifiedUseCase = isUserE2EICertifiedUseCase
     }
 
     public func invoke() async throws -> Bool {
+        let isE2EIEnabled = await context.perform {
+            featureRepository.fetchE2EI().isEnabled
+        }
+        guard isE2EIEnabled else { return false }
 
         let (selfUser, selfMLSConversation) = await context.perform {
             let selfUser = ZMUser.selfUser(in: context)

--- a/wire-ios-data-model/Tests/UseCases/IsSelfUserE2EICertifiedUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/IsSelfUserE2EICertifiedUseCaseTests.swift
@@ -48,6 +48,7 @@ final class IsSelfUserE2EICertifiedUseCaseTests: ZMBaseManagedObjectTest {
         sut = .init(
             context: context,
             featureRepository: mockFeatureRepository,
+            featureRepositoryContext: context,
             isUserE2EICertifiedUseCase: mockIsUserE2EICertifiedUseCase
         )
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -286,6 +286,7 @@ extension ZMUserSession: UserSession {
     public var isSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol {
         IsSelfUserE2EICertifiedUseCase(
             context: syncContext,
+            featureRepository: FeatureRepository(context: syncContext),
             isUserE2EICertifiedUseCase: isUserE2EICertifiedUseCase
         )
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -287,6 +287,7 @@ extension ZMUserSession: UserSession {
         IsSelfUserE2EICertifiedUseCase(
             context: syncContext,
             featureRepository: FeatureRepository(context: syncContext),
+            featureRepositoryContext: syncContext,
             isUserE2EICertifiedUseCase: isUserE2EICertifiedUseCase
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7252" title="WPB-7252" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7252</a>  [iOS] : E2Ei certificate check flow initiated on Beta
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We found **"failed to get E2EI certification status: failedToGetTheSelfMLSConversation"** logs for a proteus client.
There are more info in the ticket.

### Causes

We received these logs because we were trying to get information about whether **selfClient** (Proteus client) is certified or not. There is no self MLS conversion in the Proteus client.

### Solutions

`IsSelfUserE2EICertifiedUseCase` is responsible for answering whether **selfClient** is certified or not. We should check the E2EI feature flag before asking the CC about the client's certification status. This feature flag should be enabled in Team settings for mls clients only.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
