### PR TITLE
fix: ipad call layout broken - just formatting [WPB-6987]

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -29,7 +29,10 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     private let stackView = UIStackView(axis: .vertical)
     private var participantsHeaderView = UIView()
     private let securityLevelView = SecurityLevelView()
-    private var participantsHeaderLabel = DynamicFontLabel(fontSpec: .smallSemiboldFont, color: SemanticColors.Label.textSectionHeader)
+    private var participantsHeaderLabel = DynamicFontLabel(
+        fontSpec: .smallSemiboldFont,
+        color: SemanticColors.Label.textSectionHeader
+    )
     private(set) var actionsViewHeightConstraint: NSLayoutConstraint!
     var isIncomingCall: Bool = false
 
@@ -42,8 +45,10 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
         }
     }
 
-    init(participants: CallParticipantsList,
-         selfUser: UserType) {
+    init(
+        participants: CallParticipantsList,
+        selfUser: UserType
+    ) {
         self.participants = participants
         self.selfUser = selfUser
         super.init(nibName: nil, bundle: nil)
@@ -93,7 +98,14 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
         collectionView.bounces = true
         collectionView.delegate = self
         self.collectionView = collectionView
-        [securityLevelView, actionsView, participantsHeaderView, collectionView].forEach(stackView.addArrangedSubview)
+
+        [
+            securityLevelView,
+            actionsView,
+            participantsHeaderView,
+            collectionView
+        ].forEach(stackView.addArrangedSubview)
+
         CallParticipantsListCellConfiguration.prepare(collectionView)
         view.backgroundColor = SemanticColors.View.backgroundDefaultWhite
     }
@@ -140,12 +152,16 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
         collectionView?.rows = participants
     }
 
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.bounds.size.width, height: cellHeight)
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        CGSize(width: collectionView.bounds.size.width, height: cellHeight)
     }
 
     func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
-        return false
+        false
     }
 
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
@@ -153,6 +169,8 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
 }
+
+// MARK: - CallInfoConfigurationObserver
 
 extension CallingActionsInfoViewController: CallInfoConfigurationObserver {
     func didUpdateConfiguration(configuration: CallInfoConfiguration) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -65,11 +65,6 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
         createConstraints()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        updateActionViewHeight()
-    }
-
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateRows()
@@ -116,7 +111,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     private func createConstraints() {
-        actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: calculateHeightConstant())
+        actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: 128.0)
 
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
@@ -152,7 +147,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
 
     private func calculateHeightConstant() -> CGFloat {
         if UIDevice.current.twoDimensionOrientation.isLandscape {
-            return 128 + view.safeAreaInsets.bottom
+            return 128
         } else {
             return (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -139,13 +139,13 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     func updateActionViewHeight() {
-        guard UIDevice.current.twoDimensionOrientation.isLandscape else {
+        if UIDevice.current.twoDimensionOrientation.isLandscape {
+            actionsViewHeightConstraint.constant = 128.0
+            actionsView.verticalStackView.alignment = .center
+        } else {
             actionsViewHeightConstraint.constant = (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
             actionsView.verticalStackView.alignment = .fill
-            return
         }
-        actionsViewHeightConstraint.constant = 128.0
-        actionsView.verticalStackView.alignment = .center
     }
 
     private func updateRows() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -112,6 +112,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
 
     private func createConstraints() {
         actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: 128.0)
+
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeTopAnchor),
@@ -177,7 +178,8 @@ extension CallingActionsInfoViewController: CallInfoConfigurationObserver {
         isIncomingCall = configuration.state.isIncoming
         actionsView.isIncomingCall = isIncomingCall
         actionsView.update(with: configuration)
-        updateActionViewHeight()
         securityLevelView.configure(with: configuration.classification)
+
+        updateActionViewHeight()
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -141,6 +141,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
         updateActionViewHeight()
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -122,7 +122,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
             stackView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeTopAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -20),
 
             actionsView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
             actionsView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -65,6 +65,11 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
         createConstraints()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateActionViewHeight()
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateRows()
@@ -111,13 +116,13 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     private func createConstraints() {
-        actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: 128.0)
+        actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: calculateHeightConstant())
 
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeTopAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -20),
+            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor),
 
             actionsView.leadingAnchor.constraint(equalTo: view.safeLeadingAnchor),
             actionsView.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),
@@ -140,12 +145,23 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     func updateActionViewHeight() {
+        actionsViewHeightConstraint.constant = calculateHeightConstant()
+        actionsView.verticalStackView.alignment = determineStackViewAlignment()
+    }
+
+    private func calculateHeightConstant() -> CGFloat {
         if UIDevice.current.twoDimensionOrientation.isLandscape {
-            actionsViewHeightConstraint.constant = 128.0
-            actionsView.verticalStackView.alignment = .center
+            return 128 + view.safeAreaInsets.bottom
         } else {
-            actionsViewHeightConstraint.constant = (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
-            actionsView.verticalStackView.alignment = .fill
+            return (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
+        }
+    }
+
+    private func determineStackViewAlignment() -> UIStackView.Alignment {
+        if UIDevice.current.twoDimensionOrientation.isLandscape {
+            return .center
+        } else {
+            return .fill
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -169,8 +169,8 @@ class CallingActionsView: UIView {
             largeHangUpButton.centerXAnchor.constraint(equalTo: microphoneButton.centerXAnchor).withPriority(.required),
             largePickUpButton.centerXAnchor.constraint(equalTo: speakerButton.centerXAnchor).withPriority(.required),
 
-            largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34.0),
-            largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34.0)
+            largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -42),
+            largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -42)
         ]
         largeButtonsLandscapeConstraints = [
             largeHangUpButton.centerYAnchor.constraint(equalTo: microphoneButton.centerYAnchor).withPriority(.required),

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -194,8 +194,8 @@ final class CallingActionsView: UIView {
             largeHangUpButton.centerXAnchor.constraint(equalTo: microphoneButton.centerXAnchor).withPriority(.required),
             largePickUpButton.centerXAnchor.constraint(equalTo: speakerButton.centerXAnchor).withPriority(.required),
 
-            largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -42),
-            largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -42)
+            largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34),
+            largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -34)
         ]
 
         largeButtonsLandscapeConstraints = [

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -60,8 +60,15 @@ final class CallingActionsView: UIView {
     private let largeHangUpButton = EndCallButton.bigEndCallButton()
 
     private var establishedCallButtons: [IconLabelButton] {
-        return [microphoneButton, cameraButton, speakerButton, flipCameraButton, endCallButton]
+        [
+            microphoneButton,
+            cameraButton,
+            speakerButton,
+            flipCameraButton,
+            endCallButton
+        ]
     }
+
     private var largeButtonsPortraitConstraints: [NSLayoutConstraint] = []
     private var largeButtonsLandscapeConstraints: [NSLayoutConstraint] = []
 
@@ -72,7 +79,12 @@ final class CallingActionsView: UIView {
             handleContainerView.isHidden = isIncomingCall
             handleView.accessibilityElementsHidden = isIncomingCall
             if isIncomingCall {
-                [microphoneButton, cameraButton, speakerButton].forEach(topStackView.addArrangedSubview)
+                [
+                    microphoneButton,
+                    cameraButton,
+                    speakerButton
+                ].forEach(topStackView.addArrangedSubview)
+
                 addIncomingCallControllButtons()
                 verticalStackView.layoutMargins = UIEdgeInsets(top: 16, left: 4, bottom: 0, right: 4)
             } else {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionsView.swift
@@ -31,7 +31,7 @@ protocol BottomSheetScrollingDelegate: AnyObject {
 
 // A view showing multiple buttons depending on the given `CallActionsView.Input`.
 // Button touches result in `CallActionsView.Action` cases to be sent to the objects delegate.
-class CallingActionsView: UIView {
+final class CallingActionsView: UIView {
 
     weak var delegate: CallingActionsViewDelegate?
     weak var bottomSheetScrollingDelegate: BottomSheetScrollingDelegate? {
@@ -44,7 +44,7 @@ class CallingActionsView: UIView {
 
     let verticalStackView = UIStackView(axis: .vertical)
     private let topStackView = UIStackView(axis: .horizontal)
-    private let botttomStackView = UIStackView(axis: .horizontal)
+    private let bottomStackView = UIStackView(axis: .horizontal)
     private var input: CallActionsViewInputType?
     private var videoButtonDisabledTapRecognizer: UITapGestureRecognizer?
 
@@ -110,7 +110,12 @@ class CallingActionsView: UIView {
         handleView.layer.cornerRadius = 3.0
         handleView.backgroundColor = SemanticColors.View.backgroundCallDragBarIndicator
         handleContainerView.addSubview(handleView)
-        [handleContainerView, topStackView].forEach(verticalStackView.addArrangedSubview)
+
+        [
+            handleContainerView,
+            topStackView
+        ].forEach(verticalStackView.addArrangedSubview)
+
         [
             flipCameraButton,
             cameraButton,
@@ -120,6 +125,7 @@ class CallingActionsView: UIView {
             largeHangUpButton,
             largePickUpButton
         ].forEach { $0.addTarget(self, action: #selector(performButtonAction), for: .touchUpInside) }
+
         setupContentViewer()
     }
 
@@ -153,12 +159,19 @@ class CallingActionsView: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         establishedCallButtons.forEach { $0.updateState() }
-        [largePickUpButton, largeHangUpButton].forEach { $0.updateState() }
+
+        [
+            largePickUpButton,
+            largeHangUpButton
+        ].forEach { $0.updateState() }
 
     }
 
     private func addIncomingCallControllButtons() {
-        [largeHangUpButton, largePickUpButton].forEach {
+        [
+            largeHangUpButton,
+            largePickUpButton
+        ].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.updateButtonWidth(width: 72.0)
             $0.subtitleTransformLabel.font = FontSpec(.small, .bold).font!
@@ -172,6 +185,7 @@ class CallingActionsView: UIView {
             largeHangUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -42),
             largePickUpButton.bottomAnchor.constraint(equalTo: safeBottomAnchor, constant: -42)
         ]
+
         largeButtonsLandscapeConstraints = [
             largeHangUpButton.centerYAnchor.constraint(equalTo: microphoneButton.centerYAnchor).withPriority(.required),
             largePickUpButton.centerYAnchor.constraint(equalTo: largeHangUpButton.centerYAnchor).withPriority(.required),
@@ -185,7 +199,10 @@ class CallingActionsView: UIView {
     }
 
     private func removeIncomingCallControllButtons() {
-        [largeHangUpButton, largePickUpButton].forEach {
+        [
+            largeHangUpButton,
+            largePickUpButton
+        ].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.removeFromSuperview()
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
@@ -142,29 +142,6 @@ final class SecurityLevelView: UIView {
             assertionFailure("should not reach this point")
         }
     }
-
-    private func configureLegacyCallingUI(with classification: SecurityClassification?) {
-        switch classification {
-
-        case .classified:
-            securityLevelLabel.textColor = LabelColors.textDefault
-            backgroundColor = ViewColors.backgroundSecurityLevel
-            iconImageView.setTemplateIcon(.checkmark, size: .tiny)
-            iconImageView.tintColor = IconColors.backgroundCheckMarkSelected
-            topBorder.backgroundColor = ViewColors.backgroundSeparatorCell
-
-        case .notClassified:
-            securityLevelLabel.textColor = LabelColors.textDefault
-            backgroundColor = ViewColors.backgroundSecurityLevel
-            iconImageView.setTemplateIcon(.exclamationMarkCircle, size: .tiny)
-            iconImageView.tintColor = IconColors.foregroundCheckMarkSelected
-            topBorder.backgroundColor = ViewColors.backgroundSeparatorCell
-
-        case .none:
-            isHidden = true
-            assertionFailure("should not reach this point")
-        }
-    }
 }
 
 // MARK: - SecurityClassification Extension

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
@@ -59,8 +59,10 @@ final class SecurityLevelView: UIView {
 
     func configure(with classification: SecurityClassification?) {
         securityLevelLabel.font = FontSpec.smallSemiboldFont.font!
+
         guard let classification, let levelText = classification.levelText else {
-            return isHidden = true
+            isHidden = true
+            return
         }
 
         configureCallingUI(with: classification)
@@ -68,7 +70,10 @@ final class SecurityLevelView: UIView {
         bottomBorder.backgroundColor = topBorder.backgroundColor
 
         let securityLevelText = SecurityLocalization.securityLevel.uppercased()
-        securityLevelLabel.text = [securityLevelText, levelText].joined(separator: " ")
+        securityLevelLabel.text = [
+            securityLevelText,
+            levelText
+        ].joined(separator: " ")
 
         accessibilityIdentifier = "ClassificationBanner" + classification.accessibilitySuffix
     }
@@ -78,8 +83,10 @@ final class SecurityLevelView: UIView {
         conversationDomain: String?,
         provider: SecurityClassificationProviding? = ZMUserSession.shared()
     ) {
-
-        guard let classification = provider?.classification(users: otherUsers, conversationDomain: conversationDomain) else {
+        guard let classification = provider?.classification(
+            users: otherUsers,
+            conversationDomain: conversationDomain
+        ) else {
             isHidden = true
             return
         }
@@ -120,7 +127,7 @@ final class SecurityLevelView: UIView {
         ])
     }
 
-    private func configureCallingUI(with classification: SecurityClassification?) {
+    private func configureCallingUI(with classification: SecurityClassification) {
         switch classification {
 
         case .classified:
@@ -136,10 +143,6 @@ final class SecurityLevelView: UIView {
             iconImageView.image = .init(resource: .attention)
             iconImageView.tintColor = IconColors.foregroundCheckMarkSelected
             topBorder.backgroundColor = .clear
-
-        case .none:
-            isHidden = true
-            assertionFailure("should not reach this point")
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
@@ -90,14 +90,23 @@ final class SecurityLevelView: UIView {
     private func setupViews() {
         securityLevelLabel.textAlignment = .center
         iconImageView.contentMode = .scaleAspectFit
-        [topBorder, securityLevelLabel, iconImageView, bottomBorder].forEach { addSubview($0) }
+
+        [
+            topBorder,
+            securityLevelLabel,
+            iconImageView,
+            bottomBorder
+        ].forEach { addSubview($0) }
 
         topBorder.addConstraintsForBorder(for: .top, borderWidth: 1.0, to: self)
         bottomBorder.addConstraintsForBorder(for: .bottom, borderWidth: 1.0, to: self)
     }
 
     private func createConstraints() {
-        [securityLevelLabel, iconImageView].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+        [
+            securityLevelLabel,
+            iconImageView
+        ].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
 
         NSLayoutConstraint.activate([
             securityLevelLabel.centerXAnchor.constraint(equalTo: centerXAnchor),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6987" title="WPB-6987" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6987</a>  iPad layout for call broken
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Just some formatting of code, no behaviour should be changed. I was not able to fix this bug in time.


### Testing

- Call user on iPad (for simulator use iOS 16 as 17 is broken currently [WPB-8806]).

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.



[WPB-8806]: https://wearezeta.atlassian.net/browse/WPB-8806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ