### PR TITLE
ci: use new cherry-pick action [WPB-8770]

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -47,3 +47,4 @@ jobs:
               with:
                   target-branch: develop
                   pr-labels: 'cherry-pick'
+                  pr-title-suffix: ''

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -16,9 +16,6 @@
 # 7. The branch with the cherry-picked changes is pushed.
 # 8. A new pull request is created against `develop` with the cherry-picked changes.
 #
-# Note: Ensure you add a "cherry-pick" label to your project. This label is required for the creation of cherry-picked PRs.
-# If needed, you can also set the `TARGET_BRANCH` environment variable to specify a different target branch for the cherry-pick.
-# By default, it's set to `develop`.
 
 name: "Cherry-pick from rc to develop"
 
@@ -28,9 +25,6 @@ on:
             - release/*
         types:
             - closed
-
-env:
-    TARGET_BRANCH: develop
 
 jobs:
     cherry-pick:
@@ -47,113 +41,9 @@ jobs:
                   token: ${{ secrets.SUBMODULE_PAT }}
                   fetch-depth: 0
                   submodules: recursive
-            
-            - name: Setup Git User
-              uses: fregante/setup-git-user@v2
 
-            - name: Append -cherry-pick to branch name
-              id: extract
-              run: |
-                  PR_BRANCH="${{ github.event.pull_request.head.ref }}"
-                  NEW_BRANCH_NAME="${PR_BRANCH}-cherry-pick"
-                  echo "New branch name: $NEW_BRANCH_NAME"
-                  echo "newBranchName=$NEW_BRANCH_NAME" >> $GITHUB_ENV
-
-            - name: Check for changes excluding submodule
-              id: check_changes
-              run: |
-                  if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
-                    # If SUBMODULE_NAME is set
-                    NUM_CHANGES=$(git diff origin/${{ env.TARGET_BRANCH }} --name-only | grep -v "^${{ env.SUBMODULE_NAME }}/" | wc -l)
-                  else
-                    # If SUBMODULE_NAME is not set
-                    NUM_CHANGES=$(git diff origin/${{ env.TARGET_BRANCH }} --name-only | wc -l)
-                  fi
-                  if [ "$NUM_CHANGES" -gt 0 ]; then
-                       echo "shouldCherryPick=true" >> $GITHUB_ENV
-                  else
-                    if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
-                      echo "No changes outside of ${{ env.SUBMODULE_NAME }} submodule, skipping cherry-pick"
-                    else
-                      echo "No changes detected, skipping cherry-pick"
-                    fi
-                    echo "shouldCherryPick=false" >> $GITHUB_ENV
-                  fi
-
-            - name: Update submodule
-              if: env.SUBMODULE_NAME && env.SUBMODULE_TRACK == 'true' && env.shouldCherryPick == 'true'
-              run: |
-                  set -x
-                  git submodule update --init --recursive || true
-                  # Create a temporary branch and get the last commit message
-                  git checkout -b temp-branch-for-cherry-pick
-                  LAST_COMMIT_MESSAGE=$(git log --format=%B -n 1 ${{ github.event.pull_request.merge_commit_sha }})
-                  cd ${{ env.SUBMODULE_NAME }}
-                  git checkout ${{ env.TARGET_BRANCH }}
-                  git pull origin ${{ env.TARGET_BRANCH }}
-                  cd ..
-                  git add ${{ env.SUBMODULE_NAME }}
-                  git commit -m "Update submodule ${{ env.SUBMODULE_NAME }} to latest from ${{ env.TARGET_BRANCH }}"
-                  # Base64 encode the commit message to avoid issues with newlines and special characters
-                  echo "lastCommitMessageBase64=$(echo "$LAST_COMMIT_MESSAGE" | base64 -w 0 )" >> $GITHUB_ENV
-
-            - name: Get Cherry-pick commit
-              id: get-cherry
-              if: env.shouldCherryPick == 'true'
-              run: |
-                  if [[ -n "${{ env.SUBMODULE_NAME }}" && "${{ env.SUBMODULE_TRACK }}" == "true" ]]; then
-                    # If SUBMODULE_NAME is set
-                    git reset --soft HEAD~2
-                    # Decode the base64-encoded string
-                    LAST_COMMIT_MESSAGE=$(echo "${{ env.lastCommitMessageBase64 }}" | base64 --decode)
-                    git commit -m "$LAST_COMMIT_MESSAGE"
-                  fi
-                  
-                  # Get the SHA of the current commit (either squashed or not based on the condition above)
-                  CHERRY_PICK_COMMIT=$(git rev-parse HEAD)
-                  echo "cherryPickCommit=$CHERRY_PICK_COMMIT" >> $GITHUB_ENV
-
-            - name: Get Original Author
-              id: get-author
-              if: env.shouldCherryPick == 'true'
-              run: |
-                  ORIGINAL_AUTHOR=$(git log -1 --pretty=format:'%an <%ae>' ${{ github.event.pull_request.merge_commit_sha }})
-                  echo "Original author: $ORIGINAL_AUTHOR"
-                  echo "originalAuthor=$ORIGINAL_AUTHOR" >> $GITHUB_ENV
-
-            - name: Cherry-pick commits
-              id: commit-cherry-pick
-              if: env.shouldCherryPick == 'true'
-              run: |
-                  # Checkout the desired branch and cherry-pick the commit
-                  git checkout ${{ env.TARGET_BRANCH }}
-                  git checkout -b ${{ env.newBranchName }}
-                  OUTPUT=$(git cherry-pick ${{ env.cherryPickCommit }} || true)
-                  
-                  # Handle conflicts
-                  CONFLICTED_FILES=$(git diff --name-only --diff-filter=U | awk 'ORS="\\\\n"' | sed 's/\\\\n$/\\n/')
-                  echo "Captured conflicted files: $CONFLICTED_FILES"
-                  if [[ "$OUTPUT" == *"CONFLICT"* ]]; then
-                      # Commit the remaining conflicts
-                      git add .
-                      git commit --author "${{ env.originalAuthor }}" -am "Commit with unresolved merge conflicts outside of ${{ env.SUBMODULE_NAME }}"
-                  else
-                      git commit --author "${{ env.originalAuthor }}" --amend --no-edit
-                  fi
-                  
-                  # Push branch and remove temp
-                  git push origin ${{ env.newBranchName }} || (echo "Failed to push to origin" && exit 1)
-                  echo "conflictedFiles=$CONFLICTED_FILES" >> $GITHUB_ENV
-                  if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
-                  git branch -D temp-branch-for-cherry-pick
-                  fi
-
-            - name: Create PR
-              if: env.shouldCherryPick == 'true'
-              env:
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_BRANCH: ${{ env.newBranchName }}
-                  PR_ASSIGNEE: ${{ github.event.pull_request.user.login }}
-              run: |
-                  PR_BODY=$(echo -e "Cherry pick from the original PR: \n- #${{ github.event.pull_request.number }}\n\n---- \n\n ⚠️ Conflicts during cherry-pick:\n${{ env.conflictedFiles }}\n\n${{ github.event.pull_request.body }}")
-                  gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base ${{ env.TARGET_BRANCH }} --head "$PR_BRANCH" --label "cherry-pick" --assignee "$PR_ASSIGNEE"
+            - name: Cherry pick to develop
+              uses: wireapp/action-auto-cherry-pick@v1.0.0
+              with:
+                  target-branch: develop
+                  pr-labels: 'cherry-pick'


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8770" title="WPB-8770" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8770</a>  Refactor the automatic Cherry-Pick into a proper GitHub Action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The current cherry-pick action is hard to maintain across many copies.
Recently an issue was identified where the yaml file wasn't escaping the user input properly. Things like backticks in the title of the PR or the body of the PR would be ran by the action. Like in this screenshot below:

![grafik](https://github.com/wireapp/wire-ios/assets/9389043/1adae500-b1ba-4bec-be05-0f07f2a6de6e)

### Solution

Use the [new cherry-pick action](https://github.com/wireapp/action-auto-cherry-pick), which is easier to use (with defined inputs), and to maintain, as it can be updated by publishing a new version and updating the number on the repositories' side.

---

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

