### PR TITLE
fix: `Double-quoted  in framework header, expected angle-bracketed instead` warning in Objective-C headers

### DIFF
--- a/wire-ios-data-model/Source/ConversationList/ZMConversationList+Internal.h
+++ b/wire-ios-data-model/Source/ConversationList/ZMConversationList+Internal.h
@@ -17,7 +17,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "ZMConversationList.h"
+#import <WireDataModel/ZMConversationList.h>
 
 @class NSManagedObjectContext;
 @class NSFetchRequest;

--- a/wire-ios-data-model/Source/Model/Connection/ZMConnection+Internal.h
+++ b/wire-ios-data-model/Source/Model/Connection/ZMConnection+Internal.h
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMConnection.h"
-#import "ZMManagedObject+Internal.h"
+#import <WireDataModel/ZMConnection.h>
+#import <WireDataModel/ZMManagedObject+Internal.h>
 
 @class ZMConversation;
 @class ZMUser;

--- a/wire-ios-data-model/Source/Model/Connection/ZMConnection.h
+++ b/wire-ios-data-model/Source/Model/Connection/ZMConnection.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMManagedObject.h"
+#import <WireDataModel/ZMManagedObject.h>
 
 @class ZMUser;
 @class ZMConversation;

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Internal.h
@@ -16,11 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMConversation.h"
-#import "ZMManagedObject+Internal.h"
-#import "ZMMessage.h"
-#import "ZMConnection.h"
-#import "ZMConversationSecurityLevel.h"
+#import <WireDataModel/ZMConversation.h>
+#import <WireDataModel/ZMManagedObject+Internal.h>
+#import <WireDataModel/ZMMessage.h>
+#import <WireDataModel/ZMConnection.h>
+#import <WireDataModel/ZMConversationSecurityLevel.h>
 
 @import WireImages;
 

--- a/wire-ios-data-model/Source/Model/Message/ZMMessage+Internal.h
+++ b/wire-ios-data-model/Source/Model/Message/ZMMessage+Internal.h
@@ -20,9 +20,9 @@
 @import WireProtos;
 @import WireTransport;
 
-#import "ZMMessage.h"
-#import "ZMManagedObject+Internal.h"
-#import "ZMFetchRequestBatch.h"
+#import <WireDataModel/ZMMessage.h>
+#import <WireDataModel/ZMManagedObject+Internal.h>
+#import <WireDataModel/ZMFetchRequestBatch.h>
 
 @class ZMUser;
 @class Reaction;

--- a/wire-ios-data-model/Source/Model/Message/ZMOTRMessage.h
+++ b/wire-ios-data-model/Source/Model/Message/ZMOTRMessage.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMMessage+Internal.h"
+#import <WireDataModel/ZMMessage+Internal.h>
 
 @class UserClient;
 @class MessageUpdateResult;

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Internal.h
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Internal.h
@@ -18,10 +18,10 @@
 
 @import WireImages;
 
-#import "ZMUser.h"
-#import "ZMEditableUserType.h"
-#import "ZMManagedObject+Internal.h"
-#import "ZMUser+OneOnOne.h"
+#import <WireDataModel/ZMUser.h>
+#import <WireDataModel/ZMEditableUserType.h>
+#import <WireDataModel/ZMManagedObject+Internal.h>
+#import <WireDataModel/ZMUser+OneOnOne.h>
 
 @class ZMConnection;
 @class Team;

--- a/wire-ios-data-model/Source/Public/ZMConversation.h
+++ b/wire-ios-data-model/Source/Public/ZMConversation.h
@@ -18,8 +18,8 @@
 
 @import WireSystem;
 
-#import "ZMManagedObject.h"
-#import "ZMMessage.h"
+#import <WireDataModel/ZMManagedObject.h>
+#import <WireDataModel/ZMMessage.h>
 
 @class ZMUser;
 @class ZMMessage;

--- a/wire-ios-data-model/Source/Public/ZMMessage.h
+++ b/wire-ios-data-model/Source/Public/ZMMessage.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMManagedObject.h"
+#import <WireDataModel/ZMManagedObject.h>
 #import <CoreGraphics/CoreGraphics.h>
 
 @class ZMUser;

--- a/wire-ios-data-model/Source/Public/ZMUser+OneOnOne.h
+++ b/wire-ios-data-model/Source/Public/ZMUser+OneOnOne.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMUser.h"
+#import <WireDataModel/ZMUser.h>
 
 @class Team;
 

--- a/wire-ios-data-model/Source/Public/ZMUser.h
+++ b/wire-ios-data-model/Source/Public/ZMUser.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMManagedObject.h"
+#import <WireDataModel/ZMManagedObject.h>
 @import WireUtilities;
 
 @class ZMConversation;

--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,24 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AppAuth",
-        "repositoryURL": "https://github.com/openid/AppAuth-iOS.git",
-        "state": {
-          "branch": null,
-          "revision": "71cde449f13d453227e687458144bde372d30fc7",
-          "version": "1.6.2"
-        }
-      },
-      {
-        "package": "DifferenceKit",
-        "repositoryURL": "https://github.com/wireapp/DifferenceKit",
-        "state": {
-          "branch": null,
-          "revision": "eaf29c583df322d1d7c4c72c46a59eeb33bb54bf",
-          "version": "1.3.0"
-        }
-      },
-      {
         "package": "PINCache",
         "repositoryURL": "https://github.com/pinterest/PINCache",
         "state": {

--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "AppAuth",
+        "repositoryURL": "https://github.com/openid/AppAuth-iOS.git",
+        "state": {
+          "branch": null,
+          "revision": "71cde449f13d453227e687458144bde372d30fc7",
+          "version": "1.6.2"
+        }
+      },
+      {
+        "package": "DifferenceKit",
+        "repositoryURL": "https://github.com/wireapp/DifferenceKit",
+        "state": {
+          "branch": null,
+          "revision": "eaf29c583df322d1d7c4c72c46a59eeb33bb54bf",
+          "version": "1.3.0"
+        }
+      },
+      {
         "package": "PINCache",
         "repositoryURL": "https://github.com/pinterest/PINCache",
         "state": {

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.h
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.h
@@ -18,8 +18,8 @@
 
 @import Foundation;
 @import WireTransport;
-#import "ZMSingleRequestSync.h"
-#import "ZMRequestGenerator.h"
+#import <WireRequestStrategy/ZMSingleRequestSync.h>
+#import <WireRequestStrategy/ZMRequestGenerator.h>
 
 @protocol ZMSimpleListRequestPaginatorSync;
 

--- a/wire-ios-request-strategy/Sources/Image Preprocessing/ZMImagePreprocessingTracker+Testing.h
+++ b/wire-ios-request-strategy/Sources/Image Preprocessing/ZMImagePreprocessingTracker+Testing.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMImagePreprocessingTracker.h"
+#import <WireRequestStrategy/ZMImagePreprocessingTracker.h>
 
 @class ZMAssetsPreprocessor;
 

--- a/wire-ios-request-strategy/Sources/Image Preprocessing/ZMImagePreprocessingTracker.h
+++ b/wire-ios-request-strategy/Sources/Image Preprocessing/ZMImagePreprocessingTracker.h
@@ -19,8 +19,8 @@
 @import Foundation;
 @import WireImages;
 
-#import "ZMContextChangeTracker.h"
-#import "ZMOutstandingItems.h"
+#import <WireRequestStrategy/ZMContextChangeTracker.h>
+#import <WireRequestStrategy/ZMOutstandingItems.h>
 
 @protocol ZMAssetsPreprocessor;
 @class ZMImageMessage;

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMChangeTrackerBootstrap+Testing.h
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMChangeTrackerBootstrap+Testing.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMChangeTrackerBootstrap.h"
+#import <WireRequestStrategy/ZMChangeTrackerBootstrap.h>
 @protocol ZMContextChangeTracker;
 
 @interface ZMChangeTrackerBootstrap ()

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMRemoteIdentifierObjectSync.h
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMRemoteIdentifierObjectSync.h
@@ -17,7 +17,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "ZMRequestGenerator.h"
+#import <WireRequestStrategy/ZMRequestGenerator.h>
 
 @class ZMRemoteIdentifierObjectSync;
 @class ZMTransportRequest;

--- a/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamInsertedObjectSync.h
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Upstream/ZMUpstreamInsertedObjectSync.h
@@ -18,7 +18,7 @@
 
 @import Foundation;
 
-#import "ZMContextChangeTracker.h"
+#import <WireRequestStrategy/ZMContextChangeTracker.h>
 #import <WireRequestStrategy/ZMRequestGenerator.h>
 
 @protocol ZMTransportData;

--- a/wire-ios-request-strategy/Sources/Protocols/ZMObjectSyncStrategy.h
+++ b/wire-ios-request-strategy/Sources/Protocols/ZMObjectSyncStrategy.h
@@ -20,8 +20,8 @@
 @import WireDataModel;
 @import WireSystem;
 
-#import "ZMRequestGenerator.h"
-#import "ZMContextChangeTracker.h"
+#import <WireRequestStrategy/ZMRequestGenerator.h>
+#import <WireRequestStrategy/ZMContextChangeTracker.h>
 
 @class ZMTransportRequest;
 @class ZMSyncStrategy;

--- a/wire-ios-request-strategy/Sources/Request Strategies/Base Strategies/ZMAbstractRequestStrategy.h
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Base Strategies/ZMAbstractRequestStrategy.h
@@ -18,8 +18,8 @@
 
 @import Foundation;
 
-#import "ZMStrategyConfigurationOption.h"
-#import "RequestStrategy.h"
+#import <WireRequestStrategy/ZMStrategyConfigurationOption.h>
+#import <WireRequestStrategy/RequestStrategy.h>
 
 @class ZMTransportRequest;
 @class NSManagedObjectContext;

--- a/wire-ios-sync-engine/Source/Synchronization/ZMOperationLoop+Private.h
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMOperationLoop+Private.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "ZMOperationLoop.h"
+#import <WireSyncEngine/ZMOperationLoop.h>
 
 @class APSSignalingKeysStore;
 @class ZMSyncStrategy;

--- a/wire-ios-sync-engine/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
+++ b/wire-ios-sync-engine/Source/UnauthenticatedSession/ZMAuthenticationStatus.h
@@ -19,7 +19,7 @@
 @import Foundation;
 @import CoreData;
 
-#import "NSError+ZMUserSession.h"
+#import <WireSyncEngine/NSError+ZMUserSession.h>
 
 @class UserInfo;
 @class ZMCredentials;

--- a/wire-ios-sync-engine/Source/UserSession/NSError+ZMUserSessionInternal.h
+++ b/wire-ios-sync-engine/Source/UserSession/NSError+ZMUserSessionInternal.h
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import "NSError+ZMUserSession.h"
+#import <WireSyncEngine/NSError+ZMUserSession.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

With this PR we fix a bunch of `Double-quoted  in framework header, expected angle-bracketed instead` warnings throughout the codebase. 

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

