### PR TITLE
chore: rename `SelfUserType`

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+LegalHoldRequest.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+LegalHoldRequest.swift
@@ -21,7 +21,7 @@ import WireCryptobox
 
 private let log = ZMSLog(tag: "UserClient")
 
-public typealias SelfUserType = UserType & EditableUserType & SelfLegalHoldSubject
+public typealias SelfUserLegalHoldable = UserType & EditableUserType & SelfLegalHoldSubject
 
 /**
  * A protocol for objects that provide the legal hold status for the self user.

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -116,7 +116,9 @@ public protocol UserSession: AnyObject {
     ///
     /// This can only be used on the main thread.
 
-    var selfUser: SelfUserType { get }
+    var selfUser: any UserType { get }
+
+    var selfUserLegalHoldSubject: any SelfUserLegalHoldable { get }
 
     func perform(_ changes: @escaping () -> Void)
 

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -120,6 +120,8 @@ public protocol UserSession: AnyObject {
 
     var selfUserLegalHoldSubject: any SelfUserLegalHoldable { get }
 
+    var editableSelfUser: any UserType & EditableUserType { get }
+
     func perform(_ changes: @escaping () -> Void)
 
     func enqueue(_ changes: @escaping () -> Void)

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -120,7 +120,11 @@ extension ZMUserSession: UserSession {
         try appLockController.deletePasscode()
     }
 
-    public var selfUser: SelfUserType {
+    public var selfUser: any UserType {
+        ZMUser.selfUser(inUserSession: self)
+    }
+
+    public var selfUserLegalHoldSubject: any SelfUserLegalHoldable {
         ZMUser.selfUser(inUserSession: self)
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -128,6 +128,10 @@ extension ZMUserSession: UserSession {
         ZMUser.selfUser(inUserSession: self)
     }
 
+    public var editableSelfUser: any EditableUserType & UserType {
+        ZMUser.selfUser(inUserSession: self)
+    }
+
     public func addUserObserver(
         _ observer: UserObserving,
         for user: UserType

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -73,6 +73,8 @@ final class UserSessionMock: UserSession {
 
     var selfUserLegalHoldSubject: any SelfUserLegalHoldable
 
+    var editableSelfUser: any EditableUserType & UserType
+
     var mockConversationList: ZMConversationList?
 
     var searchUsersCache: SearchUsersCache
@@ -89,23 +91,28 @@ final class UserSessionMock: UserSession {
     convenience init(mockUser: MockZMEditableUser) {
         self.init(
             selfUser: mockUser,
-            selfUserLegalHoldSubject: mockUser
+            selfUserLegalHoldSubject: mockUser,
+            editableSelfUser: mockUser
         )
     }
 
     convenience init(mockUser: MockUserType = .createDefaultSelfUser()) {
         self.init(
             selfUser: mockUser,
-            selfUserLegalHoldSubject: mockUser
+            selfUserLegalHoldSubject: mockUser,
+            editableSelfUser: mockUser
         )
     }
 
     init(
         selfUser: any UserType,
-        selfUserLegalHoldSubject: any SelfUserLegalHoldable
+        selfUserLegalHoldSubject: any SelfUserLegalHoldable,
+        editableSelfUser: any EditableUserType & UserType
     ) {
         self.selfUser = selfUser
         self.selfUserLegalHoldSubject = selfUserLegalHoldSubject
+        self.editableSelfUser = editableSelfUser
+
         searchUsersCache = .init()
     }
 

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -69,7 +69,10 @@ final class UserSessionMock: UserSession {
 
     var networkState: ZMNetworkState = .offline
 
-    var selfUser: SelfUserType
+    var selfUser: any UserType
+
+    var selfUserLegalHoldSubject: any SelfUserLegalHoldable
+
     var mockConversationList: ZMConversationList?
 
     var searchUsersCache: SearchUsersCache
@@ -84,15 +87,25 @@ final class UserSessionMock: UserSession {
     }
 
     convenience init(mockUser: MockZMEditableUser) {
-        self.init(selfUser: mockUser)
+        self.init(
+            selfUser: mockUser,
+            selfUserLegalHoldSubject: mockUser
+        )
     }
 
     convenience init(mockUser: MockUserType = .createDefaultSelfUser()) {
-        self.init(selfUser: mockUser)
+        self.init(
+            selfUser: mockUser,
+            selfUserLegalHoldSubject: mockUser
+        )
     }
 
-    init(selfUser: SelfUserType) {
+    init(
+        selfUser: any UserType,
+        selfUserLegalHoldSubject: any SelfUserLegalHoldable
+    ) {
         self.selfUser = selfUser
+        self.selfUserLegalHoldSubject = selfUserLegalHoldSubject
         searchUsersCache = .init()
     }
 

--- a/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerTests.swift
@@ -53,7 +53,7 @@ final class ConversationListViewControllerTests: XCTestCase {
         let account = Account.mockAccount(imageData: mockImageData)
         let viewModel = ConversationListViewController.ViewModel(
             account: account,
-            selfUser: selfUser,
+            selfUserLegalHoldSubject: selfUser,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: mockIsSelfUserE2EICertifiedUseCase
         )

--- a/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerViewModelSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerViewModelSnapshotTests.swift
@@ -45,7 +45,7 @@ final class ConversationListViewControllerViewModelSnapshotTests: XCTestCase {
         let selfUser = MockUserType.createSelfUser(name: "Bob")
         sut = ConversationListViewController.ViewModel(
             account: account,
-            selfUser: selfUser,
+            selfUserLegalHoldSubject: selfUser,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: mockIsSelfUserE2EICertifiedUseCase
         )

--- a/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerViewModelTests.swift
@@ -40,7 +40,7 @@ final class ConversationListViewControllerViewModelTests: XCTestCase {
         mockIsSelfUserE2EICertifiedUseCase.invoke_MockValue = false
         sut = ConversationListViewController.ViewModel(
             account: account,
-            selfUser: selfUser,
+            selfUserLegalHoldSubject: selfUser,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: mockIsSelfUserE2EICertifiedUseCase
         )

--- a/wire-ios/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/LegalHoldDisclosureController.swift
@@ -60,7 +60,7 @@ final class LegalHoldDisclosureController: UserObserving {
     // MARK: - Properties
 
     /// The self user, that can become under legal hold.
-    let selfUser: SelfUserType
+    let selfUserLegalHoldSubject: any SelfUserLegalHoldable
 
     /// The block that presents view controllers when requested.
     let presenter: ViewControllerPresenter
@@ -80,8 +80,12 @@ final class LegalHoldDisclosureController: UserObserving {
 
     // MARK: - Initialization
 
-    init(selfUser: SelfUserType, userSession: UserSession, presenter: @escaping ViewControllerPresenter) {
-        self.selfUser = selfUser
+    init(
+        selfUserLegalHoldSubject: SelfUserLegalHoldable,
+        userSession: UserSession,
+        presenter: @escaping ViewControllerPresenter
+    ) {
+        self.selfUserLegalHoldSubject = selfUserLegalHoldSubject
         self.presenter = presenter
 
         configureObservers(userSession: userSession)
@@ -89,7 +93,7 @@ final class LegalHoldDisclosureController: UserObserving {
 
     private func configureObservers(userSession: UserSession) {
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterForeground), name: UIApplication.didBecomeActiveNotification, object: nil)
-        userObserverToken = userSession.addUserObserver(self, for: selfUser)
+        userObserverToken = userSession.addUserObserver(self, for: selfUserLegalHoldSubject)
     }
 
     // MARK: - Notifications
@@ -112,7 +116,7 @@ final class LegalHoldDisclosureController: UserObserving {
 
     /// Present the current legal hold state.
     func discloseCurrentState(cause: DisclosureCause) {
-        switch selfUser.legalHoldStatus {
+        switch selfUserLegalHoldSubject.legalHoldStatus {
         case .enabled:
             discloseEnabledStateIfPossible()
 
@@ -132,7 +136,7 @@ final class LegalHoldDisclosureController: UserObserving {
             return
         default:
             // If there is a current alert, replace it with the latest disclosure
-            if selfUser.needsToAcknowledgeLegalHoldStatus {
+            if selfUserLegalHoldSubject.needsToAcknowledgeLegalHoldStatus {
                 currentState = .warningAboutEnabled
             }
         }
@@ -144,7 +148,7 @@ final class LegalHoldDisclosureController: UserObserving {
         if case .acceptingRequest = currentState { return }
 
         Task {
-            let fingerprint = await selfUser.fingerprint ?? "<fingerprint unavailable>"
+            let fingerprint = await selfUserLegalHoldSubject.fingerprint ?? "<fingerprint unavailable>"
             await MainActor.run(body: { currentState = .warningAboutPendingRequest(request, fingerprint) })
         }
 
@@ -165,7 +169,7 @@ final class LegalHoldDisclosureController: UserObserving {
         }
 
         // Do not show the alert for a remote change unless it requires attention
-        if selfUser.needsToAcknowledgeLegalHoldStatus {
+        if selfUserLegalHoldSubject.needsToAcknowledgeLegalHoldStatus {
             currentState = .warningAboutDisabled
         }
     }
@@ -191,14 +195,14 @@ final class LegalHoldDisclosureController: UserObserving {
 
         switch state {
         case .warningAboutDisabled:
-            alertController = LegalHoldAlertFactory.makeLegalHoldDeactivatedAlert(for: selfUser, suggestedStateChangeHandler: assignState)
+            alertController = LegalHoldAlertFactory.makeLegalHoldDeactivatedAlert(for: selfUserLegalHoldSubject, suggestedStateChangeHandler: assignState)
         case .warningAboutEnabled:
-            alertController = LegalHoldAlertFactory.makeLegalHoldActivatedAlert(for: selfUser, suggestedStateChangeHandler: assignState)
+            alertController = LegalHoldAlertFactory.makeLegalHoldActivatedAlert(for: selfUserLegalHoldSubject, suggestedStateChangeHandler: assignState)
         case .warningAboutPendingRequest(let request, let fingerprint):
             alertController = LegalHoldAlertFactory.makeLegalHoldActivationAlert(
                 for: request,
                 fingerprint: fingerprint,
-                user: selfUser,
+                user: selfUserLegalHoldSubject,
                 suggestedStateChangeHandler: assignState
             )
         case .warningAboutAcceptationResult(let alert):

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar.swift
@@ -88,7 +88,7 @@ extension ConversationListViewController {
     // MARK: - Title View
 
     func updateTitleView() {
-        if viewModel.selfUser.isTeamMember {
+        if viewModel.selfUserLegalHoldSubject.isTeamMember {
             defer { userStatusViewController?.userStatus = viewModel.selfUserStatus }
             guard userStatusViewController == nil else { return }
 
@@ -172,7 +172,7 @@ extension ConversationListViewController {
     }
 
     func updateLegalHoldIndictor() {
-        switch viewModel.selfUser.legalHoldStatus {
+        switch viewModel.selfUserLegalHoldSubject.legalHoldStatus {
         case .disabled:
             navigationItem.rightBarButtonItem = nil
         case .pending:
@@ -194,7 +194,7 @@ extension ConversationListViewController {
 
     @objc
     func presentLegalHoldRequest() {
-        guard case .pending = viewModel.selfUser.legalHoldStatus else {
+        guard case .pending = viewModel.selfUserLegalHoldSubject.legalHoldStatus else {
             return
         }
 
@@ -211,7 +211,7 @@ extension ConversationListViewController: UserStatusViewControllerDelegate {
 
         // this should be done by some use case instead of accessing the `session` and the `UserType` directly here
         viewModel.userSession.perform { [weak self] in
-            self?.viewModel.selfUser.availability = availability
+            self?.viewModel.selfUserLegalHoldSubject.availability = availability
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -71,7 +71,7 @@ final class ConversationListViewController: UIViewController {
 
     convenience init(
         account: Account,
-        selfUser: SelfUserType,
+        selfUserLegalHoldSubject: any SelfUserLegalHoldable,
         userSession: UserSession,
         isSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol,
         isFolderStatePersistenceEnabled: Bool,
@@ -79,7 +79,7 @@ final class ConversationListViewController: UIViewController {
     ) {
         let viewModel = ConversationListViewController.ViewModel(
             account: account,
-            selfUser: selfUser,
+            selfUserLegalHoldSubject: selfUserLegalHoldSubject,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: isSelfUserE2EICertifiedUseCase
         )

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel+StartUIDelegate.swift
@@ -66,7 +66,7 @@ extension ConversationListViewController.ViewModel: StartUIDelegate {
     func openUserProfile(_ user: UserType) {
         let profileViewController = ProfileViewController(
             user: user,
-            viewer: selfUser,
+            viewer: selfUserLegalHoldSubject,
             context: .profileViewer,
             userSession: userSession
         )

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ViewModel/ConversationListViewControllerViewModel.swift
@@ -66,7 +66,7 @@ extension ConversationListViewController {
             didSet { viewController?.conversationListViewControllerViewModel(self, didUpdate: selfUserStatus) }
         }
 
-        let selfUser: SelfUserType
+        let selfUserLegalHoldSubject: any SelfUserLegalHoldable
         let userSession: UserSession
         private let isSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol
         private let notificationCenter: NotificationCenter
@@ -88,16 +88,16 @@ extension ConversationListViewController {
 
         init(
             account: Account,
-            selfUser: SelfUserType,
+            selfUserLegalHoldSubject: SelfUserLegalHoldable,
             userSession: UserSession,
             isSelfUserE2EICertifiedUseCase: IsSelfUserE2EICertifiedUseCaseProtocol,
             notificationCenter: NotificationCenter = .default
         ) {
             self.account = account
-            self.selfUser = selfUser
+            self.selfUserLegalHoldSubject = selfUserLegalHoldSubject
             self.userSession = userSession
             self.isSelfUserE2EICertifiedUseCase = isSelfUserE2EICertifiedUseCase
-            selfUserStatus = .init(user: selfUser, isE2EICertified: false)
+            selfUserStatus = .init(user: selfUserLegalHoldSubject, isE2EICertified: false)
             shouldPresentNotificationPermissionHintUseCase = ShouldPresentNotificationPermissionHintUseCase()
             didPresentNotificationPermissionHintUseCase = DidPresentNotificationPermissionHintUseCase()
             self.notificationCenter = notificationCenter
@@ -124,7 +124,7 @@ extension ConversationListViewController.ViewModel {
 
         if let userSession = ZMUserSession.shared() {
             initialSyncObserverToken = ZMUserSession.addInitialSyncCompletionObserver(self, userSession: userSession)
-            userObservationToken = userSession.addUserObserver(self, for: selfUser)
+            userObservationToken = userSession.addUserObserver(self, for: selfUserLegalHoldSubject)
         }
 
         updateObserverTokensForActiveTeam()
@@ -210,7 +210,7 @@ extension ConversationListViewController.ViewModel {
         // We only want to present the notification takeover when the user already has a handle
         // and is not coming from the registration flow (where we alreday ask for permissions).
         guard
-            selfUser.handle != nil,
+            selfUserLegalHoldSubject.handle != nil,
             !isComingFromRegistration,
             !AutomationHelper.sharedHelper.skipFirstLoginAlerts
         else { return }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/LegalHoldAlertFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/LegalHoldAlertFactory.swift
@@ -26,7 +26,7 @@ typealias SuggestedStateChangeHandler = (LegalHoldDisclosureController.Disclosur
 enum LegalHoldAlertFactory {
 
     static func makeLegalHoldDeactivatedAlert(
-        for user: SelfUserType,
+        for user: SelfUserLegalHoldable,
         suggestedStateChangeHandler: SuggestedStateChangeHandler?
     ) -> UIAlertController {
         let alert = UIAlertController(
@@ -47,7 +47,7 @@ enum LegalHoldAlertFactory {
     }
 
     static func makeLegalHoldActivatedAlert(
-        for user: SelfUserType,
+        for user: SelfUserLegalHoldable,
         suggestedStateChangeHandler: SuggestedStateChangeHandler?
     ) -> UIAlertController {
         let alert = UIAlertController(
@@ -70,7 +70,7 @@ enum LegalHoldAlertFactory {
     static func makeLegalHoldActivationAlert(
         for legalHoldRequest: LegalHoldRequest,
         fingerprint: String,
-        user: SelfUserType,
+        user: SelfUserLegalHoldable,
         suggestedStateChangeHandler: SuggestedStateChangeHandler?
     ) -> UIAlertController {
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -71,7 +71,7 @@ final class ZClientViewController: UIViewController {
         )
         conversationListViewController = .init(
             account: account,
-            selfUser: userSession.selfUser,
+            selfUserLegalHoldSubject: userSession.selfUserLegalHoldSubject,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: userSession.isSelfUserE2EICertifiedUseCase,
             isFolderStatePersistenceEnabled: false,
@@ -80,7 +80,7 @@ final class ZClientViewController: UIViewController {
         // TODO [WPB-6647]: Remove this temporary instance within the navigation overhaul epic. (folder support is removed completeley)
         conversationListWithFoldersViewController = .init(
             account: account,
-            selfUser: userSession.selfUser,
+            selfUserLegalHoldSubject: userSession.selfUserLegalHoldSubject,
             userSession: userSession,
             isSelfUserE2EICertifiedUseCase: userSession.isSelfUserE2EICertifiedUseCase,
             isFolderStatePersistenceEnabled: true,
@@ -613,7 +613,7 @@ final class ZClientViewController: UIViewController {
 
     private func createLegalHoldDisclosureController() {
         legalHoldDisclosureController = LegalHoldDisclosureController(
-            selfUser: userSession.selfUser,
+            selfUserLegalHoldSubject: userSession.selfUserLegalHoldSubject,
             userSession: userSession,
             presenter: { viewController, animated, completion in
                 viewController.presentTopmost(animated: animated, completion: completion)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -64,7 +64,7 @@ final class ZClientViewController: UIViewController {
         self.userSession = userSession
 
         let selfProfileViewControllerBuilder = SelfProfileViewControllerBuilder(
-            selfUser: userSession.selfUser,
+            selfUser: userSession.editableSelfUser,
             userRightInterfaceType: UserRight.self,
             userSession: userSession,
             accountSelector: SessionManager.shared


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

- Name `SelfUserType` to `SelfUserLegalHoldable`
- Restrict access on user session `selfUser: any UserType` to a single mainly read-only protocol
- Made visible that legal hold requires different access
- Made editable user visible, currently only for Settings relevant

Access becomes clearer and easier to mock, e.g. in such cases now less attributes are available:
```swift
let team = userSession.selfUser.membership?.team
```

### Testing

- Build and run unit tests

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

