### PR TITLE
fix: Team Name in contacts view forces standard capitalization instead of respecting what team owner put - WPB-9084

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -121,9 +121,9 @@ final class StartUIViewController: UIViewController, SpinnerCapable {
         searchResultsViewController.searchResultsView.collectionView.accessibilityIdentifier = "search.list"
 
         if let title = userSession.selfUser.membership?.team?.name {
-            navigationItem.setupNavigationBarTitle(title: title.capitalized)
+            navigationItem.setupNavigationBarTitle(title: title)
         } else if let title = userSession.selfUser.name {
-            navigationItem.setupNavigationBarTitle(title: title.capitalized)
+            navigationItem.setupNavigationBarTitle(title: title)
         }
 
         searchHeader.delegate = self


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9084" title="WPB-9084" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9084</a>  [iOS] Team Name in contacts view forces standard capitalization instead of respecting what team owner put
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


## Summary:

This PR addresses an issue where navigation bar titles were being forcibly capitalized, disregarding the specific capitalization set by personal users or team owners for their team names or personal names.

## Details:

- Updated the logic for rendering navigation bar titles to respect the user-defined capitalization.
- Ensured that the titles in the navigation bar accurately reflect the team or personal names as set by the users without altering their chosen capitalization.

## Impact:

- Personal and team names in the navigation bar will now appear exactly as set by users, enhancing user customization and accuracy.
- This fix improves the user experience by preserving the integrity of user-defined names.

## Testing:

- Verified that navigation bar titles retain the exact capitalization as input by the user.
- Tested across various user profiles and team settings to ensure consistency and correctness of the displayed titles.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

