### PR TITLE
fix: file headers in wire-ios-notification-engine

### DIFF
--- a/wire-ios-notification-engine/Resources/Configurations/version.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/version.xcconfig
@@ -1,2 +1,20 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 MAJOR_VERSION = 17
 CURRENT_PROJECT_VERSION = 17.0.2

--- a/wire-ios-notification-engine/Resources/Configurations/wire-ios-notification-engine.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/wire-ios-notification-engine.xcconfig
@@ -1,3 +1,20 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 APPLICATION_EXTENSION_API_ONLY = YES
 PRODUCT_NAME = WireNotificationEngine
-

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/ios-test-host.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/ios-test-host.xcconfig
@@ -1,18 +1,17 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/ios-test-target.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/ios-test-target.xcconfig
@@ -1,19 +1,19 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 #include "tests.xcconfig"

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/project-debug.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/project-debug.xcconfig
@@ -1,50 +1,41 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings-debug.xcconfig"
 #include "project-common.xcconfig"
-
-
 
 // Architectures
 //
 ONLY_ACTIVE_ARCH = YES
 
-
-
 // Deployment
 //
 COPY_PHASE_STRIP = NO
 
-
 // LLVM - Code Generation
 //
 GCC_OPTIMIZATION_LEVEL = 0
-
 
 // Swift Compiler - Code Generation
 //
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 OTHER_SWIFT_FLAGS = -D DEBUG
 ENABLE_TESTABILITY = YES
-
-
 
 // LLVM - Preprocessing
 //

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/project.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/project.xcconfig
@@ -1,21 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings.xcconfig"
 #include "project-common.xcconfig"
@@ -29,8 +28,6 @@ VALIDATE_PRODUCT = YES
 //
 COPY_PHASE_STRIP = YES
 
-
 // LLVM - Preprocessing
 //
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=0 ZM_MAJOR_VERSION=$(MAJOR_VERSION) $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_shared)
-

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/tests.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/tests.xcconfig
@@ -1,25 +1,21 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
-
+//
 
 // Preprocessing
 //
 GCC_PREPROCESSOR_DEFINITIONS_shared = TEST_TARGET=1
-
-

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/warnings-debug.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/warnings-debug.xcconfig
@@ -1,24 +1,22 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings.xcconfig"
-
 
 // LLVM - Warning Policies
 //

--- a/wire-ios-notification-engine/Resources/Configurations/zmc-config/warnings.xcconfig
+++ b/wire-ios-notification-engine/Resources/Configurations/zmc-config/warnings.xcconfig
@@ -1,22 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
-
+//
 
 // Warnings - All languages
 //

--- a/wire-ios-notification-engine/Sources/AppDelegate.swift
+++ b/wire-ios-notification-engine/Sources/AppDelegate.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2021 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/ApplicationStatusDirectory.swift
+++ b/wire-ios-notification-engine/Sources/ApplicationStatusDirectory.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/AuthenticationStatus.swift
+++ b/wire-ios-notification-engine/Sources/AuthenticationStatus.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/AuthenticationStatusProvider.swift
+++ b/wire-ios-notification-engine/Sources/AuthenticationStatusProvider.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/ClientRegistrationStatus.swift
+++ b/wire-ios-notification-engine/Sources/ClientRegistrationStatus.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/Synchronization/OperationLoop.swift
+++ b/wire-ios-notification-engine/Sources/Synchronization/OperationLoop.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/Sources/Synchronization/Strategies/PushNotificationStrategy.swift
+++ b/wire-ios-notification-engine/Sources/Synchronization/Strategies/PushNotificationStrategy.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2022 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		069712972497C1BF00C32169 /* NotificationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069712952497C1BC00C32169 /* NotificationSession.swift */; };
 		069712992497C2B900C32169 /* AuthenticationStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069712982497C2B900C32169 /* AuthenticationStatusProvider.swift */; };
 		0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697129C2497CAC200C32169 /* PushNotificationStrategy.swift */; };
+		59B170E62BCE70E200575995 /* WireDataModelSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59B170E52BCE70E200575995 /* WireDataModelSupport.framework */; };
 		630A582D29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */; };
 		EE0BA28A29D59B1D004E93B5 /* NotificationSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */; };
 		EE3245FE28229E8600F2A84A /* ApplicationStatusDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3245FD28229E8600F2A84A /* ApplicationStatusDirectory.swift */; };
@@ -83,6 +84,7 @@
 		06BD1D392487B01C002F82A6 /* project-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "project-debug.xcconfig"; sourceTree = "<group>"; };
 		06BD1D3A2487B01C002F82A6 /* warnings-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "warnings-debug.xcconfig"; sourceTree = "<group>"; };
 		06BD1D3B2487B01C002F82A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		59B170E52BCE70E200575995 /* WireDataModelSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDataModelSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNotificationSessionTests.swift; sourceTree = "<group>"; };
 		EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSessionTests.swift; sourceTree = "<group>"; };
 		EE3245FD28229E8600F2A84A /* ApplicationStatusDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStatusDirectory.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE761669299E60C9005DB75F /* WireNotificationEngine.framework in Frameworks */,
+				59B170E62BCE70E200575995 /* WireDataModelSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +136,7 @@
 		060256312489322000E060E1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				59B170E52BCE70E200575995 /* WireDataModelSupport.framework */,
 				EEC80B5629B6054A00099727 /* WireMockTransport.framework */,
 				EE67F6FB296F09A0001D7C88 /* WireTesting.framework */,
 				EE668BC52954BA4C00D939E7 /* WireRequestStrategy.framework */,

--- a/wire-ios-notification-engine/WireNotificationEngine/WireNotificationEngine.h
+++ b/wire-ios-notification-engine/WireNotificationEngine/WireNotificationEngine.h
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/AppDelegate.swift
@@ -1,9 +1,19 @@
 //
-//  AppDelegate.swift
-//  WireNotificationEngineTestHost
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
 //
-//  Created by John Nguyen on 06/03/23.
-//  Copyright © 2023 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import UIKit

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/ContentView.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/ContentView.swift
@@ -1,9 +1,19 @@
 //
-//  ContentView.swift
-//  WireNotificationEngineTestHost
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
 //
-//  Created by David Henner on 02.03.23.
-//  Copyright © 2023 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import SwiftUI

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/SceneDelegate.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/SceneDelegate.swift
@@ -1,9 +1,19 @@
 //
-//  SceneDelegate.swift
-//  WireNotificationEngineTestHost
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
 //
-//  Created by John Nguyen on 06/03/23.
-//  Copyright © 2023 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import UIKit

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/ViewController.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/ViewController.swift
@@ -1,9 +1,19 @@
 //
-//  ViewController.swift
-//  WireNotificationEngineTestHost
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
 //
-//  Created by John Nguyen on 06/03/23.
-//  Copyright © 2023 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import UIKit

--- a/wire-ios-notification-engine/WireNotificationEngineTestHost/WireNotificationEngineTestHostApp.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTestHost/WireNotificationEngineTestHostApp.swift
@@ -1,9 +1,19 @@
 //
-//  WireNotificationEngineTestHostApp.swift
-//  WireNotificationEngineTestHost
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
 //
-//  Created by David Henner on 02.03.23.
-//  Copyright © 2023 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import SwiftUI

--- a/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-notification-engine/WireNotificationEngineTests/NotificationSessionTests.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/NotificationSessionTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2023 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-protos/Protos/WireProtos.h
+++ b/wire-ios-protos/Protos/WireProtos.h
@@ -1,21 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #import <Foundation/Foundation.h>
 

--- a/wire-ios-protos/ProtosTests/ProtosTests.swift
+++ b/wire-ios-protos/ProtosTests/ProtosTests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/wire-ios-protos/Resources/Configurations/WireProtos.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/WireProtos.xcconfig
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -21,4 +21,3 @@
 
 APPLICATION_EXTENSION_API_ONLY = YES
 PRODUCT_NAME = WireProtos
-

--- a/wire-ios-protos/Resources/Configurations/version.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/version.xcconfig
@@ -1,2 +1,20 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 MAJOR_VERSION = 32
 CURRENT_PROJECT_VERSION = 32.0.0

--- a/wire-ios-protos/Resources/Configurations/zmc-config/ios-test-host.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/ios-test-host.xcconfig
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 #include "ios.xcconfig"
 #include "swift.xcconfig"

--- a/wire-ios-protos/Resources/Configurations/zmc-config/ios-test-target.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/ios-test-target.xcconfig
@@ -1,20 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 #include "ios.xcconfig"
 #include "tests.xcconfig"
@@ -23,7 +23,6 @@
 ARCHS[sdk=iphonesimulator*] = x86_64
 VALID_ARCHS[sdk=iphoneos*] = arm64 armv7
 VALID_ARCHS[sdk=iphonesimulator*] = x86_64
-
 
 // Linking
 //

--- a/wire-ios-protos/Resources/Configurations/zmc-config/ios.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/ios.xcconfig
@@ -1,17 +1,17 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
@@ -21,13 +21,10 @@
 // It gets included by {target}-ios.xcconfig
 //
 
-
-
 // Architectures
 //
 VALID_ARCHS[sdk=iphoneos*] = arm64 armv7
 VALID_ARCHS[sdk=iphonesimulator*] = x86_64 arm64
-
 
 // Deployment
 //
@@ -35,7 +32,6 @@ IPHONEOS_DEPLOYMENT_TARGET = 15.0
 TARGETED_DEVICE_FAMILY = 1,2
 DYLIB_INSTALL_NAME_BASE = @rpath
 FRAMEWORK_VERSION = A
-
 
 // Linking
 //

--- a/wire-ios-protos/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -1,21 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings.xcconfig"
 #include "../version.xcconfig"
@@ -36,18 +35,14 @@ INFOPLIST_PREPROCESS = YES
 DYLIB_COMPATIBILITY_VERSION = $(MAJOR_VERSION).0
 DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
 
-
 // Search Paths
 //
 ALWAYS_SEARCH_USER_PATHS = NO
-
-
 
 // Deployment
 //
 COMBINE_HIDPI_IMAGES = YES
 ENABLE_BITCODE = NO
-
 
 // Versioning
 //
@@ -62,12 +57,9 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) $(PLATFORM_DIR)/Developer/Library/Framewor
 //
 GCC_DYNAMIC_NO_PIC = NO
 
-
 // LLVM - Language
 //
 GCC_C_LANGUAGE_STANDARD = gnu99
-
-
 
 // LLVM - Language - C++
 //
@@ -75,14 +67,10 @@ CLANG_CXX_LANGUAGE_STANDARD = gnu++0x
 CLANG_CXX_LIBRARY = libc++
 GCC_ENABLE_CPP_EXCEPTIONS = NO
 
-
-
 // LLVM - Language - Modules
 //
 CLANG_ENABLE_MODULES = YES
 CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES
-
-
 
 // LLVM - Language - Objective C
 //
@@ -90,10 +78,6 @@ GCC_ENABLE_OBJC_EXCEPTIONS = YES
 CLANG_ENABLE_OBJC_ARC = YES
 ENABLE_STRICT_OBJC_MSGSEND = YES
 
-
 // LLVM - Preprocessing
 //
 ENABLE_NS_ASSERTIONS = YES
-
-
-

--- a/wire-ios-protos/Resources/Configurations/zmc-config/project-debug.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/project-debug.xcconfig
@@ -1,50 +1,41 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings-debug.xcconfig"
 #include "project-common.xcconfig"
-
-
 
 // Architectures
 //
 ONLY_ACTIVE_ARCH = YES
 
-
-
 // Deployment
 //
 COPY_PHASE_STRIP = NO
 
-
 // LLVM - Code Generation
 //
 GCC_OPTIMIZATION_LEVEL = 0
-
 
 // Swift Compiler - Code Generation
 //
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 OTHER_SWIFT_FLAGS = -D DEBUG
 ENABLE_TESTABILITY = YES
-
-
 
 // LLVM - Preprocessing
 //

--- a/wire-ios-protos/Resources/Configurations/zmc-config/project.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/project.xcconfig
@@ -1,21 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings.xcconfig"
 #include "project-common.xcconfig"
@@ -29,8 +28,6 @@ VALIDATE_PRODUCT = YES
 //
 COPY_PHASE_STRIP = YES
 
-
 // LLVM - Preprocessing
 //
 GCC_PREPROCESSOR_DEFINITIONS = DEBUG=0 ZM_MAJOR_VERSION=$(MAJOR_VERSION) $(inherited) $(GCC_PREPROCESSOR_DEFINITIONS_shared)
-

--- a/wire-ios-protos/Resources/Configurations/zmc-config/simulator.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/simulator.xcconfig
@@ -1,30 +1,25 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
-
-
+//
 
 //
 // This file is used to build a version for the iOS simulator
 // from the command line.
 //
-
-
 
 // Architectures
 //

--- a/wire-ios-protos/Resources/Configurations/zmc-config/test-host-ios.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/test-host-ios.xcconfig
@@ -1,23 +1,22 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 GCC_PREPROCESSOR_DEFINITIONS_shared = TEST_TARGET=1
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator
 ARCHS = arm64 armv7 armv7s
 ONLY_ACTIVE_ARCH = YES
-

--- a/wire-ios-protos/Resources/Configurations/zmc-config/test-target.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/test-target.xcconfig
@@ -1,19 +1,19 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
 GCC_PREPROCESSOR_DEFINITIONS_shared = TEST_TARGET=1

--- a/wire-ios-protos/Resources/Configurations/zmc-config/tests.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/tests.xcconfig
@@ -1,25 +1,21 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
-
+//
 
 // Preprocessing
 //
 GCC_PREPROCESSOR_DEFINITIONS_shared = TEST_TARGET=1
-
-

--- a/wire-ios-protos/Resources/Configurations/zmc-config/warnings-debug.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/warnings-debug.xcconfig
@@ -1,24 +1,22 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
+//
 
 #include "warnings.xcconfig"
-
 
 // LLVM - Warning Policies
 //

--- a/wire-ios-protos/Resources/Configurations/zmc-config/warnings.xcconfig
+++ b/wire-ios-protos/Resources/Configurations/zmc-config/warnings.xcconfig
@@ -1,22 +1,20 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2024 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
-
-
+//
 
 // Warnings - All languages
 //


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

Updates the file headers for source files in wire-ios-notification-engine.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

