### PR TITLE
fix: datadog map keys

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -127,7 +127,7 @@ public final class DatadogWrapper {
                 partialResult[item.key.rawValue] = item.value
             }
         }
-        plainAttributes["build_number"] = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        plainAttributes["build_number"] = bundleVersion
 
         logger?.log(
             level: level,

--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -122,9 +122,12 @@ public final class DatadogWrapper {
         error: Error? = nil,
         attributes: [LogAttributes] = []
     ) {
-        let mergedAttributes = self.flattenArray(attributes)
-        var plainAttributes = mergedAttributes.mapKeys({ key  in key.rawValue })
-        plainAttributes["build_number"] = bundleVersion
+        var plainAttributes: [String: any Encodable] = attributes.reduce(into: [:]) { partialResult, attribute in
+            attribute.forEach { item in
+                partialResult[item.key.rawValue] = item.value
+            }
+        }
+        plainAttributes["build_number"] = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
 
         logger?.log(
             level: level,


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

The used func `mapKeys` was removed with https://github.com/wireapp/wire-ios/pull/1492/files but through merge conflict still existed here.

### Testing

- Build `develop` via GitHub Actions

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

