### PR TITLE
fix: retain cycle keeping ConversationViewController alive WPB-7154

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -141,7 +141,7 @@ final class ConversationViewController: UIViewController {
         hideAndDestroyParticipantsPopover()
         contentViewController.delegate = nil
     }
-    private var observationToken: NSObjectProtocol?
+    private var observationToken: SelfUnregisteringNotificationCenterToken?
 
     private func update(conversation: ZMConversation) {
         setupNavigatiomItem()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/E2EIPrivacyWarningChecker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/E2EIPrivacyWarningChecker.swift
@@ -19,7 +19,7 @@
 import Foundation
 import WireDataModel
 
-protocol E2EIPrivacyWarningPresenter {
+protocol E2EIPrivacyWarningPresenter: AnyObject {
     func presentE2EIPrivacyWarningAlert(_ notification: Notification)
 }
 
@@ -77,8 +77,8 @@ struct E2EIPrivacyWarningChecker {
     static func addPresenter(_ observer: E2EIPrivacyWarningPresenter) -> NSObjectProtocol {
         NotificationCenter.default.addObserver(forName: .presentE2EIPrivacyWarningAlert,
                                                object: nil,
-                                               queue: .main) { note in
-            observer.presentE2EIPrivacyWarningAlert(note)
+                                               queue: .main) { [weak observer] note in
+            observer?.presentE2EIPrivacyWarningAlert(note)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/E2EIPrivacyWarningChecker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/E2EIPrivacyWarningChecker.swift
@@ -74,14 +74,15 @@ struct E2EIPrivacyWarningChecker {
     }
 
     // add object in charge to present e2eiPrivacyWarningAlert
-    static func addPresenter(_ observer: E2EIPrivacyWarningPresenter) -> NSObjectProtocol {
-        NotificationCenter.default.addObserver(forName: .presentE2EIPrivacyWarningAlert,
+    static func addPresenter(_ observer: E2EIPrivacyWarningPresenter) -> SelfUnregisteringNotificationCenterToken {
+        let token = NotificationCenter.default.addObserver(forName: .presentE2EIPrivacyWarningAlert,
                                                object: nil,
                                                queue: .main) { [weak observer] note in
             observer?.presentE2EIPrivacyWarningAlert(note)
         }
-    }
 
+        return SelfUnregisteringNotificationCenterToken(token)
+    }
 }
 
 private extension Notification.Name {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7154" title="WPB-7154" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7154</a>  Issues on logout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

`ConversationViewController` is not deallocated on logout

### Causes (Optional)

`E2EIPrivacyWarningChecker` observer holds a strong reference creating a retain cycle.

### Solutions

Hold a weak reference in the `E2EIPrivacyWarningChecker`.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
