### PR TITLE
fix: CI set ruby version [WPB-9104]

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -78,7 +78,7 @@ jobs:
       
   build_and_release:
     needs: changelog
-    runs-on: ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+    runs-on: ghcr.io/cirruslabs/macos-runner:sonoma
     env:
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
       MATCH_KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -77,7 +77,7 @@ env: # https://docs.fastlane.tools/getting-started/ios/setup/
 
 jobs:
   run-tests:
-    runs-on: ghcr.io/cirruslabs/macos-sonoma-xcode:15.3
+    runs-on: ghcr.io/cirruslabs/macos-runner:sonoma
     env:
       GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_USERNAME: ${{ secrets.ZENKINS_USERNAME }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '3.3.1'
+
 gem 'fastlane'
 gem 'git'
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,5 +234,8 @@ DEPENDENCIES
   httparty
   xcode-install
 
+RUBY VERSION
+   ruby 3.3.1p55
+
 BUNDLED WITH
    2.4.12


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9104" title="WPB-9104" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9104</a>  iOS: CirrusCI failing with fastlane error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Explicitly set `Ruby 3.3.1` to let the CI know what tooling we need.
- Then we can switch back to the speed optimised images: https://cirrus-runners.app/blog/2024/04/11/optimizing-startup-time-of-cirrus-runners/

### Testing

- Build on ci

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

