### PR TITLE
fix: add required input parameter to workflow runs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -14,4 +14,5 @@ jobs:
     uses: ./.github/workflows/_reusable_app_release.yml
     with:
       fastlane_action: development
+      is_cloud_build: true
     secrets: inherit


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

GitHub Action runs suddenly failed because the input parameter `is_cloud_build` isn't set.

https://github.com/wireapp/wire-ios/actions/runs/8687385808
https://github.com/wireapp/wire-ios/actions/runs/8686862602
https://github.com/wireapp/wire-ios/actions/runs/8686455273
...

This PR sets the value in development.yml

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

