### PR TITLE
fix: don't attempt to fetch & register trust anchor if it's already registered WPB-7337

### DIFF
--- a/wire-ios-data-model/Source/E2EIdentity/E2EISetupService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2EISetupService.swift
@@ -21,6 +21,8 @@ import WireCoreCrypto
 
 public protocol E2EISetupServiceInterface {
 
+    func isTrustAnchorRegistered()  async throws -> Bool
+
     func registerTrustAnchor(_ trustAnchor: String) async throws
 
     func registerFederationCertificate(_ certificate: String) async throws
@@ -64,6 +66,12 @@ public final class E2EISetupService: E2EISetupServiceInterface {
     }
 
     // MARK: - Public interface
+
+    public func isTrustAnchorRegistered() async throws -> Bool {
+        try await coreCryptoProvider.coreCrypto().perform { coreCrypto in
+            await coreCrypto.e2eiIsPkiEnvSetup()
+        }
+    }
 
     public func registerTrustAnchor(_ trustAnchor: String) async throws {
         try await coreCryptoProvider.coreCrypto().perform { coreCrypto in

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2EIRepository.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2EIRepository.swift
@@ -72,6 +72,10 @@ public final class E2EIRepository: E2EIRepositoryInterface {
     // MARK: - Interface
 
     public func fetchTrustAnchor() async throws {
+        guard try await !e2eiSetupService.isTrustAnchorRegistered() else {
+            logger.info("Trust anchor is already registered, skipping.")
+            return
+        }
         let trustAnchor = try await acmeApi.getTrustAnchor()
         try await e2eiSetupService.registerTrustAnchor(trustAnchor)
     }

--- a/wire-ios-request-strategy/Sources/E2EIdentity/EnrollE2EICertificateUseCase.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/EnrollE2EICertificateUseCase.swift
@@ -92,6 +92,7 @@ public final class EnrollE2EICertificateUseCase: EnrollE2EICertificateUseCasePro
             try await e2eiRepository.fetchTrustAnchor()
         } catch {
             logger.warn("failed to register trust anchor: \(error.localizedDescription)")
+            throw error
         }
 
         do {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7337" title="WPB-7337" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7337</a>  Backup and Restore is not working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We were swallowing trust anchor errors because an error was thrown because it was already registered when updating your certificate.

### Solutions

Use CC method for checking if the trust anchor is already registered and don't swallow errors.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
