### PR TITLE
fix: DDLOG errors reading logs while running tests - WPB-9714

### DIFF
--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -17,6 +17,7 @@
 //
 
 import XCTest
+import WireTesting
 @testable import WireDataModel
 @testable import WireDataModelSupport
 
@@ -212,7 +213,7 @@ final class OneOnOneMigratorTests: XCTestCase {
 
         // required to add be able to add images
         let cacheLocation = try XCTUnwrap(
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(UUID().uuidString)
+            FileManager.default.randomCacheURL
         )
 
         await syncContext.perform {

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneMigratorTests.swift
@@ -212,7 +212,7 @@ final class OneOnOneMigratorTests: XCTestCase {
 
         // required to add be able to add images
         let cacheLocation = try XCTUnwrap(
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(UUID().uuidString)
         )
 
         await syncContext.perform {

--- a/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -17,6 +17,7 @@
 // 
 
 import XCTest
+import WireTesting
 import WireDataModelSupport
 @testable import WireDataModel
 
@@ -46,7 +47,7 @@ class FileAssetCacheTests: XCTestCase {
         }
 
         location = try XCTUnwrap(
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(UUID().uuidString)
+            FileManager.default.randomCacheURL
         )
 
         try FileManager.default.removeItemIfExists(at: location!)

--- a/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -46,7 +46,7 @@ class FileAssetCacheTests: XCTestCase {
         }
 
         location = try XCTUnwrap(
-            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(UUID().uuidString)
         )
 
         try FileManager.default.removeItemIfExists(at: location!)

--- a/wire-ios-data-model/Tests/Source/Utils/DiskDatabaseTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/DiskDatabaseTests.swift
@@ -43,7 +43,7 @@ public class DiskDatabaseTest: ZMTBaseTest {
         super.setUp()
 
         accountId = .create()
-        cacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+        cacheURL = FileManager.default.randomCacheURL
         sharedContainerURL = cacheURL.appendingPathComponent(UUID().uuidString)
         cleanUp()
         createDatabase()

--- a/wire-ios-data-model/Tests/Source/Utils/DiskDatabaseTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/DiskDatabaseTests.swift
@@ -43,8 +43,8 @@ public class DiskDatabaseTest: ZMTBaseTest {
         super.setUp()
 
         accountId = .create()
-        cacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        sharedContainerURL = cacheURL.appendingPathComponent("\(UUID().uuidString)")
+        cacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+        sharedContainerURL = cacheURL.appendingPathComponent(UUID().uuidString)
         cleanUp()
         createDatabase()
         setupCaches()

--- a/wire-ios-request-strategy/Sources/Helpers/ZMTBaseTests+CoreDataStack.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMTBaseTests+CoreDataStack.swift
@@ -22,7 +22,8 @@ import WireTesting
 extension ZMTBaseTest {
 
     var sharedContainerURL: URL {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+
     }
 
     @objc

--- a/wire-ios-request-strategy/Sources/Helpers/ZMTBaseTests+CoreDataStack.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMTBaseTests+CoreDataStack.swift
@@ -22,7 +22,7 @@ import WireTesting
 extension ZMTBaseTest {
 
     var sharedContainerURL: URL {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+        FileManager.default.randomCacheURL!
 
     }
 

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -506,7 +506,7 @@ extension MessagingTestBase {
 extension MessagingTestBase {
 
     private var cacheFolder: URL {
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+        return FileManager.default.randomCacheURL!
     }
 
     fileprivate func deleteAllFilesInCache() {

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -506,7 +506,7 @@ extension MessagingTestBase {
 extension MessagingTestBase {
 
     private var cacheFolder: URL {
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
     }
 
     fileprivate func deleteAllFilesInCache() {

--- a/wire-ios-sync-engine/Tests/Source/DatabaseTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/DatabaseTest.swift
@@ -46,7 +46,8 @@ class DatabaseTest: ZMTBaseTest {
     }
 
     var cacheURL: URL {
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+
     }
 
     private func cleanUp() {

--- a/wire-ios-sync-engine/Tests/Source/DatabaseTest.swift
+++ b/wire-ios-sync-engine/Tests/Source/DatabaseTest.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireTesting
 
 class DatabaseTest: ZMTBaseTest {
 
@@ -46,7 +47,7 @@ class DatabaseTest: ZMTBaseTest {
     }
 
     var cacheURL: URL {
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+        return FileManager.default.randomCacheURL!
 
     }
 

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -30,7 +30,7 @@ final class SessionManagerTests: IntegrationTest {
     private var tmpDirectoryPath: URL { URL(fileURLWithPath: NSTemporaryDirectory()) }
 
     private var cachesDirectoryPath: URL {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
     }
 
     var mockDelegate: MockSessionManagerDelegate!

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/SessionManagerTests.swift
@@ -30,7 +30,7 @@ final class SessionManagerTests: IntegrationTest {
     private var tmpDirectoryPath: URL { URL(fileURLWithPath: NSTemporaryDirectory()) }
 
     private var cachesDirectoryPath: URL {
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!.appendingPathComponent(UUID().uuidString)
+        FileManager.default.randomCacheURL!
     }
 
     var mockDelegate: MockSessionManagerDelegate!

--- a/wire-ios-testing/Source/Public/FileManger+RandomCacheURL.swift
+++ b/wire-ios-testing/Source/Public/FileManger+RandomCacheURL.swift
@@ -1,0 +1,27 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public extension FileManager {
+
+    var randomCacheURL: URL? {
+        urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent(UUID().uuidString)
+    }
+
+}

--- a/wire-ios-testing/WireTesting.xcodeproj/project.pbxproj
+++ b/wire-ios-testing/WireTesting.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		09A218021B78DFAF0076547A /* ZMTSwiftHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A217F31B78DFAF0076547A /* ZMTSwiftHelpers.swift */; };
 		09A218041B78E01A0076547A /* FakeGroupContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09A218031B78E01A0076547A /* FakeGroupContext.swift */; };
 		166264A7216BB64100300F45 /* large.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 166264A6216BB64000300F45 /* large.jpg */; };
+		16AAA62C2C22E5BD00080A06 /* FileManger+RandomCacheURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AAA62B2C22E5BD00080A06 /* FileManger+RandomCacheURL.swift */; };
 		16E2561F21089DAE00919DB0 /* XCTestCase+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E2561E21089DAE00919DB0 /* XCTestCase+Helpers.swift */; };
 		5454E14A1B73A09100F131F8 /* ZMTExpectationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5454E1491B73A09100F131F8 /* ZMTExpectationTests.swift */; };
 		54AFD7E11CB6986A0090E33A /* 1900x1500.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 54AFD7DB1CB698690090E33A /* 1900x1500.jpg */; };
@@ -108,6 +109,7 @@
 		09F1863A1B6903A4007A3DA6 /* version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = version.xcconfig; sourceTree = "<group>"; };
 		09F1863F1B6903A4007A3DA6 /* WireTesting.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WireTesting.xcconfig; sourceTree = "<group>"; };
 		166264A6216BB64000300F45 /* large.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = large.jpg; sourceTree = "<group>"; };
+		16AAA62B2C22E5BD00080A06 /* FileManger+RandomCacheURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManger+RandomCacheURL.swift"; sourceTree = "<group>"; };
 		16E2561E21089DAE00919DB0 /* XCTestCase+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Helpers.swift"; sourceTree = "<group>"; };
 		5454E1471B73A09100F131F8 /* WireTesting-iosTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WireTesting-iosTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5454E1491B73A09100F131F8 /* ZMTExpectationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMTExpectationTests.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				CEB8FD681C11E50700ED0BE5 /* ZMMockManagedObjectContextFactory.m */,
 				87B0EF5B2139687500CE1931 /* ManagedObjectContextChangesMerger.swift */,
 				634CCB102BAC54FF00A11AB3 /* GenericArrayActor.swift */,
+				16AAA62B2C22E5BD00080A06 /* FileManger+RandomCacheURL.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -499,6 +502,7 @@
 				098CFBC51B7BAA2D000B02B1 /* XCTestCase+Helpers.m in Sources */,
 				CEB8FD6A1C11E50700ED0BE5 /* ZMMockManagedObjectContextFactory.m in Sources */,
 				09A218011B78DFAF0076547A /* ZMTFailureRecorder.m in Sources */,
+				16AAA62C2C22E5BD00080A06 /* FileManger+RandomCacheURL.swift in Sources */,
 				A971FAE123D7477200AB25B4 /* ZMTBaseTest.swift in Sources */,
 				09A217F91B78DFAF0076547A /* NSData+WireTesting.m in Sources */,
 				CE6B7B301C11ED5F00FC4C2E /* ZMMockEntity.m in Sources */,

--- a/wire-ios/Wire-iOS/Sources/Components/Settings+Logging.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Settings+Logging.swift
@@ -64,7 +64,6 @@ extension Settings {
             "URL",
             "EmoticonSubstitutionConfiguration",
             "URL Helper",
-            "Performance",
             "message-processing",
             "backend-environment",
             "Analytics",

--- a/wire-ios/Wire-iOS/Sources/Helpers/PerformanceDebugger.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/PerformanceDebugger.swift
@@ -29,7 +29,6 @@ final class PerformanceDebugger {
     /// The shared debugger.
     static let shared = PerformanceDebugger()
 
-    private let log = ZMSLog(tag: "Performance")
     private var displayLink: CADisplayLink!
 
     init() {
@@ -55,14 +54,12 @@ final class PerformanceDebugger {
         let elapsedTime = displayLink.duration * 100
 
         if elapsedTime > 16.7 {
-            log.warn("Frame dropped after \(elapsedTime)s")
             WireLogger.performance.warn("Frame dropped after \(elapsedTime)s")
         }
     }
 
     @objc
     private func handleMemoryWarning() {
-        log.warn("Application did receive memory warning.")
         WireLogger.performance.warn("Application did receive memory warning.")
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9714" title="WPB-9714" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9714</a>  Fix implementation of logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

While running tests especially on WireDataModel, it can happen we see:

```
{NSFilePath=XXXXX/CoreSimulator/Devices/AA806AC1-10E8-42F9-901E-D3B6599D9C68/data/Containers/Data/Application/7F97701E-B2EA-4C44-B06F-53903A21175A/Library/Caches/Logs/com.wire.WireDataModelTestTarget 2024-06-17--15-29-06-671.log, NSUnderlyingError=0x6000011ce4f0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2024-06-17 17:29:27.426411+0200 WireDataModelTestHost[76041:6965123] DDLogFileInfo: Failed to read file attributes: Error Domain=NSCocoaErrorDomain Code=260 "The file “com.wire.WireDataModelTestTarget 2024-06-17--15-29-06-671.log” couldn’t be opened because there is no such file."
```

This happens because some setup code use the `FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first` as cache location and it later wipes all the directory, hence we're not able to write to the file log

Solution: specify specify cache location.

### Testing

Run tests targets and check logs
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

