### PR TITLE
fix: Issue with background color of FullScreenImagesViewController when switching from light to dark mode and vice versa - WPB-9109

### DIFF
--- a/wire-ios-mono.xcworkspace/contents.xcworkspacedata
+++ b/wire-ios-mono.xcworkspace/contents.xcworkspacedata
@@ -29,6 +29,21 @@
       location = "group:fastlane"
       name = "fastlane">
       <FileRef
+         location = "group:Preview.html">
+      </FileRef>
+      <Group
+         location = "group:screenshots"
+         name = "screenshots">
+         <Group
+            location = "group:de-DE"
+            name = "de-DE">
+         </Group>
+         <Group
+            location = "group:en-US"
+            name = "en-US">
+         </Group>
+      </Group>
+      <FileRef
          location = "group:Pluginfile">
       </FileRef>
       <FileRef
@@ -36,7 +51,17 @@
          assignedFileDataType = "public.ruby-script">
       </FileRef>
       <FileRef
+         location = "group:README.md">
+      </FileRef>
+      <FileRef
          location = "group:Matchfile">
+      </FileRef>
+      <Group
+         location = "group:metadata"
+         name = "metadata">
+      </Group>
+      <FileRef
+         location = "group:report.xml">
       </FileRef>
    </Group>
    <FileRef
@@ -108,8 +133,5 @@
    </FileRef>
    <FileRef
       location = "group:wire-ios-system/WireSystem.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:WireAPI">
    </FileRef>
 </Workspace>

--- a/wire-ios-mono.xcworkspace/contents.xcworkspacedata
+++ b/wire-ios-mono.xcworkspace/contents.xcworkspacedata
@@ -29,21 +29,6 @@
       location = "group:fastlane"
       name = "fastlane">
       <FileRef
-         location = "group:Preview.html">
-      </FileRef>
-      <Group
-         location = "group:screenshots"
-         name = "screenshots">
-         <Group
-            location = "group:de-DE"
-            name = "de-DE">
-         </Group>
-         <Group
-            location = "group:en-US"
-            name = "en-US">
-         </Group>
-      </Group>
-      <FileRef
          location = "group:Pluginfile">
       </FileRef>
       <FileRef
@@ -51,17 +36,7 @@
          assignedFileDataType = "public.ruby-script">
       </FileRef>
       <FileRef
-         location = "group:README.md">
-      </FileRef>
-      <FileRef
          location = "group:Matchfile">
-      </FileRef>
-      <Group
-         location = "group:metadata"
-         name = "metadata">
-      </Group>
-      <FileRef
-         location = "group:report.xml">
       </FileRef>
    </Group>
    <FileRef
@@ -133,5 +108,8 @@
    </FileRef>
    <FileRef
       location = "group:wire-ios-system/WireSystem.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:WireAPI">
    </FileRef>
 </Workspace>

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
@@ -199,7 +199,7 @@ final class FullscreenImageViewController: UIViewController {
             minimumDismissMagnitude = 250
         }
 
-        view.backgroundColor = .from(scheme: .background)
+        view.backgroundColor = SemanticColors.View.backgroundDefaultWhite
     }
 
     private func setupSnapshotBackgroundView() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
@@ -199,7 +199,7 @@ final class FullscreenImageViewController: UIViewController {
             minimumDismissMagnitude = 250
         }
 
-        view.backgroundColor = SemanticColors.View.backgroundDefaultWhite
+        view.backgroundColor = .from(scheme: .background)
     }
 
     private func setupSnapshotBackgroundView() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9109" title="WPB-9109" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9109</a>  [iOS] Image View does not respect dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

With this PR we fix an issue where the background color wouldn't update from light to dark mode and vice versa. As a solution, now we use the proper semantic color. 

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

