### PR TITLE
fix: missing conversation WPB-9054

### DIFF
--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -124,6 +124,7 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
             await context.perform {
                 let conversation = ZMConversation.fetch(with: mlsGroupID, in: context)
                 conversation?.ciphersuite = ciphersuite
+                conversation?.mlsStatus = .ready
             }
         } catch {
             throw MigrateMLSOneOnOneConversationError.failedToEstablishGroup(error)

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -137,6 +137,7 @@ final class OneOnOneMigratorTests: XCTestCase {
         await syncContext.perform {
             XCTAssertEqual(mlsConversation.oneOnOneUser, connection.to)
             XCTAssertEqual(mlsConversation.ciphersuite, ciphersuite)
+            XCTAssertEqual(mlsConversation.mlsStatus, .ready)
             XCTAssertNil(proteusConversation.oneOnOneUser)
         }
         withExtendedLifetime(handler) {}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9054" title="WPB-9054" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9054</a>  [iOS] Conversation disappears after creation with cipher suite p256
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Team 1:1 MLS conversations which are created by the self user doesn't appear in the conversation list until the app is put into background/foreground.

#### Why

They don't appear in the conversation because we don't update the `mlsStatus` to `.ready`, which effectively hides the conversation.

It appears after putting the app into background/foreground because this downloads the notification stream which will include the newly created conversation event which when processed updates the `mlsStatus` to `.ready`.

### Testing

1. Sign in with two fresh team accounts
2. In the contacts start a new 1:1 with the other team user

1:1 is not visible the conversation list.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

