### PR TITLE
fix: disable flaky test, store xcodebuild logs

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -289,9 +289,9 @@ jobs:
         run: |
           echo "WireNotificationEngine has changes"
           echo "Building WireNotificationEngine..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-notification-engine.log | bundle exec xcpretty
           echo "Testing WireNotificationEngine..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireNotificationEngine.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-notification-engine.log | bundle exec xcpretty --report junit --output build/reports/WireNotificationEngine.junit
           exit ${PIPESTATUS[0]}
 
       - name: Upload Test Reports as Artifacts

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Upload Failed snapshots
         uses: actions/upload-artifact@v3
-        if: failure()
+        if: always()
         with:
           name: Failed Snapshots and log
           path: |

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -131,9 +131,9 @@ jobs:
         run: |
           echo "WireSystem has changes"
           echo "Building WireSystem..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireSystem -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireSystem -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-system.log | bundle exec xcpretty
           echo "Testing WireSystem..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireSystem -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' |bundle exec xcpretty --report junit --output build/reports/WireSystem.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireSystem -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-system.log | bundle exec xcpretty --report junit --output build/reports/WireSystem.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireTesting
@@ -141,9 +141,9 @@ jobs:
         run: |
           echo "WireTesting has changes"
           echo "Building WireTesting..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireTesting -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireTesting -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-testing.log | bundle exec xcpretty
           echo "Testing WireTesting..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireTesting -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}'  | bundle exec xcpretty --report junit --output build/reports/WireTesting.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireTesting -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-testing.log | bundle exec xcpretty --report junit --output build/reports/WireTesting.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireUtilities
@@ -151,9 +151,9 @@ jobs:
         run: |
           echo "WireUtilities has changes"
           echo "Building WireUtilities..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireUtilities -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireUtilities -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-utilities.log | bundle exec xcpretty
           echo "Testing WireUtilities..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireUtilities -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireUtilities.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireUtilities -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-utilities.log | bundle exec xcpretty --report junit --output build/reports/WireUtilities.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireCryptobox
@@ -161,9 +161,9 @@ jobs:
         run: |
           echo "WireCryptobox has changes"
           echo "Building WireCryptobox..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireCryptobox -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireCryptobox -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-cryptobox.log | bundle exec xcpretty
           echo "Testing WireCryptobox..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireCryptobox -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireCryptobox.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireCryptobox -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-cryptobox.log | bundle exec xcpretty --report junit --output build/reports/WireCryptobox.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireTransport
@@ -171,9 +171,9 @@ jobs:
         run: |
           echo "WireTransport has changes"
           echo "Building WireTransport..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-transport.log | bundle exec xcpretty
           echo "Testing WireTransport..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireTransport.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-transport.log | bundle exec xcpretty --report junit --output build/reports/WireTransport.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireLinkPreview
@@ -181,9 +181,9 @@ jobs:
         run: |
           echo "WireLinkPreview has changes"
           echo "Building WireLinkPreview..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireLinkPreview -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireLinkPreview -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-link-preview.log | bundle exec xcpretty
           echo "Testing WireLinkPreview..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireLinkPreview -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireLinkPreview.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireLinkPreview -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-link-preview.log | bundle exec xcpretty --report junit --output build/reports/WireLinkPreview.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireImages
@@ -191,9 +191,9 @@ jobs:
         run: |
           echo "WireImages has changes"
           echo "Building WireImages..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireImages -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireImages -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-images.log | bundle exec xcpretty
           echo "Testing WireImages..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireImages -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireImages.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireImages -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-images.log | bundle exec xcpretty --report junit --output build/reports/WireImages.junit
           exit ${PIPESTATUS[0]}          
 
       - name: Test WireProtos
@@ -201,9 +201,9 @@ jobs:
         run: |
           echo "WireProtos has changes"
           echo "Building WireProtos..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireProtos -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireProtos -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-protos.log | bundle exec xcpretty
           echo "Testing WireProtos..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireProtos -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireProtos -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-protos.log | bundle exec xcpretty
           exit ${PIPESTATUS[0]}          
           
       - name: Test WireMockTransport
@@ -211,9 +211,9 @@ jobs:
         run: |
           echo "WireMockTransport has changes"
           echo "Building WireMockTransport..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireMockTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireMockTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-mocktransport.log | bundle exec xcpretty
           echo "Testing WireMockTransport..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireMockTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireMockTransport.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireMockTransport -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-mocktransport.log | bundle exec xcpretty --report junit --output build/reports/WireMockTransport.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireDataModel
@@ -221,8 +221,8 @@ jobs:
         run: |
           echo "WireDataModel has changes"
           echo "Building WireDataModel..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireDataModel -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireDataModel -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireDataModel.junit
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireDataModel -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-data-model.log | bundle exec xcpretty
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireDataModel -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-data-model.log | bundle exec xcpretty --report junit --output build/reports/WireDataModel.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireRequestStrategy
@@ -230,9 +230,9 @@ jobs:
         run: |
           echo "WireRequestStrategy has changes"
           echo "Building WireRequestStrategy..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireRequestStrategy -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireRequestStrategy -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-request-strategy.log | bundle exec xcpretty
           echo "Testing WireRequestStrategy..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireRequestStrategy -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireRequestStrategy.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireRequestStrategy -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-request-strategy.log | bundle exec xcpretty --report junit --output build/reports/WireRequestStrategy.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test WireShareEngine
@@ -240,9 +240,9 @@ jobs:
         run: |
           echo "WireShareEngine has changes"
           echo "Building WireShareEngine..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireShareEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireShareEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-share-engine.log | bundle exec xcpretty
           echo "Testing WireShareEngine..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireShareEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireShareEngine.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireShareEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-share-engine.log | bundle exec xcpretty --report junit --output build/reports/WireShareEngine.junit
           exit ${PIPESTATUS[0]}
 
       - name: Test WireSyncEngine
@@ -250,9 +250,9 @@ jobs:
         run: |
           echo "WireSyncEngine has changes"
           echo "Building WireSyncEngine..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireSyncEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme WireSyncEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-sync-engine.log | bundle exec xcpretty
           echo "Testing WireSyncEngine..."
-          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireSyncEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty --report junit --output build/reports/WireSyncEngine.junit
+          xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireSyncEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-sync-engine.log | bundle exec xcpretty --report junit --output build/reports/WireSyncEngine.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test Wire-iOS
@@ -260,16 +260,16 @@ jobs:
         run: |
           echo "Wire-iOS has changes"
           echo "Building Wire-iOS..."
-          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | bundle exec xcpretty
+          xcodebuild build -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios.log | bundle exec xcpretty
           echo "Testing Wire-iOS..."
-          xcodebuild test -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -testPlan AllTests -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild.log | bundle exec xcpretty --report junit --output build/reports/Wire-iOS-EN.junit
+          xcodebuild test -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -testPlan AllTests -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios.log | bundle exec xcpretty --report junit --output build/reports/Wire-iOS-EN.junit
           exit ${PIPESTATUS[0]}
           
       - name: Test Wire-iOS German Locale Tests
         if: ${{ inputs.wire-ios || inputs.all }}
         run: |
           echo "Testing Wire-iOS German Locale Tests..."
-          xcodebuild test -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -testPlan GermanLocaleTests -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild_de.log | bundle exec xcpretty --report junit --output build/reports/Wire-iOS-DE.junit
+          xcodebuild test -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -testPlan GermanLocaleTests -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-de.log | bundle exec xcpretty --report junit --output build/reports/Wire-iOS-DE.junit
           exit ${PIPESTATUS[0]}
 
       - name: Upload Failed snapshots
@@ -279,8 +279,7 @@ jobs:
           name: Failed Snapshots and log
           path: |
             wire-ios/SnapshotResults/    
-            xcodebuild.log
-            xcodebuild_de.log
+            xcodebuild*.log
 
       # WORKAROUND: if we test WireNotificationEngine and then Wire-iOS, we'll get an error when trying to build
       # Wire-iOS stating that symbols from the notification can't be found. to workaround this, test the notification

--- a/wire-ios-data-model/Tests/Source/Model/AccountStoreTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/AccountStoreTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+
 @testable import WireDataModel
 
 final class AccountStoreTests: ZMConversationTestsBase {

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -908,23 +908,23 @@ final class WireCallCenterV3Tests: MessagingTest {
         let didJoinSubgroup = customExpectation(description: "didJoinSubgroup")
         mlsService.createOrJoinSubgroupParentQualifiedIDParentID_MockMethod = {
             defer { didJoinSubgroup.fulfill() }
-            XCTAssertEqual($0, self.uiMOC.performAndWait({ self.groupConversation.qualifiedID }), file: file, line: line)
-            XCTAssertEqual($1, parentGroupID, file: file, line: line)
+            XCTAssertEqual($0, self.uiMOC.performAndWait({ self.groupConversation.qualifiedID }), "[0] groupConversation.qualifiedID doesn't match", file: file, line: line)
+            XCTAssertEqual($1, parentGroupID, "[1] parentGroupID doesn't match", file: file, line: line)
             return subconversationGroupID
         }
 
         let didGenerateConferenceInfo1 = customExpectation(description: "didGenerateConferenceInfo1")
         mlsService.generateConferenceInfoParentGroupIDSubconversationGroupID_MockMethod = {
-            XCTAssertEqual($0, parentGroupID, file: file, line: line)
-            XCTAssertEqual($1, subconversationGroupID, file: file, line: line)
+            XCTAssertEqual($0, parentGroupID, "[2] parentGroupID doesn't match", file: file, line: line)
+            XCTAssertEqual($1, subconversationGroupID, "[3] subconversationGroupID doesn't match", file: file, line: line)
             defer { didGenerateConferenceInfo1.fulfill() }
             return conferenceInfo1
         }
 
         let didSetConferenceInfo1 = customExpectation(description: "didSetConferenceInfo1")
         mockAVSWrapper.mockSetMLSConferenceInfo = {
-            XCTAssertEqual($0, self.uiMOC.performAndWait({ self.groupConversation.avsIdentifier }), file: file, line: line)
-            XCTAssertEqual($1, conferenceInfo1, file: file, line: line)
+            XCTAssertEqual($0, self.uiMOC.performAndWait({ self.groupConversation.avsIdentifier }), "[4] avsIdentifier doesn't match", file: file, line: line)
+            XCTAssertEqual($1, conferenceInfo1, "[5] converenceInfo1 doesn't match", file: file, line: line)
             didSetConferenceInfo1.fulfill()
         }
 
@@ -950,23 +950,23 @@ final class WireCallCenterV3Tests: MessagingTest {
             try block()
         }
 
-        XCTAssert(waitForCustomExpectations(withTimeout: 0.5), file: file, line: line)
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5), "[6] waitForCustomExpectations failed", file: file, line: line)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), "[7] waitForAllGroupsToBeEmpty failed", file: file, line: line)
 
         let didSetConferenceInfo2 = customExpectation(description: "didSetConferenceInfo2")
         mockAVSWrapper.mockSetMLSConferenceInfo = {
-            XCTAssertEqual($0, self.uiMOC.performAndWait({ self.groupConversation.avsIdentifier }), file: file, line: line)
-            XCTAssertEqual($1, conferenceInfo2, file: file, line: line)
+            XCTAssertEqual($0, self.uiMOC.performAndWait({ self.groupConversation.avsIdentifier }), "[8] avsIdentifier doesn't match", file: file, line: line)
+            XCTAssertEqual($1, conferenceInfo2, "[9] conferenceInfo2 doesn't match", file: file, line: line)
             didSetConferenceInfo2.fulfill()
         }
 
         // and when the conference info changes
         conferenceInfoChangeSubject.send(conferenceInfo2)
 
-        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), "[A] waitForCustomExpectations failed", file: file, line: line)
 
         // then we set conference info 2 to avs (see expectations)
-        XCTAssert(waitForCustomExpectations(withTimeout: 0.5), file: file, line: line)
+        XCTAssert(waitForCustomExpectations(withTimeout: 1), "[B] waitForCustomExpectations failed", file: file, line: line)
     }
 
     func testThatItDoesNotStartAConferenceCall_IfConferenceCallingFeatureStatusIsDisabled() throws {

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -969,7 +969,7 @@ final class WireCallCenterV3Tests: MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5), "[A] waitForCustomExpectations failed", file: file, line: line)
 
         // then we set conference info 2 to avs (see expectations)
-        XCTAssert(waitForCustomExpectations(withTimeout: 1), "[B] waitForCustomExpectations failed", file: file, line: line)
+        XCTAssert(waitForCustomExpectations(withTimeout: 0.5), "[B] waitForCustomExpectations failed", file: file, line: line)
     }
 
     func testThatItDoesNotStartAConferenceCall_IfConferenceCallingFeatureStatusIsDisabled() throws {

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -785,6 +785,9 @@ final class WireCallCenterV3Tests: MessagingTest {
     }
 
     func testThatItAnswersACall_conference_mls() throws {
+        // TODO [WPB-7346]: enable this (flaky) test again
+        throw XCTSkip()
+
         // given
         sut.handleIncomingCall(
             conversationId: groupConversationID,

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -875,6 +875,9 @@ final class WireCallCenterV3Tests: MessagingTest {
     }
 
     func testThatItStartsACall_conference_mls() throws {
+        // TODO [WPB-7346]: enable this (flaky) test again
+        throw XCTSkip()
+
         try assertMLSConference(
             expectedCallState: .outgoing(degraded: false),
             expectedCallerID: selfUserID,

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -49,7 +49,7 @@ final class WireCallCenterTransportMock: WireCallCenterTransport {
 
 }
 
-class WireCallCenterV3Tests: MessagingTest {
+final class WireCallCenterV3Tests: MessagingTest {
 
     var flowManager: FlowManagerMock!
     var mockAVSWrapper: MockAVSWrapper!

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -22,8 +22,10 @@ extension ZMTBaseTest {
     @objc
     public static func checkForMemoryLeaksAfterTestClassCompletes() {
         let leakedObjects = "Leaked: \(MemoryReferenceDebugger.aliveObjectsDescription)"
-        print(leakedObjects)
         XCTAssert(MemoryReferenceDebugger.aliveObjects.isEmpty, leakedObjects)
+        if !MemoryReferenceDebugger.aliveObjects.isEmpty {
+            print(leakedObjects)
+        }
     }
 
     public func wait(timeout: TimeInterval = 0.5,

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -21,7 +21,9 @@ import Foundation
 extension ZMTBaseTest {
     @objc
     public static func checkForMemoryLeaksAfterTestClassCompletes() {
-        XCTAssert(MemoryReferenceDebugger.aliveObjects.isEmpty, "Leaked: \(MemoryReferenceDebugger.aliveObjectsDescription)")
+        let leakedObjects = "Leaked: \(MemoryReferenceDebugger.aliveObjectsDescription)"
+        print(leakedObjects)
+        XCTAssert(MemoryReferenceDebugger.aliveObjects.isEmpty, leakedObjects)
     }
 
     public func wait(timeout: TimeInterval = 0.5,

--- a/wire-ios-testing/Source/Public/ZMTBaseTest.swift
+++ b/wire-ios-testing/Source/Public/ZMTBaseTest.swift
@@ -21,10 +21,7 @@ import Foundation
 extension ZMTBaseTest {
     @objc
     public static func checkForMemoryLeaksAfterTestClassCompletes() {
-        if MemoryReferenceDebugger.aliveObjects.count > 0 {
-            print("Leaked: \(MemoryReferenceDebugger.aliveObjectsDescription)")
-            assert(false)
-        }
+        XCTAssert(MemoryReferenceDebugger.aliveObjects.isEmpty, "Leaked: \(MemoryReferenceDebugger.aliveObjectsDescription)")
     }
 
     public func wait(timeout: TimeInterval = 0.5,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Disable flaky test
- Stores xcodebuild logs

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
