### PR TITLE
chore: CI setup ruby action  [WPB-9535]

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -158,12 +158,10 @@ jobs:
       - name: Bootstrap Carthage if no cache
         if: steps.cache-carthage.outputs.cache-hit != 'true'
         run: ./scripts/carthage.sh bootstrap --platform ios --use-xcframeworks
-      - name: Restore Bundler Cache
-        uses: actions/cache@v4
-        id: cache-bundler
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('Gemfile.lock') }}
+          bundler-cache: true
       - name: Run setup
         run: sh ./setup.sh
       - name: Configure AWS Credentials

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -111,13 +111,6 @@ jobs:
         if: steps.cache-carthage.outputs.cache-hit != 'true'
         run: ./scripts/carthage.sh bootstrap --platform ios --use-xcframeworks
 
-      - name: Restore Bundler Cache
-        uses: actions/cache@v3
-        id: cache-bundler
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-bundler-${{ hashFiles('Gemfile.lock') }}
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -118,6 +118,11 @@ jobs:
           path: vendor/bundle
           key: ${{ runner.os }}-bundler-${{ hashFiles('Gemfile.lock') }}
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
       - name: Setup workspace
         run: |
           ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -80,8 +80,12 @@ echo "ℹ️  Fetching submodules..."
 echo ""
 
 echo "ℹ️  Installing bundler and Ruby dependencies..."
-which bundle || gem install bundler
-bundle check || bundle install
+if [[ -n "${CI-}" ]]; then # skip cache bootstrap for CI
+    echo "Skipping install since CI is defined"
+else
+    which bundle || gem install bundler
+    bundle check || bundle install
+fi
 echo ""
 
 echo "ℹ️  Overriding configuration if specified..."


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9535" title="WPB-9535" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9535</a>  [iOS] use official ruby GitHub action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

To use the ruby action in our workflows will solve the dependency on CirrusCI preinstalled ruby version, that can change with automated template updates. Instead the given local `.ruby-version` file is read and used.

Thanks for pointing to this in https://github.com/cirruslabs/macos-image-templates/issues/158

### Testing

- Run multiple workflow actions
  - `Test Develop` https://github.com/wireapp/wire-ios/actions/workflows/test_develop.yml
  - `Playground` https://github.com/wireapp/wire-ios/actions/workflows/playground.yml
- See if the cache is created and stored
- See if the cache is used next time

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

