### PR TITLE
fix: simulator call crashes app after other participant enables video [WPB-9413]

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "wire-avs.json" "9.7.17"
+binary "wire-avs.json" "9.7.18"
 github "microsoft/plcrashreporter" "1.11.2"
 github "wireapp/Down" "v2.3.4_xcframework"
 github "wireapp/FLAnimatedImage" "1.0.17"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "wire-avs.json" "9.7.16"
+binary "wire-avs.json" "9.7.17"
 github "microsoft/plcrashreporter" "1.11.2"
 github "wireapp/Down" "v2.3.4_xcframework"
 github "wireapp/FLAnimatedImage" "1.0.17"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "wire-avs.json" "9.7.14"
+binary "wire-avs.json" "9.7.16"
 github "microsoft/plcrashreporter" "1.11.2"
 github "wireapp/Down" "v2.3.4_xcframework"
 github "wireapp/FLAnimatedImage" "1.0.17"

--- a/wire-avs.json
+++ b/wire-avs.json
@@ -1,3 +1,3 @@
 {
-  "9.7.16": "https://github.com/wireapp/wire-avs/releases/download/9.7.16/avs.xcframework.zip",
+  "9.7.17": "https://github.com/wireapp/wire-avs/releases/download/9.7.17/avs.xcframework.zip",
 }

--- a/wire-avs.json
+++ b/wire-avs.json
@@ -1,3 +1,3 @@
 {
-  "9.7.14": "https://github.com/wireapp/wire-avs/releases/download/9.7.14/avs.xcframework.zip",
+  "9.7.16": "https://github.com/wireapp/wire-avs/releases/download/9.7.16/avs.xcframework.zip",
 }

--- a/wire-avs.json
+++ b/wire-avs.json
@@ -1,3 +1,3 @@
 {
-  "9.7.17": "https://github.com/wireapp/wire-avs/releases/download/9.7.17/avs.xcframework.zip",
+  "9.7.18": "https://github.com/wireapp/wire-avs/releases/download/9.7.18/avs.xcframework.zip",
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9413" title="WPB-9413" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9413</a>  [iOS] Simulator call crashes app after other participant enables video
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Update AVS to version `9.7.18`:
https://github.com/wireapp/avs-ios-binaries-appstore/releases/tag/9.7.18


### Testing

- Run full `Test Develop` action: https://github.com/wireapp/wire-ios/actions/runs/9317144246
- See ticket.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

