### PR TITLE
fix: assign cipher-suite when creating MLS groups WPB-8591

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -25,16 +25,16 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
 
     func uploadKeyPackagesIfNeeded() async
 
-    func createSelfGroup(for groupID: MLSGroupID) async
+    func createSelfGroup(for groupID: MLSGroupID) async throws -> MLSCipherSuite
 
     func joinGroup(with groupID: MLSGroupID) async throws
 
     /// Join group after creating it if needed
     func joinNewGroup(with groupID: MLSGroupID) async throws
 
-    func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws
+    func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws -> MLSCipherSuite
 
-    func createGroup(for groupID: MLSGroupID, parentGroupID: MLSGroupID?) async throws
+    func createGroup(for groupID: MLSGroupID, parentGroupID: MLSGroupID?) async throws -> MLSCipherSuite
 
     func conversationExists(groupID: MLSGroupID) async -> Bool
 
@@ -420,6 +420,7 @@ public final class MLSService: MLSServiceInterface {
     enum MLSGroupCreationError: Error, Equatable {
         case failedToGetExternalSenders
         case failedToCreateGroup
+        case invalidCiphersuite
     }
 
     /// Establish an MLS group with the given group id.
@@ -430,11 +431,11 @@ public final class MLSService: MLSServiceInterface {
     /// - Throws:
     ///   - MLSGroupCreationError if the group could not be created.
 
-    public func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws {
-        guard let context else { return }
+    public func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws -> MLSCipherSuite {
+        guard let context else { throw MLSGroupCreationError.failedToCreateGroup }
 
         do {
-            try await createGroup(for: groupID)
+            let ciphersuite = try await createGroup(for: groupID)
             let mlsSelfUser = await context.perform {
                 let selfUser = ZMUser.selfUser(in: context)
                 return MLSUser(from: selfUser)
@@ -442,6 +443,7 @@ public final class MLSService: MLSServiceInterface {
 
             let usersWithSelfUser = users + [mlsSelfUser]
             try await addMembersToConversation(with: usersWithSelfUser, for: groupID)
+            return ciphersuite
         } catch {
             try await self.wipeGroup(groupID)
             throw error
@@ -451,16 +453,16 @@ public final class MLSService: MLSServiceInterface {
     public func createGroup(
         for groupID: MLSGroupID,
         parentGroupID: MLSGroupID? = nil
-    ) async throws {
+    ) async throws -> MLSCipherSuite {
         logger.info("creating group for id: \(groupID.safeForLoggingDescription)")
 
+        let ciphersuiteRawValue = await featureRepository.fetchMLS().config.defaultCipherSuite.rawValue
+
+        guard let ciphersuite = MLSCipherSuite(rawValue: ciphersuiteRawValue) else {
+            throw MLSGroupCreationError.invalidCiphersuite
+        }
+
         do {
-            let ciphersuiteRawValue = await featureRepository.fetchMLS().config.defaultCipherSuite.rawValue
-
-            guard let ciphersuite = MLSCipherSuite(rawValue: ciphersuiteRawValue) else {
-                throw MLSGroupCreationError.failedToCreateGroup
-            }
-
             let externalSenders: [Data]
             if let parentGroupID {
                 // Anyone in the parent conversation can create a subconversation,
@@ -496,13 +498,14 @@ public final class MLSService: MLSServiceInterface {
         }
 
         staleKeyMaterialDetector.keyingMaterialUpdated(for: groupID)
+
+        return ciphersuite
     }
 
-    public func createSelfGroup(for groupID: MLSGroupID) async {
-        guard let context else { return }
-
+    public func createSelfGroup(for groupID: MLSGroupID) async throws -> MLSCipherSuite {
         do {
-            try await self.createGroup(for: groupID)
+            guard let context else { throw MLSAddMembersError.noManagedObjectContext }
+            let ciphersuite = try await self.createGroup(for: groupID)
             let mlsSelfUser = await context.perform {
                 let selfUser = ZMUser.selfUser(in: context)
                 return MLSUser(from: selfUser)
@@ -514,8 +517,10 @@ public final class MLSService: MLSServiceInterface {
                 logger.debug("createConversation noInviteesToAdd, updateKeyMaterial")
                 try await updateKeyMaterial(for: groupID)
             }
+            return ciphersuite
         } catch {
             logger.error("create group for self conversation failed: \(error.localizedDescription)")
+            throw error
         }
     }
 
@@ -525,6 +530,7 @@ public final class MLSService: MLSServiceInterface {
 
         case noMembersToAdd
         case noInviteesToAdd
+        case noManagedObjectContext
         case failedToClaimKeyPackages(users: [MLSUser])
         case invalidCiphersuite
     }
@@ -829,8 +835,11 @@ public final class MLSService: MLSServiceInterface {
             return
         }
 
+        // TODO: [WPB-9029] jacob this looks wrong,
+        // why would we create the MLS group if doesn't exist? We are about
+        // to join it via external commit.
         if await !conversationExists(groupID: groupID) {
-            try await createGroup(for: groupID)
+            try await _ = createGroup(for: groupID)
         }
 
         let mlsUser = await context.perform {

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -62,9 +62,10 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
         }
 
         if epoch == 0 {
-            try await establishLocalMLSConversationIfNeeded(
+            try await establishMLSGroupIfNeeded(
                 userID: userID,
-                mlsGroupID: mlsGroupID
+                mlsGroupID: mlsGroupID,
+                in: context
             )
         } else {
             try await mlsService.joinGroup(with: mlsGroupID)
@@ -111,14 +112,19 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
         }
     }
 
-    private func establishLocalMLSConversationIfNeeded(
+    private func establishMLSGroupIfNeeded(
         userID: QualifiedID,
-        mlsGroupID: MLSGroupID
+        mlsGroupID: MLSGroupID,
+        in context: NSManagedObjectContext
     ) async throws {
         let users = [MLSUser(userID)]
 
         do {
-            try await mlsService.establishGroup(for: mlsGroupID, with: users)
+            let ciphersuite = try await mlsService.establishGroup(for: mlsGroupID, with: users)
+            await context.perform {
+                let conversation = ZMConversation.fetch(with: mlsGroupID, in: context)
+                conversation?.ciphersuite = ciphersuite
+            }
         } catch {
             throw MigrateMLSOneOnOneConversationError.failedToEstablishGroup(error)
         }

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4115,16 +4115,24 @@ public class MockMLSServiceInterface: MLSServiceInterface {
     // MARK: - createSelfGroup
 
     public var createSelfGroupFor_Invocations: [MLSGroupID] = []
-    public var createSelfGroupFor_MockMethod: ((MLSGroupID) async -> Void)?
+    public var createSelfGroupFor_MockError: Error?
+    public var createSelfGroupFor_MockMethod: ((MLSGroupID) async throws -> MLSCipherSuite)?
+    public var createSelfGroupFor_MockValue: MLSCipherSuite?
 
-    public func createSelfGroup(for groupID: MLSGroupID) async {
+    public func createSelfGroup(for groupID: MLSGroupID) async throws -> MLSCipherSuite {
         createSelfGroupFor_Invocations.append(groupID)
 
-        guard let mock = createSelfGroupFor_MockMethod else {
-            fatalError("no mock for `createSelfGroupFor`")
+        if let error = createSelfGroupFor_MockError {
+            throw error
         }
 
-        await mock(groupID)
+        if let mock = createSelfGroupFor_MockMethod {
+            return try await mock(groupID)
+        } else if let mock = createSelfGroupFor_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `createSelfGroupFor`")
+        }
     }
 
     // MARK: - joinGroup
@@ -4171,40 +4179,46 @@ public class MockMLSServiceInterface: MLSServiceInterface {
 
     public var establishGroupForWith_Invocations: [(groupID: MLSGroupID, users: [MLSUser])] = []
     public var establishGroupForWith_MockError: Error?
-    public var establishGroupForWith_MockMethod: ((MLSGroupID, [MLSUser]) async throws -> Void)?
+    public var establishGroupForWith_MockMethod: ((MLSGroupID, [MLSUser]) async throws -> MLSCipherSuite)?
+    public var establishGroupForWith_MockValue: MLSCipherSuite?
 
-    public func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws {
+    public func establishGroup(for groupID: MLSGroupID, with users: [MLSUser]) async throws -> MLSCipherSuite {
         establishGroupForWith_Invocations.append((groupID: groupID, users: users))
 
         if let error = establishGroupForWith_MockError {
             throw error
         }
 
-        guard let mock = establishGroupForWith_MockMethod else {
+        if let mock = establishGroupForWith_MockMethod {
+            return try await mock(groupID, users)
+        } else if let mock = establishGroupForWith_MockValue {
+            return mock
+        } else {
             fatalError("no mock for `establishGroupForWith`")
         }
-
-        try await mock(groupID, users)
     }
 
     // MARK: - createGroup
 
     public var createGroupForParentGroupID_Invocations: [(groupID: MLSGroupID, parentGroupID: MLSGroupID?)] = []
     public var createGroupForParentGroupID_MockError: Error?
-    public var createGroupForParentGroupID_MockMethod: ((MLSGroupID, MLSGroupID?) async throws -> Void)?
+    public var createGroupForParentGroupID_MockMethod: ((MLSGroupID, MLSGroupID?) async throws -> MLSCipherSuite)?
+    public var createGroupForParentGroupID_MockValue: MLSCipherSuite?
 
-    public func createGroup(for groupID: MLSGroupID, parentGroupID: MLSGroupID?) async throws {
+    public func createGroup(for groupID: MLSGroupID, parentGroupID: MLSGroupID?) async throws -> MLSCipherSuite {
         createGroupForParentGroupID_Invocations.append((groupID: groupID, parentGroupID: parentGroupID))
 
         if let error = createGroupForParentGroupID_MockError {
             throw error
         }
 
-        guard let mock = createGroupForParentGroupID_MockMethod else {
+        if let mock = createGroupForParentGroupID_MockMethod {
+            return try await mock(groupID, parentGroupID)
+        } else if let mock = createGroupForParentGroupID_MockValue {
+            return mock
+        } else {
             fatalError("no mock for `createGroupForParentGroupID`")
         }
-
-        try await mock(groupID, parentGroupID)
     }
 
     // MARK: - conversationExists

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -2690,7 +2690,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         }
 
         // WHEN
-        await sut.createSelfGroup(for: groupID)
+        _ = try await sut.createSelfGroup(for: groupID)
 
         // THEN
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
@@ -2723,7 +2723,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         let groupID = MLSGroupID.random()
 
         // WHEN
-        await sut.createSelfGroup(for: groupID)
+        _ = try await sut.createSelfGroup(for: groupID)
 
         // THEN
         XCTAssertTrue(waitForCustomExpectations(withTimeout: 2.0))

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -97,6 +97,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         let sut = OneOnOneMigrator(mlsService: mockMLSService)
         let userID = QualifiedID.random()
         let mlsGroupID = MLSGroupID.random()
+        let ciphersuite = MLSCipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
 
         let (connection, proteusConversation, mlsConversation) = await createConversations(
             userID: userID,
@@ -112,7 +113,9 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         mockMLSService.conversationExistsGroupID_MockValue = false
-        mockMLSService.establishGroupForWith_MockMethod = { _, _ in }
+        mockMLSService.establishGroupForWith_MockMethod = { _, _ in
+            return ciphersuite
+        }
 
         // When
         await syncContext.perform {
@@ -133,6 +136,7 @@ final class OneOnOneMigratorTests: XCTestCase {
 
         await syncContext.perform {
             XCTAssertEqual(mlsConversation.oneOnOneUser, connection.to)
+            XCTAssertEqual(mlsConversation.ciphersuite, ciphersuite)
             XCTAssertNil(proteusConversation.oneOnOneUser)
         }
         withExtendedLifetime(handler) {}
@@ -201,7 +205,9 @@ final class OneOnOneMigratorTests: XCTestCase {
         )
 
         mockMLSService.conversationExistsGroupID_MockValue = false
-        mockMLSService.establishGroupForWith_MockMethod = { _, _ in }
+        mockMLSService.establishGroupForWith_MockMethod = { _, _ in
+            return .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
+        }
 
         // required to add be able to add images
         let cacheLocation = try XCTUnwrap(

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -618,7 +618,8 @@ struct ConversationEventPayloadProcessor {
         WireLogger.mls.debug("createOrJoinSelfConversation for \(groupID.safeForLoggingDescription); conv payload: \(String(describing: self))")
 
         if await context.perform({ conversation.epoch <= 0 }) {
-            await mlsService.createSelfGroup(for: groupID)
+            let ciphersuite = try await mlsService.createSelfGroup(for: groupID)
+            await context.perform { conversation.ciphersuite = ciphersuite }
         } else if await !mlsService.conversationExists(groupID: groupID) {
             try await mlsService.joinGroup(with: groupID)
         }
@@ -721,7 +722,7 @@ struct ConversationEventPayloadProcessor {
             conversation.mlsGroupID = mlsGroupID
         }
 
-        if let ciphersuite = payload.cipherSuite {
+        if let ciphersuite = payload.cipherSuite, payload.epoch > 0 {
             conversation.ciphersuite = MLSCipherSuite(rawValue: Int(ciphersuite))
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationServiceTests.swift
@@ -278,6 +278,7 @@ final class ConversationServiceTests: MessagingTestBase {
 
     func test_CreateGroupConversation_CreatesMLSGroup() throws {
         // Given
+        let ciphersuite = MLSCipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
         let groupID = MLSGroupID.random()
 
         syncMOC.performAndWait {
@@ -296,7 +297,7 @@ final class ConversationServiceTests: MessagingTestBase {
 
         let mlsService = MockMLSServiceInterface()
         mlsService.createGroupForParentGroupID_MockMethod = { _, _ in
-            // no op
+            return ciphersuite
         }
 
         let selfUserSync = syncMOC.performAndWait {
@@ -325,7 +326,9 @@ final class ConversationServiceTests: MessagingTestBase {
             messageProtocol: .mls
         ) {
             switch $0 {
-            case .success:
+            case .success(let conversation):
+                XCTAssertEqual(conversation.mlsStatus, .ready)
+                XCTAssertEqual(conversation.ciphersuite, ciphersuite)
                 didFinish.fulfill()
 
             case .failure(let error):
@@ -376,7 +379,7 @@ final class ConversationServiceTests: MessagingTestBase {
 
         let mlsService = MockMLSServiceInterface()
         mlsService.createGroupForParentGroupID_MockMethod = { _, _ in
-            // no op
+            return .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
         }
 
         let selfUserSync = syncMOC.performAndWait {
@@ -461,6 +464,7 @@ final class ConversationServiceTests: MessagingTestBase {
             self.syncMOC.performAndWait {
                 XCTAssertEqual(groupId, self.groupConversation.mlsGroupID)
             }
+            return .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
         }
 
         syncMOC.performAndWait {

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
@@ -1116,10 +1116,12 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
     func testUpdateOrCreate_withoutRegisteredMLSClient_dontEstablishMLSSelfGroup() async throws {
         // given
+        let ciphersuite = MLSCipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
         let expectation = XCTestExpectation(description: "didCallCreateGroup")
         expectation.isInverted = true
         mockMLSService.createSelfGroupFor_MockMethod = { _ in
             expectation.fulfill()
+            return ciphersuite
         }
         try await syncMOC.perform {
             let selfClient = try XCTUnwrap(ZMUser.selfUser(in: self.syncMOC).selfClient())
@@ -1137,9 +1139,11 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
     func testUpdateOrCreate_withMLSSelfGroupEpoch0_callsMLSServiceCreateGroup() async throws {
         // given
+        let ciphersuite = MLSCipherSuite.MLS_256_DHKEMP521_AES256GCM_SHA512_P521
         let didCallCreateGroup = XCTestExpectation(description: "didCallCreateGroup")
         mockMLSService.createSelfGroupFor_MockMethod = { _ in
             didCallCreateGroup.fulfill()
+            return ciphersuite
         }
         try await syncMOC.perform {
             let selfClient = try XCTUnwrap(ZMUser.selfUser(in: self.syncMOC).selfClient())
@@ -1153,6 +1157,11 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
         // then
         XCTAssertFalse(mockMLSService.createSelfGroupFor_Invocations.isEmpty)
+        await syncMOC.perform {
+            let selfConversation = ZMConversation.fetchSelfMLSConversation(in: self.syncMOC)
+            XCTAssertEqual(selfConversation?.ciphersuite, ciphersuite)
+        }
+
     }
 
     func testUpdateOrCreate_withMLSSelfGroupEpoch1_callsMLSServiceJoinGroup() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8591" title="WPB-8591" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-8591</a>  [iOS] Add support for ECDSA ciphersuites
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The cipher-suite is fixed after the first commit when creating an MLS conversation. Due to this and the fact that in [API V5 the backend always returns a cipher-suite when fetching a conversation](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1035632650/API+changes+v5+v6) we need to:

1. Only assign the cipher-suite if the epoch > 0
2. Assign the cipher-suite locally when we are creating the underlying MLS group.

### Testing

1. Create an MLS conversation
2. Check in the conversation details that the cipher-suite is correct

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

