### PR TITLE
fix: deadlock on logout WPB-7154

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack.swift
@@ -127,6 +127,7 @@ public class CoreDataStack: NSObject, ContextProvider {
     let dispatchGroup: ZMSDispatchGroup?
 
     private let migrator: CoreDataMessagingMigrator
+    private var hasBeenClosed = false
 
     public init(account: Account,
                 applicationContainer: URL,
@@ -185,6 +186,16 @@ public class CoreDataStack: NSObject, ContextProvider {
     }
 
     deinit {
+        close()
+    }
+
+    public func close() {
+        guard !hasBeenClosed  else {
+            return
+        }
+
+        defer { hasBeenClosed = true }
+
         viewContext.tearDown()
         syncContext.tearDown()
         searchContext.tearDown()
@@ -193,6 +204,7 @@ public class CoreDataStack: NSObject, ContextProvider {
     }
 
     func closeStores() {
+        WireLogger.localStorage.info("Closing core data stores")
         do {
             try closeStores(in: messagesContainer)
             try closeStores(in: eventsContainer)

--- a/wire-ios-data-model/Source/Model/UserClient/UserClient+MLSPublicKeys.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient+MLSPublicKeys.swift
@@ -80,6 +80,17 @@ extension UserClient {
         // all errors are ignored
         try? JSONEncoder().encode(mlsPublicKeys)
     }
+
+    /// Clear previously registered MLS public keys.
+    ///
+    /// Only do this when when the self client has been deleted/reset.
+
+    public func clearMLSPublicKeys() {
+        willChangeValue(forKey: Self.mlsPublicKeysKey)
+        primitiveMlsPublicKeys = nil
+        didChangeValue(forKey: Self.mlsPublicKeysKey)
+    }
+
 }
 
 extension UserClient {

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -95,23 +95,25 @@ extension SessionManager: APIVersionResolverDelegate {
 
                 // 1. Tear down the user sessions
                 DispatchQueue.main.sync {
-                    self.tearDownBackgroundSession(for: account.userIdentifier)
-                }
-
-                // 2. Migrate users and conversations
-                CoreDataStack.migrateLocalStorage(
-                    accountIdentifier: account.userIdentifier,
-                    applicationContainer: self.sharedContainerURL,
-                    dispatchGroup: dispatchGroup,
-                    migration: {
-                        try $0.migrateToFederation()
-                    },
-                    completion: { result in
-                        if case .failure = result {
-                            log.error("Failed to migrate account for federation")
-                        }
+                    dispatchGroup.enter()
+                    self.tearDownBackgroundSession(for: account.userIdentifier) {
+                        // 2. Migrate users and conversations
+                        CoreDataStack.migrateLocalStorage(
+                            accountIdentifier: account.userIdentifier,
+                            applicationContainer: self.sharedContainerURL,
+                            dispatchGroup: dispatchGroup,
+                            migration: {
+                                try $0.migrateToFederation()
+                            },
+                            completion: { result in
+                                if case .failure = result {
+                                    log.error("Failed to migrate account for federation")
+                                }
+                            }
+                        )
+                        dispatchGroup.leave()
                     }
-                )
+                }
             }
 
             // The migration above will call enter() / leave() on the dispatch group

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+APIVersionResolver.swift
@@ -94,7 +94,7 @@ extension SessionManager: APIVersionResolverDelegate {
             self.accountManager.accounts.forEach { account in
 
                 // 1. Tear down the user sessions
-                DispatchQueue.main.sync {
+                DispatchQueue.main.async {
                     dispatchGroup.enter()
                     self.tearDownBackgroundSession(for: account.userIdentifier) {
                         // 2. Migrate users and conversations

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+EncryptionAtRest.swift
@@ -28,22 +28,23 @@ extension SessionManager: UserSessionEncryptionAtRestDelegate {
         let dispatchGroup = self.dispatchGroup
 
         delegate?.sessionManagerWillMigrateAccount(userSessionCanBeTornDown: { [weak self] in
-            self?.tearDownBackgroundSession(for: account.userIdentifier)
-            self?.activeUserSession = nil
-            CoreDataStack.migrateLocalStorage(
-                accountIdentifier: account.userIdentifier,
-                applicationContainer: sharedContainerURL,
-                dispatchGroup: dispatchGroup,
-                migration: onReady,
-                completion: { result in
-                    switch result {
-                    case .success:
-                        self?.loadSession(for: account, completion: { _ in })
-                    case .failure(let error):
-                        WireLogger.ear.error("failed to migrate account: \(error)")
+            self?.tearDownBackgroundSession(for: account.userIdentifier) {
+                self?.activeUserSession = nil
+                CoreDataStack.migrateLocalStorage(
+                    accountIdentifier: account.userIdentifier,
+                    applicationContainer: sharedContainerURL,
+                    dispatchGroup: dispatchGroup,
+                    migration: onReady,
+                    completion: { result in
+                        switch result {
+                        case .success:
+                            self?.loadSession(for: account, completion: { _ in })
+                        case .failure(let error):
+                            WireLogger.ear.error("failed to migrate account: \(error)")
+                        }
                     }
-                }
-            )
+                )
+            }
         })
     }
 

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -767,7 +767,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
         self.createUnauthenticatedSession(accountId: deleteAccount ? nil : account.userIdentifier)
 
-        guard let activeUserSession = activeUserSession else {
+        guard let activeUserSession else {
             delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: nil)
 
             if deleteAccount {

--- a/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMClientRegistrationStatus.swift
@@ -553,6 +553,7 @@ public class ZMClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
 
         selfClient.remoteIdentifier = nil
         selfClient.resetLocallyModifiedKeys(selfClient.keysThatHaveLocalModifications)
+        selfClient.clearMLSPublicKeys()
         managedObjectContext.setPersistentStoreMetadata(nil as String?, key: ZMPersistedClientIdKey)
         managedObjectContext.saveOrRollback()
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -301,19 +301,7 @@ public final class ZMUserSession: NSObject {
         transportSession.tearDown()
         notificationDispatcher.tearDown()
         callCenter?.tearDown()
-
-        // Wait for all sync operations to finish
-        syncManagedObjectContext.performGroupedBlockAndWait { }
-
-        let uiMOC = coreDataStack.viewContext
-        coreDataStack = nil
-
-        let shouldWaitOnUIMoc = !(OperationQueue.current == OperationQueue.main && uiMOC.concurrencyType == .mainQueueConcurrencyType)
-        if shouldWaitOnUIMoc {
-            uiMOC.performAndWait {
-                // warning: this will hang if the uiMoc queue is same as self.requestQueue (typically uiMoc queue is the main queue)
-            }
-        }
+        coreDataStack.close()
 
         NotificationCenter.default.removeObserver(self)
 
@@ -968,7 +956,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
                 }
             }
 
-            await managedObjectContext.perform(schedule: .enqueued) { [weak self] in
+            await managedObjectContext.perform { [weak self] in
                 self?.isPerformingSync = isSyncing || processingInterrupted
                 self?.updateNetworkState()
             }

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
@@ -144,6 +144,8 @@ extension IntegrationTest {
 
     @objc
     func _tearDown() {
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
         PrekeyGenerator._test_overrideNumberOfKeys = nil
         destroyTimers()
         sharedSearchDirectory?.tearDown()
@@ -174,7 +176,6 @@ extension IntegrationTest {
         groupConversationWithServiceUser = nil
         application = nil
         notificationCenter = nil
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         deleteSharedContainerContent()
         sharedContainerDirectory = nil

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+AccountDeletion.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+AccountDeletion.swift
@@ -60,6 +60,7 @@ final class SessionManagerAccountDeletionTests: IntegrationTest {
         performIgnoringZMLogError {
             self.sessionManager!.delete(account: account)
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
         XCTAssertFalse(FileManager.default.fileExists(atPath: accountFolder.path))
@@ -106,6 +107,7 @@ class SessionManagerTests_PasswordVerificationFailure_With_DeleteAccountAfterThr
 
         // when
         sessionManager?.passwordVerificationDidFail(with: threshold!)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
         guard let sharedContainer = Bundle.main.appGroupIdentifier.map(FileManager.sharedContainerDirectory) else { return XCTFail() }
@@ -164,6 +166,7 @@ class SessionManagerTests_AuthenticationFailure_With_DeleteAccountOnAuthentictio
 
         // when
         sessionManager?.authenticationInvalidated(NSError(code: .accessTokenExpired, userInfo: nil), accountId: account.userIdentifier)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
         guard let sharedContainer = Bundle.main.appGroupIdentifier.map(FileManager.sharedContainerDirectory) else { return XCTFail() }

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+AuthenticationFailure.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+AuthenticationFailure.swift
@@ -46,6 +46,7 @@ final class SessionManagerAuthenticationFailureTests: IntegrationTest {
 
         // when
         sessionManager?.authenticationInvalidated(NSError(code: .clientDeletedRemotely, userInfo: nil), accountId: account.userIdentifier)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
         guard let sharedContainer = Bundle.main.appGroupIdentifier.map(FileManager.sharedContainerDirectory) else { return XCTFail() }

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+MultiUserSession.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests+MultiUserSession.swift
@@ -86,6 +86,7 @@ final class SessionManagerMultiUserSessionTests: IntegrationTest {
 
         // AND WHEN
         self.sessionManager!.tearDownAllBackgroundSessions()
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertNil(self.sessionManager!.backgroundUserSessions[account.userIdentifier])

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -139,6 +139,7 @@ final class SessionManagerTests: IntegrationTest {
             analytics: nil,
             delegate: nil,
             application: application,
+            dispatchGroup: dispatchGroup,
             environment: sessionManager!.environment,
             configuration: SessionManagerConfiguration(blacklistDownloadInterval: -1),
             requiredPushTokenType: .standard,
@@ -182,6 +183,7 @@ final class SessionManagerTests: IntegrationTest {
         withExtendedLifetime(destroyToken) {
             testSessionManager.tearDownBackgroundSession(for: account.userIdentifier)
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertEqual([account.userIdentifier], observer.destroyedUserSessions)
@@ -233,6 +235,7 @@ final class SessionManagerTests: IntegrationTest {
             analytics: nil,
             delegate: self.mockDelegate,
             application: application,
+            dispatchGroup: dispatchGroup,
             environment: sessionManager!.environment,
             configuration: SessionManagerConfiguration(blacklistDownloadInterval: -1),
             detector: jailbreakDetector,
@@ -278,6 +281,7 @@ final class SessionManagerTests: IntegrationTest {
         withExtendedLifetime(destroyToken) {
             NotificationCenter.default.post(Notification(name: UIApplication.didReceiveMemoryWarningNotification))
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         XCTAssertEqual([account1.userIdentifier], observer.destroyedUserSessions)
@@ -357,8 +361,8 @@ final class SessionManagerTests: IntegrationTest {
         }
 
         // WHEN && THEN
-        sut.start(launchOptions: [:])
         sut.accountManager.addAndSelect(createAccount())
+        sut.start(launchOptions: [:])
         XCTAssertEqual(sut.accountManager.accounts.count, 1)
 
         performIgnoringZMLogError {
@@ -430,6 +434,7 @@ final class SessionManagerTests: IntegrationTest {
 
         // GIVEN
         XCTAssertTrue(login())
+        let account = try XCTUnwrap(sessionManager?.accountManager.selectedAccount)
         let observer = MockSessionManagerObserver()
         let token = sessionManager?.addSessionManagerDestroyedSessionObserver(observer)
         let tempUrl = tmpDirectoryPath.appendingPathComponent("testFile.txt")
@@ -441,8 +446,9 @@ final class SessionManagerTests: IntegrationTest {
 
         // WHEN
         withExtendedLifetime(token) {
-            sessionManager?.logoutCurrentSession()
+            sessionManager?.delete(account: account)
         }
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         let fileCount = try FileManager.default.contentsOfDirectory(atPath: tmpDirectoryPath.path).count
 
@@ -453,29 +459,18 @@ final class SessionManagerTests: IntegrationTest {
 
     func testThatItClearsCRLExpirationDatesAfterLogout() throws {
         // GIVEN
-        let account = createAccount()
-        let sut = sessionManagerBuilder.build()
-        sut.accountManager.addAndSelect(account)
-        sut.start(launchOptions: [:])
-        sut.delegate = mockDelegate
-
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertTrue(login())
+        let account = try XCTUnwrap(sessionManager?.accountManager.selectedAccount)
 
         let url = try XCTUnwrap( URL(string: "https://example.com"))
         let expirationDatesRepository = CRLExpirationDatesRepository(userID: account.userIdentifier)
         expirationDatesRepository.storeCRLExpirationDate(.now, for: url)
 
-        let expectation = XCTestExpectation(description: "session torn down")
-        mockDelegate.sessionManagerWillLogoutErrorUserSessionCanBeTornDown_MockMethod = { _, block in
-            block?()
-            expectation.fulfill()
-        }
-
         // WHEN
-        sut.logoutCurrentSession()
+        sessionManager?.delete(account: account)
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
-        wait(for: [expectation], timeout: 0.5)
         XCTAssertTrue(expirationDatesRepository.fetchAllCRLExpirationDates().isEmpty)
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -66,6 +66,10 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         factory.activityManager = activityManager
     }
 
+    /// This workaround is needed because all tests here are based on assumptions
+    /// that the `managedObjectContext` is changed.
+    /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
+    /// a real instance of `EARService`.
     override func createSut() -> ZMUserSession {
         let earService = EARService(
             accountID: coreDataStack.account.userIdentifier,

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -64,19 +64,9 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         activityManager = MockBackgroundActivityManager()
         factory = BackgroundActivityFactory.shared
         factory.activityManager = activityManager
-
-        setUpEARServiceWorkaround()
     }
 
-    /// This workaround is needed because all tests here are based on assumptions
-    /// that the `managedObjectContext` is changed.
-    /// To remove the workaround simply the `mockEARService` should be used instead of
-    /// a real instance of `EARService`.
-    private func setUpEARServiceWorkaround() {
-        mockEARService = nil
-        sut.tearDown()
-        sut = nil
-
+    override func createSut() -> ZMUserSession {
         let earService = EARService(
             accountID: coreDataStack.account.userIdentifier,
             databaseContexts: [
@@ -88,7 +78,8 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
             sharedUserDefaults: sharedUserDefaults,
             authenticationContext: MockAuthenticationContextProtocol()
         )
-        sut = createSut(earService: earService)
+
+        return createSut(earService: earService)
     }
 
     override func tearDown() {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -92,7 +92,7 @@ class ZMUserSessionTestsBase: MessagingTest {
             return self.mockResolveOneOnOneConversationUseCase
         }
 
-        sut = createSut(earService: mockEARService)
+        sut = createSut()
         sut.thirdPartyServicesDelegate = self.thirdPartyServices
         sut.sessionManager = mockSessionManager
 
@@ -118,12 +118,18 @@ class ZMUserSessionTestsBase: MessagingTest {
         self.flowManagerMock = nil
         self.mockUseCaseFactory = nil
         self.mockResolveOneOnOneConversationUseCase = nil
+        self.mockEARService.delegate = nil
+        self.mockEARService = nil
         let sut = self.sut
         self.sut = nil
         mockGetFeatureConfigsActionHandler = nil
         sut?.tearDown()
 
         super.tearDown()
+    }
+
+    func createSut() -> ZMUserSession {
+        createSut(earService: mockEARService)
     }
 
     func createSut(earService: EARServiceInterface) -> ZMUserSession {
@@ -172,7 +178,7 @@ class ZMUserSessionTestsBase: MessagingTest {
     }
 
     private func clearCache() {
-        let cachesURL = FileManager.default.cachesURLForAccount(with: userIdentifier, in: sut.sharedContainerURL)
+        let cachesURL = FileManager.default.cachesURLForAccount(with: userIdentifier, in: coreDataStack.applicationContainer)
         let items = try? FileManager.default.contentsOfDirectory(at: cachesURL, includingPropertiesForKeys: nil)
 
         if let items {

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -164,6 +164,7 @@ extension String: LogConvertible {
 
 public extension WireLogger {
 
+    static let appState = WireLogger(tag: "AppState")
     static let appDelegate = WireLogger(tag: "AppDelegate")
     static let appLock = WireLogger(tag: "AppLock")
     static let assets = WireLogger(tag: "assets")

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -119,7 +119,7 @@ final class AppStateCalculator {
 
         self.appState = appState
         self.pendingAppState = nil
-        ZMSLog(tag: "AppState").debug("transitioning to app state: \(appState)")
+        WireLogger.appState.debug("transitioning to app state: \(appState)")
         delegate?.appStateCalculator(self, didCalculate: appState, completion: {
             completion?()
         })


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7154" title="WPB-7154" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7154</a>  Issues on logout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a user gets logged out from another device the app gets stuck in `ZMOperationLoop.tearDown()` because the sync ManagedObjectContext dispatch group never becomes gets empty.

So I added trace logging to all dispatch groups and was able to pin point that we fail to leave the dispatch in `ZMUserSession.processEvents()`. This happens because we enter a deadlock like this:

1. Enter sync dispatch  group
2. Process events which includes the client.deleted event which trigger the logout
3. Switch to landing screen
4. Call tearDown() on ZMUserSession which will call tearDown() on ZMOperationLoop
5. Inside ZMOperationLoop.tearDown we spin the main queue until the sync dispatch group is empty
6. We enqueue an operation on the UI ManagedObjectContext which will deadlock since we are spinning the main queue

#### Solution

Make closing a `ZMUserSession` an asynchronous operation in order to break the deadlock.

### Testing

Several integration tests needed to updated because closing / logout of a user session is now asynchronous  so we need to wait for this to complete.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

