### PR TITLE
fix: Animation glitch when tapping on an accent color - WPB-9197

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
@@ -38,10 +38,8 @@ struct AccentColorPicker: View {
                 cell(for: color)
                     .listRowBackground(Color(SemanticColors.View.backgroundUserCell))
                     .onTapGesture {
-                        withAnimation {
-                            self.selectedColor = color
-                            onColorSelect?(color)
-                        }
+                        self.selectedColor = color
+                        onColorSelect?(color)
                     }
             }
             .listStyle(.plain)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9197" title="WPB-9197" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9197</a>  [iOS] Weird animation glitch when tapping on an accent color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


## Issue:
- An animation glitch occurs on the text of a cell when tapping on an accent color. The glitch appears when the font changes due to the applied animation.

## Fix:
- The animation on the font change has been removed to resolve the glitch issue.

## Changes:
- Removed animation from the font change on cell text when an accent color is selected.

## Result:
- The text now updates smoothly without any glitches when an accent color is tapped.


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

