### PR TITLE
fix: Observe the verification status on the group details screen WPB-8836

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -299,7 +299,6 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         } else {
             updateUserE2EICertificationStatuses()
         }
-
         if changeInfo.mlsVerificationStatusChanged {
             setupNavigatiomItem()
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -299,6 +299,10 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         } else {
             updateUserE2EICertificationStatuses()
         }
+
+        if changeInfo.mlsVerificationStatusChanged {
+            setupNavigatiomItem()
+        }
     }
 
     func footerView(_ view: GroupDetailsFooterView,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -299,6 +299,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         } else {
             updateUserE2EICertificationStatuses()
         }
+
         if changeInfo.mlsVerificationStatusChanged {
             setupNavigatiomItem()
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8836" title="WPB-8836" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-8836</a>  [iOS] Adding non E2EI user to a verified conversation doesn't show degradation immediately on group details
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Adding non E2EI user to a verified conversation doesn't show degradation immediately on group details.


### Testing

- mls conversation is verified
- open the group details screen and add the user with the expired certificate
- the title “Verified (End-to-end Identity)” is not shown anymore

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

