### PR TITLE
fix: ignore incoming messages in readonly conversations WPB-7164

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMOTRMessage+UpdateEvent.swift
@@ -38,6 +38,11 @@ extension ZMOTRMessage {
                 return nil
         }
 
+        guard !conversation.isForcedReadOnly else {
+            zmLog.warn("Ignoring incoming message in readonly conversation.")
+            return nil
+        }
+
         guard
             let message = GenericMessage(from: updateEvent),
             let content = message.content

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -455,6 +455,11 @@ extension NotificationSession: PushNotificationStrategyDelegate {
             return nil
         }
 
+        if conversation.isForcedReadOnly {
+            WireLogger.calling.info("should not handle call event: conversation is forced readonly")
+            return nil
+        }
+
         guard VoIPPushHelper.isAVSReady else {
             WireLogger.calling.warn("should not handle call event: AVS is not ready")
             return nil

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -27,6 +27,7 @@ public extension ZMLocalNotification {
 
         switch event.type {
         case .conversationOtrMessageAdd, .conversationMLSMessageAdd:
+            guard conversation?.isForcedReadOnly != true else { break }
             guard let message = GenericMessage(from: event) else { break }
             builderType = message.hasReaction ? ReactionEventNotificationBuilder.self : NewMessageNotificationBuilder.self
 

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -369,6 +369,21 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
         }
     }
 
+    func testThatItDoesNotCreateANotificationWhenConversationIsForceReadonly() {
+        // given
+        syncMOC.performGroupedBlockAndWait {
+            self.oneOnOneConversation.isForcedReadOnly = true
+            let event = self.createUpdateEvent(UUID.create(), conversationID: UUID.create(), genericMessage: GenericMessage(content: Text(content: "Stimpy just joined Wire")))
+            var note: ZMLocalNotification?
+
+            // when
+            note = ZMLocalNotification(event: event, conversation: self.oneOnOneConversation, managedObjectContext: self.syncMOC)
+
+            // then
+            XCTAssertNil(note)
+        }
+    }
+
     func testThatItDoesNotCreateANotificationForConfirmationEvents() {
         // given
         syncMOC.performGroupedBlockAndWait {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7164" title="WPB-7164" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7164</a>  [iOS] Can still message to a read only conversation when it was previously used
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

If a 1-1 conversation is read-only due to the two users having no common supported protocols we should ignore any incoming messages that might still be sent due to fact the discovery that there are no common protocols isn't instantaneous.

### Solutions

- Don't process message event if the target conversation is `forceReadOnly`
- Don't generate a notification if the target conversation is `forceReadOnly`

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
