### PR TITLE
chore: delete redundant property UserSession.selfLegalHoldSubject

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+LegalHoldRequest.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+LegalHoldRequest.swift
@@ -21,6 +21,8 @@ import WireCryptobox
 
 private let log = ZMSLog(tag: "UserClient")
 
+public typealias SelfUserType = UserType & SelfLegalHoldSubject
+
 /**
  * A protocol for objects that provide the legal hold status for the self user.
  */

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -112,9 +112,7 @@ public protocol UserSession: AnyObject {
     ///
     /// This can only be used on the main thread.
 
-    var selfUser: UserType { get }
-
-    var selfLegalHoldSubject: UserType & SelfLegalHoldSubject { get }
+    var selfUser: SelfUserType { get }
 
     func perform(_ changes: @escaping () -> Void)
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -110,12 +110,8 @@ extension ZMUserSession: UserSession {
         try appLockController.deletePasscode()
     }
 
-    public var selfUser: UserType {
-        return ZMUser.selfUser(inUserSession: self)
-    }
-
-    public var selfLegalHoldSubject: UserType & SelfLegalHoldSubject {
-        return ZMUser.selfUser(inUserSession: self)
+    public var selfUser: SelfUserType {
+        ZMUser.selfUser(inUserSession: self)
     }
 
     public func addUserObserver(

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -69,8 +69,7 @@ final class UserSessionMock: UserSession {
 
     var networkState: ZMNetworkState = .offline
 
-    var selfUser: UserType
-    var selfLegalHoldSubject: SelfLegalHoldSubject & UserType
+    var selfUser: SelfUserType
     var mockConversationList: ZMConversationList?
 
     func makeGetMLSFeatureUseCase() -> GetMLSFeatureUseCaseProtocol {
@@ -80,25 +79,15 @@ final class UserSessionMock: UserSession {
     }
 
     convenience init(mockUser: MockZMEditableUser) {
-        self.init(
-            selfUser: mockUser,
-            selfLegalHoldSubject: mockUser
-        )
+        self.init(selfUser: mockUser)
     }
 
     convenience init(mockUser: MockUserType = .createDefaultSelfUser()) {
-        self.init(
-            selfUser: mockUser,
-            selfLegalHoldSubject: mockUser
-        )
+        self.init(selfUser: mockUser)
     }
 
-    init(
-        selfUser: UserType,
-        selfLegalHoldSubject: SelfLegalHoldSubject & UserType
-    ) {
+    init(selfUser: SelfUserType) {
         self.selfUser = selfUser
-        self.selfLegalHoldSubject = selfLegalHoldSubject
     }
 
     var lock: SessionLock? = .screen

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -21,8 +21,6 @@ import WireDataModel
 import WireSyncEngine
 import WireCommonComponents
 
-typealias SelfUserType = UserType & SelfLegalHoldSubject
-
 final class ConversationListTopBarViewController: UIViewController {
 
     private let account: Account

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -68,7 +68,7 @@ final class ZClientViewController: UIViewController {
         )
         conversationListViewController = ConversationListViewController(
             account: account,
-            selfUser: userSession.selfLegalHoldSubject,
+            selfUser: userSession.selfUser,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: userSession.isSelfUserE2EICertifiedUseCase
         )
@@ -599,7 +599,7 @@ final class ZClientViewController: UIViewController {
 
     private func createLegalHoldDisclosureController() {
         legalHoldDisclosureController = LegalHoldDisclosureController(
-            selfUser: userSession.selfLegalHoldSubject,
+            selfUser: userSession.selfUser,
             userSession: userSession,
             presenter: { viewController, animated, completion in
                 viewController.presentTopmost(animated: animated, completion: completion)


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

There is a property `UserSession.selfLegalHoldSubject` which is the same as `UserSession.selfUser`.
This PR removes the property.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

