### PR TITLE
fix: remove batchSize parameter - WPB-8695

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
@@ -25,15 +25,9 @@ class ConnectionsAPIV0: ConnectionsAPI, VersionedAPI {
     }
 
     let httpClient: HTTPClient
-    let fetchLimit: Int
 
-    convenience init(httpClient: HTTPClient) {
-        self.init(httpClient: httpClient, batchSize: Constants.batchSize)
-    }
-
-    init(httpClient: HTTPClient, batchSize: Int) {
+    init(httpClient: HTTPClient) {
         self.httpClient = httpClient
-        self.fetchLimit = Constants.batchSize
     }
 
     var apiVersion: APIVersion {

--- a/WireAPI/Tests/WireAPITests/ConnectionsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/ConnectionsAPITests.swift
@@ -86,6 +86,8 @@ class ConnectionsAPITests: XCTestCase {
     func testGetConnections_MultiplePages_SuccessResponse_V0() async throws {
         // Given
         var requestIndex = 0
+        // We fake responses with 1 element per page even if batchSize is 500
+        // pager is driven by has_more attribute in response
         let httpClient = HTTPClientMock { _ in
             let response = HTTPClientMock.PredefinedResponse(resourceName: "GetConnectionsMultiplePagesSuccessResponseV0.\(requestIndex)")
             requestIndex += 1
@@ -94,7 +96,7 @@ class ConnectionsAPITests: XCTestCase {
         }
 
         // WHEN
-        let sut = ConnectionsAPIV0(httpClient: httpClient, batchSize: 1)
+        let sut = ConnectionsAPIV0(httpClient: httpClient)
         let pager = try await sut.getConnections()
         for try await _ in pager {
             // do something with the data


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8695" title="WPB-8695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8695</a>  [iOS] Create ConnectionsAPI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

~Renames fetchLimit in batchSize and use it~

Remove batchSize parameter as it is internal implementation detail

### Testing

Added a test on it
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

