### PR TITLE
fix: showing onboarding hint

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -114,8 +114,6 @@ final class ConversationListViewController: UIViewController {
 
         super.init(nibName: nil, bundle: nil)
 
-        viewModel.viewController = self
-
         definesPresentationContext = true
 
         /// setup UI
@@ -130,6 +128,8 @@ final class ConversationListViewController: UIViewController {
         setupNetworkStatusBar()
 
         createViewConstraints()
+
+        viewModel.viewController = self
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

back-porting https://github.com/wireapp/wire-ios/pull/1315

### Issue

Currently there is an issue in the initialisation of the `ConversationListViewController` which first tries to set the onboarding hint view to visible if needed in the `init` method, while afterwards in `viewDidLoad` the onboarding view is initialised to be invisible.
This PR reverses the order of these actions.

<img width="366" alt="Screenshot 2024-04-19 at 5 53 29 PM" src="https://github.com/wireapp/wire-ios/assets/15628584/8282918c-2eed-498c-8399-42472d9978a5">

### Testing

Log into the app with a new user which has no conversations.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

