### PR TITLE
fix: configure font on AccessoryTextFieldValidationTests

### DIFF
--- a/wire-ios/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
+++ b/wire-ios/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
@@ -16,10 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-@testable import Wire
+import WireCommonComponents
 import XCTest
 
-final class AccessoryTextFieldValidateionTests: XCTestCase {
+@testable import Wire
+
+final class AccessoryTextFieldValidationTests: XCTestCase {
     var sut: ValidatedTextField!
     var mockViewController: MockViewController!
 
@@ -43,6 +45,8 @@ final class AccessoryTextFieldValidateionTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
+        FontScheme.configure(with: .large)
 
         sut = ValidatedTextField(style: .default)
         mockViewController = MockViewController()


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Fixes poped up crash after https://github.com/wireapp/wire-ios/pull/1218

🤯 My understanding is that the change `AccentColorPickerSnapshotTests: BaseSnapshotTestCase` to `AccentColorPickerSnapshotTests: XCTestCase` caused it in the PR [refactor: ColorPickerController to SwiftUI](https://github.com/wireapp/wire-ios/pull/1218).

Why? because `BaseSnapshotTestCase` runs the global static `FontScheme.configure(with: .large)` and the tests seem to be executed in an alphabetical order. So it has been the first test that configured the font and now this global configuration is missing and other tests crash. 


### Testing

- Run unit test suite

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

