### PR TITLE
fix: Tapping the Done button doesn't dismiss the keyboard - WPB-9198

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/CreateSecureGuestLink/CreateSecureGuestLinkViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/CreateSecureGuestLink/CreateSecureGuestLinkViewController.swift
@@ -120,6 +120,7 @@ class CreateSecureGuestLinkViewController: UIViewController, CreatePasswordSecur
 
         textField.placeholder = SecuredGuestLinkWithPasswordLocale.Textfield.placeholder
         textField.addDoneButtonOnKeyboard()
+        textField.delegate = self
         return textField
     }()
 
@@ -164,7 +165,7 @@ class CreateSecureGuestLinkViewController: UIViewController, CreatePasswordSecur
         textField.placeholder = SecuredGuestLinkWithPasswordLocale.VerifyPasswordTextField.placeholder
         textField.addDoneButtonOnKeyboard()
         textField.returnKeyType = .done
-
+        textField.delegate = self
         return textField
     }()
 
@@ -399,6 +400,21 @@ extension CreateSecureGuestLinkViewController: UITextFieldDelegate {
 
     @objc
     func textFieldDidChange(_ textField: UITextField) {
+        evaluateTextfieldsAndToggleCreateLinkButtonState()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if textField == securedGuestLinkPasswordTextfield {
+            securedGuestLinkPasswordValidatedTextField.becomeFirstResponder()
+        } else {
+            textField.resignFirstResponder()
+            evaluateTextfieldsAndToggleCreateLinkButtonState()
+        }
+
+        return true
+    }
+
+    private func evaluateTextfieldsAndToggleCreateLinkButtonState() {
         if let text1 = securedGuestLinkPasswordTextfield.text,
            let text2 = securedGuestLinkPasswordValidatedTextField.text,
            !text1.isEmpty,
@@ -410,5 +426,4 @@ extension CreateSecureGuestLinkViewController: UITextFieldDelegate {
             createSecuredLinkButton.isEnabled = false
         }
     }
-
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/CreateSecureGuestLink/CreateSecureGuestLinkViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/CreateSecureGuestLink/CreateSecureGuestLinkViewController.swift
@@ -404,9 +404,11 @@ extension CreateSecureGuestLinkViewController: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if textField == securedGuestLinkPasswordTextfield {
+        if textField === securedGuestLinkPasswordTextfield {
+            // Move focus to the password confirmation text field
             securedGuestLinkPasswordValidatedTextField.becomeFirstResponder()
         } else {
+            // Dismiss keyboard and finalize
             textField.resignFirstResponder()
             evaluateTextfieldsAndToggleCreateLinkButtonState()
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9198" title="WPB-9198" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9198</a>  [iOS] Tapping the Done button doesn't dismiss the keyboard
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->

This PR enhances the CreateSecureGuestLinkViewController by introducing a more robust and reusable approach to managing the validation of password fields and the state of the “Create Link” button. The key improvements include:

1. New Method for State Management:

- Added evaluateAndToggleCreateLinkButtonState, a new method that centralizes the logic for validating the password fields and enabling or disabling the “Create Link” button based on the validation results. This improves code readability and maintainability by avoiding repetitive code.

2. Delegation and Keyboard Management:

- Implemented textFieldShouldReturn to move focus to the next text field when the “Next” button is tapped. When the “Done” button is tapped on the second text field, the keyboard is dismissed and validation is performed.
- Ensured that both text fields (securedGuestLinkPasswordTextfield and securedGuestLinkPasswordValidatedTextField) have their delegates set to the view controller.

## How to Test

### Password Validation:

- Enter a password in the first text field.
- Ensure the “Next” button moves focus to the second text field.
- Ensure the “Done” button on the second text field dismisses the keyboard.
- Verify that the “Create Link” button is only enabled when both password fields are filled with matching and valid passwords.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

