### PR TITLE
fix: crash accessing callSnapshots WPB-9549

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -369,6 +369,7 @@ extension WireCallCenterV3 {
     }
 
     func handleActiveSpeakersChange(conversationId: AVSIdentifier, data: String) {
+        // TODO: - refactor to avoid processing call data on the UI context WPB-9604
         handleEventInContext("active-speakers-change") {
 
             guard let data = data.data(using: .utf8) else {

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -369,7 +369,7 @@ extension WireCallCenterV3 {
     }
 
     func handleActiveSpeakersChange(conversationId: AVSIdentifier, data: String) {
-        // TODO: - refactor to avoid processing call data on the UI context https://wearezeta.atlassian.net/browse/WPB-9604
+        // TODO: - refactor to avoid processing call data on the UI context [WPB-9604]
         handleEventInContext("active-speakers-change") {
 
             guard let data = data.data(using: .utf8) else {

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -369,7 +369,7 @@ extension WireCallCenterV3 {
     }
 
     func handleActiveSpeakersChange(conversationId: AVSIdentifier, data: String) {
-        // TODO: - refactor to avoid processing call data on the UI context [WPB-9604]
+        // TODO [WPB-9604]: - refactor to avoid processing call data on the UI context 
         handleEventInContext("active-speakers-change") {
 
             guard let data = data.data(using: .utf8) else {

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -369,7 +369,7 @@ extension WireCallCenterV3 {
     }
 
     func handleActiveSpeakersChange(conversationId: AVSIdentifier, data: String) {
-        // TODO: - refactor to avoid processing call data on the UI context WPB-9604
+        // TODO: - refactor to avoid processing call data on the UI context https://wearezeta.atlassian.net/browse/WPB-9604
         handleEventInContext("active-speakers-change") {
 
             guard let data = data.data(using: .utf8) else {

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -369,43 +369,44 @@ extension WireCallCenterV3 {
     }
 
     func handleActiveSpeakersChange(conversationId: AVSIdentifier, data: String) {
-        guard let data = data.data(using: .utf8) else {
-            WireLogger.calling.error("Invalid active speakers data", attributes: .safePublic)
-            return
-        }
+        handleEventInContext("active-speakers-change") {
 
-        // Example of `data`
-        //  {
-        //      "audio_levels": [
-        //          {
-        //              "userid": "3f49da1d-0d52-4696-9ef3-0dd181383e8a",
-        //              "clientid": "24cc758f602fb1f4",
-        //              "audio_level": 100,
-        //              "audio_level_now": 100
-        //          }
-        //      ]
-        // }
+            guard let data = data.data(using: .utf8) else {
+                WireLogger.calling.error("Invalid active speakers data", attributes: .safePublic)
+                return
+            }
 
-        do {
-            let change = try self.decoder.decode(AVSActiveSpeakersChange.self, from: data)
+            // Example of `data`
+            //  {
+            //      "audio_levels": [
+            //          {
+            //              "userid": "3f49da1d-0d52-4696-9ef3-0dd181383e8a",
+            //              "clientid": "24cc758f602fb1f4",
+            //              "audio_level": 100,
+            //              "audio_level_now": 100
+            //          }
+            //      ]
+            // }
 
-            if let call = self.callSnapshots[conversationId] {
+            do {
+                let change = try self.decoder.decode(AVSActiveSpeakersChange.self, from: data)
 
-                self.callSnapshots[conversationId] = call.updateActiveSpeakers(change.activeSpeakers)
+                if let call = self.callSnapshots[conversationId] {
 
-                guard self.isSignificantActiveSpeakersChange(
-                    change: change,
-                    in: call
-                ) else {
-                    return
-                }
+                    self.callSnapshots[conversationId] = call.updateActiveSpeakers(change.activeSpeakers)
 
-                handleEventInContext("active-speakers-change") {
+                    guard self.isSignificantActiveSpeakersChange(
+                        change: change,
+                        in: call
+                    ) else {
+                        return
+                    }
+
                     WireCallCenterActiveSpeakersNotification().post(in: $0.notificationContext)
                 }
+            } catch {
+                WireLogger.calling.error("Cannot decode active speakers change JSON", attributes: .safePublic)
             }
-        } catch {
-            WireLogger.calling.error("Cannot decode active speakers change JSON", attributes: .safePublic)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9549" title="WPB-9549" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9549</a>  Crash on calling 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The app crashes when accessing the `callSnapshots` dictionary due to a concurrency issue introduced when moving code processing the active speakers change (in `handleActiveSpeakersChange`) out of the main thread (out of the `handleEventInContext` block)

**Solution:** move the code back into `handleEventInContext`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

