### PR TITLE
fix: thread access `ConversationListObserverCenter`

### DIFF
--- a/wire-ios-data-model/Source/Notifications/ConversationListObserverCenter.swift
+++ b/wire-ios-data-model/Source/Notifications/ConversationListObserverCenter.swift
@@ -28,22 +28,16 @@ extension Notification.Name {
 
 extension NSManagedObjectContext {
 
-    static let ConversationListObserverCenterKey = "ConversationListObserverCenterKey"
+    static let conversationListObserverCenterKey = "ConversationListObserverCenterKey"
 
+    /// Note: uses `self.userInfo` and must be accessed from NSManagedObjectContext queue!
     @objc public var conversationListObserverCenter: ConversationListObserverCenter {
-        // swiftlint:disable todo_requires_jira_link
-        // FIXME: Uncomment and fix crash when running tests
-        // when the assert is check, all userInfo of context have been torn down so we can't check this property
-        // nevertheless tearDown seems to be expected to happen on mainThread
-        // swiftlint:enable todo_requires_jira_link
-//        assert(zm_isUserInterfaceContext, "ConversationListObserver does not exist in syncMOC")
-
-        if let observer = self.userInfo[NSManagedObjectContext.ConversationListObserverCenterKey] as? ConversationListObserverCenter {
+        if let observer = userInfo[NSManagedObjectContext.conversationListObserverCenterKey] as? ConversationListObserverCenter {
             return observer
         }
 
         let newObserver = ConversationListObserverCenter(managedObjectContext: self)
-        self.userInfo[NSManagedObjectContext.ConversationListObserverCenterKey] = newObserver
+        userInfo[NSManagedObjectContext.conversationListObserverCenterKey] = newObserver
         return newObserver
     }
 }

--- a/wire-ios-data-model/Source/Notifications/NotificationDispatcher.swift
+++ b/wire-ios-data-model/Source/Notifications/NotificationDispatcher.swift
@@ -54,13 +54,17 @@ import CoreData
         didSet {
             guard operationMode != oldValue else { return }
 
+            let observerCenter = managedObjectContext.performAndWait {
+                managedObjectContext.conversationListObserverCenter
+            }
+
             if operationMode == .economical {
-                conversationListObserverCenter.stopObserving()
+                observerCenter.stopObserving()
             }
 
             if oldValue == .economical {
                 fireAllNotifications()
-                conversationListObserverCenter.startObserving()
+                observerCenter.startObserving()
             }
 
             changeDetector = changeDetectorBuilder(operationMode)
@@ -78,14 +82,14 @@ import CoreData
     private var changeInfoConsumers = [UnownedNSObject]()
 
     private var allChangeInfoConsumers: [ChangeInfoConsumer] {
+        let observerCenter = managedObjectContext.performAndWait {
+            managedObjectContext.conversationListObserverCenter
+        }
+
         var consumers = changeInfoConsumers.compactMap { $0.unbox as? ChangeInfoConsumer }
         consumers.append(searchUserObserverCenter)
-        consumers.append(conversationListObserverCenter)
+        consumers.append(observerCenter)
         return consumers
-    }
-
-    private var conversationListObserverCenter: ConversationListObserverCenter {
-        return managedObjectContext.conversationListObserverCenter
     }
 
     private var searchUserObserverCenter: SearchUserObserverCenter {
@@ -170,7 +174,11 @@ import CoreData
         NotificationCenter.default.removeObserver(self)
         notificationCenterTokens.forEach(NotificationCenter.default.removeObserver)
         notificationCenterTokens = []
-        conversationListObserverCenter.tearDown()
+
+        managedObjectContext.performAndWait {
+            managedObjectContext.conversationListObserverCenter.tearDown()
+        }
+
         isTornDown = true
     }
 
@@ -286,7 +294,12 @@ import CoreData
     private func forwardChangesToConversationListObserver(modifiedObjects: ModifiedObjects) {
         let insertedLabels = modifiedObjects.inserted.compactMap { $0 as? Label }
         let deletedLabels = modifiedObjects.deleted.compactMap { $0 as? Label }
-        conversationListObserverCenter.folderChanges(inserted: insertedLabels, deleted: deletedLabels)
+
+        let conversationListObserverCenter = managedObjectContext.performAndWait {
+            managedObjectContext.conversationListObserverCenter
+        }
+
+        managedObjectContext.conversationListObserverCenter.folderChanges(inserted: insertedLabels, deleted: deletedLabels)
 
         let insertedConversations = modifiedObjects.inserted.compactMap { $0 as? ZMConversation }
         let deletedConversations = modifiedObjects.deleted.compactMap { $0 as? ZMConversation }

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -77,7 +77,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
         // when
         weak var observerCenter = uiMOC.conversationListObserverCenter
-        uiMOC.userInfo.removeObject(forKey: NSManagedObjectContext.ConversationListObserverCenterKey)
+        uiMOC.userInfo.removeObject(forKey: NSManagedObjectContext.conversationListObserverCenterKey)
 
         // then
         XCTAssertNil(observerCenter)

--- a/wire-ios-data-model/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -94,7 +94,7 @@ extension ObjectChangeInfo {
 
 }
 
-class NotificationDispatcherTests: NotificationDispatcherTestBase {
+final class NotificationDispatcherTests: NotificationDispatcherTestBase {
 
     class Wrapper {
         let dispatcher: NotificationDispatcher

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1071,12 +1071,14 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     deinit {
-        backgroundUserSessions.forEach { (_, session) in
-            session.tearDown()
+        DispatchQueue.main.async { [backgroundUserSessions, blacklistVerificator, unauthenticatedSession, reachability] in
+            backgroundUserSessions.values.forEach { session in
+                session.tearDown()
+            }
+            blacklistVerificator?.tearDown()
+            unauthenticatedSession?.tearDown()
+            reachability.tearDown()
         }
-        blacklistVerificator?.tearDown()
-        unauthenticatedSession?.tearDown()
-        reachability.tearDown()
 
         if let memoryWarningObserver {
             NotificationCenter.default.removeObserver(memoryWarningObserver)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Failing tests:
```
WireCallCenterV3Tests.testThatItAnswersACall_conference_mls()
-[ConversationTestsOTR testThatItDeliversOTRMessageAfterIgnoringAndResending]
SessionManagerMultiUserSessionTests.testThatItDoesNotUnloadActiveUserSessionFromMemoryWarning()
```

Thread access crashes:
```console
Thread 7 Crashed::  Dispatch queue: sessionLoadingQueue
0   CoreData                      	       0x106685468 _PFAssertSafeMultiThreadedAccess_impl + 520
1   CoreData                      	       0x106693a04 -[NSManagedObjectContext userInfo] + 88
2   WireDataModel                 	       0x1103aed0c NSManagedObjectContext.conversationListObserverCenter.getter + 92 (ConversationListObserverCenter.swift:41)
3   WireDataModel                 	       0x1103aec8c @objc NSManagedObjectContext.conversationListObserverCenter.getter + 44
4   WireDataModel                 	       0x1103c4648 NotificationDispatcher.conversationListObserverCenter.getter + 60 (NotificationDispatcher.swift:88)
5   WireDataModel                 	       0x1103c56f4 NotificationDispatcher.tearDown() + 324 (NotificationDispatcher.swift:173)
6   WireDataModel                 	       0x1103c58a8 @objc NotificationDispatcher.tearDown() + 36
7   WireSyncEngine                	       0x1045761ac -[ZMSyncStrategy tearDown] + 156 (ZMSyncStrategy.m:140)
8   WireSyncEngine                	       0x10484c06c ZMUserSession.tearDown() + 544 (ZMUserSession.swift:280)
9   WireSyncEngine                	       0x104776cb8 closure #1 in SessionManager.deinit + 60 (SessionManager.swift:1075)
10  WireSyncEngine                	       0x104776d10 thunk for @callee_guaranteed (@in_guaranteed UUID, @guaranteed ZMUserSession) -> (@error @owned Error) + 72
11  WireSyncEngine                	       0x10478022c partial apply for thunk for @callee_guaranteed (@in_guaranteed UUID, @guaranteed ZMUserSession) -> (@error @owned Error) + 28
12  libswiftCore.dylib            	       0x107678148 Sequence.forEach(_:) + 440
13  WireSyncEngine                	       0x1047769e8 SessionManager.__deallocating_deinit + 232 (SessionManager.swift:1074)
14  WireSyncEngine                	       0x104776d6c @objc SessionManager.__deallocating_deinit + 28
```

### Causes (Optional)

Access from different thread than core data `NSManagedObjectContext` queue on `userInfo`.

### Solutions

Access via queue.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

- Run test suite.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
