### PR TITLE
fix: missing messages - WPB-9221

### DIFF
--- a/wire-ios-data-model/Source/Utilis/LastUpdateEventIDRepository.swift
+++ b/wire-ios-data-model/Source/Utilis/LastUpdateEventIDRepository.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 
+// sourcery: AutoMockable
 @objc
 public protocol LastEventIDRepositoryInterface {
 

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -3654,6 +3654,48 @@ public class MockLAContextStorable: LAContextStorable {
 
 }
 
+public class MockLastEventIDRepositoryInterface: LastEventIDRepositoryInterface {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - fetchLastEventID
+
+    public var fetchLastEventID_Invocations: [Void] = []
+    public var fetchLastEventID_MockMethod: (() -> UUID?)?
+    public var fetchLastEventID_MockValue: UUID??
+
+    public func fetchLastEventID() -> UUID? {
+        fetchLastEventID_Invocations.append(())
+
+        if let mock = fetchLastEventID_MockMethod {
+            return mock()
+        } else if let mock = fetchLastEventID_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `fetchLastEventID`")
+        }
+    }
+
+    // MARK: - storeLastEventID
+
+    public var storeLastEventID_Invocations: [UUID?] = []
+    public var storeLastEventID_MockMethod: ((UUID?) -> Void)?
+
+    public func storeLastEventID(_ id: UUID?) {
+        storeLastEventID_Invocations.append(id)
+
+        guard let mock = storeLastEventID_MockMethod else {
+            fatalError("no mock for `storeLastEventID`")
+        }
+
+        mock(id)
+    }
+
+}
+
 class MockMLSActionsProviderProtocol: MLSActionsProviderProtocol {
 
     // MARK: - Life cycle

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -105,6 +105,7 @@ public final class NotificationSession {
 
     private var callEvent: CallEventPayload?
     private var localNotifications = [ZMLocalNotification]()
+    private var processingTask: Task<Void, Error>?
 
     private var context: NSManagedObjectContext { coreDataStack.syncContext }
 
@@ -396,14 +397,26 @@ extension NotificationSession: PushNotificationStrategyDelegate {
         _ strategy: PushNotificationStrategy,
         didFetchEvents events: [ZMUpdateEvent]
     ) async throws {
-        let decodedEvents = try await eventDecoder.decryptAndStoreEvents(
-            events,
-            publicKeys: try? earService.fetchPublicKeys()
-        )
+        try await enqueueTask {
+            let decodedEvents = try await self.eventDecoder.decryptAndStoreEvents(
+                events,
+                publicKeys: try? self.earService.fetchPublicKeys()
+            )
 
-        await context.perform { [self] in
-            processDecodedEvents(decodedEvents)
+            await self.context.perform { [self] in
+                processDecodedEvents(decodedEvents)
+            }
         }
+    }
+
+    private func enqueueTask(_ block: @escaping @Sendable () async throws -> Void) async throws {
+        processingTask = Task { [processingTask] in
+            _ = await processingTask?.result
+            return try await block()
+        }
+
+        // throw error if any
+        _ = try await processingTask?.value
     }
 
     private func processDecodedEvents(_ events: [ZMUpdateEvent]) {

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -395,8 +395,8 @@ extension NotificationSession: PushNotificationStrategyDelegate {
     func pushNotificationStrategy(
         _ strategy: PushNotificationStrategy,
         didFetchEvents events: [ZMUpdateEvent]
-    ) async {
-        let decodedEvents = await eventDecoder.decryptAndStoreEvents(
+    ) async throws {
+        let decodedEvents = try await eventDecoder.decryptAndStoreEvents(
             events,
             publicKeys: try? earService.fetchPublicKeys()
         )

--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -267,7 +267,8 @@ public final class NotificationSession {
             cryptoboxMigrationManager: cryptoboxMigrationManager,
             earService: earService,
             proteusService: ProteusService(coreCryptoProvider: coreCryptoProvider),
-            mlsDecryptionService: MLSDecryptionService(context: coreDataStack.syncContext, mlsActionExecutor: mlsActionExecutor)
+            mlsDecryptionService: MLSDecryptionService(context: coreDataStack.syncContext, mlsActionExecutor: mlsActionExecutor),
+            lastEventIDRepository: lastEventIDRepository
         )
     }
 
@@ -283,7 +284,8 @@ public final class NotificationSession {
         cryptoboxMigrationManager: CryptoboxMigrationManagerInterface,
         earService: EARServiceInterface,
         proteusService: ProteusServiceInterface,
-        mlsDecryptionService: MLSDecryptionServiceInterface
+        mlsDecryptionService: MLSDecryptionServiceInterface,
+        lastEventIDRepository: LastEventIDRepositoryInterface
 
     ) throws {
         self.coreDataStack = coreDataStack
@@ -296,7 +298,8 @@ public final class NotificationSession {
 
         eventDecoder = EventDecoder(
             eventMOC: coreDataStack.eventContext,
-            syncMOC: coreDataStack.syncContext
+            syncMOC: coreDataStack.syncContext,
+            lastEventIDRepository: lastEventIDRepository
         )
 
         pushNotificationStrategy.delegate = self

--- a/wire-ios-notification-engine/Sources/Synchronization/Strategies/PushNotificationStrategy.swift
+++ b/wire-ios-notification-engine/Sources/Synchronization/Strategies/PushNotificationStrategy.swift
@@ -111,7 +111,8 @@ extension PushNotificationStrategy: NotificationStreamSyncDelegate {
                     delegate?.pushNotificationStrategyDidFinishFetchingEvents(self)
                 }
             } catch {
-                // TODO we must enqueue the decryption 
+                WireLogger.notifications.warn("Failed to process fetched events: \(error)")
+                sync.reset()
                 delegate?.pushNotificationStrategyDidFinishFetchingEvents(self)
             }
 

--- a/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
+++ b/wire-ios-notification-engine/WireNotificationEngineTests/BaseNotificationSessionTests.swift
@@ -176,7 +176,8 @@ class BaseTest: ZMTBaseTest {
             cryptoboxMigrationManager: mockCryptoboxMigrationManager,
             earService: mockEARService,
             proteusService: mockProteusService,
-            mlsDecryptionService: mockMLSDecryptionService
+            mlsDecryptionService: mockMLSDecryptionService,
+            lastEventIDRepository: lastEventIDRepository
         )
     }
 }

--- a/wire-ios-request-strategy/Sources/Helpers/EventDecoderDecryptionTests.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/EventDecoderDecryptionTests.swift
@@ -22,12 +22,14 @@ import WireDataModel
 import WireProtos
 import WireCryptobox
 @testable import WireRequestStrategy
+@testable import WireDataModelSupport
 
 class EventDecoderDecryptionTests: MessagingTestBase {
 
     func testThatItCanDecryptOTRMessageAddEvent() async throws {
         // GIVEN
-        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC)
+        let lastEventIDRepository = MockLastEventIDRepositoryInterface()
+        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC, lastEventIDRepository: lastEventIDRepository)
         let text = "Trentatre trentini andarono a Trento tutti e trentatre trotterellando"
         let generic = GenericMessage(content: Text(content: text))
 
@@ -52,7 +54,8 @@ class EventDecoderDecryptionTests: MessagingTestBase {
 
     func testThatItCanDecryptOTRAssetAddEvent() async throws {
         // GIVEN
-        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC)
+        let lastEventIDRepository = MockLastEventIDRepositoryInterface()
+        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC, lastEventIDRepository: lastEventIDRepository)
         let image = self.verySmallJPEGData()
         let imageSize = ZMImagePreprocessor.sizeOfPrerotatedImage(with: image)
         let properties = ZMIImageProperties(size: imageSize, length: UInt(image.count), mimeType: "image/jpg")
@@ -77,7 +80,8 @@ class EventDecoderDecryptionTests: MessagingTestBase {
 
     func testThatItInsertsAUnableToDecryptMessageIfItCanNotEstablishASession() async throws {
         // GIVEN
-        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC)
+        let lastEventIDRepository = MockLastEventIDRepositoryInterface()
+        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC, lastEventIDRepository: lastEventIDRepository)
         var event: ZMUpdateEvent!
 
         await self.syncMOC.perform {
@@ -124,7 +128,8 @@ class EventDecoderDecryptionTests: MessagingTestBase {
 
     func testThatItInsertsAnUnableToDecryptMessageIfTheEncryptedPayloadIsLongerThan_18_000() async throws {
         // Given
-        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC)
+        let lastEventIDRepository = MockLastEventIDRepositoryInterface()
+        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC, lastEventIDRepository: lastEventIDRepository)
         let crlf = "\u{0000}\u{0001}\u{0000}\u{000D}\u{0000A}"
         let text = "https://wir\("".padding(toLength: crlf.count * 20_000, withPad: crlf, startingAt: 0))e.com/"
         XCTAssertGreaterThan(text.count, 18_000)
@@ -173,7 +178,8 @@ class EventDecoderDecryptionTests: MessagingTestBase {
 
     func testThatItInsertsAnUnableToDecryptMessageIfTheEncryptedPayloadIsLongerThan_18_000_External_Message() async throws {
         // Given
-        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC)
+        let lastEventIDRepository = MockLastEventIDRepositoryInterface()
+        let sut = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC, lastEventIDRepository: lastEventIDRepository)
         let crlf = "\u{0000}\u{0001}\u{0000}\u{000D}\u{0000A}"
         let text = "https://wir\("".padding(toLength: crlf.count * 20_000, withPad: crlf, startingAt: 0))e.com/"
         XCTAssertGreaterThan(text.count, 18_000)

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.m
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.m
@@ -97,6 +97,8 @@ ZM_EMPTY_ASSERTING_INIT()
         UserClient *selfClient = [ZMUser selfUserInContext:self.moc].selfClient;
         if (selfClient.remoteIdentifier != nil) {
             [queryItems addObject:[NSURLQueryItem queryItemWithName:@"client" value:selfClient.remoteIdentifier]];
+        } else {
+            return nil;
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
@@ -75,13 +75,7 @@ public class NotificationStreamSync: NSObject, ZMRequestGenerator, ZMSimpleListR
     }
 
     private var lastUpdateEventID: UUID? {
-        get {
-            lastEventIDRepository.fetchLastEventID()
-        }
-
-        set {
-            lastEventIDRepository.storeLastEventID(newValue)
-        }
+        lastEventIDRepository.fetchLastEventID()
     }
 
     @objc(nextUUIDFromResponse:forListPaginator:)

--- a/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
@@ -50,6 +50,10 @@ public class NotificationStreamSync: NSObject, ZMRequestGenerator, ZMSimpleListR
         notificationStreamSyncDelegate = delegate
     }
 
+    public func reset() {
+        listPaginator.resetFetching()
+    }
+
     public func nextRequest(for apiVersion: APIVersion) -> ZMTransportRequest? {
 
        // We only reset the paginator if it is neither in progress nor has more pages to fetch.

--- a/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatus.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatus.swift
@@ -109,10 +109,6 @@ open class PushNotificationStatus: NSObject {
 
         WireLogger.updateEvent.info("finished fetching all available events, last event id: " + String(describing: lastEventId?.uuidString), attributes: .safePublic)
 
-        if let lastEventId = lastEventId {
-            lastEventIDRepository.storeLastEventID(lastEventId)
-        }
-
         guard finished else { return }
 
         // We take all events that are older than or equal to lastEventId and add highest ranking event ID

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategyTests.swift
@@ -20,6 +20,7 @@ import XCTest
 
 @testable import WireRequestStrategy
 @testable import WireRequestStrategySupport
+@testable import WireDataModelSupport
 
 class ClientMessageRequestStrategyTests: MessagingTestBase {
 
@@ -209,7 +210,8 @@ extension ClientMessageRequestStrategyTests {
 
     func testThatANewOtrMessageIsCreatedFromADecryptedAPNSEvent() async throws {
         // GIVEN
-        let eventDecoder = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC)
+        let lastEventIDRepository = MockLastEventIDRepositoryInterface()
+        let eventDecoder = EventDecoder(eventMOC: self.eventMOC, syncMOC: self.syncMOC, lastEventIDRepository: lastEventIDRepository)
         let text = "Everything"
         let event = try await self.decryptedUpdateEventFromOtherClient(text: text, eventDecoder: eventDecoder)
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -251,7 +251,7 @@ extension EventDecoder {
         }
 
         await syncMOC.perform {
-            if let eventUUID = event.uuid {
+            if let eventUUID = event.uuid, !event.isTransient {
                 self.lastEventIDRepository.storeLastEventID(eventUUID)
             }
         }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -161,7 +161,7 @@ extension EventDecoder {
                         Task {
                             do {
                                 try await self.startWork(block: block, semaphore: semaphore).value
-                                WireLogger.backgroundActivity.debug("Expiring activity completed")
+                                WireLogger.backgroundActivity.debug("Expiring activity completed: \(reason)")
                                 continuation.resume()
                             } catch {
                                 WireLogger.backgroundActivity.debug("Expiring activity ended with an error: \(error)")
@@ -171,7 +171,7 @@ extension EventDecoder {
                         }
                         semaphore.wait()
                     } else {
-                        WireLogger.backgroundActivity.warn("Backgrond activity is expiring: \(reason)")
+                        WireLogger.backgroundActivity.warn("Background activity is expiring: \(reason)")
                         Task {
                             await self.stopWork()
                         }
@@ -220,7 +220,9 @@ extension EventDecoder {
             var index = startIndex
             for event in events {
                 try Task.checkCancellation()
-//                try await Task.sleep(nanoseconds: 1_000_000_000)
+                if DeveloperFlag.debugDuplicateObjects.isOn {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                }
                 await decryptedEvents += self.decryptAndStoreEvent(event: event, at: index, publicKeys: publicKeys, proteusService: proteusService)
                 index += 1
             }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -220,7 +220,7 @@ extension EventDecoder {
             var index = startIndex
             for event in events {
                 try Task.checkCancellation()
-                try await Task.sleep(nanoseconds: 3_000_000_000)
+//                try await Task.sleep(nanoseconds: 1_000_000_000)
                 await decryptedEvents += self.decryptAndStoreEvent(event: event, at: index, publicKeys: publicKeys, proteusService: proteusService)
                 index += 1
             }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -275,6 +275,10 @@ extension EventDecoder {
 
         }
 
+        if let lastEventID = decryptedEvents.last(where: { !$0.isTransient })?.uuid {
+            lastEventIDRepository.storeLastEventID(lastEventID)
+        }
+
         return decryptedEvents
     }
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -19,7 +19,6 @@
 import WireDataModelSupport
 import WireTesting
 @testable import WireRequestStrategy
-
 public enum EventConversation {
     static let add = "conversation.message-add"
     static let addClientMessage = "conversation.client-message-add"
@@ -32,10 +31,13 @@ class EventDecoderTest: MessagingTestBase {
 
     var sut: EventDecoder!
     var mockMLSService = MockMLSServiceInterface()
+    var lastEventIDRepository = MockLastEventIDRepositoryInterface()
 
     override func setUp() {
         super.setUp()
-        sut = EventDecoder(eventMOC: eventMOC, syncMOC: syncMOC)
+        sut = EventDecoder(eventMOC: eventMOC, syncMOC: syncMOC, lastEventIDRepository: lastEventIDRepository)
+
+        lastEventIDRepository.storeLastEventID_MockMethod = { _ in }
 
         syncMOC.performGroupedBlockAndWait {
             self.mockMLSService.commitPendingProposalsIfNeeded_MockMethod = {}
@@ -58,14 +60,14 @@ class EventDecoderTest: MessagingTestBase {
 // MARK: - Processing events
 extension EventDecoderTest {
 
-    func testThatItProcessesEvents() async {
+    func testThatItProcessesEvents() async throws {
         // given
         var didCallBlock = false
         let event = await syncMOC.perform {
             self.eventStreamEvent()
         }
 
-        _ = await sut.decryptAndStoreEvents([event])
+        _ = try await sut.decryptAndStoreEvents([event])
 
         // when
         await sut.processStoredEvents { (events) in
@@ -101,7 +103,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = await sut.decryptAndStoreEvents(
+        _ = try await sut.decryptAndStoreEvents(
             [event],
             publicKeys: publicKeys
         )
@@ -118,7 +120,7 @@ extension EventDecoderTest {
         XCTAssertTrue(didCallBlock)
     }
 
-    func testThatItProcessesPreviouslyStoredEventsFirst() async {
+    func testThatItProcessesPreviouslyStoredEventsFirst() async throws {
         EventDecoder.testingBatchSize = 1
         var callCount = 0
 
@@ -130,10 +132,10 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = await self.sut.decryptAndStoreEvents([event1])
+        _ = try await self.sut.decryptAndStoreEvents([event1])
 
         // when
-        _ = await self.sut.decryptAndStoreEvents([event2])
+        _ = try await self.sut.decryptAndStoreEvents([event2])
         await self.sut.processStoredEvents { (events) in
             if callCount == 0 {
                 XCTAssertTrue(events.contains(event1))
@@ -151,7 +153,7 @@ extension EventDecoderTest {
         XCTAssertEqual(callCount, 2)
     }
 
-    func testThatItProcessesInBatches() async {
+    func testThatItProcessesInBatches() async throws {
 
         EventDecoder.testingBatchSize = 2
         var callCount = 0
@@ -170,7 +172,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = await sut.decryptAndStoreEvents([event1, event2, event3, event4])
+        _ = try await sut.decryptAndStoreEvents([event1, event2, event3, event4])
 
         // when
         await sut.processStoredEvents { (events) in
@@ -192,7 +194,7 @@ extension EventDecoderTest {
         XCTAssertEqual(callCount, 2)
     }
 
-    func testThatItDoesNotProcessTheSameEventsTwiceWhenCalledSuccessively() async {
+    func testThatItDoesNotProcessTheSameEventsTwiceWhenCalledSuccessively() async throws {
         EventDecoder.testingBatchSize = 2
 
         // given
@@ -209,7 +211,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = await self.sut.decryptAndStoreEvents([event1, event2])
+        _ = try await self.sut.decryptAndStoreEvents([event1, event2])
 
         await sut.processStoredEvents(with: nil) { (events) in
             XCTAssert(events.contains(event1))
@@ -311,7 +313,7 @@ extension EventDecoderTest {
 // MARK: - Already seen events
 extension EventDecoderTest {
 
-    func testThatItProcessesEventsWithDifferentUUIDWhenThroughPushEventsFirst() async {
+    func testThatItProcessesEventsWithDifferentUUIDWhenThroughPushEventsFirst() async throws {
 
         // given
         let pushProcessed = self.customExpectation(description: "Push event processed")
@@ -324,7 +326,7 @@ extension EventDecoderTest {
         }
 
         // when
-        _ = await sut.decryptAndStoreEvents([pushEvent])
+        _ = try await sut.decryptAndStoreEvents([pushEvent])
         await sut.processStoredEvents { (events) in
             XCTAssertTrue(events.contains(pushEvent))
             pushProcessed.fulfill()
@@ -335,7 +337,7 @@ extension EventDecoderTest {
 
         // and when
         let streamProcessed = self.customExpectation(description: "Stream event processed")
-        _ = await sut.decryptAndStoreEvents([streamEvent])
+        _ = try await sut.decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { (events) in
             XCTAssertTrue(events.contains(streamEvent))
             streamProcessed.fulfill()
@@ -345,7 +347,7 @@ extension EventDecoderTest {
         XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
     }
 
-    func testThatItDoesNotProcessesEventsWithSameUUIDWhenThroughPushEventsFirst() async {
+    func testThatItDoesNotProcessesEventsWithSameUUIDWhenThroughPushEventsFirst() async throws {
 
         // given
         let pushProcessed = self.customExpectation(description: "Push event processed")
@@ -359,7 +361,7 @@ extension EventDecoderTest {
         }
 
         // when
-        _ = await sut.decryptAndStoreEvents([pushEvent])
+        _ = try await sut.decryptAndStoreEvents([pushEvent])
         await sut.processStoredEvents { (events) in
             XCTAssertTrue(events.contains(pushEvent))
             pushProcessed.fulfill()
@@ -371,7 +373,7 @@ extension EventDecoderTest {
         // and when
         let streamProcessed = self.customExpectation(description: "Stream event not processed")
 
-        _ = await sut.decryptAndStoreEvents([streamEvent])
+        _ = try await sut.decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { (events) in
             XCTAssertTrue(events.isEmpty)
             streamProcessed.fulfill()
@@ -381,7 +383,7 @@ extension EventDecoderTest {
         XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
     }
 
-    func testThatItProcessesEventsWithSameUUIDWhenThroughPushEventsFirstAndDiscarding() async {
+    func testThatItProcessesEventsWithSameUUIDWhenThroughPushEventsFirstAndDiscarding() async throws {
 
         // given
         let pushProcessed = self.customExpectation(description: "Push event processed")
@@ -395,7 +397,7 @@ extension EventDecoderTest {
         }
 
         // when
-        _ = await self.sut.decryptAndStoreEvents([pushEvent])
+        _ = try await self.sut.decryptAndStoreEvents([pushEvent])
         await self.sut.processStoredEvents { (events) in
             XCTAssertTrue(events.contains(pushEvent))
             pushProcessed.fulfill()
@@ -408,7 +410,7 @@ extension EventDecoderTest {
         // and when
         let streamProcessed = self.customExpectation(description: "Stream event processed")
 
-        _ = await self.sut.decryptAndStoreEvents([streamEvent])
+        _ = try await self.sut.decryptAndStoreEvents([streamEvent])
         await self.sut.processStoredEvents { (events) in
             XCTAssertTrue(events.contains(streamEvent))
             streamProcessed.fulfill()
@@ -445,7 +447,7 @@ extension EventDecoderTest {
         }
 
         // When
-        _ = await self.sut.decryptAndStoreEvents([event])
+        _ = try await self.sut.decryptAndStoreEvents([event])
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
@@ -468,7 +470,7 @@ extension EventDecoderTest {
         proteusViaCoreCrypto.isOn = false
 
         // When
-        let decryptedEvents = await self.sut.decryptAndStoreEvents([event])
+        let decryptedEvents = try await self.sut.decryptAndStoreEvents([event])
         XCTAssertEqual(decryptedEvents.count, 1)
 
         // Then
@@ -662,7 +664,7 @@ extension EventDecoderTest {
         XCTAssertTrue(decryptedEvents.isEmpty)
     }
 
-    func test_DecryptWelcomeMessage_ReturnsEvent() async {
+    func test_DecryptWelcomeMessage_ReturnsEvent() async throws {
         // Given
         let conversationID = QualifiedID.random()
         let groupID = MLSGroupID.random()
@@ -671,13 +673,13 @@ extension EventDecoderTest {
         mockMLSService.processWelcomeMessageWelcomeMessage_MockValue = groupID
 
         // When
-        let result = await sut.decryptAndStoreEvents([event])
+        let result = try await sut.decryptAndStoreEvents([event])
 
         // Then
         XCTAssertEqual(result, [event])
     }
 
-    func test_DecryptWelcomeMessage_ProcessWelcomeMessage() async {
+    func test_DecryptWelcomeMessage_ProcessWelcomeMessage() async throws {
         // Given
         let conversationID = QualifiedID.random()
         let groupID = MLSGroupID.random()
@@ -686,7 +688,7 @@ extension EventDecoderTest {
         mockMLSService.processWelcomeMessageWelcomeMessage_MockValue = groupID
 
         // When
-        _ = await sut.decryptAndStoreEvents([event])
+        _ = await try sut.decryptAndStoreEvents([event])
 
         // Then
         XCTAssertEqual(mockMLSService.processWelcomeMessageWelcomeMessage_Invocations.count, 1)

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -67,7 +67,7 @@ actor EventProcessor: UpdateEventProcessor {
             guard !DeveloperFlag.ignoreIncomingEvents.isOn else { return }
 
             let publicKeys = try? self.earService.fetchPublicKeys()
-            let decryptedEvents = await self.eventDecoder.decryptAndStoreEvents(events, publicKeys: publicKeys)
+            let decryptedEvents = try await self.eventDecoder.decryptAndStoreEvents(events, publicKeys: publicKeys)
             await self.processBackgroundEvents(decryptedEvents)
 
             let isLocked = await self.syncContext.perform { self.syncContext.isLocked }

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -41,11 +41,16 @@ actor EventProcessor: UpdateEventProcessor {
         eventProcessingTracker: EventProcessingTrackerProtocol,
         earService: EARServiceInterface,
         eventConsumers: [ZMEventConsumer],
-        eventAsyncConsumers: [ZMEventAsyncConsumer]
+        eventAsyncConsumers: [ZMEventAsyncConsumer],
+        lastEventIDRepository: LastEventIDRepositoryInterface
     ) {
         self.syncContext = storeProvider.syncContext
         self.eventContext = storeProvider.eventContext
-        self.eventDecoder = EventDecoder(eventMOC: eventContext, syncMOC: syncContext)
+        self.eventDecoder = EventDecoder(
+            eventMOC: eventContext,
+            syncMOC: syncContext,
+            lastEventIDRepository: lastEventIDRepository
+        )
         self.eventProcessingTracker = eventProcessingTracker
         self.earService = earService
         self.bufferedEvents = []

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -194,11 +194,12 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
 
     NSLog(@"ZMMissingUpdateEventsTranscoder process %lu events", (unsigned long)parsedEvents.count);
     [self.eventProcessor processEvents:parsedEvents completionHandler:^(NSError * _Nullable error) {
-        NOT_USED(error);
         [self.managedObjectContext performBlock:^{
             if (error != nil) {
+                NSLog(@"ZMMissingUpdateEventsTranscoder error processing events: %@", error);
                 [self.pushNotificationStatus didFailToFetchEventsWithRecoverable:NO];
                 self.isProcessingEvents = NO;
+                [self.listPaginator resetFetching];
                 [self.managedObjectContext leaveAllGroups:groups];
                 return;
             }

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -261,16 +261,7 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
 
 - (void)processEvents:(nonnull NSArray<ZMUpdateEvent *> *)events liveEvents:(BOOL)liveEvents prefetchResult:(ZMFetchRequestBatchResult * _Nullable)prefetchResult
 {
-    
-    if (!liveEvents) {
-        return;
-    }
-    
-    for (ZMUpdateEvent *event in events) {
-        if (event.uuid != nil && ! event.isTransient && event.source != ZMUpdateEventSourcePushNotification) {
-            [self.lastEventIDRepository storeLastEventID:event.uuid];
-        }
-    }
+
 }
 
 - (ZMTransportRequest *)nextRequestIfAllowedForAPIVersion:(APIVersion)apiVersion

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -656,7 +656,8 @@ public final class ZMUserSession: NSObject {
             eventProcessingTracker: eventProcessingTracker,
             earService: earService,
             eventConsumers: strategyDirectory?.eventConsumers ?? [],
-            eventAsyncConsumers: (strategyDirectory?.eventAsyncConsumers ?? []) + [conversationEventProcessor]
+            eventAsyncConsumers: (strategyDirectory?.eventAsyncConsumers ?? []) + [conversationEventProcessor],
+            lastEventIDRepository: lastEventIDRepository
         )
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -51,7 +51,8 @@ class EventProcessorTests: MessagingTest {
             eventProcessingTracker: eventProcessingTracker,
             earService: earService,
             eventConsumers: mockEventsConsumers,
-            eventAsyncConsumers: mockEventAsyncConsumers
+            eventAsyncConsumers: mockEventAsyncConsumers,
+            lastEventIDRepository: lastEventIDRepository
         )
     }
 

--- a/wire-ios-system/Source/ExpiringActivity.swift
+++ b/wire-ios-system/Source/ExpiringActivity.swift
@@ -35,7 +35,7 @@ public struct ExpiringActivityNotAllowedToRun: Error { }
 /// calling [Task.checkCancellation](https://developer.apple.com/documentation/swift/task/checkcancellation()) at the appropriate time.
 ///
 /// - Parameters:
-///   - reason: Discription of what the activity does, helpful for debugging purposes.
+///   - reason: Description of what the activity does, helpful for debugging purposes.
 ///   - block: async operation which supports cancellation.
 
 public func withExpiringActivity(reason: String, block: @escaping () async throws -> Void) async throws {

--- a/wire-ios-system/Source/ExpiringActivity.swift
+++ b/wire-ios-system/Source/ExpiringActivity.swift
@@ -1,0 +1,80 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+/// Execute an async function inside an [performExpiringActivity](https://developer.apple.com/documentation/foundation/processinfo/1617030-performexpiringactivity)
+/// which cancels the task when the activity expires. It's up to the async function to handle the cancellation by for example
+/// calling [Task.checkCancellation](https://developer.apple.com/documentation/swift/task/checkcancellation()) at the appropriate time.
+///
+/// - Parameters:
+///   - reason: Discription of what the activity does, helpful for debugging purposes.
+///   - block: async operation which supports cancellation.
+
+public func withExpiringActivity(reason: String, block: @escaping () async throws -> Void) async throws {
+    let manager = ExpiringActivityManager()
+    try await manager.withExpiringActivity(reason: reason, block: block)
+}
+
+actor ExpiringActivityManager {
+    var task: Task<Void, Error>?
+
+    func withExpiringActivity(reason: String, block: @escaping () async throws -> Void) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            ProcessInfo.processInfo.performExpiringActivity(withReason: reason) { expiring in
+                if !expiring {
+                    let semaphore = DispatchSemaphore(value: 0)
+                    Task {
+                        do {
+                            try await self.startWork(block: block, semaphore: semaphore).value
+                            WireLogger.backgroundActivity.debug("Expiring activity completed: \(reason)")
+                            continuation.resume()
+                        } catch {
+                            WireLogger.backgroundActivity.debug("Expiring activity ended with an error: \(error)")
+                            continuation.resume(throwing: error)
+                        }
+
+                    }
+                    semaphore.wait()
+                } else {
+                    WireLogger.backgroundActivity.warn("Background activity is expiring: \(reason)")
+                    Task {
+                        await self.stopWork()
+                    }
+                }
+            }
+        }
+    }
+
+    func startWork(block: @escaping () async throws -> Void, semaphore: DispatchSemaphore) -> Task<Void, Error> {
+        let task = Task {
+            defer {
+                WireLogger.backgroundActivity.debug("Releasing semaphore")
+                semaphore.signal()
+            }
+            try await block()
+        }
+        self.task = task
+        return task
+    }
+
+    func stopWork() {
+        self.task?.cancel()
+        self.task = nil
+    }
+}

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -20,7 +20,7 @@ import Foundation
 import XCTest
 @testable import WireSystem
 
-class MockExpiringActivityAPI: ExpiringActivityInterface {
+private class MockExpiringActivityAPI: ExpiringActivityInterface {
 
     typealias MethodCall = (_ reason: String, _ block: @escaping @Sendable (Bool) -> Void) -> Void
 
@@ -63,7 +63,7 @@ class ExpiringActivityTests: XCTestCase {
                     try Task.checkCancellation()
                 }
             }
-            XCTFail("Expected an cancellation error to be thrown")
+            XCTFail("Expected a cancellation error to be thrown")
         } catch { }
     }
 

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -1,0 +1,116 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireSystem
+
+class MockExpiringActivityAPI: ExpiringActivityInterface {
+
+    typealias MethodCall = (_ reason: String, _ block: @escaping @Sendable (Bool) -> Void) -> Void
+
+    var method: MethodCall?
+
+    func performExpiringActivity(withReason reason: String, using block: @escaping @Sendable (Bool) -> Void) {
+        if let method {
+            method(reason, block)
+        } else {
+            fatalError("no mock for `performExpiringActivity(withReason:using:)`")
+        }
+    }
+
+}
+
+class ExpiringActivityTests: XCTestCase {
+
+    let concurrentQueue = DispatchQueue(label: "activity queue", attributes: [.concurrent])
+
+    func testThatTaskIsCancelled_WhenActivityExpires() async throws {
+
+        // given
+        let api = MockExpiringActivityAPI()
+        let sut = ExpiringActivityManager(api: api)
+
+        api.method = { _, block in
+            self.concurrentQueue.async {
+                block(false)
+            }
+            self.concurrentQueue.async {
+                block(true)
+            }
+        }
+
+        // when
+        do {
+            try await sut.withExpiringActivity(reason: "Expiring test activity") {
+                while true {
+                    await Task.yield()
+                    try Task.checkCancellation()
+                }
+            }
+            XCTFail("Expected an cancellation error to be thrown")
+        } catch { }
+    }
+
+    func testThatTaskIsCancelled_WhenActivityIsNotAllowedToBegin() async throws {
+
+        // given
+        let api = MockExpiringActivityAPI()
+        let sut = ExpiringActivityManager(api: api)
+
+        api.method = { _, block in
+            self.concurrentQueue.async {
+                block(true)
+            }
+        }
+
+        // when
+        do {
+            try await sut.withExpiringActivity(reason: "Expiring test activity") {
+                while true {
+                    await Task.yield()
+                    try Task.checkCancellation()
+                }
+            }
+            XCTFail("Expected an expiring activity not allowed to run error to be thrown")
+        } catch { }
+    }
+
+    func testThatTaskEndsWithoutError_WhenActivityCompletes() async throws {
+
+        // given
+        let api = MockExpiringActivityAPI()
+        let sut = ExpiringActivityManager(api: api)
+
+        api.method = { _, block in
+            self.concurrentQueue.async {
+                block(false)
+            }
+        }
+
+        // when
+        do {
+            try await sut.withExpiringActivity(reason: "Expiring test activity") {
+                try Task.checkCancellation()
+            }
+        } catch {
+            XCTFail("Expected the activity to end without any error thrown")
+        }
+    }
+
+}

--- a/wire-ios-system/Tests/ExpiringActivityTests.swift
+++ b/wire-ios-system/Tests/ExpiringActivityTests.swift
@@ -20,22 +20,6 @@ import Foundation
 import XCTest
 @testable import WireSystem
 
-private class MockExpiringActivityAPI: ExpiringActivityInterface {
-
-    typealias MethodCall = (_ reason: String, _ block: @escaping @Sendable (Bool) -> Void) -> Void
-
-    var method: MethodCall?
-
-    func performExpiringActivity(withReason reason: String, using block: @escaping @Sendable (Bool) -> Void) {
-        if let method {
-            method(reason, block)
-        } else {
-            fatalError("no mock for `performExpiringActivity(withReason:using:)`")
-        }
-    }
-
-}
-
 class ExpiringActivityTests: XCTestCase {
 
     let concurrentQueue = DispatchQueue(label: "activity queue", attributes: [.concurrent])
@@ -110,6 +94,22 @@ class ExpiringActivityTests: XCTestCase {
             }
         } catch {
             XCTFail("Expected the activity to end without any error thrown")
+        }
+    }
+
+}
+
+private class MockExpiringActivityAPI: ExpiringActivityInterface {
+
+    typealias MethodCall = (_ reason: String, _ block: @escaping @Sendable (Bool) -> Void) -> Void
+
+    var method: MethodCall?
+
+    func performExpiringActivity(withReason reason: String, using block: @escaping @Sendable (Bool) -> Void) {
+        if let method {
+            method(reason, block)
+        } else {
+            fatalError("no mock for `performExpiringActivity(withReason:using:)`")
         }
     }
 

--- a/wire-ios-system/WireSystem.xcodeproj/project.pbxproj
+++ b/wire-ios-system/WireSystem.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		096A3A211B67CEF700565001 /* ZMSLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 096A3A1D1B67CEF700565001 /* ZMSLogging.m */; };
 		16962EDD20221F970069D88D /* ZMSLogNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 16962EDB20221F970069D88D /* ZMSLogNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16962EDE20221F970069D88D /* ZMSLogNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 16962EDC20221F970069D88D /* ZMSLogNotifications.m */; };
+		16AAA62A2C21903200080A06 /* ExpiringActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AAA6292C21903200080A06 /* ExpiringActivity.swift */; };
 		16BBA1F02AF2611000CDF38A /* SystemLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1EF2AF2611000CDF38A /* SystemLogger.swift */; };
 		54180BD81F459DCF0020D2BD /* MemoryReferenceDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = 54180BD61F459DCF0020D2BD /* MemoryReferenceDebugger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54180BD91F459DCF0020D2BD /* MemoryReferenceDebugger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54180BD71F459DCF0020D2BD /* MemoryReferenceDebugger.swift */; };
@@ -84,6 +85,7 @@
 		09F186211B68FD52007A3DA6 /* WireSystem-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "WireSystem-Info.plist"; sourceTree = "<group>"; };
 		16962EDB20221F970069D88D /* ZMSLogNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMSLogNotifications.h; sourceTree = "<group>"; };
 		16962EDC20221F970069D88D /* ZMSLogNotifications.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMSLogNotifications.m; sourceTree = "<group>"; };
+		16AAA6292C21903200080A06 /* ExpiringActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringActivity.swift; sourceTree = "<group>"; };
 		16BBA1EF2AF2611000CDF38A /* SystemLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLogger.swift; sourceTree = "<group>"; };
 		3ECC35191AD436750089FD4B /* WireSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		54180BD61F459DCF0020D2BD /* MemoryReferenceDebugger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryReferenceDebugger.h; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 				16962EDB20221F970069D88D /* ZMSLogNotifications.h */,
 				16962EDC20221F970069D88D /* ZMSLogNotifications.m */,
 				EEDC67182A1778D600201436 /* UserDefaults+Temporary.swift */,
+				16AAA6292C21903200080A06 /* ExpiringActivity.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -503,6 +506,7 @@
 				F19E554522AA8748005C792D /* SafeForLoggingStringConvertible.swift in Sources */,
 				013404E42B5F162D00D2D2D5 /* LegacyLogger.swift in Sources */,
 				54DB81631DBF66CF00AF495D /* ZMSLog+Levels.swift in Sources */,
+				16AAA62A2C21903200080A06 /* ExpiringActivity.swift in Sources */,
 				54FF9F121C48F67300B29ACE /* ZMSTimePoint.m in Sources */,
 				54D5736A1DBFBAFA00D6C2C4 /* ZMSLog+Recording.swift in Sources */,
 				5442AB7F1CA29CC000BC099C /* ZMSAsserts.swift in Sources */,

--- a/wire-ios-system/WireSystem.xcodeproj/project.pbxproj
+++ b/wire-ios-system/WireSystem.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		16962EDD20221F970069D88D /* ZMSLogNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 16962EDB20221F970069D88D /* ZMSLogNotifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		16962EDE20221F970069D88D /* ZMSLogNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 16962EDC20221F970069D88D /* ZMSLogNotifications.m */; };
 		16AAA62A2C21903200080A06 /* ExpiringActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AAA6292C21903200080A06 /* ExpiringActivity.swift */; };
+		16AAA62E2C22F7D500080A06 /* ExpiringActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AAA62D2C22F7D500080A06 /* ExpiringActivityTests.swift */; };
 		16BBA1F02AF2611000CDF38A /* SystemLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BBA1EF2AF2611000CDF38A /* SystemLogger.swift */; };
 		54180BD81F459DCF0020D2BD /* MemoryReferenceDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = 54180BD61F459DCF0020D2BD /* MemoryReferenceDebugger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54180BD91F459DCF0020D2BD /* MemoryReferenceDebugger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54180BD71F459DCF0020D2BD /* MemoryReferenceDebugger.swift */; };
@@ -86,6 +87,7 @@
 		16962EDB20221F970069D88D /* ZMSLogNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMSLogNotifications.h; sourceTree = "<group>"; };
 		16962EDC20221F970069D88D /* ZMSLogNotifications.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ZMSLogNotifications.m; sourceTree = "<group>"; };
 		16AAA6292C21903200080A06 /* ExpiringActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringActivity.swift; sourceTree = "<group>"; };
+		16AAA62D2C22F7D500080A06 /* ExpiringActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpiringActivityTests.swift; sourceTree = "<group>"; };
 		16BBA1EF2AF2611000CDF38A /* SystemLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemLogger.swift; sourceTree = "<group>"; };
 		3ECC35191AD436750089FD4B /* WireSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		54180BD61F459DCF0020D2BD /* MemoryReferenceDebugger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryReferenceDebugger.h; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				54FF9F131C4906C700B29ACE /* ZMTimePointTests.m */,
 				54FF9F151C4914D100B29ACE /* ZMSTestDetectionTests.m */,
 				54C0CC421C9C7862000A9286 /* ZMSAssertionTests.m */,
+				16AAA62D2C22F7D500080A06 /* ExpiringActivityTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -531,6 +534,7 @@
 				54A3273A1B99A3840004EB95 /* ZMLoggingTests.m in Sources */,
 				54180BDF1F459DFF0020D2BD /* MemoryReferenceDebuggerTests.swift in Sources */,
 				5457426C1BA9C50C0009409B /* ZMDefinesTest.m in Sources */,
+				16AAA62E2C22F7D500080A06 /* ExpiringActivityTests.swift in Sources */,
 				54DB81671DBFB16700AF495D /* CircularArrayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -29,6 +29,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case forceDatabaseLoadingFailure
     case ignoreIncomingEvents
     case debugDuplicateObjects
+    case decryptAndStoreEventsSleep
     case forceCRLExpiryAfterOneMinute
 
     public var description: String {
@@ -53,6 +54,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .debugDuplicateObjects:
             return "Turn on to have actions to insert duplicate users, conversations, teams"
+
+        case .decryptAndStoreEventsSleep:
+            return "Adds a delay when decrypting and storing events"
 
         case .forceCRLExpiryAfterOneMinute:
             return "Turn on to force CRLs to expire after 1 minute"
@@ -92,7 +96,7 @@ public enum DeveloperFlag: String, CaseIterable {
             return "ProteusByCoreCryptoEnabled"
         case .forceDatabaseLoadingFailure:
             return "ForceDatabaseLoadingFailure"
-        case .nseV2, .debugDuplicateObjects, .forceCRLExpiryAfterOneMinute:
+        case .nseV2, .debugDuplicateObjects, .forceCRLExpiryAfterOneMinute, .decryptAndStoreEventsSleep:
             return nil
         case .ignoreIncomingEvents:
             return "IgnoreIncomingEventsEnabled"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9221" title="WPB-9221" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9221</a>  Missing messages during sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issue

We have observed cases where messages have been missing from conversations. While investigating once such case we could determine this was caused by the application crashing while decrypting messages. When the app was started again it would attempt to decrypt the messages again, but would now fail with a "duplicate message" error since the cryptographic state had already been updated.

The application crashed because while decrypting we are holding a file lock on the cryptographic state which is not allowed when the app gets suspended, which causes the system to kill the app with the `0xdead10cc` (deadlock) error.

#### Solution

Preferably we would only save the cryptographic state after persisting the decrypted message but that's currently not possible with the current API so we do our best to mitigate the issue.

1. Release the file lock and stop the decryption task before the application is about to get suspended.
2. Persist a decrypted message directly after decrypting it (No batch save).
3. Update the last event ID directly after persisting a decrypted message.
4. Avoid decrypting multiple pages of message in parallel in the notification extension.

Other minor fixes:

1. Don't fetch notification if don't have the self client ID, doing so will corrupt the app state since we then get events intended for other self clients.

### Testing

Runt the app and look for missing messages.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

