### PR TITLE
fix: Display only legal instead of terms of use and privacy policy under 'About' in settings tab - WPB-8865

### DIFF
--- a/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
+++ b/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
@@ -48,6 +48,7 @@ final class URL_WireTests: XCTestCase {
         XCTAssertEqual(URL.wr_createTeamFeatures, websiteURL.appendingPathComponent("teams/learnmore"))
         XCTAssertEqual(URL.wr_emailInUseLearnMore, websiteURL.appendingPathComponent("support/email-in-use"))
         XCTAssertEqual(URL.wr_termsOfServicesURL, websiteURL.appendingPathComponent("legal"))
+        XCTAssertEqual(URL.wr_legal, websiteURL.appendingPathComponent("legal"))
     }
 
     func testThatSupportURLsAreLoadedCorrectly() {

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -1022,6 +1022,10 @@ internal enum L10n {
         /// © Wire Swiss GmbH
         internal static let title = L10n.tr("Localizable", "about.copyright.title", fallback: "© Wire Swiss GmbH")
       }
+      internal enum Legal {
+        /// Legal
+        internal static let title = L10n.tr("Localizable", "about.legal.title", fallback: "Legal")
+      }
       internal enum License {
         /// Acknowledgements
         internal static let licenseHeader = L10n.tr("Localizable", "about.license.license_header", fallback: "Acknowledgements")

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1043,6 +1043,7 @@
 "self.add_email_password" = "Add email address and password";
 
 // About screen
+"about.legal.title" = "Legal";
 "about.tos.title"="Terms of Use";
 "about.privacy.title"="Privacy Policy";
 "about.license.title" = "License Information";

--- a/wire-ios/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -22,6 +22,7 @@ import WireTransport
 private enum WebsitePages {
     case termsOfServices
     case privacyPolicy
+    case legal
 }
 
 enum TeamSource: Int {
@@ -119,6 +120,10 @@ extension URL {
         BackendEnvironment.localizedWebsiteLink(forPage: .privacyPolicy)
     }
 
+    static var wr_legal: URL {
+        BackendEnvironment.localizedWebsiteLink(forPage: .legal)
+    }
+
     static var wr_licenseInformation: URL {
         BackendEnvironment.websiteLink(path: "legal/licenses/embed")
     }
@@ -209,13 +214,17 @@ private extension BackendEnvironment {
     }
 
     static func localizedWebsiteLink(forPage page: WebsitePages) -> URL {
+        let languageCode = Locale.autoupdatingCurrent.languageCode
+        let baseURL = shared.websiteURL
+
         switch page {
         case .termsOfServices, .privacyPolicy:
-            if Locale.autoupdatingCurrent.languageCode == "de" {
-                return shared.websiteURL.appendingPathComponent("datenschutz")
-            } else {
-                return shared.websiteURL.appendingPathComponent("legal")
-            }
+            let pathComponent = (languageCode == "de") ? "datenschutz" : "legal"
+            return baseURL.appendingPathComponent(pathComponent)
+
+        case .legal:
+            let pathComponent = (languageCode == "de") ? "de/nutzungsbedingungen" : "legal"
+            return baseURL.appendingPathComponent(pathComponent)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -211,12 +211,11 @@ struct SettingsCellDescriptorFactory {
 
     func aboutSection() -> SettingsCellDescriptorType {
 
-        let privacyPolicyButton = SettingsExternalScreenCellDescriptor(title: L10n.Localizable.About.Privacy.title, isDestructive: false, presentationStyle: .modal, presentationAction: {
-            return BrowserViewController(url: URL.wr_privacyPolicy.appendingLocaleParameter)
-        }, previewGenerator: .none)
-        let tosButton = SettingsExternalScreenCellDescriptor(title: L10n.Localizable.About.Tos.title, isDestructive: false, presentationStyle: .modal, presentationAction: {
-            let url = URL.wr_termsOfServicesURL.appendingLocaleParameter
-            return BrowserViewController(url: url)
+        let legalButton = SettingsExternalScreenCellDescriptor(title: L10n.Localizable.About.Legal.title,
+                                                               isDestructive: false,
+                                                               presentationStyle: .modal,
+                                                               presentationAction: {
+            return BrowserViewController(url: URL.wr_legal.appendingLocaleParameter)
         }, previewGenerator: .none)
 
         let shortVersion = Bundle.main.shortVersionString ?? "Unknown"
@@ -231,7 +230,7 @@ struct SettingsCellDescriptorFactory {
         let copyrightInfo = String(format: L10n.Localizable.About.Copyright.title, currentYear)
 
         let linksSection = SettingsSectionDescriptor(
-            cellDescriptors: [tosButton, privacyPolicyButton, licensesSection()],
+            cellDescriptors: [legalButton, licensesSection()],
             header: nil,
             footer: "\n" + version + "\n" + copyrightInfo
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8865" title="WPB-8865" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-8865</a>  [iOS] : Display only "Legal" instead of "Terms of Use" and "Privacy Policy" under 'About' in Settings tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


With this PR we replace terms of use and privacy policy cells under About in settings tab with Legal. 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

