### PR TITLE
fix: ensure MLS thumbprint view is expanded horizontally [WPB-7172]

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/CopyValueView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/CopyValueView.swift
@@ -35,11 +35,11 @@ struct CopyValueView: View {
             HStack {
                 Text(value)
                     .font(FontSpec.normalRegularFont.swiftUIFont.monospaced())
+                Spacer()
 
                 if isCopyEnabled {
-                    Spacer()
                     VStack {
-                        SwiftUI.Button(action: copy) {
+                        Button(action: copy) {
                             Image(.copy)
                                 .renderingMode(.template)
                                 .foregroundColor(SemanticColors.Icon.foregroundDefaultBlack.swiftUIColor)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7172" title="WPB-7172" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7172</a>  [iOS] When logged into an E2EI user on the C1 build, my MLS thumbprint is misaligned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

If `CLIPBOARD_ENABLED` is `false` and the `CopyValueView` does not display the copy button, the MLS thumbprint view was not expanded. This PR fixes it.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
