### PR TITLE
fix: unit test messages retention limit [WPB-7266]

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+MessageRetention.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+MessageRetention.swift
@@ -64,7 +64,8 @@ final class SessionManagerMessageRetentionTests: IntegrationTest {
         remotelyInsert(text: "Hello 2", from: user2.clients.anyObject() as! MockUserClient, into: groupConversation)
         remotelyInsert(text: "Hello 3", from: user2.clients.anyObject() as! MockUserClient, into: groupConversation)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        XCTAssertEqual(conversation(for: groupConversation)?.allMessages.count, 4) // text messages + system messages
+
+        XCTAssertEqual(conversation(for: groupConversation)?.allMessages.count, 4) // text messages + system message
 
         // when
         sessionManager?.configuration.messageRetentionInterval = 100
@@ -73,7 +74,10 @@ final class SessionManagerMessageRetentionTests: IntegrationTest {
         XCTAssertTrue(login())
 
         // then
-        XCTAssertEqual(conversation(for: groupConversation)?.allMessages.count, 4)
+
+        // only text messages
+        // system message is ignored due to `messageRetentionInterval`.
+        XCTAssertEqual(conversation(for: groupConversation)?.allMessages.count, 3)
     }
 
     func testThatItKeepsMessagesIfThereIsNoRetentionLimit() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7266" title="WPB-7266" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7266</a>  [iOS] Missing Added to Group System Messages in Federated MLS groups
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The unit test `testThatItKeepsMessagesNewerThanTheRetentionLimit` failed after changes from #1266.

The date of the system message was changed from `serverTime` (current time) to `.distantPast`.


### Testing

Run unit test.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

