### PR TITLE
fix: reset bundle cache for new Xcode version [WPB-9379]

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -137,7 +137,7 @@ jobs:
         id: cache-bundler
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-xcode${{ steps.xcode-version.outputs.XCODE_VERSION }}-bundler-${{ hashFiles('Gemfile.lock') }}
       - name: Run setup
         run: sh ./setup.sh
       - name: Configure AWS Credentials

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -120,7 +120,7 @@ jobs:
         id: cache-bundler
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('Gemfile.lock') }}
+          key: ${{ runner.os }}-xcode${{ steps.xcode-version.outputs.XCODE_VERSION }}-bundler-${{ hashFiles('Gemfile.lock') }}
 
       - name: Setup workspace
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9379" title="WPB-9379" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9379</a>  Update to Xcode 15.4
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

It seem that the bundler cache got invalid. I could make it work locally when deleting it, as suggested here:
https://github.com/fastlane/fastlane/issues/21942


### Testing

- Run fastlane on ci like `bundle exec fastlane development`.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

