### PR TITLE
chore: stop using NSManagedObjectContext category method in Swift - WPB-8907

### DIFF
--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Analytics.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack+Analytics.swift
@@ -16,6 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireUtilities
+
 extension CoreDataStack {
 
     public func linkAnalytics(_ analytics: (any AnalyticsType)?) {

--- a/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack.swift
+++ b/wire-ios-data-model/Source/ManagedObjectContext/CoreDataStack.swift
@@ -19,6 +19,7 @@
 import CoreData
 import Foundation
 import WireSystem
+import WireUtilities
 
 enum CoreDataStackError: Error {
     case simulateDatabaseLoadingFailure
@@ -45,7 +46,6 @@ public protocol ContextProvider {
     var syncContext: NSManagedObjectContext { get }
     var searchContext: NSManagedObjectContext { get }
     var eventContext: NSManagedObjectContext { get }
-
 }
 
 extension URL {

--- a/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
+++ b/wire-ios-data-model/Source/ManagedObjectContext/NSManagedObjectContext+zmessaging.m
@@ -16,9 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-@import WireUtilities;
 @import UIKit;
 @import WireCryptobox;
+@import WireUtilities;
 
 #import "NSManagedObjectContext+zmessaging-Internal.h"
 #import "NSManagedObjectContext+tests.h"

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+MLS.swift
@@ -197,7 +197,7 @@ public extension ZMConversation {
             argumentArray: [Self.mlsGroupIdKey, groupID.data]
         )
 
-        let result = context.executeFetchRequestOrAssert(request)
+        let result = try! context.fetch(request)
         require(result.count <= 1, "More than one conversation found for a single group id")
         return result.first as? ZMConversation
     }
@@ -212,7 +212,7 @@ public extension ZMConversation {
             argumentArray: [Self.commitPendingProposalDateKey]
         )
 
-        return context.executeFetchRequestOrAssert(request) as? [ZMConversation] ?? []
+        return try! context.fetch(request) as? [ZMConversation] ?? []
     }
 
     static func fetchConversationsWithMLSGroupStatus(
@@ -242,7 +242,7 @@ public extension ZMConversation {
             .hasConversationType(.`self`), .isMLSConversation
         ])
 
-        let result = context.executeFetchRequestOrAssert(request)
+        let result = try! context.fetch(request)
         require(result.count <= 1, "More than one conversation found for a single group id")
         return result.first as? ZMConversation
     }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -98,7 +98,7 @@ extension ZMConversation {
     static public func appendNewPotentialGapSystemMessage(at timestamp: Date?, inContext moc: NSManagedObjectContext) {
         let offset = 0.1
         var lastMessageTimestamp = timestamp
-        guard let conversations = moc.executeFetchRequestOrAssert(ZMConversation.sortedFetchRequest()) as? [ZMConversation] else {
+        guard let conversations = try? moc.fetch(ZMConversation.sortedFetchRequest()) as? [ZMConversation] else {
             return
         }
         for conversation in conversations {

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -98,7 +98,7 @@ extension ZMConversation {
     static public func appendNewPotentialGapSystemMessage(at timestamp: Date?, inContext moc: NSManagedObjectContext) {
         let offset = 0.1
         var lastMessageTimestamp = timestamp
-        guard let conversations = try? moc.fetch(ZMConversation.sortedFetchRequest()) as? [ZMConversation] else {
+        guard let conversations = try! moc.fetch(ZMConversation.sortedFetchRequest()) as? [ZMConversation] else {
             return
         }
         for conversation in conversations {

--- a/wire-ios-data-model/Source/Model/Message/ZMMessage+Removal.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMMessage+Removal.swift
@@ -30,7 +30,7 @@ extension ZMMessage {
 
         let requestForInsertedMessages = ZMClientMessage.sortedFetchRequest(with: predicate)
 
-        let possibleMatches = self.managedObjectContext?.executeFetchRequestOrAssert(requestForInsertedMessages) as? [ZMClientMessage]
+        let possibleMatches = try! self.managedObjectContext?.fetch(requestForInsertedMessages) as? [ZMClientMessage]
         let confirmationReceipts = possibleMatches?.filter { candidateConfirmationReceipt in
             guard let genericMessage = candidateConfirmationReceipt.underlyingMessage else {
                 return false

--- a/wire-ios-data-model/Source/Model/User/ZMUser.m
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.m
@@ -374,8 +374,8 @@ static NSString *const PrimaryKey = @"primaryKey";
     
     NSFetchRequest *usersWithEmailFetch = [NSFetchRequest fetchRequestWithEntityName:[ZMUser entityName]];
     usersWithEmailFetch.predicate = [NSPredicate predicateWithFormat:@"%K = %@", EmailAddressKey, emailAddress];
-    NSArray<ZMUser *> *users = [context executeFetchRequestOrAssert:usersWithEmailFetch];
-    
+    NSArray<ZMUser *> *users = (NSArray<ZMUser *> *) [context executeFetchRequestOrAssert:usersWithEmailFetch];
+
     RequireString(users.count <= 1, "More than one user with the same email address");
     
     if (0 == users.count) {
@@ -395,7 +395,7 @@ static NSString *const PrimaryKey = @"primaryKey";
     
     NSFetchRequest *usersWithPhoneFetch = [NSFetchRequest fetchRequestWithEntityName:[ZMUser entityName]];
     usersWithPhoneFetch.predicate = [NSPredicate predicateWithFormat:@"%K = %@", PhoneNumberKey, phoneNumber];
-    NSArray<ZMUser *> *users = [context executeFetchRequestOrAssert:usersWithPhoneFetch];
+    NSArray<ZMUser *> *users = (NSArray<ZMUser *> *) [context executeFetchRequestOrAssert:usersWithPhoneFetch];
     
     RequireString(users.count <= 1, "More than one user with the same phone number");
     

--- a/wire-ios-data-model/Source/Utilis/ZMFetchRequestBatch.m
+++ b/wire-ios-data-model/Source/Utilis/ZMFetchRequestBatch.m
@@ -145,7 +145,6 @@
 @end
 
 
-
 @implementation NSManagedObjectContext (ZMFetchRequestBatch)
 
 - (ZMFetchRequestBatchResult *)executeFetchRequestBatchOrAssert:(ZMFetchRequestBatch *)fetchRequestbatch

--- a/wire-ios-data-model/Source/Utilis/ZMMessageTimer.h
+++ b/wire-ios-data-model/Source/Utilis/ZMMessageTimer.h
@@ -16,10 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-#import <Foundation/Foundation.h>
+@import CoreData;
 
 @class ZMMessage;
-
 
 @interface ZMMessageTimer : NSObject <TearDownCapable>
 
@@ -34,13 +33,10 @@
 /// @managedObjectContext The context on which changes are supposed to be performed on timer firing.
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)managedObjectContext;
 
-
-
 /// Starts a new timer if there is no existing one
 /// @param fireDate The date at which the timer should fire
 /// @param userInfo Additional info that should be added to the timer
 - (void)startTimerForMessageIfNeeded:(ZMMessage*)message fireDate:(NSDate *)fireDate userInfo:(NSDictionary *)userInfo;
-
 
 /// Stops an existing timer
 - (void)stopTimerForMessage:(ZMMessage *)message;

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseMigrationTests.swift
@@ -105,13 +105,13 @@ final class DatabaseMigrationTests: DatabaseBaseTest {
             let connectionCount = try directory.viewContext.count(for: ZMConnection.sortedFetchRequest())
             let userClientCount = try directory.viewContext.count(for: UserClient.sortedFetchRequest())
             let assetClientMessagesCount = try directory.viewContext.count(for: ZMAssetClientMessage.sortedFetchRequest())
-            let messages = directory.viewContext.executeFetchRequestOrAssert(ZMMessage.sortedFetchRequest()) as! [ZMMessage]
+            let messages = try directory.viewContext.fetch(ZMMessage.sortedFetchRequest()) as! [ZMMessage]
             let users = directory.viewContext.fetchOrAssert(request: NSFetchRequest<ZMUser>(entityName: ZMUser.entityName()))
 
             let userFetchRequest = ZMUser.sortedFetchRequest()
             userFetchRequest.resultType = .dictionaryResultType
             userFetchRequest.propertiesToFetch = userPropertiesToFetch
-            let userDictionaries = directory.viewContext.executeFetchRequestOrAssert(userFetchRequest)
+            let userDictionaries = try directory.viewContext.fetch(userFetchRequest)
 
             // THEN
             XCTAssertEqual(assetClientMessagesCount, 0)

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ConversationTests+gapsAndWindows.swift
@@ -49,7 +49,7 @@ final class ConversationGapsAndWindowTests: ZMConversationTestsBase {
         XCTAssertEqual(expectedParticipants, conversation?.localParticipants)
     }
 
-    func testThatItInsertsANewConversationInUIContext() {
+    func testThatItInsertsANewConversationInUIContext() throws {
         // given
 
         let user1 = ZMUser.insertNewObject(in: uiMOC)
@@ -66,7 +66,7 @@ final class ConversationGapsAndWindowTests: ZMConversationTestsBase {
         XCTAssertNotNil(conversation)
 
         let fetchRequest = ZMConversation.sortedFetchRequest()
-        let conversations = uiMOC.executeFetchRequestOrAssert(fetchRequest)
+        let conversations = try uiMOC.fetch(fetchRequest)
 
         XCTAssertEqual(conversations.count, 1)
         let fetchedConversation = conversations[0] as? ZMConversation

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ConversationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ConversationTests.swift
@@ -33,70 +33,70 @@ final class ConversationTests: ZMConversationTestsBase {
         return conversation
     }
 
-    func testThatItFindsConversationByUserDefinedNameDiacriticsWithSymbol() {
+    func testThatItFindsConversationByUserDefinedNameDiacriticsWithSymbol() throws {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
 
         // when
 
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "@Sømebôdy", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
     }
 
-    func testThatItFindsConversationByUserDefinedNameDiacritics() {
+    func testThatItFindsConversationByUserDefinedNameDiacritics() throws {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
 
         // when
 
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
     }
 
-    func testThatItFindsConversationByUserDefinedNameWithPunctuationCharacter() {
+    func testThatItFindsConversationByUserDefinedNameWithPunctuationCharacter() throws {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "[Feature] [9:30]")
 
         // when
 
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "9:3", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
     }
 
-    func testThatItFindsConversationWithQueryStringWithTrailingSpace() {
+    func testThatItFindsConversationWithQueryStringWithTrailingSpace() throws {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ")
 
         // when
 
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy ", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         // then
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result.first as? ZMConversation, conversation)
     }
 
-    func testThatItFindsConversationWithQueryStringWithWords() {
+    func testThatItFindsConversationWithQueryStringWithWords() throws {
         // given
         let conversation = insertMockGroupConversation(userDefinedName: "Sömëbodÿ to")
 
         // when
 
         let request = ZMConversation.sortedFetchRequest(with: ZMConversation.predicate(forSearchQuery: "Sømebôdy to", selfUser: selfUser))
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         // then
         XCTAssertEqual(result.count, 1)

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.swift
@@ -45,7 +45,7 @@ extension ZMConversationTests {
 
     // MARK: - SendOnlyEncryptedMessages
 
-    func testThatItInsertsEncryptedKnockMessages() {
+    func testThatItInsertsEncryptedKnockMessages() throws {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
 
@@ -54,13 +54,13 @@ extension ZMConversationTests {
 
         // then
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: ZMMessage.entityName())
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         XCTAssertEqual(result.count, 1)
         XCTAssertTrue((result.first is ZMClientMessage))
     }
 
-    func testThatItInsertsEncryptedTextMessages() {
+    func testThatItInsertsEncryptedTextMessages() throws {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
 
@@ -69,13 +69,13 @@ extension ZMConversationTests {
 
         // then
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: ZMMessage.entityName())
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         XCTAssertEqual(result.count, 1)
         XCTAssertTrue((result.first is ZMClientMessage))
     }
 
-    func testThatItInsertsEncryptedImageMessages() {
+    func testThatItInsertsEncryptedImageMessages() throws {
         // given
         let conversation = ZMConversation.insertNewObject(in: uiMOC)
 
@@ -84,7 +84,7 @@ extension ZMConversationTests {
 
         // then
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: ZMMessage.entityName())
-        let result = uiMOC.executeFetchRequestOrAssert(request)
+        let result = try uiMOC.fetch(request)
 
         XCTAssertEqual(result.count, 1)
         XCTAssertTrue((result.first is ZMAssetClientMessage))

--- a/wire-ios-data-model/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -64,7 +64,7 @@ class BaseZMClientMessageTests: BaseZMMessageTests {
             self.syncSelfUser = ZMUser.selfUser(in: self.syncMOC)
 
             self.syncSelfClient1 = self.createSelfClient(onMOC: self.syncMOC)
-            self.syncMOC.setPersistentStoreMetadata(self.syncSelfClient1.remoteIdentifier!, key: "PersistedClientId")
+            self.syncMOC.setPersistentStoreMetadata(self.syncSelfClient1.remoteIdentifier!, key: ZMPersistedClientIdKey)
 
             self.syncSelfClient2 = self.createClient(for: self.syncSelfUser, createSessionWithSelfUser: true, onMOC: self.syncMOC)
 
@@ -103,7 +103,7 @@ class BaseZMClientMessageTests: BaseZMMessageTests {
 
         self.selfUser = try! self.uiMOC.existingObject(with: self.syncSelfUser.objectID) as! ZMUser
         self.selfClient1 = try! self.uiMOC.existingObject(with: self.syncSelfClient1.objectID) as! UserClient
-        self.uiMOC.setPersistentStoreMetadata(self.selfClient1.remoteIdentifier!, key: "PersistedClientId")
+        self.uiMOC.setPersistentStoreMetadata(self.selfClient1.remoteIdentifier!, key: ZMPersistedClientIdKey)
 
         self.selfClient2 = try! self.uiMOC.existingObject(with: self.syncSelfClient2.objectID) as! UserClient
 
@@ -135,7 +135,7 @@ class BaseZMClientMessageTests: BaseZMMessageTests {
 
     override func tearDown() {
         syncMOC.performGroupedAndWait {
-            self.syncMOC.setPersistentStoreMetadata(nil as String?, key: "PersistedClientId")
+            self.syncMOC.setPersistentStoreMetadata(nil as String?, key: ZMPersistedClientIdKey)
         }
         wipeCaches()
         self.syncSelfUser = nil

--- a/wire-ios-data-model/Tests/Source/Model/TeamDeletionRuleTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/TeamDeletionRuleTests.swift
@@ -62,7 +62,7 @@ class TeamDeletionRuleTests: BaseZMClientMessageTests {
         XCTAssertEqual(ZMConversation.fetch(with: uuid3, in: uiMOC), conversation3)
     }
 
-    func testThatItDeletesMembersWhichArePartOfATeamWhenTeamGetsDeleted() {
+    func testThatItDeletesMembersWhichArePartOfATeamWhenTeamGetsDeleted() throws {
         // given
         let team = Team.insertNewObject(in: uiMOC)
         let member1 = Member.insertNewObject(in: uiMOC)
@@ -83,7 +83,7 @@ class TeamDeletionRuleTests: BaseZMClientMessageTests {
 
         // then
 
-        guard let members = uiMOC.executeFetchRequestOrAssert(NSFetchRequest(entityName: Member.entityName())) as? [Member] else {
+        guard let members = try uiMOC.fetch(NSFetchRequest(entityName: Member.entityName())) as? [Member] else {
             return XCTFail("No members fetched")
         }
 

--- a/wire-ios-mocktransport/Source/Clients and OTR/MockTransportSession+OTR.swift
+++ b/wire-ios-mocktransport/Source/Clients and OTR/MockTransportSession+OTR.swift
@@ -51,7 +51,7 @@ extension MockTransportSession {
 
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "UserClient")
         request.predicate = NSPredicate(format: "identifier == %@", senderClientId)
-        let client = managedObjectContext.executeFetchRequestOrAssert(request).first as? MockUserClient
+        let client = try! managedObjectContext.fetch(request).first as? MockUserClient
         return client
     }
 
@@ -172,7 +172,7 @@ extension MockTransportSession {
 
         let allClientsRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "UserClient")
         allClientsRequest.predicate = NSPredicate(format: "identifier IN %@", activeClients)
-        let allClients1 = managedObjectContext.executeFetchRequestOrAssert(allClientsRequest)
+        let allClients1 = try! managedObjectContext.fetch(allClientsRequest)
         let allClients = allClients1 as? [MockUserClient]
 
         let clientsEntries = recipients.flatMap { return $0.clients }

--- a/wire-ios-mocktransport/Source/Conversations/MockTransportSession+conversations.swift
+++ b/wire-ios-mocktransport/Source/Conversations/MockTransportSession+conversations.swift
@@ -25,7 +25,7 @@ extension MockTransportSession {
     public func fetchConversation(with identifier: String) -> MockConversation? {
         let request = MockConversation.sortedFetchRequest()
         request.predicate = NSPredicate(format: "identifier == %@", identifier.lowercased())
-        let conversations = managedObjectContext.executeFetchRequestOrAssert(request) as? [MockConversation]
+        let conversations = try! managedObjectContext.fetch(request) as? [MockConversation]
         return conversations?.first
     }
 
@@ -318,7 +318,7 @@ extension MockTransportSession {
     private func fetchConversation(selfUserIdentifier: String) -> MockConversation? {
         let request = MockConversation.sortedFetchRequest()
         request.predicate = NSPredicate(format: "selfIdentifier == %@", selfUserIdentifier.lowercased())
-        let conversations = managedObjectContext.executeFetchRequestOrAssert(request) as? [MockConversation]
+        let conversations = try! managedObjectContext.fetch(request) as? [MockConversation]
         return conversations?.first
     }
 }

--- a/wire-ios-mocktransport/Source/MockTransportSession.swift
+++ b/wire-ios-mocktransport/Source/MockTransportSession.swift
@@ -170,7 +170,6 @@ extension MockTransportSession: TransportSessionType {
     public func addCompletionHandlerForBackgroundSession(identifier: String, handler: @escaping () -> Void) {
 
     }
-
 }
 
 public extension MockTransportSession {

--- a/wire-ios-mocktransport/Source/Push Events/MockEvent.m
+++ b/wire-ios-mocktransport/Source/Push Events/MockEvent.m
@@ -24,8 +24,6 @@
 #import "MockConversation.h"
 #import <WireMockTransport/WireMockTransport-Swift.h>
 
-static ZMLogLevel_t const ZMLogLevel ZM_UNUSED = ZMLogLevelWarn;
-
 @implementation MockEvent
 
 @dynamic from;

--- a/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionJoinConversationTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Conversations/MockTransportSessionJoinConversationTests.swift
@@ -161,8 +161,7 @@ class MockTransportSessionJoinConversationTests: MockTransportSessionTests {
     private func fetchConversation(with identifier: String, in managedObjectContext: NSManagedObjectContext) -> MockConversation? {
         let request = MockConversation.sortedFetchRequest()
         request.predicate = NSPredicate(format: "identifier == %@", identifier.lowercased())
-        let conversations = managedObjectContext.executeFetchRequestOrAssert(request) as? [MockConversation]
+        let conversations = try! managedObjectContext.fetch(request) as? [MockConversation]
         return conversations?.first
     }
-
 }

--- a/wire-ios-notification-engine/Sources/ClientRegistrationStatus.swift
+++ b/wire-ios-notification-engine/Sources/ClientRegistrationStatus.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireDataModel
 import WireRequestStrategy
 
 final class ClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
@@ -34,7 +35,7 @@ final class ClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
     // MARK: - Methods
 
     var clientIsReadyForRequests: Bool {
-        if let clientId = context.persistentStoreMetadata(forKey: "PersistedClientId") as? String {
+        if let clientId = context.persistentStoreMetadata(forKey: ZMPersistedClientIdKey) as? String {
             // swiftlint:disable todo_requires_jira_link
             // TODO: move constant into shared framework
             // swiftlint:enable todo_requires_jira_link

--- a/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatusTests.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/PushNotificationStatusTests.swift
@@ -34,7 +34,7 @@ class FakeGroupQueue: NSObject, ZMSGroupQueue {
 
 // MARK: - Tests
 
-class PushNotificationStatusTests: MessagingTestBase {
+final class PushNotificationStatusTests: MessagingTestBase {
 
     var sut: PushNotificationStatus!
     var lastEventIDRepository: LastEventIDRepository!

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -456,7 +456,7 @@ extension MessagingTestBase {
         selfClient.remoteIdentifier = "baddeed"
         selfClient.user = user
 
-        self.syncMOC.setPersistentStoreMetadata(selfClient.remoteIdentifier!, key: "PersistedClientId")
+        self.syncMOC.setPersistentStoreMetadata(selfClient.remoteIdentifier!, key: ZMPersistedClientIdKey)
         selfClient.type = .permanent
         self.syncMOC.saveOrRollback()
         return selfClient

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -38,7 +38,7 @@ final class ClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
     }
 
     var clientIsReadyForRequests: Bool {
-        if let clientId = context.persistentStoreMetadata(forKey: "PersistedClientId") as? String { // TODO move constant into shared framework
+        if let clientId = context.persistentStoreMetadata(forKey: ZMPersistedClientIdKey) as? String { // TODO move constant into shared framework
             return !clientId.isEmpty
         }
 

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchResult+AddressBook.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchResult+AddressBook.swift
@@ -102,7 +102,7 @@ extension SearchResult {
         let fetchRequest = ZMUser.sortedFetchRequest(with: predicate)
         fetchRequest.returnsObjectsAsFaults = false
 
-        guard let users = managedObjectContext.executeFetchRequestOrAssert(fetchRequest) as? [ZMUser] else {
+        guard let users = try! managedObjectContext.fetch(fetchRequest) as? [ZMUser] else {
             fatal("fetchOrAssert failed")
         }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/CoreDataStack+Caches.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/CoreDataStack+Caches.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireDataModel
+import WireUtilities
 
 extension CoreDataStack {
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+APIAdapter.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+APIAdapter.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireAPI
+import WireSystem
 
 // Note: this is just a tempory helper for debugging
 // purposes and should eventually be removed.
@@ -33,7 +34,6 @@ extension ZMUserSession {
         return BackendInfoAPIBuilder(httpClient: httpClient)
             .makeAPI()
     }
-
 }
 
 private class HTTPClientImpl: HTTPClient {
@@ -52,10 +52,10 @@ private class HTTPClientImpl: HTTPClient {
     public func executeRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
         await withCheckedContinuation { continuation in
             let request = request.toZMTransportRequest()
-            request.add(ZMCompletionHandler(on: queue, block: { response in
+            request.add(ZMCompletionHandler(on: queue) { response in
                 let response = response.toHTTPResponse()
                 continuation.resume(returning: response)
-            }))
+            })
 
             transportSession.enqueueOneTime(request)
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -59,7 +59,7 @@ extension ZMUserSession {
                 let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ZMConversation.entityName())
                 fetchRequest.predicate = ZMConversation.predicateForConversationsArePendingToRefreshMetadata()
 
-                guard let conversations = context.executeFetchRequestOrAssert(fetchRequest) as? [ZMConversation] else {
+                guard let conversations = try! context.fetch(fetchRequest) as? [ZMConversation] else {
                     return
                 }
 

--- a/wire-ios-sync-engine/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/CallParticipantsSnapshotTests.swift
@@ -17,6 +17,8 @@
 //
 
 import Foundation
+import WireDataModel
+
 @testable import WireSyncEngine
 
 final class CallParticipantsSnapshotTests: MessagingTest {
@@ -281,7 +283,7 @@ final class CallParticipantsSnapshotTests: MessagingTest {
             self.selfClient = UserClient.insertNewObject(in: self.uiMOC)
             self.selfClient.user = self.selfUser
             self.selfClient.remoteIdentifier = self.aliceIphone.clientId
-            self.uiMOC.setPersistentStoreMetadata(self.selfClient.remoteIdentifier, key: "PersistedClientId")
+            self.uiMOC.setPersistentStoreMetadata(self.selfClient.remoteIdentifier, key: ZMPersistedClientIdKey)
 
             self.client1 = UserClient.insertNewObject(in: self.uiMOC)
             self.client1.user = self.selfUser

--- a/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/IntegrationTest.swift
@@ -510,7 +510,7 @@ extension IntegrationTest {
         let data = (uuid as NSUUID).data() as NSData
         let predicate = NSPredicate(format: "remoteIdentifier_data == %@", data)
         let request = ZMUser.sortedFetchRequest(with: predicate)
-        let result = userSession?.managedObjectContext.executeFetchRequestOrAssert(request) as? [ZMUser]
+        let result = try! userSession?.managedObjectContext.fetch(request) as? [ZMUser]
 
         if let user = result?.first {
             return user
@@ -528,7 +528,7 @@ extension IntegrationTest {
         let predicate = NSPredicate(format: "remoteIdentifier_data == %@", data)
         let request = ZMConversation.sortedFetchRequest(with: predicate)
 
-        let result = userSession?.managedObjectContext.performAndWait { userSession?.managedObjectContext.executeFetchRequestOrAssert(request) as? [ZMConversation]
+        let result = userSession?.managedObjectContext.performAndWait { try! userSession?.managedObjectContext.fetch(request) as? [ZMConversation]
         }
 
         if let conversation = result?.first {

--- a/wire-ios-sync-engine/Tests/Source/Repositories/ConnectionsRepositoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Repositories/ConnectionsRepositoryTests.swift
@@ -79,10 +79,10 @@ final class ConnectionsRepositoryTests: XCTestCase {
         try await sut.pullConnections()
 
         // Then
-        await context.perform { [context] in
+        try await context.perform { [context] in
             // There is a connection in the database.
             let fetchRequest = NSFetchRequest<any NSFetchRequestResult>(entityName: ZMConnection.entityName())
-            let a = context.executeFetchRequestOrAssert(fetchRequest)
+            let a = try context.fetch(fetchRequest)
             XCTAssertEqual(a.count, 1)
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ConversationRoleDownstreamRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/ConversationRoleDownstreamRequestStrategyTests.swift
@@ -91,7 +91,7 @@ final class ConversationRoleDownstreamRequestStrategyTests: MessagingTest {
             self.mockApplicationStatus.mockSynchronizationState = .online
 
             // when
-            let objs: [ZMConversation] = self.sut.contextChangeTrackers.compactMap({ $0.fetchRequestForTrackedObjects() }).flatMap({ self.syncMOC.executeFetchRequestOrAssert($0) as! [ZMConversation] })
+            let objs: [ZMConversation] = self.sut.contextChangeTrackers.compactMap({ $0.fetchRequestForTrackedObjects() }).flatMap({ try! self.syncMOC.fetch($0) as! [ZMConversation] })
 
             // then            
             XCTAssertEqual(objs, [convo1])

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ConversationStatusStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ConversationStatusStrategyTests.swift
@@ -128,7 +128,7 @@ class ConversationStatusStrategyTests: MessagingTest {
 
             // when
             let request = self.sut.fetchRequestForTrackedObjects()
-            let result = self.syncMOC.executeFetchRequestOrAssert(request! ) as! [NSManagedObject]
+            let result = try! self.syncMOC.fetch(request!) as! [NSManagedObject]
             if result.count > 0 {
                 self.sut.addTrackedObjects(Set<NSManagedObject>(result))
             } else {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/ZMHotFixTests.swift
@@ -298,7 +298,7 @@ final class ZMHotFixTests_Integration: MessagingTest {
         selfClient.remoteIdentifier = UUID().transportString()
         selfClient.user = ZMUser.selfUser(in: context)
         context.saveOrRollback()
-        context.setPersistentStoreMetadata(selfClient.remoteIdentifier, key: "PersistedClientId")
+        context.setPersistentStoreMetadata(selfClient.remoteIdentifier, key: ZMPersistedClientIdKey)
         return selfClient
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ClientUpdateStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ClientUpdateStatusTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireDataModel
 import WireTesting
 
 @testable import WireSyncEngine
@@ -76,7 +77,7 @@ class ClientUpdateStatusTests: MessagingTest {
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
         if isSelfClient {
             syncMOC.performAndWait {
-                syncMOC.setPersistentStoreMetadata(client.remoteIdentifier, key: "PersistedClientId")
+                syncMOC.setPersistentStoreMetadata(client.remoteIdentifier, key: ZMPersistedClientIdKey)
             }
         }
         return client

--- a/wire-ios-sync-engine/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
@@ -314,7 +314,7 @@ extension TopConversationsDirectoryTests {
             self.stopMeasuring()
 
             // clean up for the next block execution
-            self.uiMOC.executeFetchRequestOrAssert(ZMConversation.sortedFetchRequest()).forEach {
+            try! self.uiMOC.fetch(ZMConversation.sortedFetchRequest()).forEach {
                 self.uiMOC.delete($0 as! NSManagedObject)
             }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMAuthenticationStatusTests.m
@@ -97,7 +97,7 @@
     
     // then
     XCTAssertEqual(self.sut.currentPhase, ZMAuthenticationPhaseAuthenticated);
-    [self.uiMOC setPersistentStoreMetadata:nil forKey:@"PersistedClientId"];
+    [self.uiMOC setPersistentStoreMetadata:nil forKey:ZMPersistedClientIdKey];
 }
 
 @end

--- a/wire-ios-system/Tests/DispatchQueueHelperTests.swift
+++ b/wire-ios-system/Tests/DispatchQueueHelperTests.swift
@@ -19,7 +19,8 @@
 import WireSystem
 import XCTest
 
-class DispatchQueueHelperTests: XCTestCase {
+final class DispatchQueueHelperTests: XCTestCase {
+
     func testThatItEntersAndLeavesADispatchGroup() {
         // Given
         let group = ZMSDispatchGroup(label: name)

--- a/wire-ios-transport/Source/Public/ZMTransportRequestScheduler.h
+++ b/wire-ios-transport/Source/Public/ZMTransportRequestScheduler.h
@@ -15,10 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
+@import Foundation;
+@import WireSystem;
+@import WireUtilities;
 
-#import <Foundation/Foundation.h>
-#import <WireSystem/WireSystem.h>
-#import <WireUtilities/WireUtilities.h>
 #import <WireTransport/ZMReachability.h>
 #import <WireTransport/ZMTransportRequest.h>
 
@@ -37,8 +37,6 @@ enum {
     FederationRemoteError = 533
 };
 
-
-
 typedef NS_ENUM(int8_t, ZMTransportRequestSchedulerState) {
     ZMTransportRequestSchedulerStateNormal = 1,
     ZMTransportRequestSchedulerStateOffline,
@@ -49,8 +47,6 @@ typedef NS_ENUM(int8_t, ZMTransportRequestSchedulerState) {
 
 /// For use with @c concurrentRequestCountLimit when there's no limit in effect.
 extern NSInteger const ZMTransportRequestSchedulerRequestCountUnlimited;
-
-
 
 @interface ZMTransportRequestScheduler : NSObject <ZMReachabilityObserver, ZMSGroupQueue, TearDownCapable>
 
@@ -77,7 +73,6 @@ extern NSInteger const ZMTransportRequestSchedulerRequestCountUnlimited;
 @property (nonatomic, readonly) id<ReachabilityProvider> reachability;
 
 @end
-
 
 
 @protocol ZMTransportRequestSchedulerItem <NSObject>
@@ -118,7 +113,6 @@ extern NSInteger const ZMTransportRequestSchedulerRequestCountUnlimited;
 - (void)schedulerWentOffline:(ZMTransportRequestScheduler *)scheduler;
 
 @end
-
 
 
 @interface ZMTransportRequestScheduler (Testing)

--- a/wire-ios-transport/Source/Public/ZMTransportRequestScheduler.h
+++ b/wire-ios-transport/Source/Public/ZMTransportRequestScheduler.h
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
+
 @import Foundation;
 @import WireSystem;
 @import WireUtilities;

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -127,7 +127,6 @@ static NSInteger const DefaultMaximumRequests = 6;
 
     NSURLSessionConfiguration *foregroundConfiguration = [[self class] foregroundSessionConfigurationWithMinTLSVersion:minTLSVersion];
     foregroundConfiguration.connectionProxyDictionary = proxyDictionary;
-
     ZMURLSession *foregroundSession = [[ZMURLSession alloc] initWithConfiguration:foregroundConfiguration
                                                                     trustProvider:environment
                                                                          delegate:self

--- a/wire-ios-utilities/Source/NSManagedObjectContext+DispatchGroups.swift
+++ b/wire-ios-utilities/Source/NSManagedObjectContext+DispatchGroups.swift
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import CoreData
 
 public extension NSManagedObjectContext {
 
@@ -29,5 +29,4 @@ public extension NSManagedObjectContext {
         let secondaryGroup = dispatchGroupContext.groups[1]
         return dispatchGroupContext.enterAll(except: secondaryGroup)
     }
-
 }

--- a/wire-ios-utilities/Source/Public/NSManagedObjectContext+WireUtilities.h
+++ b/wire-ios-utilities/Source/Public/NSManagedObjectContext+WireUtilities.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Executes a fetch request and asserts in case of error
 /// For generic requests in Swift please refer to `func fetchOrAssert<T>(request: NSFetchRequest<T>) -> [T]`
-- (nonnull NSArray *)executeFetchRequestOrAssert:(nonnull NSFetchRequest *)request;
+- (nonnull NSArray *)executeFetchRequestOrAssert:(nonnull NSFetchRequest *)request NS_SWIFT_UNAVAILABLE("Use `try fetch(request)` instead!");
 
 - (NSArray<ZMSDispatchGroup*>*_Nonnull)enterAllGroups;
 - (void)leaveAllGroups:(NSArray <ZMSDispatchGroup*>*_Null_unspecified)groups;

--- a/wire-ios/Wire-iOS Tests/FontBookSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/FontBookSnapshotTests.swift
@@ -17,9 +17,10 @@
 //
 
 import SnapshotTesting
-@testable import Wire
 import WireCommonComponents
 import XCTest
+
+@testable import Wire
 
 final class FontBookSnapshotTests: XCTestCase {
 

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -62,6 +62,36 @@ enum AppState: Equatable {
     }
 }
 
+extension AppState: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        switch self {
+        case .retryStart:
+            "retryStart"
+        case .headless:
+            "headless"
+        case .locked:
+            "locked"
+        case .authenticated:
+            "authenticated"
+        case .unauthenticated(error: let error):
+            "unauthenticated"
+        case .blacklisted(reason: let reason):
+            "blacklisted"
+        case .jailbroken:
+            "jailbroken"
+        case .certificateEnrollmentRequired:
+            "certificateEnrollmentRequired"
+        case .databaseFailure(reason: let reason):
+            "databaseFailure"
+        case .migrating:
+            "migrating"
+        case .loading(account: let account, from: let from):
+            "loading"
+        }
+    }
+}
+
 // sourcery: AutoMockable
 protocol AppStateCalculatorDelegate: AnyObject {
     func appStateCalculator(

--- a/wire-ios/WireCommonComponents/Typography/Font+WireTextStyle.swift
+++ b/wire-ios/WireCommonComponents/Typography/Font+WireTextStyle.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import SwiftUI
 
 extension Font {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8907" title="WPB-8907" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8907</a>  Migrate Objective C code to Swift
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->

This PR removes calls from Swift code to the custom NSManagedObjectContext extension method `executeFetchRequestOrAssert` in order to reduce dependencies from Swift to Objective C.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

