### PR TITLE
fix: Notification $@ has added you - WPB-7146

### DIFF
--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Localization.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/LocalNotificationType+Localization.swift
@@ -244,7 +244,7 @@ extension LocalNotificationType {
         }
 
         let conversationName = conversation?.userDefinedName ?? ""
-        let senderName = sender?.name ?? ""
+        let senderName = sender?.name ?? "conversation.status.someone"
         var senderKey = self.senderKey(sender, conversation)
         var conversationTypeKey: String? = (conversation?.conversationType != .oneOnOne) ? GroupKey : OneOnOneKey
         let conversationKey = self.conversationKey(conversation)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7146" title="WPB-7146" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7146</a>  Notification $@ has added you
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…e the someone

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

There would be cases where the username couldn't be retrieved and instead of having and shown in the UI:

`%@ added you`

Now we will show:

`Someone added you`

Improves the user experience. 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
