### PR TITLE
fix: use correct keys when parsing the self mls public keys

### DIFF
--- a/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
+++ b/wire-ios-data-model/Source/Model/UserClient/UserClient.swift
@@ -426,9 +426,9 @@ public extension UserClient {
         let mlsPublicKeys = payloadAsDictionary.optionalDictionary(forKey: "mls_public_keys")
         let mlsEd25519 = mlsPublicKeys?.optionalString(forKey: "ed25519")
         let mlsEd448 = mlsPublicKeys?.optionalString(forKey: "ed448")
-        let mlsP256 = mlsPublicKeys?.optionalString(forKey: "p256")
-        let mlsP384 = mlsPublicKeys?.optionalString(forKey: "p384")
-        let mlsP521 = mlsPublicKeys?.optionalString(forKey: "p521")
+        let mlsP256 = mlsPublicKeys?.optionalString(forKey: "ecdsa_secp256r1_sha256")
+        let mlsP384 = mlsPublicKeys?.optionalString(forKey: "ecdsa_secp384r1_sha384")
+        let mlsP521 = mlsPublicKeys?.optionalString(forKey: "ecdsa_secp521r1_sha512")
 
         client.label = label
         client.type = DeviceType(rawValue: type)


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

We weren't parsing the self mls public keys using the correct keys. This resulting other self clients not appearing as having e2ei enabled.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

