### PR TITLE
fix: incorrect system messages for MLS 1-1 WPB-7399

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -642,7 +642,7 @@ struct ConversationEventPayloadProcessor {
             conversation.conversationType = .connection
 
             updateAttributes(from: payload, for: conversation, context: context)
-            updateMessageProtocol(from: payload, for: conversation, in: context)
+            assignMessageProtocol(from: payload, for: conversation, in: context)
             updateMetadata(from: payload, for: conversation, context: context)
             updateMembers(from: payload, for: conversation, context: context)
             updateConversationTimestamps(for: conversation, serverTimestamp: serverTimestamp)
@@ -677,7 +677,7 @@ struct ConversationEventPayloadProcessor {
 
             conversation.conversationType = self.conversationType(for: conversation, from: conversationType)
             updateAttributes(from: payload, for: conversation, context: context)
-            updateMessageProtocol(from: payload, for: conversation, in: context)
+            assignMessageProtocol(from: payload, for: conversation, in: context)
             updateMetadata(from: payload, for: conversation, context: context)
             updateMembers(from: payload, for: conversation, context: context)
             updateConversationTimestamps(for: conversation, serverTimestamp: serverTimestamp)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. MLS 1-1 conversations have an MLS migration system message
2. Some MLS 1-1 conversation are missing the 1-1 header (round avatar)

### Causes

1. We first insert and an empty conversation which then gets messageProtocol assigned to proteus by default and we immediately update it to MLS which causes an MLS migration message to be inserted.
2. Due to a backend bug some MLS 1-1 conversations don't include the other participant as member.

### Solutions

1. Always directly assign messageProtocol for 1-1 conversations it can never change
2. Patch the backend payload until they fix the bug.
----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
