### PR TITLE
fix: Update the string for E2EI registration

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -4919,14 +4919,14 @@ internal enum L10n {
           }
         }
         internal enum E2ei {
+          /// [Learn more](%@)
+          internal static func learnMore(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "registration.signin.e2ei.learn_more", String(describing: p1), fallback: "[Learn more](%@)")
+          }
           /// Your team now uses end-to-end identity to make Wire's usage more secure.
           /// 
-          ///  Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device. 
-          /// 
-          ///  [Learn more about end-to-end identity](%@)
-          internal static func subtitle(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "registration.signin.e2ei.subtitle", String(describing: p1), fallback: "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device. \n\n [Learn more about end-to-end identity](%@)")
-          }
+          ///  Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device.
+          internal static let subtitle = L10n.tr("Localizable", "registration.signin.e2ei.subtitle", fallback: "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device.")
           /// End-to-end identity certificate
           internal static let title = L10n.tr("Localizable", "registration.signin.e2ei.title", fallback: "End-to-end identity certificate")
           internal enum Error {

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1604,7 +1604,8 @@
 "registration.signin.alert.password_needed.message" = "Please enter your Password in order to log in.";
 
 "registration.signin.e2ei.title" = "End-to-end identity certificate";
-"registration.signin.e2ei.subtitle" = "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device. \n\n [Learn more about end-to-end identity](%@)";
+"registration.signin.e2ei.subtitle" = "Your team now uses end-to-end identity to make Wire's usage more secure.\n\n Enter your identity provider's credentials in the next step to automatically get a verification certificate for this device.";
+"registration.signin.e2ei.learn_more" = "[Learn more](%@)";
 "registration.signin.e2ei.get_certificate_button.title" = "Get Certificate";
 "registration.signin.e2ei.error.alert.title" = "Something went wrong";
 "registration.signin.e2ei.error.alert.message" = "Failed to retrieve certificate";

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/EnrollE2EIdentityStepDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Descriptions/ScreenDescriptions/Login/EnrollE2EIdentityStepDescription.swift
@@ -40,7 +40,8 @@ class EnrollE2EIdentityStepDescription: AuthenticationStepDescription {
         )
         secondaryView = nil
         headline = E2ei.title
-        subtext = .markdown(from: E2ei.subtitle(URL.wr_e2eiLearnMore), style: .login)
+        let details = [E2ei.subtitle, E2ei.learnMore(URL.wr_e2eiLearnMore)].joined(separator: "\n")
+        subtext = .markdown(from: details, style: .login)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/BlockerViewController.swift
@@ -100,7 +100,7 @@ final class BlockerViewController: LaunchImageViewController {
 
         let getCertificateAlert = UIAlertController(
             title: E2EI.title,
-            message: E2EI.subtitle(URL.wr_e2eiLearnMore),
+            message: E2EI.subtitle,
             preferredStyle: .alert
         )
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/BlockerViewController.swift
@@ -124,7 +124,6 @@ final class BlockerViewController: LaunchImageViewController {
 
         getCertificateAlert.addAction(learnMoreAction)
         getCertificateAlert.addAction(getCertificateAction)
-
         present(getCertificateAlert, animated: true)
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/BlockerViewController.swift
@@ -124,6 +124,7 @@ final class BlockerViewController: LaunchImageViewController {
 
         getCertificateAlert.addAction(learnMoreAction)
         getCertificateAlert.addAction(getCertificateAction)
+
         present(getCertificateAlert, animated: true)
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. We should use **Learn more** instead of **Learn more about end-to-end identity**
2. I moved **Learn more** to a separate string because we need to reuse the main string for the alert and it shouldn't have the **Learn more** part.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
