### PR TITLE
fix: quick sync never completing on a cold start WPB-8897

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
@@ -164,7 +164,6 @@ extension SyncStatus {
     public func finishCurrentSyncPhase(phase: SyncPhase) {
         precondition(phase == currentSyncPhase, "Finished syncPhase does not match currentPhase '\(currentSyncPhase)'!")
 
-        zmLog.debug("finished sync phase: \(phase)")
         log("finished sync phase")
 
         if phase.isLastSlowSyncPhase {
@@ -180,9 +179,9 @@ extension SyncStatus {
                 // We need to restart fetching the notification stream since we might be missing notifications
                 currentSyncPhase = .fetchingMissedEvents
                 needsToRestartQuickSync = false
-                zmLog.debug("restarting quick sync since push channel was closed")
+                WireLogger.sync.debug("restarting quick sync since push channel was closed or open after request to fetch notifiations")
             } else {
-                zmLog.debug("sync complete")
+                WireLogger.sync.debug("sync complete")
                 notifyQuickSyncDidFinish()
                 isForceQuickSync = false
             }
@@ -193,7 +192,7 @@ extension SyncStatus {
     public func failCurrentSyncPhase(phase: SyncPhase) {
         precondition(phase == currentSyncPhase, "Failed syncPhase does not match currentPhase")
 
-        zmLog.debug("failed sync phase: \(phase)")
+        WireLogger.sync.warn("failed sync phase: \(phase)")
 
         if currentSyncPhase == .fetchingMissedEvents {
             lastEventIDRepository.storeLastEventID(nil)
@@ -207,19 +206,19 @@ extension SyncStatus {
     }
 
     public func updateLastUpdateEventID(eventID: UUID) {
-        zmLog.debug("update last eventID: \(eventID)")
+        WireLogger.sync.debug("update last eventID: \(eventID)")
         lastUpdateEventID = eventID
     }
 
     public func persistLastUpdateEventID() {
         guard let lastUpdateEventID = lastUpdateEventID else { return }
-        zmLog.debug("persist last eventID: \(lastUpdateEventID)")
+        WireLogger.sync.debug("persist last eventID: \(lastUpdateEventID)")
         lastEventIDRepository.storeLastEventID(lastUpdateEventID)
     }
 
     public func removeLastUpdateEventID() {
         lastUpdateEventID = nil
-        zmLog.debug("remove last eventID")
+        WireLogger.sync.debug("remove last eventID")
         lastEventIDRepository.storeLastEventID(nil)
     }
 }
@@ -241,12 +240,16 @@ extension SyncStatus {
 
     @objc(completedFetchingNotificationStreamFetchBeganAt:)
     public func completedFetchingNotificationStream(fetchBeganAt: Date?) {
-        if currentSyncPhase == .fetchingMissedEvents &&
-            pushChannelEstablishedDate < fetchBeganAt {
+        WireLogger.sync.debug("completedFetchingNotificationStream began at: \(fetchBeganAt?.description ?? "<unknown>")")
+        if currentSyncPhase == .fetchingMissedEvents {
 
             // Only complete the .fetchingMissedEvents phase if the push channel was
             // established before we initiated the notification stream fetch.
             // If the push channel disconnected in between we'll fetch the stream again
+            if pushChannelEstablishedDate > fetchBeganAt {
+                needsToRestartQuickSync = true
+            }
+
             finishCurrentSyncPhase(phase: .fetchingMissedEvents)
         }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
@@ -320,6 +320,25 @@ final class SyncStatusTests: MessagingTest {
         XCTAssertEqual(sut.currentSyncPhase, .fetchingLastUpdateEventID)
     }
 
+    func testThatItRestartsQuickSyncWhenPushChannelWasOpenedAfterNotificationFetchBegan() {
+        // given
+        lastEventIDRepository.storeLastEventID(UUID.timeBasedUUID() as UUID)
+        sut.pushChannelDidOpen()
+        sut.determineInitialSyncPhase()
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
+        XCTAssertFalse(sut.needsToRestartQuickSync)
+
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
+
+        // and when
+        let beforePushChannelEstablished = sut.pushChannelEstablishedDate?.addingTimeInterval(-.oneSecond)
+        sut.completedFetchingNotificationStream(fetchBeganAt: beforePushChannelEstablished)
+
+        // then
+        XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
+    }
+
     func testThatItRestartsQuickSyncWhenPushChannelOpens_PreviousInQuickSync() {
         // given
         lastEventIDRepository.storeLastEventID(UUID.timeBasedUUID() as UUID)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SyncStatusTests.swift
@@ -328,10 +328,7 @@ final class SyncStatusTests: MessagingTest {
         XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
         XCTAssertFalse(sut.needsToRestartQuickSync)
 
-        // then
-        XCTAssertEqual(sut.currentSyncPhase, .fetchingMissedEvents)
-
-        // and when
+        // when
         let beforePushChannelEstablished = sut.pushChannelEstablishedDate?.addingTimeInterval(-.oneSecond)
         sut.completedFetchingNotificationStream(fetchBeganAt: beforePushChannelEstablished)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8897" title="WPB-8897" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8897</a>  Endless syncing bar on cold start
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The quick sync never completes on a cold start of the app (until you put the app into the background/foreground).

#### Cause

On a cold start we begin fetching the `/notifications` immediately before the push channel has been established. In order to safely end the quick sync the push channel has to have been connected before we start fetching `/notifications` in order to ensure that we don't miss any events. The correct thing to do in this scenario is to fetch the `/notification` again but that wasn't happening and the sync thus never completes.

#### Solution

Restart the quick sync if the push channel wasn't already open when the fetch `/notifications` began.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

