### PR TITLE
chore: cherry pick strings from develop

### DIFF
--- a/wire-ios/Wire-iOS/Resources/ar.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/ar.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/da.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/da.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/de.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Abgelaufen";
 "device.details.section.e2ei.status.invalid" = "Ungültig";
 "device.details.section.e2ei.serial_number" = "Seriennummer";
-"device.details.section.mls.signature" = "MLS mit Ed25519 Signatur";
+"device.details.section.mls.signature" = "MLS mit %@ Signatur";
 "device.details.section.mls.title" = "MLS-Daumenabdruck";
 "device.details.section.mls.thumbprint" = "MLS-Daumenabdruck: %@";
 "device.details.certificate_details.title" = "Zertifikatsdetails";

--- a/wire-ios/Wire-iOS/Resources/es.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/es.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/et.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/et.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/fi.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/fi.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/fr.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/it.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/it.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/ja.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/ja.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/lt.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/lt.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/nl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/nl.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/pl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/pl.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/pt-BR.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/ru.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/ru.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Истек";
 "device.details.section.e2ei.status.invalid" = "Недействителен";
 "device.details.section.e2ei.serial_number" = "Серийный номер";
-"device.details.section.mls.signature" = "MLS с подписью Ed25519";
+"device.details.section.mls.signature" = "MLS с подписью %@";
 "device.details.section.mls.title" = "Отпечаток MLS";
 "device.details.section.mls.thumbprint" = "Отпечаток MLS: %@";
 "device.details.certificate_details.title" = "Сведения о сертификате";

--- a/wire-ios/Wire-iOS/Resources/sl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/sl.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/tr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/tr.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/uk.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/uk.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/zh-Hans.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";

--- a/wire-ios/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/zh-Hant.lproj/Localizable.strings
@@ -2146,7 +2146,7 @@
 "device.details.section.e2ei.status.expired" = "Expired";
 "device.details.section.e2ei.status.invalid" = "Invalid";
 "device.details.section.e2ei.serial_number" = "Serial Number";
-"device.details.section.mls.signature" = "MLS with Ed25519 Signature";
+"device.details.section.mls.signature" = "MLS with %@ Signature";
 "device.details.section.mls.title" = "MLS Thumbprint";
 "device.details.section.mls.thumbprint" = "MLS Thumbprint: %@";
 "device.details.certificate_details.title" = "Certificate Details";


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

A string had to be changed when making the cipher-suite configurable. This PR pulls in localisations of it from develop.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

