### PR TITLE
fix: slow sync never completes api v4 [WPB-8714]

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/PushSupportedProtocolActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/Actions/PushSupportedProtocolActionHandlerTests.swift
@@ -45,11 +45,20 @@ final class PushSupportedProtocolsActionHandlerTests: ActionHandlerTestBase<Push
     }
 
     func testPushSupportedProtocolsRequestGeneration_APIV4() throws {
+        // given
+        // when
+        let request = handler.request(for: action, apiVersion: .v4)
+
+        // then
+        XCTAssertNil(request)
+    }
+
+    func testPushSupportedProtocolsRequestGeneration_APIV5() throws {
         try test_itGeneratesARequest(
             for: action,
-            expectedPath: "/v4/self/supported-protocols",
+            expectedPath: "/v5/self/supported-protocols",
             expectedMethod: .put,
-            apiVersion: .v4
+            apiVersion: .v5
         )
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/SelfSupportedProtocolsRequestBuilder.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/SelfSupportedProtocolsRequestBuilder.swift
@@ -28,7 +28,7 @@ struct SelfSupportedProtocolsRequestBuilder {
     var supportedProtocols: Set<MessageProtocol>
 
     private var isAPIVersionSupported: Bool {
-        apiVersion >= .v4
+        apiVersion >= .v5
     }
 
     // MARK: Funcs

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/SelfSupportedProtocolsRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/SelfSupportedProtocolsRequestStrategy.swift
@@ -87,7 +87,10 @@ public final class SelfSupportedProtocolsRequestStrategy: AbstractRequestStrateg
 
         guard let request = transportBuilder.buildTransportRequest() else {
             // finish sync instead of fail, because we can never execute a request
-            WireLogger.sync.warn("can not create transport request, one reason could be an unsupported api version!")
+            WireLogger.sync.warn(
+                "can not create transport request, one reason could be an unsupported api version!",
+                attributes: .safePublic
+            )
             finishSlowSync()
             return nil
         }
@@ -99,7 +102,10 @@ public final class SelfSupportedProtocolsRequestStrategy: AbstractRequestStrateg
         guard isSlowSyncing else {
             // skip result if we are not in the slow sync...
             assertionFailure("expected response during slow sync phase!")
-            WireLogger.sync.error("received response, but expected during slow sync phase '\(syncPhase.description)'!")
+            WireLogger.sync.error(
+                "received response, but expected during slow sync phase '\(syncPhase.description)'!",
+                attributes: .safePublic
+            )
             return
         }
 
@@ -128,7 +134,10 @@ public final class SelfSupportedProtocolsRequestStrategy: AbstractRequestStrateg
     }
 
     private func failSlowSync() {
-        WireLogger.sync.error("failed slow sync phase '\(syncPhase.description)'!")
+        WireLogger.sync.error(
+            "failed slow sync phase '\(syncPhase.description)'!",
+            attributes: .safePublic
+        )
         managedObjectContext.performAndWait {
             self.syncProgress.failCurrentSyncPhase(phase: self.syncPhase)
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/SelfUserRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/SelfUserRequestStrategyTests.swift
@@ -46,7 +46,7 @@ final class SelfUserRequestStrategyTests: MessagingTestBase {
 
     // MARK: - Supported protocols
 
-    func test_ItGeneratesARequest_WhenSupportedProtocolsChanges() throws {
+    func test_ItGeneratesANoRequest_givenAPIVersionV4_WhenSupportedProtocolsChanges() throws {
         // GIVEN
         var action = PushSupportedProtocolsAction(supportedProtocols: [.proteus, .mls])
         action.perform(in: syncMOC.notificationContext) { _ in }
@@ -55,12 +55,26 @@ final class SelfUserRequestStrategyTests: MessagingTestBase {
 
         syncMOC.performGroupedAndWait { _ in
             // WHEN
-            guard let request = self.sut.nextRequest(for: .v4) else {
+            let request = self.sut.nextRequest(for: .v4)
+            XCTAssertNil(request)
+        }
+    }
+
+    func test_ItGeneratesARequest_givenAPIVersionV5_WhenSupportedProtocolsChanges() throws {
+        // GIVEN
+        var action = PushSupportedProtocolsAction(supportedProtocols: [.proteus, .mls])
+        action.perform(in: syncMOC.notificationContext) { _ in }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        syncMOC.performGroupedAndWait { _ in
+            // WHEN
+            guard let request = self.sut.nextRequest(for: .v5) else {
                 return XCTFail("expected a request")
             }
 
             // Then
-            XCTAssertEqual(request.path, "/v4/self/supported-protocols")
+            XCTAssertEqual(request.path, "/v5/self/supported-protocols")
             XCTAssertEqual(request.method, .put)
 
             guard
@@ -75,7 +89,5 @@ final class SelfUserRequestStrategyTests: MessagingTestBase {
                 Set(["mls", "proteus"])
             )
         }
-
     }
-
 }

--- a/wire-ios-request-strategy/Tests/Sources/Request Strategies/User/SelfSupportedProtocolsRequestBuilderTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Request Strategies/User/SelfSupportedProtocolsRequestBuilderTests.swift
@@ -22,22 +22,11 @@ import XCTest
 final class SelfSupportedProtocolsRequestBuilderTests: XCTestCase {
 
     // the api version is required to build and should not influence the tests
-    private let minimumAPIVersion: APIVersion = .v4
+    private let minimumAPIVersion: APIVersion = .v5
 
     // MARK: Transport Request
 
-    func testBuildTransportRequest_givenAPIVersion0_thenDontBuildRequest() {
-        // given
-        let builder = makeBuilder(apiVersion: .v0)
-
-        // when
-        let request = builder.buildTransportRequest()
-
-        // then
-        XCTAssertNil(request)
-    }
-
-    func testBuildTransportRequest_givenAPIVersion4_thenBuildRequest() {
+    func testBuildTransportRequest_givenAPIVersion4_thenDontBuildRequest() {
         // given
         let builder = makeBuilder(apiVersion: .v4)
 
@@ -45,7 +34,7 @@ final class SelfSupportedProtocolsRequestBuilderTests: XCTestCase {
         let request = builder.buildTransportRequest()
 
         // then
-        XCTAssertNotNil(request)
+        XCTAssertNil(request)
     }
 
     func testBuildTransportRequest_givenAPIVersion5_thenBuildRequest() {
@@ -61,13 +50,13 @@ final class SelfSupportedProtocolsRequestBuilderTests: XCTestCase {
 
     func testBuildTransportRequest_thenPathIsSet() {
         // given
-        let builder = makeBuilder(apiVersion: .v4)
+        let builder = makeBuilder(apiVersion: .v5)
 
         // when
         let request = builder.buildTransportRequest()
 
         // then
-        XCTAssertEqual(request?.path, "/v4/self/supported-protocols")
+        XCTAssertEqual(request?.path, "/v5/self/supported-protocols")
     }
 
     func testBuildTransportRequest_thenMethodIsPUT() {
@@ -108,18 +97,7 @@ final class SelfSupportedProtocolsRequestBuilderTests: XCTestCase {
 
     // MARK: Upstream Request
 
-    func testBuildUpstreamRequest_givenAPIVersion0_thenDontBuildRequest() {
-        // given
-        let builder = makeBuilder(apiVersion: .v0)
-
-        // when
-        let request = builder.buildUpstreamRequest(keys: .init())
-
-        // then
-        XCTAssertNil(request)
-    }
-
-    func testBuildUpstreamRequest_givenAPIVersion4_thenBuildRequest() {
+    func testBuildUpstreamRequest_givenAPIVersion4_thenDontBuildRequest() {
         // given
         let builder = makeBuilder(apiVersion: .v4)
 
@@ -127,7 +105,7 @@ final class SelfSupportedProtocolsRequestBuilderTests: XCTestCase {
         let request = builder.buildUpstreamRequest(keys: .init())
 
         // then
-        XCTAssertNotNil(request)
+        XCTAssertNil(request)
     }
 
     func testBuildUpstreamRequest_givenAPIVersion5_thenBuildRequest() {
@@ -143,13 +121,13 @@ final class SelfSupportedProtocolsRequestBuilderTests: XCTestCase {
 
     func testBuildUpstreamRequest_thenTransportRequestPathIsSet() {
         // given
-        let builder = makeBuilder(apiVersion: .v4)
+        let builder = makeBuilder(apiVersion: .v5)
 
         // when
         let request = builder.buildUpstreamRequest(keys: .init())
 
         // then
-        XCTAssertEqual(request?.transportRequest.path, "/v4/self/supported-protocols")
+        XCTAssertEqual(request?.transportRequest.path, "/v5/self/supported-protocols")
     }
 
     func testBuildUpstreamRequest_thenKeysAreSet() {

--- a/wire-ios-request-strategy/Tests/Sources/Request Strategies/User/SelfSupportedProtocolsRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Request Strategies/User/SelfSupportedProtocolsRequestStrategyTests.swift
@@ -24,7 +24,7 @@ import WireRequestStrategySupport
 final class SelfSupportedProtocolsRequestStrategyTests: XCTestCase {
 
     // the api version is just required to build and not influence the tests
-    private let defaultAPIVersion: APIVersion = .v4
+    private let defaultAPIVersion: APIVersion = .v5
 
     private var coreDataStackHelper: CoreDataStackHelper!
     private var mockCoreDataStack: CoreDataStack!


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8714" title="WPB-8714" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8714</a>  Slow sync never completes when running against a V4 backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a slow sync phase fails, it will repeat and not skip automatically.

API version `v4` does not provide the used endpoint `/self/supported-protocols`.

Solution: skip version `v4` and increase the minimum required version to `v5`.

### Testing

- Before login
  - Change environment to `staging`
  - Set preferred api version to `v4`
- Login (slow sync is executed automatically)

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

