### PR TITLE
fix: playground workflow - WPB-8615

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -5,7 +5,6 @@ on:
         required: true
         type: string
       is_cloud_build:
-        required: true
         type: boolean
         default: true
     secrets:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8615" title="WPB-8615" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8615</a>  Changelog generation on C builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The last change https://github.com/wireapp/wire-ios/pull/1257 broke other workflows:

`The workflow is not valid. .github/workflows/playground.yml (Line: 10, Col: 11): Input is_cloud_build is required, but not provided while calling.`

See https://github.com/wireapp/wire-ios/actions/runs/8657773448

Make the parameter not required as it has a default value.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

