### PR TITLE
fix: Issue where dark mode is not respected - WPB-9083

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConnectRequestsViewControllerSnapshotTests.swift
@@ -59,7 +59,7 @@ final class ConnectRequestsViewControllerSnapshotTests: BaseSnapshotTestCase {
     }
 
     func testForOneRequest() {
-        verify(matching: sut.wrapInNavigationController(setBackgroundColor: true))
+        verify(matching: sut.wrapInNavigationController())
     }
 
     func testForTwoRequests() {
@@ -73,6 +73,6 @@ final class ConnectRequestsViewControllerSnapshotTests: BaseSnapshotTestCase {
         sut.connectionRequests = [secondConnectionRequest, mockConnectionRequest]
         sut.reload(animated: false)
 
-        verify(matching: sut.wrapInNavigationController(setBackgroundColor: true))
+        verify(matching: sut.wrapInNavigationController())
     }
 }

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift
@@ -210,7 +210,7 @@ final class GroupDetailsViewControllerSnapshotTests: BaseSnapshotTestCase {
         )
 
         // THEN
-        verify(matching: sut.wrapInNavigationController(setBackgroundColor: true))
+        verify(matching: sut.wrapInNavigationController())
     }
 
     func testForMlsConversation_withNotVerifiedStatus() throws {
@@ -229,7 +229,7 @@ final class GroupDetailsViewControllerSnapshotTests: BaseSnapshotTestCase {
         )
 
         // THEN
-        verify(matching: sut.wrapInNavigationController(setBackgroundColor: true))
+        verify(matching: sut.wrapInNavigationController())
     }
 
     func testForProteusConversation_withVerifiedStatus() throws {
@@ -248,7 +248,7 @@ final class GroupDetailsViewControllerSnapshotTests: BaseSnapshotTestCase {
         )
 
         // THEN
-        verify(matching: sut.wrapInNavigationController(setBackgroundColor: true))
+        verify(matching: sut.wrapInNavigationController())
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/OtherUserDeviceDetailsViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/OtherUserDeviceDetailsViewTests.swift
@@ -109,7 +109,7 @@ final class OtherUserDeviceDetailsViewTests: BaseSnapshotTestCase {
     ) -> UINavigationController {
         sut = DeviceInfoViewController(rootView: OtherUserDeviceDetailsView(viewModel: viewModel))
         sut.overrideUserInterfaceStyle = mode
-        return sut.wrapInNavigationController(setBackgroundColor: true, mode: mode)
+        return sut.wrapInNavigationController()
     }
 
     func testWhenMLSViewIsDisabled() {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -594,7 +594,7 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
         countryCodePicker.delegate = self
         countryCodePicker.modalPresentationStyle = .formSheet
 
-        let navigationController = countryCodePicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self, setBackgroundColor: true)
+        let navigationController = countryCodePicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self)
         present(navigationController, animated: true)
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
@@ -183,7 +183,7 @@ final class ConfirmAssetViewController: UIViewController {
         canvasViewController.title = previewTitle
         canvasViewController.select(editMode: editMode, animated: false)
 
-        let navigationController = canvasViewController.wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = canvasViewController.wrapInNavigationController()
 
         present(navigationController, animated: true)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/DefaultNavigationBar.swift
@@ -61,16 +61,11 @@ class DefaultNavigationBar: UINavigationBar, DynamicTypeCapable {
 extension UIViewController {
     func wrapInNavigationController(
         navigationControllerClass: UINavigationController.Type = RotationAwareNavigationController.self,
-        navigationBarClass: AnyClass? = DefaultNavigationBar.self,
-        setBackgroundColor: Bool = false,
-        mode: UIUserInterfaceStyle = .light
+        navigationBarClass: AnyClass? = DefaultNavigationBar.self
     ) -> UINavigationController {
         let navigationController = navigationControllerClass.init(navigationBarClass: navigationBarClass, toolbarClass: nil)
         navigationController.setViewControllers([self], animated: false)
-        navigationController.overrideUserInterfaceStyle = mode
-        if setBackgroundColor {
-            navigationController.view.backgroundColor = SemanticColors.View.backgroundDefault
-        }
+        navigationController.view.backgroundColor = SemanticColors.View.backgroundDefault
 
         return navigationController
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -167,7 +167,7 @@ final class GiphySearchViewController: VerticalColumnCollectionViewController {
     // MARK: - Presentation
 
     func wrapInsideNavigationController() -> UINavigationController {
-        let navigationController = self.wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = self.wrapInNavigationController()
 
         return navigationController
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -50,7 +50,7 @@ extension ConversationContentViewController {
         canvasViewController.navigationItem.setupNavigationBarTitle(title: message.conversationLike?.displayName ?? "")
         canvasViewController.select(editMode: editMode, animated: false)
 
-        present(canvasViewController.wrapInNavigationController(setBackgroundColor: true), animated: true)
+        present(canvasViewController.wrapInNavigationController(), animated: true)
     }
 
     func messageAction(actionId: MessageAction,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
@@ -41,7 +41,7 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
 
         endEditing()
 
-        createAndPresentParticipantsPopoverController(with: frame, from: view, contentViewController: profileViewController.wrapInNavigationController(setBackgroundColor: true))
+        createAndPresentParticipantsPopoverController(with: frame, from: view, contentViewController: profileViewController.wrapInNavigationController())
     }
 
     func conversationContentViewController(
@@ -145,7 +145,7 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
             userSession: userSession,
             isUserE2EICertifiedUseCase: userSession.isUserE2EICertifiedUseCase
         )
-        let navigationController = groupDetailsViewController.wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = groupDetailsViewController.wrapInNavigationController()
         groupDetailsViewController.presentGuestOptions(animated: false)
         presentParticipantsViewController(navigationController, from: sourceView)
     }
@@ -164,7 +164,7 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
             userSession: userSession,
             isUserE2EICertifiedUseCase: userSession.isUserE2EICertifiedUseCase
         )
-        let navigationController = groupDetailsViewController.wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = groupDetailsViewController.wrapInNavigationController()
         groupDetailsViewController.presentServicesOptions(animated: false)
         presentParticipantsViewController(navigationController, from: sourceView)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+PrivacyAlert.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+PrivacyAlert.swift
@@ -165,7 +165,7 @@ extension ConversationViewController {
             let profileViewController = ProfileViewController(user: connectedUser, viewer: selfUser, conversation: conversation, context: .deviceList, userSession: userSession)
             profileViewController.delegate = self
             profileViewController.viewControllerDismisser = self
-            let navigationController = profileViewController.wrapInNavigationController(setBackgroundColor: true)
+            let navigationController = profileViewController.wrapInNavigationController()
             navigationController.modalPresentationStyle = .formSheet
             present(navigationController, animated: true)
         } else if conversation.conversationType == .group {
@@ -174,7 +174,7 @@ extension ConversationViewController {
                 conversation: conversation,
                 userSession: userSession
             )
-            let navigationController = participantsViewController.wrapInNavigationController(setBackgroundColor: true)
+            let navigationController = participantsViewController.wrapInNavigationController()
             navigationController.modalPresentationStyle = .formSheet
             present(navigationController, animated: true)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -101,7 +101,7 @@ final class ConversationViewController: UIViewController {
             break
         }
 
-        return viewController?.wrapInNavigationController(setBackgroundColor: true)
+        return viewController?.wrapInNavigationController()
     }
 
     required init(conversation: ZMConversation,
@@ -661,7 +661,7 @@ extension ConversationViewController: ConversationInputBarViewControllerDelegate
 
         collectionController?.shouldTrackOnNextOpen = true
 
-        let navigationController = KeyboardAvoidingViewController(viewController: collectionController!).wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = KeyboardAvoidingViewController(viewController: collectionController!).wrapInNavigationController()
 
         ZClientViewController.shared?.present(navigationController, animated: true)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -900,7 +900,7 @@ extension ConversationInputBarViewController: UIImagePickerControllerDelegate {
         viewController.delegate = self
         viewController.navigationItem.setupNavigationBarTitle(title: conversation.displayNameWithFallback)
 
-        parent?.present(viewController.wrapInNavigationController(setBackgroundColor: true), animated: true)
+        parent?.present(viewController.wrapInNavigationController(), animated: true)
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsContentViewController.swift
@@ -409,7 +409,7 @@ extension MessageDetailsContentViewController {
 
     /// Presents a profile view controller as a popover or a modal depending on the context.
     fileprivate func presentDetailsViewController(_ controller: ProfileViewController, above cell: UserCell) {
-        let presentedController = controller.wrapInNavigationController(setBackgroundColor: true)
+        let presentedController = controller.wrapInNavigationController()
         presentedController.modalPresentationStyle = .formSheet
 
         if let popover = presentedController.popoverPresentationController {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -73,7 +73,7 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
         )
         profileViewController.delegate = self
 
-        let navigationController = profileViewController.wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = profileViewController.wrapInNavigationController()
         navigationController.modalPresentationStyle = .formSheet
 
         ZClientViewController.shared?.present(navigationController, animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Folders.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Folders.swift
@@ -26,7 +26,7 @@ extension ConversationActionController {
         guard let directory = ZMUserSession.shared()?.conversationDirectory else { return }
         let folderPicker = FolderPickerViewController(conversation: conversation, directory: directory)
         folderPicker.delegate = self
-        self.present(folderPicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self))
+        self.present(folderPicker.wrapInNavigationController())
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Folders.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Folders.swift
@@ -26,7 +26,7 @@ extension ConversationActionController {
         guard let directory = ZMUserSession.shared()?.conversationDirectory else { return }
         let folderPicker = FolderPickerViewController(conversation: conversation, directory: directory)
         folderPicker.delegate = self
-        self.present(folderPicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self, setBackgroundColor: true))
+        self.present(folderPicker.wrapInNavigationController(navigationBarClass: DefaultNavigationBar.self))
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -313,7 +313,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
                 conversation: conversation,
                 userSession: userSession
             )
-            let navigationController = addParticipantsViewController.wrapInNavigationController(setBackgroundColor: true)
+            let navigationController = addParticipantsViewController.wrapInNavigationController()
             navigationController.modalPresentationStyle = .currentContext
 
             present(navigationController, animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ShowContentDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ShowContentDelegate.swift
@@ -23,7 +23,7 @@ import WireSyncEngine
 
 extension ZClientViewController {
     private func wrapInNavigationControllerAndPresent(viewController: UIViewController) {
-        let navWrapperController: UINavigationController = viewController.wrapInNavigationController(setBackgroundColor: true)
+        let navWrapperController: UINavigationController = viewController.wrapInNavigationController()
         navWrapperController.modalPresentationStyle = .formSheet
 
         dismissAllModalControllers(callback: { [weak self] in

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -347,7 +347,7 @@ final class ZClientViewController: UIViewController {
         currentConversation = nil
 
         let inbox = ConnectRequestsViewController(userSession: userSession)
-        pushContentViewController(inbox.wrapInNavigationController(setBackgroundColor: true), focusOnView: focus, animated: animated)
+        pushContentViewController(inbox.wrapInNavigationController(), focusOnView: focus, animated: animated)
     }
 
     /// Open the user clients detail screen
@@ -359,7 +359,7 @@ final class ZClientViewController: UIViewController {
             userSession: userSession,
             isUserE2EICertifiedUseCase: userSession.isUserE2EICertifiedUseCase
         )
-        let navController = controller.wrapInNavigationController(setBackgroundColor: true)
+        let navController = controller.wrapInNavigationController()
         navController.modalPresentationStyle = .formSheet
 
         present(navController, animated: true)
@@ -669,7 +669,7 @@ final class ZClientViewController: UIViewController {
             viewController = profileViewController
         }
 
-        let navWrapperController: UINavigationController? = viewController?.wrapInNavigationController(setBackgroundColor: true)
+        let navWrapperController: UINavigationController? = viewController?.wrapInNavigationController()
         navWrapperController?.modalPresentationStyle = .formSheet
         if let aController = navWrapperController {
             present(aController, animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/Common/ProfilePresenter.swift
@@ -84,7 +84,7 @@ final class ProfilePresenter: NSObject, ViewControllerDismisser {
         profileViewController.delegate = self
         profileViewController.viewControllerDismisser = self
 
-        let navigationController = profileViewController.wrapInNavigationController(setBackgroundColor: true)
+        let navigationController = profileViewController.wrapInNavigationController()
         navigationController.modalPresentationStyle = .formSheet
 
         controllerToPresentOn?.present(navigationController, animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+SearchResults.swift
@@ -120,7 +120,7 @@ extension StartUIViewController: SearchResultsViewControllerDelegate {
             self.navigationController?.pushViewController(avoiding, animated: true) {
             }
         } else {
-            let embeddedNavigationController = controller.wrapInNavigationController(setBackgroundColor: true)
+            let embeddedNavigationController = controller.wrapInNavigationController()
             embeddedNavigationController.modalPresentationStyle = .formSheet
             self.present(embeddedNavigationController, animated: true)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/DeviceDetailsViewActionsHandler+ConversationUserClientDetailsActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Devices/DeviceDetailsViewActionsHandler+ConversationUserClientDetailsActions.swift
@@ -32,7 +32,7 @@ extension DeviceDetailsViewActionsHandler: ConversationUserClientDetailsActions 
         let selfClientController = SettingsClientViewController(userClient: selfUserClient,
                                                                 userSession: userSession,
                                                                 fromConversation: true)
-        let navigationControllerWrapper = selfClientController.wrapInNavigationController(setBackgroundColor: true)
+        let navigationControllerWrapper = selfClientController.wrapInNavigationController()
         navigationControllerWrapper.presentTopmost()
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -133,7 +133,7 @@ final class ProfileViewController: UIViewController {
         )
         controller.delegate = self
 
-        let wrappedController = controller.wrapInNavigationController(setBackgroundColor: true)
+        let wrappedController = controller.wrapInNavigationController()
         wrappedController.modalPresentationStyle = .formSheet
         present(wrappedController, animated: true)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9083" title="WPB-9083" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9083</a>  [iOS] Dark Mode being ignored in various places
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


## Description:

This PR addresses the persistent issue where dark mode settings were not consistently applied across the app, particularly in the navigation bar and modals. The changes ensure that the app respects the user’s system-wide dark mode preference, providing a consistent and expected user experience.

## Changes:

1. Removed unnecessary user interface style setting in wrapInNavigationController.
2. Ensured the navigation controller’s background color is always set to SemanticColors.View.backgroundDefault.

Impact:

- The navigation bar no longer becomes transparent in dark mode.
- Modals consistently adhere to the dark mode settings.

Testing:

-  Verified that the navigation bar respects dark mode settings.
-  Ensured modals display correctly in both light and dark modes.
- Tested various app sections to confirm the fix resolves the issue without introducing new bugs.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

