### PR TITLE
fix: don't repair MLS groups where local group is past the remote WPB-7399

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1067,7 +1067,7 @@ public final class MLSService: MLSServiceInterface {
             let localEpoch = try await coreCrypto.conversationEpoch(conversationId: groupID.data)
 
             logger.info("epochs(remote: \(epoch), local: \(localEpoch)) for (\(groupID.safeForLoggingDescription))")
-            return localEpoch != epoch
+            return localEpoch < epoch
         } catch {
             logger.info("cannot resolve conversation epoch \(String(describing: error)) for (\(groupID.safeForLoggingDescription))")
             return false

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -324,7 +324,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         await uiMOC.perform {
             self.setMocksForConversationRepair(
                 parentGroupID: groupID,
-                epoch: conversation.epoch + 1,
+                epoch: conversation.epoch - 1,
                 onJoinGroup: { joinedGroupID in
                     XCTAssertEqual(groupID, joinedGroupID)
                     expectation.fulfill()
@@ -1352,7 +1352,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
                 }
 
                 let epoch = await self.uiMOC.perform { tuple.conversation.epoch }
-                return tuple.isOutOfSync ? epoch + 1 : epoch
+                return tuple.isOutOfSync ? epoch - 1 : epoch
             }
         }
 
@@ -1388,7 +1388,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         await uiMOC.perform { [self] in
             setMocksForConversationRepair(
                 parentGroupID: groupID,
-                epoch: conversation.epoch + 1,
+                epoch: conversation.epoch - 1,
                 onJoinGroup: { joinedGroupID in
                     XCTAssertEqual(groupID, joinedGroupID)
                     expectation.fulfill()
@@ -1456,7 +1456,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         await uiMOC.perform {
             self.setMocksForConversationRepair(
                 parentGroupID: groupID,
-                epoch: UInt64(subgroup.epoch + 1),
+                epoch: UInt64(subgroup.epoch - 1),
                 subgroup: subgroup,
                 onJoinGroup: { joinedGroupID in
                     XCTAssertEqual(subgroupID, joinedGroupID)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7399" title="WPB-7399" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7399</a>  [iOS] 1:1 System Message "You haven’t used this device for a while" with first login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After a fresh login some conversation will be detected as out of sync and repaired

### Causes

After Joining via external commit backend will resend any pending proposals (for removing deleted clients) which existed in the MLS group which we will then attempt to commit. While we are in the process of committing these the local epoch will be higher than remote epoch.

We are checking for out sync MLS group at the same and since the epoch doesn't match we will attempt to re-join.

### Solutions

Only consider a MLS group out of sync if the local epoch < remote epoch.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
