### PR TITLE
fix: persist logs across runs - WPB-9714

### DIFF
--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CocoaLumberjack",
+        "repositoryURL": "https://github.com/CocoaLumberjack/CocoaLumberjack",
+        "state": {
+          "branch": null,
+          "revision": "4b8714a7fb84d42393314ce897127b3939885ec3",
+          "version": "3.8.5"
+        }
+      },
+      {
         "package": "DifferenceKit",
         "repositoryURL": "https://github.com/wireapp/DifferenceKit/",
         "state": {
@@ -44,6 +53,15 @@
           "branch": null,
           "revision": "bf73a16e7409a83c38872726e45e4f432512315e",
           "version": "4.0.8"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log",
+        "state": {
+          "branch": null,
+          "revision": "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+          "version": "1.5.4"
         }
       },
       {

--- a/wire-ios-system/Source/Logging/AggregatedLogger.swift
+++ b/wire-ios-system/Source/Logging/AggregatedLogger.swift
@@ -69,12 +69,6 @@ public class AggregatedLogger: LoggerProtocol {
         }
     }
 
-    public func persist(fileDestination: FileLoggerDestination) async {
-        for logger in loggers {
-            await logger.persist(fileDestination: fileDestination)
-        }
-    }
-
     public func addTag(_ key: LogAttributesKey, value: String?) {
         loggers.forEach {
             $0.addTag(key, value: value)

--- a/wire-ios-system/Source/Logging/AggregatedLogger.swift
+++ b/wire-ios-system/Source/Logging/AggregatedLogger.swift
@@ -25,6 +25,10 @@ public class AggregatedLogger: LoggerProtocol {
         self.loggers = loggers
     }
 
+    public var logFiles: [URL] {
+        return loggers.reduce(into: [], { $0 += $1.logFiles })
+    }
+
     public func addLogger(_ logger: LoggerProtocol) {
         self.loggers.append(logger)
     }

--- a/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
+++ b/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
@@ -23,7 +23,7 @@ import CocoaLumberjackSwift
 public class CocoaLumberjackLogger: LoggerProtocol {
 
     private let fileLogger: DDFileLogger = DDFileLogger() // File Logger
- 
+
     init() {
         fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours
         fileLogger.maximumFileSize = 100_000_000 // 100Mb

--- a/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
+++ b/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
@@ -62,7 +62,6 @@ public class CocoaLumberjackLogger: LoggerProtocol {
     private func log(_ message: LogConvertible, attributes: LogAttributes?, level: DDLogLevel) {
         var entry = "\(message.logDescription)\(attributesDescription(from: attributes))"
 
-
         if let tag = attributes?["tag"] as? String {
             entry = "[\(tag)] - \(entry)"
         }
@@ -74,16 +73,4 @@ public class CocoaLumberjackLogger: LoggerProtocol {
     public func addTag(_ key: LogAttributesKey, value: String?) {
         // do nothing
     }
-
-    public func persist(fileDestination: FileLoggerDestination) async {
-        // do nothing
-    }
-}
-
-private func attributesDescription(from attributes: LogAttributes?) -> String {
-    var logAttributes = attributes
-    // drop attributes used for visibility and category
-    logAttributes?.removeValue(forKey: "public")
-    logAttributes?.removeValue(forKey: "tag")
-    return logAttributes?.isEmpty == false ? " - \(logAttributes!.description)" : ""
 }

--- a/wire-ios-system/Source/Logging/LegacyLogger.swift
+++ b/wire-ios-system/Source/Logging/LegacyLogger.swift
@@ -25,7 +25,6 @@ public class LegacyLogger: LoggerProtocol {
         return []
     }
 
-
     private var loggers = [String: ZMSLog]()
 
     subscript(tag: String) -> ZMSLog {

--- a/wire-ios-system/Source/Logging/LegacyLogger.swift
+++ b/wire-ios-system/Source/Logging/LegacyLogger.swift
@@ -73,8 +73,4 @@ public class LegacyLogger: LoggerProtocol {
     public func addTag(_ key: LogAttributesKey, value: String?) {
         // do nothing
     }
-
-    public func persist(fileDestination: FileLoggerDestination) async {
-        // do nothing
-    }
 }

--- a/wire-ios-system/Source/Logging/SystemLogger.swift
+++ b/wire-ios-system/Source/Logging/SystemLogger.swift
@@ -27,6 +27,10 @@ struct SystemLogger: LoggerProtocol {
 
     let persistQueue = DispatchQueue(label: "persistQueue")
 
+    var logFiles: [URL] {
+        return []
+    }
+
     var lastReportTime: Date? {
         get {
             guard let interval = UserDefaults.standard.object(forKey: "com.wire.log.lastReportTime") as? TimeInterval else { return nil }

--- a/wire-ios-system/Source/Logging/SystemLogger.swift
+++ b/wire-ios-system/Source/Logging/SystemLogger.swift
@@ -41,31 +41,6 @@ struct SystemLogger: LoggerProtocol {
         }
     }
 
-    var fileLogger = FileLogger()
-
-    func persist(fileDestination: FileLoggerDestination) async {
-        var entries: [String] = []
-
-        do {
-            let store = try OSLogStore(scope: .currentProcessIdentifier)
-            let position: OSLogPosition
-            if let lastReportTime {
-                position = store.position(date: lastReportTime)
-            } else {
-                position = store.position(timeIntervalSinceLatestBoot: 0)
-            }
-            entries = try store
-                .getEntries(at: position)
-                .compactMap { $0 as? OSLogEntryLog }
-                .filter { $0.subsystem == Bundle.main.bundleIdentifier! }
-                .map { "[\($0.date.formatted(.iso8601))] [\($0.category)] \($0.composedMessage)" }
-        } catch {
-            warn(error.localizedDescription, attributes: .safePublic)
-        }
-
-        fileLogger.write(entries: entries, to: fileDestination.log)
-    }
-
     func debug(_ message: LogConvertible, attributes: LogAttributes?) {
         log(message, attributes: attributes, osLogType: .debug)
     }
@@ -108,53 +83,6 @@ struct SystemLogger: LoggerProtocol {
             os_log(osLogType, log: logger, "\(message)")
         }
     }
-
-    private func attributesDescription(from attributes: LogAttributes?) -> String {
-        var logAttributes = attributes
-        // drop attributes used for visibility and category
-        logAttributes?.removeValue(forKey: "public")
-        logAttributes?.removeValue(forKey: "tag")
-        return logAttributes?.isEmpty == false ? " - \(logAttributes!.description)" : ""
-    }
 }
 
 private var loggers: [String: OSLog] = [:]
-
-public class FileLogger {
-
-    var updatingHandle: FileHandle?
-
-    func write(entries: [String], to url: URL?) {
-        guard let currentLogPath = url?.path else { return }
-
-        let manager = FileManager.default
-
-        if !manager.fileExists(atPath: currentLogPath) {
-            manager.createFile(atPath: currentLogPath, contents: nil, attributes: nil)
-            // if there was no file, force to recreate the fileHandle
-            updatingHandle = nil
-        }
-
-        if updatingHandle == nil {
-            updatingHandle = FileHandle(forUpdatingAtPath: currentLogPath)
-            updatingHandle?.seekToEndOfFile()
-        }
-
-        do {
-            if let data = entries.joined(separator: "\n").data(using: .utf8) {
-                try updatingHandle?.write(contentsOf: data)
-            }
-        } catch {
-            updatingHandle = nil
-        }
-    }
-
-    func closeFile() {
-        updatingHandle?.closeFile()
-        updatingHandle = nil
-    }
-
-    deinit {
-        closeFile()
-    }
-}

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -156,7 +156,6 @@ public protocol LoggerProtocol {
     func error(_ message: LogConvertible, attributes: LogAttributes?)
     func critical(_ message: LogConvertible, attributes: LogAttributes?)
 
-    
     var logFiles: [URL] { get }
 
     /// Add an attribute, value to each logs - DataDog only

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -19,16 +19,19 @@
 import Foundation
 
 public struct WireLogger: LoggerProtocol {
+    public var logFiles: [URL]
+
     public func addTag(_ key: LogAttributesKey, value: String?) {
         Self.provider?.addTag(key, value: value)
     }
 
-    public static var provider: LoggerProtocol? = AggregatedLogger(loggers: [SystemLogger()])
+    public static var provider: LoggerProtocol? = AggregatedLogger(loggers: [SystemLogger(), CocoaLumberjackLogger()])
 
     public let tag: String
 
     public init(tag: String = "") {
         self.tag = tag
+        self.logFiles = []
     }
 
     public func debug(
@@ -155,6 +158,7 @@ public protocol LoggerProtocol {
     func critical(_ message: LogConvertible, attributes: LogAttributes?)
 
     func persist(fileDestination: FileLoggerDestination) async
+    var logFiles: [URL] { get }
 
     /// Add an attribute, value to each logs - DataDog only
     func addTag(_ key: LogAttributesKey, value: String?)

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -19,11 +19,6 @@
 import Foundation
 
 public struct WireLogger: LoggerProtocol {
-    public var logFiles: [URL]
-
-    public func addTag(_ key: LogAttributesKey, value: String?) {
-        Self.provider?.addTag(key, value: value)
-    }
 
     public static var provider: LoggerProtocol? = AggregatedLogger(loggers: [SystemLogger(), CocoaLumberjackLogger()])
 
@@ -31,7 +26,14 @@ public struct WireLogger: LoggerProtocol {
 
     public init(tag: String = "") {
         self.tag = tag
-        self.logFiles = []
+    }
+
+    public var logFiles: [URL] {
+        Self.provider?.logFiles ?? []
+    }
+
+    public func addTag(_ key: LogAttributesKey, value: String?) {
+        Self.provider?.addTag(key, value: value)
     }
 
     public func debug(

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -128,7 +128,6 @@ public struct WireLogger: LoggerProtocol {
         case critical
 
     }
-
 }
 
 public typealias LogAttributes = [String: Encodable]
@@ -157,7 +156,7 @@ public protocol LoggerProtocol {
     func error(_ message: LogConvertible, attributes: LogAttributes?)
     func critical(_ message: LogConvertible, attributes: LogAttributes?)
 
-    func persist(fileDestination: FileLoggerDestination) async
+    
     var logFiles: [URL] { get }
 
     /// Add an attribute, value to each logs - DataDog only
@@ -165,8 +164,14 @@ public protocol LoggerProtocol {
 }
 
 extension LoggerProtocol {
+    func attributesDescription(from attributes: LogAttributes?) -> String {
+        var logAttributes = attributes
+        // drop attributes used for visibility and category
+        logAttributes?.removeValue(forKey: "public")
+        logAttributes?.removeValue(forKey: "tag")
+        return logAttributes?.isEmpty == false ? " - \(logAttributes!.description)" : ""
+    }
 
-    public func persist(fileDestination: FileLoggerDestination) async {}
 }
 
 public protocol LogConvertible {

--- a/wire-ios-system/Source/ZMSLog.swift
+++ b/wire-ios-system/Source/ZMSLog.swift
@@ -329,7 +329,12 @@ extension ZMSLog {
     }
 
     static public var pathsForExistingLogs: [URL] {
-        var paths: [URL] = previousZipLogURLs
+        var paths: [URL] = []
+        previousZipLogURLs.forEach { url in
+            if FileManager.default.fileExists(atPath: url.path) {
+                paths.append(url)
+            }
+        }
         if let assertionFile = ZMLastAssertionFile(), FileManager.default.fileExists(atPath: assertionFile.path) {
             paths.append(assertionFile)
         }

--- a/wire-ios-system/WireSystem.xcodeproj/project.pbxproj
+++ b/wire-ios-system/WireSystem.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		013404E22B5E762A00D2D2D5 /* AggregatedLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013404E12B5E762A00D2D2D5 /* AggregatedLogger.swift */; };
 		013404E42B5F162D00D2D2D5 /* LegacyLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013404E32B5F162D00D2D2D5 /* LegacyLogger.swift */; };
+		018B81AB2C1B3BCD006678D0 /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 018B81AA2C1B3BCD006678D0 /* CocoaLumberjackSwift */; };
+		018B81AD2C1B3BF6006678D0 /* CocoaLumberjackLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018B81AC2C1B3BF6006678D0 /* CocoaLumberjackLogger.swift */; };
 		01CB030E2A0CED010000CFF2 /* WireLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CB030C2A0CED010000CFF2 /* WireLogger.swift */; };
 		01CB030F2A0CED010000CFF2 /* Flow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CB030D2A0CED010000CFF2 /* Flow.swift */; };
 		096A3A211B67CEF700565001 /* ZMSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 096A3A1D1B67CEF700565001 /* ZMSLogging.m */; };
@@ -72,6 +74,7 @@
 /* Begin PBXFileReference section */
 		013404E12B5E762A00D2D2D5 /* AggregatedLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregatedLogger.swift; sourceTree = "<group>"; };
 		013404E32B5F162D00D2D2D5 /* LegacyLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyLogger.swift; sourceTree = "<group>"; };
+		018B81AC2C1B3BF6006678D0 /* CocoaLumberjackLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocoaLumberjackLogger.swift; sourceTree = "<group>"; };
 		01CB030C2A0CED010000CFF2 /* WireLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireLogger.swift; sourceTree = "<group>"; };
 		01CB030D2A0CED010000CFF2 /* Flow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Flow.swift; sourceTree = "<group>"; };
 		092758691B70E68F00AD5A78 /* WireSystem.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WireSystem.xcconfig; sourceTree = "<group>"; };
@@ -138,6 +141,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				018B81AB2C1B3BCD006678D0 /* CocoaLumberjackSwift in Frameworks */,
 				E6B58E412B21D8920046B6E1 /* ZipArchive.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -161,6 +165,7 @@
 				16BBA1EF2AF2611000CDF38A /* SystemLogger.swift */,
 				013404E32B5F162D00D2D2D5 /* LegacyLogger.swift */,
 				013404E12B5E762A00D2D2D5 /* AggregatedLogger.swift */,
+				018B81AC2C1B3BF6006678D0 /* CocoaLumberjackLogger.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -351,6 +356,9 @@
 			dependencies = (
 			);
 			name = WireSystem;
+			packageProductDependencies = (
+				018B81AA2C1B3BCD006678D0 /* CocoaLumberjackSwift */,
+			);
 			productName = SyncEngineSystem;
 			productReference = 3ECC35191AD436750089FD4B /* WireSystem.framework */;
 			productType = "com.apple.product-type.framework";
@@ -401,6 +409,9 @@
 				Base,
 			);
 			mainGroup = 3ECC34C31AD430BB0089FD4B;
+			packageReferences = (
+				018B81A92C1B3BCD006678D0 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
+			);
 			productRefGroup = 3ECC34E61AD433520089FD4B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -474,6 +485,7 @@
 				544CFC511B70B933007AA694 /* ZMSLog.swift in Sources */,
 				59059B9B2B4DBA1D0087D1F1 /* SystemDateProvider.swift in Sources */,
 				01CB030F2A0CED010000CFF2 /* Flow.swift in Sources */,
+				018B81AD2C1B3BF6006678D0 /* CocoaLumberjackLogger.swift in Sources */,
 				8701221620F64171001E6342 /* Cache.swift in Sources */,
 				01CB030E2A0CED010000CFF2 /* WireLogger.swift in Sources */,
 				16BBA1F02AF2611000CDF38A /* SystemLogger.swift in Sources */,
@@ -624,6 +636,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		018B81A92C1B3BCD006678D0 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/CocoaLumberjack/CocoaLumberjack";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.8.5;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		018B81AA2C1B3BCD006678D0 /* CocoaLumberjackSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 018B81A92C1B3BCD006678D0 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */;
+			productName = CocoaLumberjackSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3ECC34C41AD430BB0089FD4B /* Project object */;
 }

--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -241,6 +241,11 @@ extension RemoteMonitoring.Level {
 }
 
 extension DatadogWrapper: WireSystem.LoggerProtocol {
+
+    public var logFiles: [URL] {
+        return []
+    }
+
     public func debug(_ message: LogConvertible, attributes: LogAttributes?) {
         log(level: .debug, message: message.logDescription, attributes: attributes)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/MFMailComposeViewController+Logs.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/MFMailComposeViewController+Logs.swift
@@ -70,38 +70,14 @@ extension MFMailComposeViewController {
                 try? FileManager.default.removeItem(at: url)
             }
         }
-        // save current logs to file in order to send them
-        await WireLogger.provider?.persist(fileDestination: LogFileDestination.main)
 
-        for destination in LogFileDestination.allCases {
-            if let data = FileManager.default.zipData(from: destination.log) {
-                addAttachmentData(data, mimeType: "application/zip", fileName: "\(destination.filename).zip")
-            } else {
-                WireLogger.system.debug("no logs for WireLogger to send \(destination.filename)")
-            }
-        }
+        var logFiles = WireLogger.provider?.logFiles ?? []
+        logFiles.append(contentsOf: ZMSLog.pathsForExistingLogs)
 
-        if let crashLog = ZMLastAssertionFile(),
-           FileManager.default.fileExists(atPath: crashLog.path) {
-            do {
-                let data = try Data(contentsOf: crashLog)
-                addAttachmentData(data, mimeType: "text/plain", fileName: "last_crash.log")
-            } catch {
-                // ignore error for now, it's possible a file does not exist.
-            }
-        }
-
-        if let currentLog = ZMSLog.currentZipLog {
-            addAttachmentData(currentLog, mimeType: "application/zip", fileName: "current.log.zip")
-        }
-
-        ZMSLog.previousZipLogURLs.forEach { url in
-            do {
-                let data = try Data(contentsOf: url)
-                addAttachmentData(data, mimeType: "application/zip", fileName: url.lastPathComponent)
-            } catch {
-                // ignore error for now, it's possible a file does not exist.
-            }
+        if let data = FileManager.default.zipData(from: logFiles) {
+            addAttachmentData(data, mimeType: "application/zip", fileName: "logs.zip")
+        } else {
+            WireLogger.system.debug("no logs for WireLogger to send \(logFiles.description)")
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9714" title="WPB-9714" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9714</a>  Fix implementation of logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Current default logger (based on os_log) doesn't allow to keep logs through runs. See for more [info](https://developer.apple.com/forums/thread/705868)

* Introduce new logger based on [CocoaLumberjack logger](https://github.com/CocoaLumberjack/CocoaLumberjack)
* Refactor logs sending to send only one zip of logs (containing previous logs of previous loggers)

### Testing

* Content of logs.zip attached to the mail
<img width="408" alt="Screenshot 2024-06-14 at 08 51 42" src="https://github.com/wireapp/wire-ios/assets/254198/9747d131-de84-4b28-b337-54d221278607">

* Log extract:
<img width="856" alt="Screenshot 2024-06-14 at 08 52 07" src="https://github.com/wireapp/wire-ios/assets/254198/7146508f-2a48-40b1-869f-100b9b4b8ad6">

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

