### PR TITLE
chore: unify accent color names [WPB-7307]

### DIFF
--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -213,7 +213,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
         // when
         self.checkThatItNotifiesTheObserverOfAChange(conversation,
                                                      modifier: { _, _ in
-                                                        otherUser.accentColorValue = ZMAccentColor.softPink
+                                                        otherUser.accentColorValue = ZMAccentColor.turquoise
             },
                                                      expectedChangedField: nil,
                                                      expectedChangedKeys: []

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -205,7 +205,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
         let conversation = ZMConversation.insertNewObject(in: self.uiMOC)
         conversation.conversationType = ZMConversationType.group
         let otherUser = ZMUser.insertNewObject(in: self.uiMOC)
-        otherUser.accentColorValue = .brightOrange
+        otherUser.accentColorValue = .amber
         conversation.addParticipantAndUpdateConversationState(user: otherUser, role: nil)
         self.uiMOC.saveOrRollback()
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
@@ -29,7 +29,7 @@ class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
 
     func testThatItCreatesASnapshotOfAllValues_noUser() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .amber, remoteIdentifier: UUID())
 
         // when
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
@@ -165,7 +165,7 @@ class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
         user.name = "Bernd"
         user.remoteIdentifier = UUID()
 
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .amber, remoteIdentifier: UUID())
         let sut = SearchUserSnapshot(searchUser: searchUser, managedObjectContext: self.uiMOC)
 
         // expect
@@ -224,7 +224,7 @@ class SearchUserObserverCenterTests: ModelObjectsTests {
 
     func testThatItAddsASnapshot() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .amber, remoteIdentifier: UUID())
         XCTAssertEqual(sut.snapshots.count, 0)
 
         // when
@@ -236,7 +236,7 @@ class SearchUserObserverCenterTests: ModelObjectsTests {
 
     func testThatItRemovesAllSnapshotsOnReset() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .amber, remoteIdentifier: UUID())
         sut.addSearchUser(searchUser)
         XCTAssertEqual(sut.snapshots.count, 1)
 
@@ -280,7 +280,7 @@ class SearchUserObserverCenterTests: ModelObjectsTests {
 
     func testThatItForwardCallsForUserUpdatesToTheSnapshot() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Bernd", handle: "dasBrot", accentColor: .amber, remoteIdentifier: UUID())
         sut.addSearchUser(searchUser)
 
         // expect

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
@@ -69,7 +69,7 @@ final class SearchUserObserverTests: NotificationDispatcherTestBase {
         let user = ZMUser.insertNewObject(in: self.uiMOC)
         user.remoteIdentifier = UUID.create()
         self.uiMOC.saveOrRollback()
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: nil, accentColor: .brightYellow, remoteIdentifier: nil, user: user)
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "", handle: nil, accentColor: .deprecatedYellow, remoteIdentifier: nil, user: user)
 
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
         self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
@@ -48,7 +48,7 @@ final class SearchUserObserverTests: NotificationDispatcherTestBase {
 
         // given
         let remoteID = UUID.create()
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .amber, remoteIdentifier: remoteID)
 
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
         self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
@@ -90,7 +90,7 @@ final class SearchUserObserverTests: NotificationDispatcherTestBase {
 
         // given
         let remoteID = UUID.create()
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .amber, remoteIdentifier: remoteID)
 
         uiMOC.searchUserObserverCenter.addSearchUser(searchUser)
         self.token = UserChangeInfo.add(observer: testObserver, for: searchUser, in: self.uiMOC)
@@ -107,7 +107,7 @@ final class SearchUserObserverTests: NotificationDispatcherTestBase {
 
         // given
         let remoteID = UUID.create()
-        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .brightOrange, remoteIdentifier: remoteID)
+        let searchUser = ZMSearchUser(contextProvider: coreDataStack, name: "Hans", handle: "hans", accentColor: .amber, remoteIdentifier: remoteID)
         let actionHandler = MockActionHandler<ConnectToUserAction>(result: .success(()),
                                                                    context: uiMOC.notificationContext)
 

--- a/wire-ios-data-model/Tests/Source/Model/Observer/UserChangeInfoObservationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/UserChangeInfoObservationTests.swift
@@ -143,7 +143,7 @@ final class UserChangeInfoObservationTests: NotificationDispatcherTestBase {
 
         // when
         self.checkThatItNotifiesTheObserverOfAChange(user,
-                                                     modifier: { $0.accentColorValue = ZMAccentColor.softPink },
+                                                     modifier: { $0.accentColorValue = ZMAccentColor.turquoise },
                                                      expectedChangedField: .accentColor)
 
     }

--- a/wire-ios-data-model/Tests/Source/Model/Observer/UserChangeInfoObservationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/UserChangeInfoObservationTests.swift
@@ -138,7 +138,7 @@ final class UserChangeInfoObservationTests: NotificationDispatcherTestBase {
     func testThatItNotifiesTheObserverOfAnAccentColorChange() {
         // given
         let user = ZMUser.insertNewObject(in: self.uiMOC)
-        user.accentColorValue = ZMAccentColor.strongBlue
+        user.accentColorValue = ZMAccentColor.blue
         uiMOC.saveOrRollback()
 
         // when

--- a/wire-ios-data-model/Tests/Source/Model/User/UnregisteredUserTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/UnregisteredUserTests.swift
@@ -119,7 +119,7 @@ class UnregisteredUserTests: XCTestCase {
         user.name = "Mario"
         user.credentials = .phone("+49123456789")
         user.verificationCode = "123456"
-        user.accentColorValue = .softPink
+        user.accentColorValue = .turquoise
         user.acceptedTermsOfService = true
         user.marketingConsent = false
 
@@ -136,7 +136,7 @@ class UnregisteredUserTests: XCTestCase {
         user.name = "Mario"
         user.credentials = .email("alexis@example.com")
         user.verificationCode = "123456"
-        user.accentColorValue = .softPink
+        user.accentColorValue = .turquoise
         user.acceptedTermsOfService = true
         user.marketingConsent = false
 

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+Connections.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+Connections.swift
@@ -25,7 +25,7 @@ final class ZMSearchUserTests_Connections: ModelObjectsTests {
         let searchUser = ZMSearchUser(contextProvider: coreDataStack,
                                       name: "John Doe",
                                       handle: "johndoe",
-                                      accentColor: .softPink,
+                                      accentColor: .turquoise,
                                       remoteIdentifier: UUID())
 
         // expect

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+ProfileImages.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+ProfileImages.swift
@@ -23,7 +23,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
     func testThatItReturnsPreviewsProfileImageIfItWasPreviouslyUpdated() {
         // given
         let imageData = verySmallJPEGData()
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID())
 
         // when
         searchUser.updateImageData(for: .preview, imageData: imageData)
@@ -35,7 +35,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
     func testThatItReturnsCompleteProfileImageIfItWasPreviouslyUpdated() {
         // given
         let imageData = verySmallJPEGData()
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID())
 
         // when
         searchUser.updateImageData(for: .complete, imageData: imageData)
@@ -78,7 +78,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
 
     func testThatItReturnsPreviewImageProfileCacheKey() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID.create())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID.create())
 
         // then
         XCTAssertNotNil(searchUser.smallProfileImageCacheKey)
@@ -86,7 +86,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
 
     func testThatItReturnsCompleteImageProfileCacheKey() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID.create())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID.create())
 
         // then
         XCTAssertNotNil(searchUser.mediumProfileImageCacheKey)
@@ -94,7 +94,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
 
     func testThatItPreviewAndCompleteImageProfileCacheKeyIsDifferent() {
         // given
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID.create())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID.create())
 
         // then
         XCTAssertNotEqual(searchUser.smallProfileImageCacheKey, searchUser.mediumProfileImageCacheKey)
@@ -137,7 +137,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
     func testThatItCanFetchPreviewProfileImageOnAQueue() {
         // given
         let imageData = verySmallJPEGData()
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID())
 
         // when
         searchUser.updateImageData(for: .preview, imageData: imageData)
@@ -154,7 +154,7 @@ class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
     func testThatItCanFetchCompleteProfileImageOnAQueue() {
         // given
         let imageData = verySmallJPEGData()
-        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .brightOrange, remoteIdentifier: UUID())
+        let searchUser = ZMSearchUser(contextProvider: self.coreDataStack, name: "John", handle: "john", accentColor: .amber, remoteIdentifier: UUID())
 
         // when
         searchUser.updateImageData(for: .complete, imageData: imageData)

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
@@ -27,7 +27,7 @@ class ZMSearchUserTests_TeamUser: ModelObjectsTests {
         let searchUser = ZMSearchUser(contextProvider: self.coreDataStack,
                                       name: "Foo",
                                       handle: "foo",
-                                      accentColor: .brightOrange,
+                                      accentColor: .amber,
                                       remoteIdentifier: UUID(),
                                       teamIdentifier: team.remoteIdentifier)
 
@@ -43,7 +43,7 @@ class ZMSearchUserTests_TeamUser: ModelObjectsTests {
         let searchUser = ZMSearchUser(contextProvider: self.coreDataStack,
                                       name: "Foo",
                                       handle: "foo",
-                                      accentColor: .brightOrange,
+                                      accentColor: .amber,
                                       remoteIdentifier: UUID(),
                                       teamIdentifier: UUID())
 
@@ -59,7 +59,7 @@ class ZMSearchUserTests_TeamUser: ModelObjectsTests {
         let searchUser = ZMSearchUser(contextProvider: self.coreDataStack,
                                       name: "Foo",
                                       handle: "foo",
-                                      accentColor: .brightOrange,
+                                      accentColor: .amber,
                                       remoteIdentifier: UUID(),
                                       teamIdentifier: UUID())
         uiMOC.saveOrRollback()
@@ -76,7 +76,7 @@ class ZMSearchUserTests_TeamUser: ModelObjectsTests {
         let searchUser = ZMSearchUser(contextProvider: self.coreDataStack,
                                       name: "Foo",
                                       handle: "foo",
-                                      accentColor: .brightOrange,
+                                      accentColor: .amber,
                                       remoteIdentifier: UUID(),
                                       teamIdentifier: team.remoteIdentifier)
 

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -54,7 +54,7 @@
     ZMSearchUser *user1 = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                    name:@"A"
                                                                  handle:@"a"
-                                                            accentColor:ZMAccentColorStrongLimeGreen
+                                                            accentColor:ZMAccentColorGreen
                                                        remoteIdentifier:remoteIDA
                                                                  domain:nil
                                                          teamIdentifier:nil
@@ -80,7 +80,7 @@
     ZMSearchUser *user3 = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                    name:@"A"
                                                                  handle:@"b"
-                                                            accentColor:ZMAccentColorStrongLimeGreen
+                                                            accentColor:ZMAccentColorGreen
                                                        remoteIdentifier:remoteIDB
                                                                  domain:nil
                                                          teamIdentifier:nil
@@ -119,7 +119,7 @@
     ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                         name:name
                                                                       handle:handle
-                                                                 accentColor:ZMAccentColorStrongLimeGreen
+                                                                 accentColor:ZMAccentColorGreen
                                                             remoteIdentifier:remoteID
                                                                       domain:nil
                                                               teamIdentifier:nil
@@ -129,7 +129,7 @@
     
     // then
     XCTAssertEqualObjects(searchUser.name, @"John Doe");
-    XCTAssertEqual(searchUser.accentColorValue, ZMAccentColorStrongLimeGreen);
+    XCTAssertEqual(searchUser.accentColorValue, ZMAccentColorGreen);
     XCTAssertEqual(searchUser.isConnected, NO);
     XCTAssertNil(searchUser.completeImageData);
     XCTAssertNil(searchUser.previewImageData);
@@ -158,7 +158,7 @@
     ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                         name:@"Wrong name"
                                                                       handle:@"not_my_handle"
-                                                                 accentColor:ZMAccentColorStrongLimeGreen
+                                                                 accentColor:ZMAccentColorGreen
                                                             remoteIdentifier:[NSUUID createUUID]
                                                                       domain:nil
                                                               teamIdentifier:nil
@@ -187,7 +187,7 @@
     ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                         name:@"Hans"
                                                                       handle:@"hans"
-                                                                 accentColor:ZMAccentColorStrongLimeGreen
+                                                                 accentColor:ZMAccentColorGreen
                                                             remoteIdentifier:NSUUID.createUUID
                                                                       domain:nil
                                                               teamIdentifier:nil
@@ -206,7 +206,7 @@
     ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                         name:@"Hans"
                                                                       handle:@"hans"
-                                                                 accentColor:ZMAccentColorStrongLimeGreen
+                                                                 accentColor:ZMAccentColorGreen
                                                             remoteIdentifier:nil
                                                                       domain:nil
                                                               teamIdentifier:nil

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -144,7 +144,7 @@
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
     user.name = @"Actual name";
     user.handle = @"my_handle";
-    user.accentColorValue = ZMAccentColorVividRed;
+    user.accentColorValue = ZMAccentColorRed;
     user.connection = [ZMConnection insertNewObjectInManagedObjectContext:self.uiMOC];
     user.connection.status = ZMConnectionStatusAccepted;
     user.remoteIdentifier = [NSUUID createUUID];

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -66,7 +66,7 @@
     ZMSearchUser *user2 = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
                                                                    name:@"B"
                                                                  handle:@"b"
-                                                            accentColor:ZMAccentColorSoftPink
+                                                            accentColor:ZMAccentColorTurquoise
                                                        remoteIdentifier:remoteIDA
                                                                  domain:nil
                                                          teamIdentifier:nil

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -97,7 +97,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
 
 - (void)testThatWeCanSetAttributesOnUser
 {
-    [self checkUserAttributeForKey:@"accentColorValue" value:@(ZMAccentColorVividRed)];
+    [self checkUserAttributeForKey:@"accentColorValue" value:@(ZMAccentColorRed)];
     [self checkUserAttributeForKey:@"emailAddress" value:@"foo@example.com"];
     [self checkUserAttributeForKey:@"name" value:@"Foo Bar"];
     [self checkUserAttributeForKey:@"handle" value:@"foo_bar"];

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -498,7 +498,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertEqualObjects(user.handle, payload[@"handle"]);
     XCTAssertEqual([self managedByString:user], payload[@"managed_by"]);
     XCTAssertNil(user.expiresAt);
-    XCTAssertEqual(user.accentColorValue, ZMAccentColorBrightYellow);
+    XCTAssertEqual(user.accentColorValue, ZMAccentColorDeprecatedYellow);
 }
 
 - (void)testThatItUpdatesAccountDeletionStatusOnAnExistingUser
@@ -1615,9 +1615,9 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
 {
     // given
     ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
-    user.accentColorValue = ZMAccentColorBrightYellow;
+    user.accentColorValue = ZMAccentColorDeprecatedYellow;
     [self.uiMOC saveOrRollback];
-    XCTAssertEqual(user.accentColorValue, ZMAccentColorBrightYellow);
+    XCTAssertEqual(user.accentColorValue, ZMAccentColorDeprecatedYellow);
     
     // when
     user.accentColorValue = ZMAccentColorUndefined;
@@ -1641,9 +1641,9 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     [self.syncMOC performGroupedBlockAndWait:^{
         // given
         ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
-        user.accentColorValue = ZMAccentColorBrightYellow;
+        user.accentColorValue = ZMAccentColorDeprecatedYellow;
         [self.syncMOC saveOrRollback];
-        XCTAssertEqual(user.accentColorValue, ZMAccentColorBrightYellow);
+        XCTAssertEqual(user.accentColorValue, ZMAccentColorDeprecatedYellow);
         
         // when
         user.accentColorValue = ZMAccentColorUndefined;

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -1222,7 +1222,7 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     // given
     ZMUser<ZMEditableUser> *user = [ZMUser selfUserInContext:self.uiMOC];
     user.name = @"Test";
-    user.accentColorValue = ZMAccentColorBrightOrange;
+    user.accentColorValue = ZMAccentColorAmber;
     
     // when
     XCTAssertTrue([self.uiMOC saveOrRollback]);

--- a/wire-ios-data-model/Tests/Source/Model/UserTypeTests+Materialize.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserTypeTests+Materialize.swift
@@ -41,7 +41,7 @@ class UserTypeTests_Materialize: ModelObjectsTests {
         let teamSearchUser = ZMSearchUser(contextProvider: self.coreDataStack,
                                           name: "Team",
                                           handle: "team",
-                                          accentColor: .brightOrange,
+                                          accentColor: .amber,
                                           remoteIdentifier: UUID(),
                                           teamIdentifier: team.remoteIdentifier)
         uiMOC.saveOrRollback()
@@ -59,7 +59,7 @@ class UserTypeTests_Materialize: ModelObjectsTests {
         let incompleteSearchUser = ZMSearchUser(contextProvider: self.coreDataStack,
                                                 name: "Incomplete",
                                                 handle: "incomplete",
-                                                accentColor: .brightOrange,
+                                                accentColor: .amber,
                                                 remoteIdentifier: nil)
         var searchUsers = userIDs.map({ createSearchUser(name: "John Doe", remoteIdentifier: $0) }) as [UserType]
         searchUsers.append(incompleteSearchUser)
@@ -94,7 +94,7 @@ class UserTypeTests_Materialize: ModelObjectsTests {
         return ZMSearchUser(contextProvider: self.coreDataStack,
                             name: name.capitalized,
                             handle: name.lowercased(),
-                            accentColor: .brightOrange,
+                            accentColor: .amber,
                             remoteIdentifier: remoteIdentifier)
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ConnectToBotURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ConnectToBotURLActionProcessor.swift
@@ -40,7 +40,7 @@ class ConnectToBotURLActionProcessor: NSObject, URLActionProcessor {
         let serviceUser = ZMSearchUser(contextProvider: contextProvider,
                                        name: "",
                                        handle: nil,
-                                       accentColor: .strongBlue,
+                                       accentColor: .blue,
                                        remoteIdentifier: serviceUserData.service,
                                        teamIdentifier: nil,
                                        user: nil,
@@ -59,5 +59,4 @@ class ConnectToBotURLActionProcessor: NSObject, URLActionProcessor {
             }
         }
     }
-
 }

--- a/wire-ios-sync-engine/Tests/Source/Data Model/ServiceUserTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Data Model/ServiceUserTests.swift
@@ -180,7 +180,7 @@ final class DummyServiceUser: NSObject, ServiceUser {
 
     var oneToOneConversation: ZMConversation?
 
-    var accentColorValue: ZMAccentColor = ZMAccentColor.brightOrange
+    var accentColorValue: ZMAccentColor = ZMAccentColor.amber
 
     var imageMediumData: Data! = Data()
 

--- a/wire-ios-sync-engine/Tests/Source/Integration/RegistrationTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/RegistrationTests.swift
@@ -36,13 +36,13 @@ class RegistrationTests: IntegrationTest {
         sessionManager?.unauthenticatedSession?.registrationStatus.delegate = delegate
         email = "ba@a-team.de"
 
-        teamToRegister = UnregisteredTeam(teamName: "A-Team", email: email, emailCode: "911", fullName: "Bosco B. A. Baracus", password: "BadAttitude", accentColor: .vividRed)
+        teamToRegister = UnregisteredTeam(teamName: "A-Team", email: email, emailCode: "911", fullName: "Bosco B. A. Baracus", password: "BadAttitude", accentColor: .red)
 
         user = UnregisteredUser()
         user.name = "Bosco B. A. Baracus"
         user.verificationCode = "911"
         user.credentials = .email(address: email, password: "BadAttitude")
-        user.accentColorValue = .vividRed
+        user.accentColorValue = .red
         user.acceptedTermsOfService = true
         user.marketingConsent = true
     }

--- a/wire-ios-sync-engine/Tests/Source/Integration/UserProfileTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/UserProfileTests.m
@@ -32,7 +32,7 @@
 {
 
     NSString *name = @"My New Name";
-    ZMAccentColor accentColor = ZMAccentColorSoftPink;
+    ZMAccentColor accentColor = ZMAccentColorTurquoise;
     {
         // Create a UI context
         XCTAssertTrue([self login]);
@@ -76,7 +76,7 @@
 
 - (void)testThatItNotifiesObserverWhenWeChangeAccentColorForSelfUser
 {
-    ZMAccentColor accentColor = ZMAccentColorSoftPink;
+    ZMAccentColor accentColor = ZMAccentColorTurquoise;
     
     XCTAssertTrue([self login]);
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/RegistrationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/RegistrationStatusTests.swift
@@ -35,13 +35,13 @@ class RegistrationStatusTests: MessagingTest {
         sut.delegate = delegate
         email = "some@foo.bar"
         code = "123456"
-        team = UnregisteredTeam(teamName: "Dream Team", email: email, emailCode: "23", fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
+        team = UnregisteredTeam(teamName: "Dream Team", email: email, emailCode: "23", fullName: "M. Jordan", password: "qwerty", accentColor: .amber)
 
         user = UnregisteredUser()
         user.credentials = UnverifiedCredentials.email(email)
         user.name = "M. Jordan"
         user.password = "qwerty"
-        user.accentColorValue = .brightOrange
+        user.accentColorValue = .amber
         user.verificationCode = code
         user.acceptedTermsOfService = true
         user.marketingConsent = true

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
@@ -45,7 +45,7 @@ class SearchUserImageStrategyTests: MessagingTest {
     }
 
     func createSearchUser() -> ZMSearchUser {
-        return ZMSearchUser(contextProvider: coreDataStack, name: "Foo", handle: "foo", accentColor: .brightOrange, remoteIdentifier: UUID())
+        return ZMSearchUser(contextProvider: coreDataStack, name: "Foo", handle: "foo", accentColor: .amber, remoteIdentifier: UUID())
     }
 
     func userIDs(from searchUsers: Set<ZMSearchUser>) -> Set<UUID> {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamRegistrationStrategyTests.swift
@@ -31,11 +31,11 @@ class RegistrationStrategyTests: MessagingTest {
         registrationStatus = TestRegistrationStatus()
         userInfoParser = MockUserInfoParser()
         sut = WireSyncEngine.RegistrationStrategy(groupQueue: self.syncMOC, status: registrationStatus, userInfoParser: userInfoParser)
-        team = UnregisteredTeam(teamName: "Dream Team", email: "some@email.com", emailCode: "23", fullName: "M. Jordan", password: "qwerty", accentColor: .brightOrange)
+        team = UnregisteredTeam(teamName: "Dream Team", email: "some@email.com", emailCode: "23", fullName: "M. Jordan", password: "qwerty", accentColor: .amber)
 
         user = UnregisteredUser()
         user.name = "M. Jordan"
-        user.accentColorValue = .brightOrange
+        user.accentColorValue = .amber
         user.verificationCode = "23"
         user.credentials = .phone("+4912345678900")
         user.acceptedTermsOfService = true

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMSelfTranscoderTests.m
@@ -372,7 +372,7 @@
 - (void)testThatItGeneratesARequestForUpdatingChangedSelfUser
 {
     NSString *name = @"My new name testThatItGeneratesARequestForUpdatingChangedSelfUser";
-    ZMAccentColor accentColor = ZMAccentColorBrightYellow;
+    ZMAccentColor accentColor = ZMAccentColorDeprecatedYellow;
     NSDictionary* uploadPayload = @{
                                     @"name" : name,
                                     @"accent_id" : @(accentColor)
@@ -400,7 +400,7 @@
 
 - (void)testThatItGeneratesARequestForUpdatingJustTheAccentColorInChangedSelfUser
 {
-    ZMAccentColor accentColor = ZMAccentColorBrightYellow;
+    ZMAccentColor accentColor = ZMAccentColorDeprecatedYellow;
     NSDictionary* uploadPayload = @{
                                     @"accent_id" : @(accentColor)
                                     };
@@ -474,7 +474,7 @@
         // given
         ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.syncMOC];
         user.name = @"Joe Random User";
-        user.accentColorValue = ZMAccentColorBrightYellow;
+        user.accentColorValue = ZMAccentColorDeprecatedYellow;
         user.remoteIdentifier = [NSUUID createUUID];
         
         // when

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchDirectoryTests.swift
@@ -35,7 +35,7 @@ final class SearchDirectoryTests: DatabaseTest {
             refreshUsersMissingMetadataAction: .dummy,
             refreshConversationsMissingMetadataAction: .dummy
         )
-        _ = ZMSearchUser(contextProvider: coreDataStack!, name: "John Doe", handle: "john", accentColor: .brightOrange, remoteIdentifier: uuid)
+        _ = ZMSearchUser(contextProvider: coreDataStack!, name: "John Doe", handle: "john", accentColor: .amber, remoteIdentifier: uuid)
         XCTAssertNotNil(uiMOC.zm_searchUserCache?.object(forKey: uuid as NSUUID))
 
         // when

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -24,8 +24,8 @@ typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorRed,
     ZMAccentColorAmber,
     ZMAccentColorTurquoise,
-    ZMAccentColorViolet,
+    ZMAccentColorPurple,
     
     ZMAccentColorMin = ZMAccentColorBlue,
-    ZMAccentColorMax = ZMAccentColorViolet,
+    ZMAccentColorMax = ZMAccentColorPurple,
 };

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -22,7 +22,7 @@ typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorGreen,
     ZMAccentColorDeprecatedYellow,
     ZMAccentColorRed,
-    ZMAccentColorBrightOrange,
+    ZMAccentColorAmber,
     ZMAccentColorSoftPink,
     ZMAccentColorViolet,
     

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -18,7 +18,7 @@
 
 typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorUndefined = 0,
-    ZMAccentColorStrongBlue,
+    ZMAccentColorBlue,
     ZMAccentColorStrongLimeGreen,
     ZMAccentColorBrightYellow,
     ZMAccentColorVividRed,
@@ -26,6 +26,6 @@ typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorSoftPink,
     ZMAccentColorViolet,
     
-    ZMAccentColorMin = ZMAccentColorStrongBlue,
+    ZMAccentColorMin = ZMAccentColorBlue,
     ZMAccentColorMax = ZMAccentColorViolet,
 };

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorDeprecatedYellow,
     ZMAccentColorRed,
     ZMAccentColorAmber,
-    ZMAccentColorSoftPink,
+    ZMAccentColorTurquoise,
     ZMAccentColorViolet,
     
     ZMAccentColorMin = ZMAccentColorBlue,

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -19,7 +19,7 @@
 typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorUndefined = 0,
     ZMAccentColorBlue,
-    ZMAccentColorStrongLimeGreen,
+    ZMAccentColorGreen,
     ZMAccentColorBrightYellow,
     ZMAccentColorVividRed,
     ZMAccentColorBrightOrange,

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorUndefined = 0,
     ZMAccentColorBlue,
     ZMAccentColorGreen,
-    ZMAccentColorBrightYellow,
+    ZMAccentColorDeprecatedYellow,
     ZMAccentColorVividRed,
     ZMAccentColorBrightOrange,
     ZMAccentColorSoftPink,

--- a/wire-ios-utilities/Source/Public/ZMAccentColor.h
+++ b/wire-ios-utilities/Source/Public/ZMAccentColor.h
@@ -21,7 +21,7 @@ typedef NS_ENUM(int16_t, ZMAccentColor) {
     ZMAccentColorBlue,
     ZMAccentColorGreen,
     ZMAccentColorDeprecatedYellow,
-    ZMAccentColorVividRed,
+    ZMAccentColorRed,
     ZMAccentColorBrightOrange,
     ZMAccentColorSoftPink,
     ZMAccentColorViolet,

--- a/wire-ios-utilities/Tests/Source/Validation/ZMAccentColorValidatorTests.m
+++ b/wire-ios-utilities/Tests/Source/Validation/ZMAccentColorValidatorTests.m
@@ -40,11 +40,11 @@
 - (void)testThatItLimitsTheAccentColorToAValidRange;
 {
     // given
-    id value = [NSNumber numberWithInt:ZMAccentColorBrightYellow];
+    id value = [NSNumber numberWithInt:ZMAccentColorDeprecatedYellow];
     //when
     [ZMAccentColorValidator validateValue:&value error:NULL];
     //then
-    XCTAssertEqual([value intValue], ZMAccentColorBrightYellow);
+    XCTAssertEqual([value intValue], ZMAccentColorDeprecatedYellow);
     
     //given
     value = [NSNumber numberWithInt:ZMAccentColorUndefined];

--- a/wire-ios/Tests/Fixture/CoreDataFixture.swift
+++ b/wire-ios/Tests/Fixture/CoreDataFixture.swift
@@ -78,7 +78,7 @@ final class CoreDataFixture {
         }
         AppRootRouter.configureAppearance()
         UIView.setAnimationsEnabled(false)
-        accentColor = .vividRed
+        accentColor = .red
         snapshotBackgroundColor = UIColor.clear
 
         do {
@@ -148,7 +148,7 @@ final class CoreDataFixture {
         selfUser = ZMUser.selfUser(in: uiMOC)
         selfUser.remoteIdentifier = UUID()
         selfUser.name = "selfUser"
-        selfUser.accentColorValue = .vividRed
+        selfUser.accentColorValue = .red
         selfUser.emailAddress = "test@email.com"
         selfUser.phoneNumber = "+123456789"
 

--- a/wire-ios/Tests/Fixture/CoreDataFixture.swift
+++ b/wire-ios/Tests/Fixture/CoreDataFixture.swift
@@ -160,7 +160,7 @@ final class CoreDataFixture {
         otherUser.remoteIdentifier = UUID()
         otherUser.name = "Bruno"
         otherUser.handle = "bruno"
-        otherUser.accentColorValue = .brightOrange
+        otherUser.accentColorValue = .amber
 
         otherUserConversation = ZMConversation.createOtherUserConversation(moc: uiMOC, otherUser: otherUser)
 
@@ -223,7 +223,7 @@ extension CoreDataFixture {
         serviceUser.remoteIdentifier = UUID()
         serviceUser.name = "ServiceUser"
         serviceUser.handle = serviceUser.name!.lowercased()
-        serviceUser.accentColorValue = .brightOrange
+        serviceUser.accentColorValue = .amber
         serviceUser.serviceIdentifier = UUID.create().transportString()
         serviceUser.providerIdentifier = UUID.create().transportString()
         uiMOC.saveOrRollback()

--- a/wire-ios/Tests/Mocks/MockMessage+Creation.swift
+++ b/wire-ios/Tests/Mocks/MockMessage+Creation.swift
@@ -56,7 +56,7 @@ final class MockMessageFactory {
             message.senderUser = sender
         } else {
             let user = MockUserType.createSelfUser(name: "Tarja Turunen")
-            user.accentColorValue = .strongBlue
+            user.accentColorValue = .blue
             message.senderUser = user
         }
 

--- a/wire-ios/Tests/Mocks/MockServiceUserType+Creation.swift
+++ b/wire-ios/Tests/Mocks/MockServiceUserType+Creation.swift
@@ -34,7 +34,7 @@ extension MockServiceUserType {
         serviceUser.displayName = name
         serviceUser.initials = PersonName.person(withName: name, schemeTagger: nil).initials
         serviceUser.handle = serviceUser.name?.lowercased()
-        serviceUser.accentColorValue = .brightOrange
+        serviceUser.accentColorValue = .amber
         serviceUser.providerIdentifier = UUID.create().transportString()
         serviceUser.serviceIdentifier = UUID.create().transportString()
         return serviceUser

--- a/wire-ios/Tests/Mocks/MockUser+Convenience.swift
+++ b/wire-ios/Tests/Mocks/MockUser+Convenience.swift
@@ -44,7 +44,7 @@ extension MockUser {
         user.isTeamMember = teamID != nil
         user.teamIdentifier = teamID
         user.teamRole = teamID != nil ? .member : .none
-        user.accentColorValue = .vividRed
+        user.accentColorValue = .red
         user.remoteIdentifier = UUID()
         return user
     }

--- a/wire-ios/Tests/Mocks/MockUser+Convenience.swift
+++ b/wire-ios/Tests/Mocks/MockUser+Convenience.swift
@@ -66,7 +66,7 @@ extension MockUser {
         user.isTeamMember = teamID != nil
         user.teamIdentifier = teamID
         user.teamRole = teamID != nil ? .member : .none
-        user.accentColorValue = .brightOrange
+        user.accentColorValue = .amber
         user.emailAddress = teamID != nil ? "test@email.com" : nil
         user.remoteIdentifier = UUID()
         return user

--- a/wire-ios/Tests/Mocks/MockUserType+Creation.swift
+++ b/wire-ios/Tests/Mocks/MockUserType+Creation.swift
@@ -24,7 +24,7 @@ extension MockUserType {
     /// - Returns: a mock user
     class func createDefaultSelfUser() -> MockUserType {
         let mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
-        mockSelfUser.accentColorValue = .vividRed
+        mockSelfUser.accentColorValue = .red
 
         return mockSelfUser
     }
@@ -40,7 +40,7 @@ extension MockUserType {
     class func createSelfUser(name: String, inTeam teamID: UUID? = nil) -> MockUserType {
         let user = createUser(name: name, inTeam: teamID)
         user.isSelfUser = true
-        user.accentColorValue = .vividRed
+        user.accentColorValue = .red
         return user
     }
 

--- a/wire-ios/Tests/Mocks/MockUserType+Creation.swift
+++ b/wire-ios/Tests/Mocks/MockUserType+Creation.swift
@@ -57,7 +57,7 @@ extension MockUserType {
         user.isSelfUser = false
         user.isConnected = true
         user.emailAddress = teamID != nil ? "test@email.com" : nil
-        user.accentColorValue = .brightOrange
+        user.accentColorValue = .amber
         return user
     }
 
@@ -87,7 +87,7 @@ extension MockUserType {
         let user = MockUserType.createUser(name: "Bruno")
         user.handle = "bruno"
         user.initials = "B"
-        user.accentColorValue = .brightOrange
+        user.accentColorValue = .amber
         user.isConnected = true
 
         return user

--- a/wire-ios/Tests/Mocks/MockUserType.swift
+++ b/wire-ios/Tests/Mocks/MockUserType.swift
@@ -85,7 +85,7 @@ class MockUserType: NSObject, UserType, Decodable {
 
     var phoneNumber: String? = "+123456789"
 
-    var accentColorValue: ZMAccentColor = .strongBlue
+    var accentColorValue: ZMAccentColor = .blue
 
     var availability: Availability = .none
 

--- a/wire-ios/Wire-iOS Tests/AccountViewSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/AccountViewSnapshotTests.swift
@@ -25,7 +25,7 @@ final class AccountViewSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .violet
+        accentColor = .purple
         imageData = UIImage(inTestBundleNamed: "unsplash_matterhorn.jpg", for: AccountViewSnapshotTests.self)!.jpegData(compressionQuality: 0.9)
     }
 

--- a/wire-ios/Wire-iOS Tests/ArchivedNavigationBarTests.swift
+++ b/wire-ios/Wire-iOS Tests/ArchivedNavigationBarTests.swift
@@ -25,7 +25,7 @@ final class ArchivedNavigationBarTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .violet
+        accentColor = .purple
         sut = ArchivedNavigationBar(title: "Archive")
     }
 

--- a/wire-ios/Wire-iOS Tests/ArticleViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ArticleViewTests.swift
@@ -104,7 +104,7 @@ final class ArticleViewTests: BaseSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
-        accentColor = .strongBlue
+        accentColor = .blue
     }
 
     // MARK: - tearDown

--- a/wire-ios/Wire-iOS Tests/AudioRecordViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/AudioRecordViewControllerTests.swift
@@ -41,7 +41,7 @@ final class AudioRecordViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         userSession = UserSessionMock()
         sut = AudioRecordViewController(userSession: userSession)
         delegate = MockAudioRecordViewControllerDelegate()

--- a/wire-ios/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
+++ b/wire-ios/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
@@ -28,7 +28,7 @@ final class AuthenticationInterfaceBuilderTests: BaseSnapshotTestCase, CoreDataF
     override func setUp() {
         super.setUp()
         coreDataFixture = CoreDataFixture()
-        accentColor = .strongBlue
+        accentColor = .blue
 
         featureProvider = MockAuthenticationFeatureProvider()
         builder = AuthenticationInterfaceBuilder(featureProvider: featureProvider, backendEnvironmentProvider: {

--- a/wire-ios/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
@@ -54,7 +54,7 @@ final class CallGridViewControllerSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         mediaManager = ZMMockAVSMediaManager()
         configuration = MockCallGridViewControllerInput()
         mockHintView = MockCallGridHintNotificationLabel()

--- a/wire-ios/Wire-iOS Tests/Calling/RoundedPageIndicatorTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/RoundedPageIndicatorTests.swift
@@ -28,7 +28,7 @@ class RoundedPageIndicatorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         sut = RoundedPageIndicator()
         sut.frame = frame
     }

--- a/wire-ios/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
@@ -24,7 +24,7 @@ final class ChangeHandleViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         let mockSelfUser = MockUserType.createSelfUser(name: "selfUser")
         mockSelfUser.handle = nil
         mockSelfUser.domain = "wire.com"

--- a/wire-ios/Wire-iOS Tests/Collection/CollectionsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/Collection/CollectionsViewControllerTests.swift
@@ -50,7 +50,7 @@ final class CollectionsViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
 
         userSession = UserSessionMock()
 

--- a/wire-ios/Wire-iOS Tests/ConfirmAssetViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConfirmAssetViewControllerTests.swift
@@ -41,7 +41,7 @@ final class ConfirmAssetViewControllerTests: BaseSnapshotTestCase {
     func testThatItRendersTheAssetViewControllerWithPortraitImage() {
         sut = ConfirmAssetViewController(context: ConfirmAssetViewController.Context(asset: .image(mediaAsset: image(inTestBundleNamed: "unsplash_burger.jpg"))))
 
-        accentColor = .vividRed
+        accentColor = .red
         sut.previewTitle = "Burger & Beer"
 
         verifyAllIPhoneSizes(matching: sut)
@@ -50,7 +50,7 @@ final class ConfirmAssetViewControllerTests: BaseSnapshotTestCase {
     func testThatItRendersTheAssetViewControllerWithSmallImage() {
         sut = ConfirmAssetViewController(context: ConfirmAssetViewController.Context(asset: .image(mediaAsset: image(inTestBundleNamed: "unsplash_small.jpg").imageScaled(with: 0.5)!)))
 
-        accentColor = .vividRed
+        accentColor = .red
         sut.previewTitle = "Sea Food"
 
         verifyAllIPhoneSizes(matching: sut)

--- a/wire-ios/Wire-iOS Tests/ConfirmAssetViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConfirmAssetViewControllerTests.swift
@@ -32,7 +32,7 @@ final class ConfirmAssetViewControllerTests: BaseSnapshotTestCase {
     func testThatItRendersTheAssetViewControllerWithLandscapeImage() {
         sut = ConfirmAssetViewController(context: ConfirmAssetViewController.Context(asset: .image(mediaAsset: image(inTestBundleNamed: "unsplash_matterhorn.jpg"))))
 
-        accentColor = .strongLimeGreen
+        accentColor = .green
         sut.previewTitle = "Matterhorn"
 
         verifyAllIPhoneSizes(matching: sut)

--- a/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -31,7 +31,7 @@ final class ConnectRequestsViewControllerSnapshotTests: BaseSnapshotTestCase {
         super.setUp()
 
         let mockUser = MockUserType.createSelfUser(name: "Bruno")
-        mockUser.accentColorValue = .brightOrange
+        mockUser.accentColorValue = .amber
         mockUser.handle = "bruno"
 
         mockConnectionRequest = SwiftMockConversation()

--- a/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -39,7 +39,7 @@ final class ConnectRequestsViewControllerSnapshotTests: BaseSnapshotTestCase {
 
         userSession = UserSessionMock(mockUser: mockUser)
 
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
         sut = ConnectRequestsViewController(userSession: userSession)
 
         sut.loadViewIfNeeded()

--- a/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -64,7 +64,7 @@ final class ConnectRequestsViewControllerSnapshotTests: BaseSnapshotTestCase {
 
     func testForTwoRequests() {
         let otherUser = MockUserType.createConnectedUser(name: "Bill")
-        otherUser.accentColorValue = .brightYellow
+        otherUser.accentColorValue = .deprecatedYellow
         otherUser.handle = "bill"
 
         let secondConnectionRequest = SwiftMockConversation()

--- a/wire-ios/Wire-iOS Tests/ContactsCellSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ContactsCellSnapshotTests.swift
@@ -25,7 +25,7 @@ final class ContactsCellSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        XCTestCase.accentColor = .strongBlue
+        XCTestCase.accentColor = .blue
         sut = ContactsCell()
     }
 

--- a/wire-ios/Wire-iOS Tests/ContactsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ContactsViewControllerSnapshotTests.swift
@@ -30,7 +30,7 @@ final class ContactsViewControllerSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        XCTestCase.accentColor = .strongBlue
+        XCTestCase.accentColor = .blue
         sut = ContactsViewController()
         sut.searchHeaderViewController.overrideUserInterfaceStyle = .dark
         sut.overrideUserInterfaceStyle = .dark

--- a/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -68,7 +68,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
         // GIVEN
         let otherUserConversation = MockStableRandomParticipantsConversation()
         let otherUser = MockUserType.createDefaultOtherUser()
-        otherUser.accentColorValue = .strongLimeGreen
+        otherUser.accentColorValue = .green
         otherUserConversation.conversationType = .oneOnOne
         otherUserConversation.stableRandomParticipants = [otherUser]
 
@@ -82,7 +82,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
     func testThatItRendersPendingConnection() {
         // GIVEN
         let otherUser = MockUserType.createDefaultOtherUser()
-        otherUser.accentColorValue = .strongLimeGreen
+        otherUser.accentColorValue = .green
         otherUser.isConnected = false
         otherUser.isPendingApprovalBySelfUser = true
         let otherUserConversation = MockStableRandomParticipantsConversation()
@@ -105,7 +105,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
         otherUser.isConnected = true
         XCTAssert(otherUser.isServiceUser)
 
-        otherUser.accentColorValue = .strongLimeGreen
+        otherUser.accentColorValue = .green
         let otherUserConversation = MockStableRandomParticipantsConversation()
         otherUserConversation.conversationType = .oneOnOne
         otherUserConversation.stableRandomParticipants = [otherUser]

--- a/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -141,7 +141,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
         (conversation.stableRandomParticipants[0] as! MockUserType).accentColorValue = .vividRed
         (conversation.stableRandomParticipants[1] as! MockUserType).accentColorValue = .brightOrange
         (conversation.stableRandomParticipants[2] as! MockUserType).accentColorValue = .brightYellow
-        (conversation.stableRandomParticipants[3] as! MockUserType).accentColorValue = .strongBlue
+        (conversation.stableRandomParticipants[3] as! MockUserType).accentColorValue = .blue
 
         // WHEN
         sut.configure(context: .conversation(conversation: conversation))

--- a/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -140,7 +140,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
 
         (conversation.stableRandomParticipants[0] as! MockUserType).accentColorValue = .vividRed
         (conversation.stableRandomParticipants[1] as! MockUserType).accentColorValue = .brightOrange
-        (conversation.stableRandomParticipants[2] as! MockUserType).accentColorValue = .brightYellow
+        (conversation.stableRandomParticipants[2] as! MockUserType).accentColorValue = .deprecatedYellow
         (conversation.stableRandomParticipants[3] as! MockUserType).accentColorValue = .blue
 
         // WHEN

--- a/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -139,7 +139,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
         conversation.stableRandomParticipants = MockUserType.usernames.map { MockUserType.createConnectedUser(name: $0) }
 
         (conversation.stableRandomParticipants[0] as! MockUserType).accentColorValue = .red
-        (conversation.stableRandomParticipants[1] as! MockUserType).accentColorValue = .brightOrange
+        (conversation.stableRandomParticipants[1] as! MockUserType).accentColorValue = .amber
         (conversation.stableRandomParticipants[2] as! MockUserType).accentColorValue = .deprecatedYellow
         (conversation.stableRandomParticipants[3] as! MockUserType).accentColorValue = .blue
 

--- a/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationAvatarViewTests.swift
@@ -122,7 +122,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
         let conversation = MockStableRandomParticipantsConversation()
         let otherUser = MockUserType.createDefaultOtherUser()
         let thirdUser = MockUserType.createConnectedUser(name: "Anna")
-        thirdUser.accentColorValue = .vividRed
+        thirdUser.accentColorValue = .red
         conversation.stableRandomParticipants = [thirdUser, otherUser]
 
         // WHEN
@@ -138,7 +138,7 @@ final class ConversationAvatarViewTests: BaseSnapshotTestCase {
         let conversation = MockStableRandomParticipantsConversation()
         conversation.stableRandomParticipants = MockUserType.usernames.map { MockUserType.createConnectedUser(name: $0) }
 
-        (conversation.stableRandomParticipants[0] as! MockUserType).accentColorValue = .vividRed
+        (conversation.stableRandomParticipants[0] as! MockUserType).accentColorValue = .red
         (conversation.stableRandomParticipants[1] as! MockUserType).accentColorValue = .brightOrange
         (conversation.stableRandomParticipants[2] as! MockUserType).accentColorValue = .deprecatedYellow
         (conversation.stableRandomParticipants[3] as! MockUserType).accentColorValue = .blue

--- a/wire-ios/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/CompositeMessageCellTests.swift
@@ -31,7 +31,7 @@ final class CompositeMessageCellTests: ConversationMessageSnapshotTestCase {
         mockSelfUser = MockUserType.createDefaultSelfUser()
 
         // make sure the button's color is alarm red, not accent color
-        UIColor.setAccentOverride(.strongBlue)
+        UIColor.setAccentOverride(.blue)
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/ConversationCell/LocationMessageCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/LocationMessageCellTests.swift
@@ -29,7 +29,7 @@ final class LocationMessageCellTests: ConversationMessageSnapshotTestCase {
         super.setUp()
 
         mockSelfUser = MockUserType.createDefaultSelfUser()
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/MarkDownSnapshotTests.swift
@@ -27,7 +27,7 @@ final class MarkDownSnapshotTests: ConversationMessageSnapshotTestCase {
         super.setUp()
 
         mockOtherUser = MockUserType.createUser(name: "Bruno")
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
 
         mockSelfUser = MockUserType.createDefaultSelfUser()
     }

--- a/wire-ios/Wire-iOS Tests/ConversationCell/StartedConversationCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/StartedConversationCellTests.swift
@@ -27,7 +27,7 @@ final class StartedConversationCellTests: ConversationMessageSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
         SelfUser.setupMockSelfUser(inTeam: UUID())
 
         mockSelfUser = SelfUser.provider?.providedSelfUser as? MockUserType

--- a/wire-ios/Wire-iOS Tests/ConversationCell/StartedConversationCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/StartedConversationCellTests.swift
@@ -31,7 +31,7 @@ final class StartedConversationCellTests: ConversationMessageSnapshotTestCase {
         SelfUser.setupMockSelfUser(inTeam: UUID())
 
         mockSelfUser = SelfUser.provider?.providedSelfUser as? MockUserType
-        mockSelfUser.accentColorValue = .strongBlue
+        mockSelfUser.accentColorValue = .blue
 
         mockOtherUser = MockUserType.createDefaultOtherUser()
     }

--- a/wire-ios/Wire-iOS Tests/ConversationCell/TextMessageMentionsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/TextMessageMentionsTests.swift
@@ -38,7 +38,7 @@ final class TextMessageMentionsTests: ConversationMessageSnapshotTestCase {
         super.setUp()
         otherUser = MockUserType.createUser(name: "Bruno")
         selfUser = MockUserType.createDefaultSelfUser()
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
     }
 
     // MARK: - tearDown

--- a/wire-ios/Wire-iOS Tests/ConversationCreationControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCreationControllerSnapshotTests.swift
@@ -30,7 +30,7 @@ final class ConversationCreationControllerSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .violet
+        accentColor = .purple
     }
 
     // MARK: - tearDown

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
@@ -43,7 +43,7 @@ final class GroupDetailsViewControllerSnapshotTests: BaseSnapshotTestCase {
         otherUser.remoteIdentifier = .init()
         otherUser.isConnected = true
         otherUser.handle = "bruno"
-        otherUser.accentColorValue = .brightOrange
+        otherUser.accentColorValue = .amber
 
         userSession = UserSessionMock(mockUser: mockSelfUser)
     }

--- a/wire-ios/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewControllerTests.swift
@@ -37,7 +37,7 @@ final class ConversationInputBarViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
         mockConversation = MockInputBarConversationType()
         mockClassificationProvider = MockClassificationProvider()
         userSession = UserSessionMock()

--- a/wire-ios/Wire-iOS Tests/ConversationList/ConnectRequestsCell/ConnectRequestsCellSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/ConnectRequestsCell/ConnectRequestsCellSnapshotTests.swift
@@ -25,7 +25,7 @@ final class ConnectRequestsCellSnapshotTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .brightOrange
+        accentColor = .amber
         sut = ConnectRequestsCell(frame: CGRect(x: 0, y: 0, width: 375, height: 56))
         let titleString = L10n.Localizable.List.ConnectRequest.peopleWaiting(1)
         let title = NSAttributedString(string: titleString)

--- a/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
@@ -43,7 +43,7 @@ final class ConversationListViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
 
         userSession = UserSessionMock()
 

--- a/wire-ios/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
@@ -78,7 +78,7 @@ final class ConversationListCellTests: BaseSnapshotTestCase {
         otherUser = MockUserType.createDefaultOtherUser()
         otherUserConversation = MockConversation.createOneOnOneConversation(otherUser: otherUser)
 
-        accentColor = .strongBlue
+        accentColor = .blue
         // The cell must higher than 64, otherwise it breaks the constraints.
         sut = ConversationListCell(frame: CGRect(x: 0, y: 0, width: 375, height: ConversationListItemView.minHeight))
 

--- a/wire-ios/Wire-iOS Tests/ConversationListAccessoryViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationListAccessoryViewTests.swift
@@ -29,7 +29,7 @@ final class ConversationListAccessoryViewTests: BaseSnapshotTestCase {
         super.setUp()
         userSession = UserSessionMock()
         self.sut = ConversationListAccessoryView(mediaPlaybackManager: MediaPlaybackManager(name: "test", userSession: userSession))
-        accentColor = .violet
+        accentColor = .purple
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/ConversationListTabBarTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationListTabBarTests.swift
@@ -29,7 +29,7 @@ final class ConversationListTabBarTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .brightYellow
+        accentColor = .deprecatedYellow
         UIView.performWithoutAnimation({
             self.sut = ConversationListTabBar()
             sut.backgroundColor = UIColor(white: 0.2, alpha: 1) // In order to make the separator more visible

--- a/wire-ios/Wire-iOS Tests/ConversationListTabBarTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationListTabBarTests.swift
@@ -66,7 +66,7 @@ final class ConversationListTabBarTests: BaseSnapshotTestCase {
     func testThatItShowsTheContactsTitleAndHidesTheArchivedButtonWhen_ShowArchived_WasSetToYesAndIsSetToNo() throws {
         // GIVEN
         // To make the snapshot distinguishable from the inital state
-        accentColor = .strongBlue
+        accentColor = .blue
         sut.showArchived = true
 
         // WHEN

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
@@ -28,7 +28,7 @@ final class ConversationAudioMessageCellTests: ConversationMessageSnapshotTestCa
     override func setUp() {
         super.setUp()
 
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
 
         mockSelfUser = MockUserType.createDefaultSelfUser()
         message = MockMessageFactory.audioMessage(sender: mockSelfUser)!

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationAudioMessageCellTests.swift
@@ -74,7 +74,7 @@ final class ConversationAudioMessageCellTests: ConversationMessageSnapshotTestCa
         message.backingFileMessageData.fileURL = nil
         message.backingFileMessageData.normalizedLoudness = [0.25, 0.5, 1]
 
-        UIColor.setAccentOverride(.strongBlue)
+        UIColor.setAccentOverride(.blue)
         verify(message: message)
     }
 

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationFileMessageCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationFileMessageCellTests.swift
@@ -27,7 +27,7 @@ final class ConversationFileMessageTests: ConversationMessageSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
 
         mockSelfUser = MockUserType.createDefaultSelfUser()
         message = MockMessageFactory.fileTransferMessage(sender: mockSelfUser)

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationImageMessageTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationImageMessageTests.swift
@@ -29,7 +29,7 @@ final class ConversationImageMessageTests: ConversationMessageSnapshotTestCase {
     override func setUp() {
         super.setUp()
 
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
     }
 
     // MARK: - tearDown

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationTextMessageTests.swift
@@ -30,7 +30,7 @@ final class ConversationTextMessageTests: ConversationMessageSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
         message = createMessage()
     }
 

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationVideoMessageCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationVideoMessageCellTests.swift
@@ -26,7 +26,7 @@ final class ConversationVideoMessageCellTests: ConversationMessageSnapshotTestCa
 
     override func setUp() {
         super.setUp()
-        UIColor.setAccentOverride(.vividRed)
+        UIColor.setAccentOverride(.red)
 
         mockSelfUser = MockUserType.createDefaultSelfUser()
 

--- a/wire-ios/Wire-iOS Tests/ConversationViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationViewControllerSnapshotTests.swift
@@ -114,7 +114,7 @@ extension ConversationViewControllerSnapshotTests {
         teamMember.user = otherUser
         teamMember.team = team
         otherUser.membership?.setTeamRole(.partner)
-        UIColor.setAccentOverride(.strongLimeGreen)
+        UIColor.setAccentOverride(.green)
 
         // when
         sut.updateGuestsBarVisibility()
@@ -128,7 +128,7 @@ extension ConversationViewControllerSnapshotTests {
         mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
         mockConversation.addParticipantAndUpdateConversationState(user: serviceUser)
 
-        UIColor.setAccentOverride(.strongLimeGreen)
+        UIColor.setAccentOverride(.green)
 
         // when
         sut.updateGuestsBarVisibility()
@@ -147,7 +147,7 @@ extension ConversationViewControllerSnapshotTests {
         mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
         mockConversation.addParticipantAndUpdateConversationState(user: serviceUser)
 
-        UIColor.setAccentOverride(.strongLimeGreen)
+        UIColor.setAccentOverride(.green)
 
         // when
         sut.updateGuestsBarVisibility()

--- a/wire-ios/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/CountryCodeTableViewControllerTests.swift
@@ -25,7 +25,7 @@ final class CountryCodeTableViewControllerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         sut = CountryCodeTableViewController()
     }
 

--- a/wire-ios/Wire-iOS Tests/CustomAppLock/PasscodeSetupViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/CustomAppLock/PasscodeSetupViewControllerTests.swift
@@ -30,7 +30,7 @@ final class PasscodeSetupViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
     }
 
     // MARK: tearDown

--- a/wire-ios/Wire-iOS Tests/DeviceManagement/ProfileViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/DeviceManagement/ProfileViewControllerTests.swift
@@ -35,7 +35,7 @@ final class ProfileViewControllerTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         userSession = UserSessionMock()
         teamIdentifier = UUID()
         selfUser = MockUser.createSelfUser(name: "George Johnson", inTeam: teamIdentifier)

--- a/wire-ios/Wire-iOS Tests/FolderCreationControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/FolderCreationControllerSnapshotTests.swift
@@ -34,7 +34,7 @@ final class FolderCreationControllerSnapshotTests: XCTestCase, CoreDataFixtureTe
         let convo = createTeamGroupConversation()
         let conversationDirectory = coreDataFixture.uiMOC.conversationListDirectory()
         sut = FolderCreationController(conversation: convo, directory: conversationDirectory)
-        accentColor = .violet
+        accentColor = .purple
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/FolderPickerControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/FolderPickerControllerSnapshotTests.swift
@@ -30,7 +30,7 @@ final class FolderPickerControllerSnapshotTests: XCTestCase {
 
         mockConversation = MockConversation.groupConversation()
         directory = MockConversationDirectory()
-        accentColor = .violet
+        accentColor = .purple
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/IncomingConnectionViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/IncomingConnectionViewTests.swift
@@ -31,7 +31,7 @@ final class IncomingConnectionViewTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
     }
 
     // MARK: - Snapshot Tests

--- a/wire-ios/Wire-iOS Tests/IncomingRequestFooterTests.swift
+++ b/wire-ios/Wire-iOS Tests/IncomingRequestFooterTests.swift
@@ -25,7 +25,7 @@ final class IncomingRequestFooterTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        UIColor.setAccentOverride(.strongBlue)
+        UIColor.setAccentOverride(.blue)
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/InputBar/InputBarEditViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/InputBar/InputBarEditViewTests.swift
@@ -24,7 +24,7 @@ final class InputBarEditViewTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
         sut = InputBarEditView()
 
         sut.backgroundColor = UIColor.lowAccentColor()

--- a/wire-ios/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewTests.swift
@@ -74,7 +74,7 @@ final class NetworkStatusViewSnapShotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .violet
+        accentColor = .purple
         mockContainer = MockContainer()
         sut = NetworkStatusView()
         sut.overrideUserInterfaceStyle = .light

--- a/wire-ios/Wire-iOS Tests/SearchResultLabelTests.swift
+++ b/wire-ios/Wire-iOS Tests/SearchResultLabelTests.swift
@@ -25,7 +25,7 @@ final class SearchResultLabelTests: ZMSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .violet
+        accentColor = .purple
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS Tests/Settings/SettingsTechnicalReportViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/Settings/SettingsTechnicalReportViewControllerSnapshotTests.swift
@@ -30,7 +30,7 @@ final class SettingsTechnicalReportViewControllerSnapshotTests: BaseSnapshotTest
 
     override func setUp() {
         super.setUp()
-        accentColor = .strongBlue
+        accentColor = .blue
     }
 
     // MARK: - tearDown

--- a/wire-ios/Wire-iOS Tests/ShareContactsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ShareContactsViewControllerSnapshotTests.swift
@@ -26,7 +26,7 @@ final class ShareContactsViewControllerSnapshotTests: BaseSnapshotTestCase {
 
     override func setUp() {
         super.setUp()
-        XCTestCase.accentColor = .vividRed
+        XCTestCase.accentColor = .red
         sut = ShareContactsViewController()
     }
 

--- a/wire-ios/Wire-iOS Tests/ShareDestinationCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ShareDestinationCellTests.swift
@@ -73,7 +73,7 @@ final class ShareDestinationCellTests: BaseSnapshotTestCase {
         // swiftlint:disable todo_requires_jira_link
         // TODO: check what would be the default value after test
         // swiftlint:enable todo_requires_jira_link
-        accentColor = .vividRed
+        accentColor = .red
         sut = ShareDestinationCell(style: .default, reuseIdentifier: "reuseIdentifier")
         sut.overrideUserInterfaceStyle = .dark
         sut.backgroundColor = .black

--- a/wire-ios/Wire-iOS Tests/UserCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserCellTests.swift
@@ -182,7 +182,7 @@ final class UserCellTests: BaseSnapshotTestCase {
     func testSelfUser() throws {
         // GIVEN && WHEN
         mockUser = MockUserType.createUser(name: "Tarja Turunen")
-        mockUser.accentColorValue = .vividRed
+        mockUser.accentColorValue = .red
         mockUser.isConnected = true
         mockUser.handle = "tarja_turunen"
         mockUser.availability = .busy
@@ -195,7 +195,7 @@ final class UserCellTests: BaseSnapshotTestCase {
     func testNonTeamUserWithoutHandle() {
         // GIVEN && WHEN
         mockUser = MockUserType.createUser(name: "Tarja Turunen")
-        mockUser.accentColorValue = .vividRed
+        mockUser.accentColorValue = .red
         mockUser.isConnected = true
         mockUser.handle = nil
 

--- a/wire-ios/Wire-iOS Tests/UserConnectionViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserConnectionViewTests.swift
@@ -48,7 +48,7 @@ final class UserConnectionViewTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        accentColor = .violet
+        accentColor = .purple
     }
 
     func testWithUserName() {

--- a/wire-ios/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
@@ -60,7 +60,7 @@ final class UserSearchResultsViewControllerTests: BaseSnapshotTestCase {
 
         for name in MockUserType.usernames {
             let user = MockUserType.createUser(name: name)
-            user.accentColorValue = .brightOrange
+            user.accentColorValue = .amber
             XCTAssertFalse(user.isTeamMember, "user should not be a team member to generate snapshots with guest icon", file: file, line: line)
             allUsers.append(user)
         }

--- a/wire-ios/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
@@ -77,7 +77,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         selfUser = ZMUser.insertNewObject(in: uiMOC)
         selfUser.remoteIdentifier = UUID()
         selfUser.name = "selfUser"
-        selfUser.accentColorValue = .vividRed
+        selfUser.accentColorValue = .red
         selfUser.emailAddress = "test@email.com"
         selfUser.phoneNumber = "+123456789"
 

--- a/wire-ios/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/Utils/CoreDataSnapshotTestCase.swift
@@ -90,7 +90,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         otherUser.remoteIdentifier = UUID()
         otherUser.name = "Bruno"
         otherUser.handle = "bruno"
-        otherUser.accentColorValue = .brightOrange
+        otherUser.accentColorValue = .amber
 
         otherUserConversation = ZMConversation.createOtherUserConversation(moc: uiMOC, otherUser: otherUser)
 
@@ -164,7 +164,7 @@ class CoreDataSnapshotTestCase: ZMSnapshotTestCase {
         serviceUser.remoteIdentifier = UUID()
         serviceUser.name = "ServiceUser"
         serviceUser.handle = serviceUser.name!.lowercased()
-        serviceUser.accentColorValue = .brightOrange
+        serviceUser.accentColorValue = .amber
         serviceUser.serviceIdentifier = UUID.create().transportString()
         serviceUser.providerIdentifier = UUID.create().transportString()
         uiMOC.saveOrRollback()

--- a/wire-ios/Wire-iOS Tests/Utils/ZMSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/Utils/ZMSnapshotTestCase.swift
@@ -97,7 +97,7 @@ class ZMSnapshotTestCase: FBSnapshotTestCase {
         FontScheme.configure(with: .large)
 
         UIView.setAnimationsEnabled(false)
-        accentColor = .vividRed
+        accentColor = .red
         snapshotBackgroundColor = UIColor.clear
 
         // Enable when the design of the view has changed in order to update the reference snapshots

--- a/wire-ios/Wire-iOS Tests/VerticalColumns/VerticalColumnCollectionViewLayoutTests.swift
+++ b/wire-ios/Wire-iOS Tests/VerticalColumns/VerticalColumnCollectionViewLayoutTests.swift
@@ -29,7 +29,7 @@ final class VerticalColumnCollectionViewLayoutTests: XCTestCase {
         // square, upscale
         ColorTile(color: .purple, size: CGSize(width: 10, height: 10)),
         // portrait, downscale
-        ColorTile(color: .yellow, size: CGSize(width: 1000, height: 1500)),
+        ColorTile(color: .deprecatedYellow, size: CGSize(width: 1000, height: 1500)),
         // landscape, upscale
         ColorTile(color: .turquoise, size: CGSize(width: 15, height: 10)),
         // landscape, downscale
@@ -40,7 +40,7 @@ final class VerticalColumnCollectionViewLayoutTests: XCTestCase {
         ColorTile(color: .red, size: CGSize(width: 1000, height: 1000)),
         ColorTile(color: .green, size: CGSize(width: 10, height: 15)),
         ColorTile(color: .purple, size: CGSize(width: 10, height: 10)),
-        ColorTile(color: .yellow, size: CGSize(width: 1000, height: 1500))
+        ColorTile(color: .deprecatedYellow, size: CGSize(width: 1000, height: 1500))
     ]
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS/Sources/Helpers/SemanticColors.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/SemanticColors.swift
@@ -287,7 +287,7 @@ extension UIColor {
             self.init(light: Asset.Colors.blue500Light, dark: Asset.Colors.blue500Dark)
         case .green:
             self.init(light: Asset.Colors.green500Light, dark: Asset.Colors.green500Dark)
-        case .yellow: // Deprecated
+        case .deprecatedYellow: // Deprecated
             self.init(red: 0.996, green: 0.749, blue: 0.007, alpha: 1)
         case .red:
             self.init(light: Asset.Colors.red500Light, dark: Asset.Colors.red500Dark)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/AccentColor+Name.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/AccentColor+Name.swift
@@ -27,7 +27,7 @@ extension AccentColor {
             return AccentColor.blue
         case .green:
             return AccentColor.green
-        case .yellow:
+        case .deprecatedYellow:
             return AccentColor.yellow
         case .red:
             return AccentColor.red

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
@@ -37,7 +37,7 @@ extension UIColor {
             activeUserSession.providedSelfUser.accentColorValue != .undefined
         else {
             // priority 3: default color
-            return .strongBlue
+            return .blue
         }
 
         // priority 2: color from self user

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIColor+Accent.swift
@@ -80,7 +80,7 @@ extension UIColor {
             return SemanticColors.View.backgroundRed
         case .green:
             return SemanticColors.View.backgroundGreen
-        case .yellow:
+        case .deprecatedYellow:
             return SemanticColors.View.backgroundAmber
         case .amber:
             return SemanticColors.View.backgroundAmber
@@ -100,7 +100,7 @@ extension UIColor {
             return SemanticColors.View.backgroundRedUsernameMention
         case .green:
             return SemanticColors.View.backgroundGreenUsernameMention
-        case .yellow:
+        case .deprecatedYellow:
             return SemanticColors.View.backgroundAmberUsernameMention
         case .amber:
             return SemanticColors.View.backgroundAmberUsernameMention

--- a/wire-ios/WireCommonComponents/UIColor+AccentColor.swift
+++ b/wire-ios/WireCommonComponents/UIColor+AccentColor.swift
@@ -23,7 +23,7 @@ public enum AccentColor: Int16, CaseIterable {
 
     case blue = 1
     case green
-    case yellow // Deprecated
+    case deprecatedYellow // Deprecated
     case red
     case amber
     case turquoise


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7307" title="WPB-7307" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-7307</a>  [iOS] : Remove "Contacts" "Folder"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We have two AccentColor related enums in the code. In the subsequent PR https://github.com/wireapp/wire-ios/pull/1332 these will be merged to a single one.
This PR renames the enum cases, so that the subsequent PR is easier to review.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

