### PR TITLE
fix: update mls conversation verification status WPB-7404

### DIFF
--- a/wire-ios-data-model/Source/UseCases/UpdateMLSGroupVerificationStatusUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/UpdateMLSGroupVerificationStatusUseCase.swift
@@ -63,6 +63,7 @@ public class UpdateMLSGroupVerificationStatusUseCase: UpdateMLSGroupVerification
         let context = conversation.managedObjectContext ?? context
         await context.perform {
             self.updateStatusAndNotifyUserIfNeeded(newStatusFromCC: coreCryptoStatus, conversation: conversation)
+            context.saveOrRollback()
         }
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -563,6 +563,7 @@ public final class ZMUserSession: NSObject {
             self.applicationStatusDirectory.clientRegistrationStatus.determineInitialRegistrationStatus()
             self.hasCompletedInitialSync = self.applicationStatusDirectory.syncStatus.isSlowSyncing == false
 
+            self.mlsGroupVerificationStatusObserver.invoke()
             self.cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(
                 from: self.mlsService.onNewCRLsDistributionPoints()
             )
@@ -932,7 +933,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
 
         managedObjectContext.performGroupedBlock { [weak self] in
             self?.notifyThirdPartyServices()
-            self?.observeMLSGroupVerificationStatus()
         }
 
     }
@@ -1037,14 +1037,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
     func checkE2EICertificateExpiryStatus() {
         guard e2eiFeature.isEnabled else { return }
         NotificationCenter.default.post(name: .checkForE2EICertificateExpiryStatus, object: nil)
-    }
-
-    // MARK: - Observers
-
-    private func observeMLSGroupVerificationStatus() {
-        guard e2eiFeature.isEnabled else { return }
-
-        mlsGroupVerificationStatusObserver.invoke()
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -112,7 +112,7 @@ public final class ZMUserSession: NSObject {
     private(set) var proteusProvider: ProteusProviding!
     let proteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating
     let mlsConversationVerificationStatusUpdater: MLSConversationVerificationStatusUpdating
-    let mlsGroupVerificationStatusObserver: ObserveMLSGroupVerificationStatusUseCaseProtocol
+    let observeMLSGroupVerificationStatus: ObserveMLSGroupVerificationStatusUseCaseProtocol
     public let updateMLSGroupVerificationStatus: UpdateMLSGroupVerificationStatusUseCaseProtocol
 
     public var syncStatus: SyncStatusProtocol {
@@ -419,7 +419,7 @@ public final class ZMUserSession: NSObject {
         proteusToMLSMigrationCoordinator: ProteusToMLSMigrationCoordinating? = nil,
         sharedUserDefaults: UserDefaults,
         useCaseFactory: UseCaseFactoryProtocol? = nil,
-        mlsGroupVerificationStatusObserver: ObserveMLSGroupVerificationStatusUseCaseProtocol? = nil
+        observeMLSGroupVerificationStatus: ObserveMLSGroupVerificationStatusUseCaseProtocol? = nil
     ) {
         coreDataStack.syncContext.performGroupedBlockAndWait {
             coreDataStack.syncContext.analytics = analytics
@@ -511,7 +511,7 @@ public final class ZMUserSession: NSObject {
             syncContext: coreDataStack.syncContext
         )
 
-        self.mlsGroupVerificationStatusObserver = mlsGroupVerificationStatusObserver ?? ObserveMLSGroupVerificationStatusUseCase(
+        self.observeMLSGroupVerificationStatus = observeMLSGroupVerificationStatus ?? ObserveMLSGroupVerificationStatusUseCase(
             mlsService: self.mlsService,
             updateMLSGroupVerificationStatusUseCase: updateMLSGroupVerificationStatus,
             syncContext: coreDataStack.syncContext)
@@ -563,7 +563,7 @@ public final class ZMUserSession: NSObject {
             self.applicationStatusDirectory.clientRegistrationStatus.determineInitialRegistrationStatus()
             self.hasCompletedInitialSync = self.applicationStatusDirectory.syncStatus.isSlowSyncing == false
 
-            self.mlsGroupVerificationStatusObserver.invoke()
+            self.observeMLSGroupVerificationStatus.invoke()
             self.cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(
                 from: self.mlsService.onNewCRLsDistributionPoints()
             )
@@ -934,7 +934,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
         managedObjectContext.performGroupedBlock { [weak self] in
             self?.notifyThirdPartyServices()
         }
-
     }
 
     func processEvents() {
@@ -1038,7 +1037,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
         guard e2eiFeature.isEnabled else { return }
         NotificationCenter.default.post(name: .checkForE2EICertificateExpiryStatus, object: nil)
     }
-
 }
 
 extension ZMUserSession: URLActionProcessor {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -562,7 +562,6 @@ public final class ZMUserSession: NSObject {
             self.applicationStatusDirectory.clientUpdateStatus.determineInitialClientStatus()
             self.applicationStatusDirectory.clientRegistrationStatus.determineInitialRegistrationStatus()
             self.hasCompletedInitialSync = self.applicationStatusDirectory.syncStatus.isSlowSyncing == false
-
             self.cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(
                 from: self.mlsService.onNewCRLsDistributionPoints()
             )

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -562,6 +562,10 @@ public final class ZMUserSession: NSObject {
             self.applicationStatusDirectory.clientUpdateStatus.determineInitialClientStatus()
             self.applicationStatusDirectory.clientRegistrationStatus.determineInitialRegistrationStatus()
             self.hasCompletedInitialSync = self.applicationStatusDirectory.syncStatus.isSlowSyncing == false
+
+            self.cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(
+                from: self.mlsService.onNewCRLsDistributionPoints()
+            )
         }
 
         registerForCalculateBadgeCountNotification()
@@ -929,7 +933,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
         managedObjectContext.performGroupedBlock { [weak self] in
             self?.notifyThirdPartyServices()
             self?.observeMLSGroupVerificationStatus()
-            self?.observeNewCRLsDistributionPoints()
         }
 
     }
@@ -1042,14 +1045,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
         guard e2eiFeature.isEnabled else { return }
 
         mlsGroupVerificationStatusObserver.invoke()
-    }
-
-    private func observeNewCRLsDistributionPoints() {
-        guard e2eiFeature.isEnabled else { return }
-
-        cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(
-            from: mlsService.onNewCRLsDistributionPoints()
-        )
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -562,6 +562,7 @@ public final class ZMUserSession: NSObject {
             self.applicationStatusDirectory.clientUpdateStatus.determineInitialClientStatus()
             self.applicationStatusDirectory.clientRegistrationStatus.determineInitialRegistrationStatus()
             self.hasCompletedInitialSync = self.applicationStatusDirectory.syncStatus.isSlowSyncing == false
+
             self.cRLsDistributionPointsObserver.startObservingNewCRLsDistributionPoints(
                 from: self.mlsService.onNewCRLsDistributionPoints()
             )

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -19,6 +19,7 @@
 import WireDataModelSupport
 import WireSyncEngineSupport
 import WireRequestStrategySupport
+import Combine
 
 final class ThirdPartyServices: NSObject, ThirdPartyServicesDelegate {
 
@@ -114,6 +115,15 @@ class ZMUserSessionTestsBase: MessagingTest {
         mockResolveOneOnOneConversationUseCase.invoke_MockMethod = { }
 
         mockMLSService.commitPendingProposalsIfNeeded_MockMethod = {}
+
+        let newCRLsDistributionPointsFromDecryptionSerivce = PassthroughSubject<CRLsDistributionPoints, Never>()
+        mockMLSService.onNewCRLsDistributionPoints_MockValue = newCRLsDistributionPointsFromDecryptionSerivce.eraseToAnyPublisher()
+
+        let mlsGroupID = MLSGroupID.random()
+        mockMLSService.epochChanges_MockValue = .init { continuation in
+            continuation.yield(mlsGroupID)
+            continuation.finish()
+        }
 
         mockCryptoboxMigrationManager.isMigrationNeededAccountDirectory_MockValue = false
         sut = ZMUserSession(

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
@@ -40,6 +40,7 @@ final class RemoveClientStepViewController: UIViewController, AuthenticationCoor
             guard let email = $0.email, let password = $0.password else {
                 return nil
             }
+
             return ZMEmailCredentials(email: email, password: password)
         }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
@@ -40,7 +40,6 @@ final class RemoveClientStepViewController: UIViewController, AuthenticationCoor
             guard let email = $0.email, let password = $0.password else {
                 return nil
             }
-
             return ZMEmailCredentials(email: email, password: password)
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -531,6 +531,10 @@ extension ConversationViewController: ZMConversationObserver {
             note.legalHoldStatusChanged {
             setupNavigatiomItem()
         }
+
+        if note.mlsVerificationStatusChanged {
+            setupNavigatiomItem()
+        }
     }
 
     func dismissProfileClientViewController(_ sender: UIBarButtonItem?) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7404" title="WPB-7404" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7404</a>  [iOS] Adding non E2EI user to a verified conversation didn’t degrade it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. Adding non E2EI user (or with expired certificate) to a verified conversation didn’t degrade it.
2. Removing non E2EI user (or with expired certificate) from the conversation didn’t update the status.

### Causes (Optional)

Observer was setup in the `ZMUserSession` initializer before we got the `e2eiFeature` status, so it was always skipped.

### Solutions

1. Move the observer setting to the `didFinishQuickSync()`.
2. Observe `mlsVerificationStatusChanged` on the `ConversationViewController` and update the conversation title.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
