### PR TITLE
fix: showing onboarding hint

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -98,6 +98,9 @@ final class ConversationListViewController: UIViewController {
 
     required init(viewModel: ViewModel) {
         self.viewModel = viewModel
+        defer {
+            viewModel.viewController = self
+        }
 
         topBarViewController = ConversationListTopBarViewController(
             account: viewModel.account,
@@ -112,13 +115,11 @@ final class ConversationListViewController: UIViewController {
 
         super.init(nibName: nil, bundle: nil)
 
-        viewModel.viewController = self
-
         definesPresentationContext = true
 
         /// setup UI
         view.addSubview(contentContainer)
-        self.view.backgroundColor = SemanticColors.View.backgroundConversationList
+        view.backgroundColor = SemanticColors.View.backgroundConversationList
 
         setupTopBar()
         setupListContentController()
@@ -137,7 +138,6 @@ final class ConversationListViewController: UIViewController {
 
     override func loadView() {
         view = PassthroughTouchesView(frame: UIScreen.main.bounds)
-        view.backgroundColor = .clear
     }
 
     override func viewDidLoad() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -98,9 +98,6 @@ final class ConversationListViewController: UIViewController {
 
     required init(viewModel: ViewModel) {
         self.viewModel = viewModel
-        defer {
-            viewModel.viewController = self
-        }
 
         topBarViewController = ConversationListTopBarViewController(
             account: viewModel.account,
@@ -129,6 +126,8 @@ final class ConversationListViewController: UIViewController {
         setupNetworkStatusBar()
 
         createViewConstraints()
+
+        viewModel.viewController = self
     }
 
     @available(*, unavailable)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListOnboardHint.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListOnboardHint.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import UIKit
 import WireCommonComponents
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Currently there is an issue in the initialisation of the `ConversationListViewController` which first tries to set the onboarding hint view to visible if needed in the `init` method, while afterwards in `viewDidLoad` the onboarding view is initialised to be invisible.
This PR reverses the order of these actions.

<img width="366" alt="Screenshot 2024-04-19 at 5 53 29 PM" src="https://github.com/wireapp/wire-ios/assets/15628584/8282918c-2eed-498c-8399-42472d9978a5">

### Testing

Log into the app with a new user which has no conversations.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

