### PR TITLE
fix: disable interactive dismissal of backend confirmation

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/SwitchBackend/SwitchBackendConfirmationView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SwitchBackend/SwitchBackendConfirmationView.swift
@@ -34,6 +34,7 @@ struct SwitchBackendConfirmationView: View {
             buttons
         }
         .padding()
+        .interactiveDismissDisabled()
     }
 
     @ViewBuilder


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

It's easy to accidentally dismiss the confirmation modal for switching backend. This PR disables interactive dismissal so the user must make a choice.

### Testing

Use a deep link to switch backends, try to dismiss the confirmation modal by tapping outside of it or swiping it offscreen.
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

