### PR TITLE
fix: call processes events twice - WPB-9413

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/CallingRequestStrategy.swift
@@ -240,11 +240,6 @@ public final class CallingRequestStrategy: AbstractRequestStrategy, ZMSingleRequ
         events.forEach(processEvent)
     }
 
-    public func processEventsWhileInBackground(_ events: [ZMUpdateEvent]) {
-        Self.logger.trace("process events while in background: \(events)")
-        events.forEach(processEvent)
-    }
-
     private func processEvent(_ event: ZMUpdateEvent) {
         let serverTimeDelta = managedObjectContext.serverTimeDelta
         guard event.type.isOne(of: [.conversationOtrMessageAdd, .conversationMLSMessageAdd]) else { return }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/CallingRequestStrategyTests.swift
@@ -672,7 +672,7 @@ class CallingRequestStrategyTests: MessagingTest {
 
         // WHEN
         syncMOC.performAndWait {
-            sut.processEventsWhileInBackground([updateEvent])
+            sut.processEvents([updateEvent], liveEvents: false, prefetchResult: nil)
         }
 
         // THEN


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9413" title="WPB-9413" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9413</a>  [iOS] Simulator call crashes app after other participant enables video
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

1-1 calls processed events twice. This lead to several issues.

💡 This is a subset of https://github.com/wireapp/wire-ios/pull/1559/files#r1639803884 to merge in release!


### Testing

- Regression test 1-1 calls
- Regression test group calls

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

