### PR TITLE
chore: disable datadog for delivery - WPB-8613

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -31,6 +31,14 @@ on:
         required: true
       C1_APP_CENTER_APP_NAME_PRODUCTION:
         required: true
+      C2_S3_SUBFOLDER_RESTRICTED:
+        required: true
+      C2_APP_CENTER_APP_NAME_RESTRICTED:
+        required: true
+      C2_S3_SUBFOLDER_PRODUCTION:
+        required: true
+      C2_APP_CENTER_APP_NAME_PRODUCTION:
+        required: true  
       C3_S3_SUBFOLDER_RESTRICTED:
         required: true
       C3_APP_CENTER_APP_NAME_RESTRICTED:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8613" title="WPB-8613" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8613</a>  Create release candidate for C builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
### Issue

This removes Datadog enabled for C builds in wire-ios-build-assets.

Also add missing secrets for C2.

### Checklist

- [x] Title conforms to [semantic commits messages](https://github.com/wireapp/.github#usage).
- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

<!--do not remove the jira markers to link tickets automatically -->

