### PR TITLE
fix: Unable to import backup - WPB-9372

### DIFF
--- a/wire-ios-request-strategy/Sources/APIs/UserClientAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/UserClientAPI.swift
@@ -21,7 +21,7 @@ import Foundation
 // sourcery: AutoMockable
 public protocol UserClientAPI {
 
-    func deleteUserClient(clientId: String, credentials: EmailCredentials?) async throws
+    func deleteUserClient(clientId: String, password: String) async throws
 
 }
 
@@ -36,12 +36,12 @@ class UserClientAPIV0: UserClientAPI {
         return .v0
     }
 
-    func deleteUserClient(clientId: String, credentials: EmailCredentials?) async throws {
+    func deleteUserClient(clientId: String, password: String) async throws {
         let requestsFactory = UserClientRequestFactory()
 
         let request = requestsFactory.deleteClientRequest(
             clientId: clientId,
-            credentials: credentials,
+            password: password,
             apiVersion: apiVersion)
 
         let response = await httpClient.send(request)

--- a/wire-ios-request-strategy/Sources/User Client/UserClientRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/User Client/UserClientRequestFactory.swift
@@ -18,35 +18,17 @@
 
 import Foundation
 
-public struct EmailCredentials {
-    public init(email: String, password: String) {
-        self.email = email
-        self.password = password
-    }
-
-    let email: String
-    let password: String
-}
-
 public class UserClientRequestFactory {
 
     public init() {}
 
     func deleteClientRequest(
         clientId: String,
-        credentials: EmailCredentials?,
+        password: String,
         apiVersion: APIVersion) -> ZMTransportRequest {
-            let payload: [AnyHashable: Any]
-
-            if let email = credentials?.email,
-               let password = credentials?.password {
-                payload = [
-                    "email": email,
-                    "password": password
-                ]
-            } else {
-                payload = [:]
-            }
+            let payload: [AnyHashable: Any] = [
+                "password": password
+            ]
 
             let request = ZMTransportRequest(
                 path: "/clients/\(clientId)",

--- a/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1097,22 +1097,22 @@ public class MockUserClientAPI: UserClientAPI {
 
     // MARK: - deleteUserClient
 
-    public var deleteUserClientClientIdCredentials_Invocations: [(clientId: String, credentials: EmailCredentials?)] = []
-    public var deleteUserClientClientIdCredentials_MockError: Error?
-    public var deleteUserClientClientIdCredentials_MockMethod: ((String, EmailCredentials?) async throws -> Void)?
+    public var deleteUserClientClientIdPassword_Invocations: [(clientId: String, password: String)] = []
+    public var deleteUserClientClientIdPassword_MockError: Error?
+    public var deleteUserClientClientIdPassword_MockMethod: ((String, String) async throws -> Void)?
 
-    public func deleteUserClient(clientId: String, credentials: EmailCredentials?) async throws {
-        deleteUserClientClientIdCredentials_Invocations.append((clientId: clientId, credentials: credentials))
+    public func deleteUserClient(clientId: String, password: String) async throws {
+        deleteUserClientClientIdPassword_Invocations.append((clientId: clientId, password: password))
 
-        if let error = deleteUserClientClientIdCredentials_MockError {
+        if let error = deleteUserClientClientIdPassword_MockError {
             throw error
         }
 
-        guard let mock = deleteUserClientClientIdCredentials_MockMethod else {
-            fatalError("no mock for `deleteUserClientClientIdCredentials`")
+        guard let mock = deleteUserClientClientIdPassword_MockMethod else {
+            fatalError("no mock for `deleteUserClientClientIdPassword`")
         }
 
-        try await mock(clientId, credentials)
+        try await mock(clientId, password)
     }
 
 }

--- a/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
@@ -21,7 +21,7 @@ import Foundation
 // sourcery: AutoMockable
 public protocol RemoveUserClientUseCaseProtocol {
 
-    func invoke(clientId: String, credentials: EmailCredentials?) async throws
+    func invoke(clientId: String, password: String) async throws
 
 }
 
@@ -43,7 +43,7 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
 
     // MARK: - Public interface
 
-    func invoke(clientId: String, credentials: EmailCredentials?) async throws {
+    func invoke(clientId: String, password: String) async throws {
         let userClient = await syncContext.perform {
             return UserClient.fetchExistingUserClient(with: clientId, in: self.syncContext)
         }
@@ -52,7 +52,7 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
         }
 
         do {
-            try await userClientAPI.deleteUserClient(clientId: clientId, credentials: credentials)
+            try await userClientAPI.deleteUserClient(clientId: clientId, password: password)
             await didDeleteClient(userClient)
 
         } catch let networkError as NetworkError {

--- a/wire-ios-sync-engine/Tests/Source/Use cases/RemoveUserClientUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/RemoveUserClientUseCaseTests.swift
@@ -52,23 +52,23 @@ final class RemoveUserClientUseCaseTests: XCTestCase {
         let clientId = "222"
         try await createSelfClient(clientId: clientId)
         let expectation = XCTestExpectation(description: "should call deleteUserClient")
-        userClientAPI.deleteUserClientClientIdCredentials_MockMethod = {_, _ in
+        userClientAPI.deleteUserClientClientIdPassword_MockMethod = {_, _ in
             // Then
             expectation.fulfill()
         }
         mockApiProvider.userClientAPIApiVersion_MockValue = userClientAPI
 
         // When
-        try await sut.invoke(clientId: clientId, credentials: EmailCredentials(email: "", password: ""))
+        try await sut.invoke(clientId: clientId, password: "")
     }
 
     func testThatItDoesNotRemoveUserClient_WhenClientDoesNotExistLocally() async throws {
         // Given
-        userClientAPI.deleteUserClientClientIdCredentials_MockMethod = { _, _ in }
+        userClientAPI.deleteUserClientClientIdPassword_MockMethod = { _, _ in }
 
         // When / Then
         await assertItThrows(error: RemoveUserClientError.clientDoesNotExistLocally) {
-            try await sut.invoke(clientId: "", credentials: EmailCredentials(email: "", password: ""))
+            try await sut.invoke(clientId: "", password: "")
         }
     }
 
@@ -76,12 +76,12 @@ final class RemoveUserClientUseCaseTests: XCTestCase {
         // Given
         let clientId = "222"
         try await createSelfClient(clientId: clientId)
-        userClientAPI.deleteUserClientClientIdCredentials_MockMethod = { _, _ in }
-        userClientAPI.deleteUserClientClientIdCredentials_MockError = RemoveUserClientError.clientToDeleteNotFound
+        userClientAPI.deleteUserClientClientIdPassword_MockMethod = { _, _ in }
+        userClientAPI.deleteUserClientClientIdPassword_MockError = RemoveUserClientError.clientToDeleteNotFound
 
         // When / Then
         await assertItThrows(error: RemoveUserClientError.clientToDeleteNotFound) {
-            try await sut.invoke(clientId: clientId, credentials: EmailCredentials(email: "", password: ""))
+            try await sut.invoke(clientId: clientId, password: "")
         }
     }
 
@@ -89,12 +89,12 @@ final class RemoveUserClientUseCaseTests: XCTestCase {
         // Given
         let clientId = "222"
         try await createSelfClient(clientId: clientId)
-        userClientAPI.deleteUserClientClientIdCredentials_MockMethod = { _, _ in }
-        userClientAPI.deleteUserClientClientIdCredentials_MockError = RemoveUserClientError.invalidCredentials
+        userClientAPI.deleteUserClientClientIdPassword_MockMethod = { _, _ in }
+        userClientAPI.deleteUserClientClientIdPassword_MockError = RemoveUserClientError.invalidCredentials
 
         // When / Then
         await assertItThrows(error: RemoveUserClientError.invalidCredentials) {
-            try await sut.invoke(clientId: clientId, credentials: EmailCredentials(email: "", password: ""))
+            try await sut.invoke(clientId: clientId, password: "")
         }
     }
 

--- a/wire-ios-sync-engine/sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/sourcery/generated/AutoMockable.generated.swift
@@ -384,22 +384,22 @@ public class MockRemoveUserClientUseCaseProtocol: RemoveUserClientUseCaseProtoco
 
     // MARK: - invoke
 
-    public var invokeClientIdCredentials_Invocations: [(clientId: String, credentials: EmailCredentials?)] = []
-    public var invokeClientIdCredentials_MockError: Error?
-    public var invokeClientIdCredentials_MockMethod: ((String, EmailCredentials?) async throws -> Void)?
+    public var invokeClientIdPassword_Invocations: [(clientId: String, password: String)] = []
+    public var invokeClientIdPassword_MockError: Error?
+    public var invokeClientIdPassword_MockMethod: ((String, String) async throws -> Void)?
 
-    public func invoke(clientId: String, credentials: EmailCredentials?) async throws {
-        invokeClientIdCredentials_Invocations.append((clientId: clientId, credentials: credentials))
+    public func invoke(clientId: String, password: String) async throws {
+        invokeClientIdPassword_Invocations.append((clientId: clientId, password: password))
 
-        if let error = invokeClientIdCredentials_MockError {
+        if let error = invokeClientIdPassword_MockError {
             throw error
         }
 
-        guard let mock = invokeClientIdCredentials_MockMethod else {
-            fatalError("no mock for `invokeClientIdCredentials`")
+        guard let mock = invokeClientIdPassword_MockMethod else {
+            fatalError("no mock for `invokeClientIdPassword`")
         }
 
-        try await mock(clientId, credentials)
+        try await mock(clientId, password)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/AppStateCalculatorTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppStateCalculatorTests.swift
@@ -127,6 +127,19 @@ final class AppStateCalculatorTests: XCTestCase {
         XCTAssertTrue(delegate.wasNotified)
     }
 
+    func testThatAppStateChanges_OnDidFailToLogin_CanNotRegisterMoreClients() {
+        // GIVEN
+        let error = NSError(code: ZMUserSessionErrorCode.canNotRegisterMoreClients, userInfo: nil)
+        sut.applicationDidBecomeActive()
+
+        // WHEN
+        sut.sessionManagerDidFailToLogin(error: error)
+
+        // THEN
+        XCTAssertEqual(sut.appState, .unauthenticated(error: error))
+        XCTAssertTrue(delegate.wasNotified)
+    }
+
     func testThatAppStateChanges_OnSessionLockChange() {
         // GIVEN
         let userSession = UserSessionMock()

--- a/wire-ios/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
+++ b/wire-ios/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
@@ -144,11 +144,11 @@ final class AuthenticationInterfaceBuilderTests: XCTestCase, CoreDataFixtureTest
     }
 
     func testTooManyDevicesScreen() {
-        runSnapshotTest(for: .clientManagement(clients: [], credentials: nil))
+        runSnapshotTest(for: .clientManagement(clients: []))
     }
 
     func testClientRemovalScreen() {
-        runSnapshotTest(for: .deleteClient(clients: [mockUserClient()], credentials: nil))
+        runSnapshotTest(for: .deleteClient(clients: [mockUserClient()]))
     }
 
     func testAddEmailPasswordScreen() {

--- a/wire-ios/Wire-iOS Tests/RemoveClientStepViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/RemoveClientStepViewControllerSnapshotTests.swift
@@ -34,8 +34,7 @@ final class RemoveClientStepViewControllerSnapshotTests: XCTestCase, CoreDataFix
                                                        mockUserClient(),
                                                        mockUserClient(),
                                                        mockUserClient(),
-                                                       mockUserClient()],
-                                             credentials: ZMCredentials())
+                                                       mockUserClient()])
     }
 
     override func tearDown() {

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		064AD4C425DD31A600143D74 /* UIApplication+OpenURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 064AD4C325DD31A600143D74 /* UIApplication+OpenURL.swift */; };
 		0658F5AC25D16EA700DD6859 /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F174AAAE218A0B1A00AFCC4D /* ColorScheme.swift */; };
 		0658F5AD25D16EA900DD6859 /* ColorScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = F174AAAE218A0B1A00AFCC4D /* ColorScheme.swift */; };
+		06593A7A2C238B9F0049441E /* AuthenticationStartClientLimitErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06593A792C238B9F0049441E /* AuthenticationStartClientLimitErrorHandler.swift */; };
 		065A591E2BEA219E008487CF /* OtherUserDeviceDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065A591D2BEA219E008487CF /* OtherUserDeviceDetailsView.swift */; };
 		065A5AE1279B07AC002D4D1E /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065A5AE0279B07AC002D4D1E /* NotificationService.swift */; };
 		065A5AE5279B07AC002D4D1E /* Wire Notification Service Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 065A5ADE279B07AC002D4D1E /* Wire Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -2091,6 +2092,7 @@
 		06379686296491C000674AAA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		0637968E2964E2FE00674AAA /* Assets+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Assets+Generated.swift"; sourceTree = "<group>"; };
 		064AD4C325DD31A600143D74 /* UIApplication+OpenURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+OpenURL.swift"; sourceTree = "<group>"; };
+		06593A792C238B9F0049441E /* AuthenticationStartClientLimitErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationStartClientLimitErrorHandler.swift; sourceTree = "<group>"; };
 		065A591D2BEA219E008487CF /* OtherUserDeviceDetailsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OtherUserDeviceDetailsView.swift; sourceTree = "<group>"; };
 		065A5ADE279B07AC002D4D1E /* Wire Notification Service Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Wire Notification Service Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		065A5AE0279B07AC002D4D1E /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -5102,6 +5104,7 @@
 				5EE73BE52122C6DC0032986D /* AuthenticationStartAddAccountEventHandler.swift */,
 				16D74BEB2B59203C00160298 /* AuthenticationStartMissingUsernameErrorHandler.swift */,
 				1695B9DB2BA1C15000E9342A /* AuthenticationStartE2EIdentityMissingErrorHandler.swift */,
+				06593A792C238B9F0049441E /* AuthenticationStartClientLimitErrorHandler.swift */,
 			);
 			path = "Flow Start";
 			sourceTree = "<group>";
@@ -9631,6 +9634,7 @@
 				D525426F209363DC001C04C1 /* CallActionAppearance.swift in Sources */,
 				D3A74DC7294CAFEF00DD272F /* AccessibilityActionView.swift in Sources */,
 				5E3A6C25206A4E4A00907484 /* LocationPreviewController.swift in Sources */,
+				06593A7A2C238B9F0049441E /* AuthenticationStartClientLimitErrorHandler.swift in Sources */,
 				EE01D08825ADA3D5001DB205 /* AppLockModule.Interactor.swift in Sources */,
 				E964168628997173007F9756 /* ButtonStyle.swift in Sources */,
 				BF8ECC2D1E570A920015177D /* UIActivityViewController+FileSaving.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -208,7 +208,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             showCertificateEnrollRequest(completion: completionBlock)
         case .databaseFailure(let error):
             showDatabaseLoadingFailure(error: error, completion: completionBlock)
-        case .migrating: //
+        case .migrating:
             showLaunchScreen(isLoading: true, completion: completionBlock)
         case .unauthenticated(error: let error):
             screenCurtain.userSession = nil

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -208,7 +208,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             showCertificateEnrollRequest(completion: completionBlock)
         case .databaseFailure(let error):
             showDatabaseLoadingFailure(error: error, completion: completionBlock)
-        case .migrating:
+        case .migrating: //
             showLaunchScreen(isLoading: true, completion: completionBlock)
         case .unauthenticated(error: let error):
             screenCurtain.userSession = nil
@@ -321,6 +321,7 @@ extension AppRootRouter {
             self.authenticationCoordinator == nil ||
                 error?.userSessionErrorCode == .addAccountRequested ||
                 error?.userSessionErrorCode == .accountDeleted ||
+                error?.userSessionErrorCode == .canNotRegisterMoreClients ||
                 error?.userSessionErrorCode == .needsAuthenticationAfterMigration,
             let sessionManager = SessionManager.shared
         else {

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -67,7 +67,7 @@ indirect enum AuthenticationFlowStep: Equatable {
 
     // Post Sign-In
     case noHistory(credentials: ZMCredentials?, context: NoHistoryContext)
-    case clientManagement(clients: [UserClient], credentials: ZMCredentials?)
+    case clientManagement(clients: [UserClient])
     case deleteClient(clients: [UserClient])
     case addEmailAndPassword
     case enrollE2EIdentity

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -68,7 +68,7 @@ indirect enum AuthenticationFlowStep: Equatable {
     // Post Sign-In
     case noHistory(credentials: ZMCredentials?, context: NoHistoryContext)
     case clientManagement(clients: [UserClient], credentials: ZMCredentials?)
-    case deleteClient(clients: [UserClient], credentials: ZMCredentials?)
+    case deleteClient(clients: [UserClient])
     case addEmailAndPassword
     case enrollE2EIdentity
     case enrollE2EIdentitySuccess(String)

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -120,8 +120,8 @@ final class AuthenticationInterfaceBuilder {
             )
             return viewController
 
-        case .deleteClient(let clients, let credentials):
-            return RemoveClientStepViewController(clients: clients, credentials: credentials)
+        case .deleteClient(let clients):
+            return RemoveClientStepViewController(clients: clients)
 
         case .noHistory(_, let context):
             let backupStep = BackupRestoreStepDescription(context: context)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -115,7 +115,7 @@ final class AuthenticationEventResponderChain {
 
     fileprivate func registerDefaultEventHandlers() {
         // flowStartHandlers
-        registerHandler(AuthenticationClientLimitErrorHandler1(), to: &flowStartHandlers)
+        registerHandler(AuthenticationStartClientLimitErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartE2EIdentityMissingErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartMissingUsernameErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartMissingCredentialsErrorHandler(), to: &flowStartHandlers)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -115,6 +115,7 @@ final class AuthenticationEventResponderChain {
 
     fileprivate func registerDefaultEventHandlers() {
         // flowStartHandlers
+        registerHandler(AuthenticationClientLimitErrorHandler1(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartE2EIdentityMissingErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartMissingUsernameErrorHandler(), to: &flowStartHandlers)
         registerHandler(AuthenticationStartMissingCredentialsErrorHandler(), to: &flowStartHandlers)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Flow Start/AuthenticationStartClientLimitErrorHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Flow Start/AuthenticationStartClientLimitErrorHandler.swift
@@ -1,0 +1,41 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+final class AuthenticationStartClientLimitErrorHandler: AuthenticationEventHandler {
+
+    weak var statusProvider: AuthenticationStatusProvider?
+
+    func handleEvent(currentStep: AuthenticationFlowStep, context: (NSError?, Int)) -> [AuthenticationCoordinatorAction]? {
+        let (error, _) = context
+
+        // Only handle canNotRegisterMoreClients errors
+        guard
+            let error = error,
+            error.userSessionErrorCode == .canNotRegisterMoreClients,
+            let nextStep = AuthenticationFlowStep.makeClientManagementStep(
+                from: error,
+                statusProvider: self.statusProvider)
+        else {
+            return nil
+        }
+        return [.hideLoadingView, .transition(nextStep, mode: .reset)]
+    }
+
+}

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
@@ -38,8 +38,9 @@ final class AuthenticationButtonTapInputHandler: AuthenticationEventHandler {
             return [.showLoadingView, .startE2EIEnrollment]
         case .noHistory:
             return [.showLoadingView, .configureNotifications, .completeBackupStep]
+            // TODO Katerina remove credentials from clientManagement
         case .clientManagement(let clients, let credentials):
-            let nextStep = AuthenticationFlowStep.deleteClient(clients: clients, credentials: credentials)
+            let nextStep = AuthenticationFlowStep.deleteClient(clients: clients)
             return [AuthenticationCoordinatorAction.transition(nextStep, mode: .normal)]
         case .pendingEmailLinkVerification:
             return [.repeatAction]

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationButtonTapInputHandler.swift
@@ -38,8 +38,7 @@ final class AuthenticationButtonTapInputHandler: AuthenticationEventHandler {
             return [.showLoadingView, .startE2EIEnrollment]
         case .noHistory:
             return [.showLoadingView, .configureNotifications, .completeBackupStep]
-            // TODO Katerina remove credentials from clientManagement
-        case .clientManagement(let clients, let credentials):
+        case .clientManagement(let clients):
             let nextStep = AuthenticationFlowStep.deleteClient(clients: clients)
             return [AuthenticationCoordinatorAction.transition(nextStep, mode: .normal)]
         case .pendingEmailLinkVerification:

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Registration Error/AuthenticationClientLimitErrorHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Registration Error/AuthenticationClientLimitErrorHandler.swift
@@ -48,33 +48,10 @@ final class AuthenticationClientLimitErrorHandler: AuthenticationEventHandler {
             return nil
         }
 
-        guard let nextStep = AuthenticationFlowStep.makeClientManagementStep(from: error, credentials: authenticationCredentials, statusProvider: self.statusProvider) else {
+        guard let nextStep = AuthenticationFlowStep.makeClientManagementStep(from: error, statusProvider: self.statusProvider) else {
             return nil
         }
 
-        return [.hideLoadingView, .transition(nextStep, mode: .reset)]
-    }
-
-}
-
-final class AuthenticationClientLimitErrorHandler1: AuthenticationEventHandler {
-
-    weak var statusProvider: AuthenticationStatusProvider?
-
-    func handleEvent(currentStep: AuthenticationFlowStep, context: (NSError?, Int)) -> [AuthenticationCoordinatorAction]? {
-        let (error, _) = context
-
-        // Only handle canNotRegisterMoreClients errors
-        guard
-            let error = error,
-            error.userSessionErrorCode == .canNotRegisterMoreClients,
-            let nextStep = AuthenticationFlowStep.makeClientManagementStep(
-                from: error,
-                credentials: nil,
-                statusProvider: self.statusProvider)
-        else {
-            return nil
-        }
         return [.hideLoadingView, .transition(nextStep, mode: .reset)]
     }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Registration Error/AuthenticationClientLimitErrorHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Post-Login/Registration Error/AuthenticationClientLimitErrorHandler.swift
@@ -56,3 +56,26 @@ final class AuthenticationClientLimitErrorHandler: AuthenticationEventHandler {
     }
 
 }
+
+final class AuthenticationClientLimitErrorHandler1: AuthenticationEventHandler {
+
+    weak var statusProvider: AuthenticationStatusProvider?
+
+    func handleEvent(currentStep: AuthenticationFlowStep, context: (NSError?, Int)) -> [AuthenticationCoordinatorAction]? {
+        let (error, _) = context
+
+        // Only handle canNotRegisterMoreClients errors
+        guard
+            let error = error,
+            error.userSessionErrorCode == .canNotRegisterMoreClients,
+            let nextStep = AuthenticationFlowStep.makeClientManagementStep(
+                from: error,
+                credentials: nil,
+                statusProvider: self.statusProvider)
+        else {
+            return nil
+        }
+        return [.hideLoadingView, .transition(nextStep, mode: .reset)]
+    }
+
+}

--- a/wire-ios/Wire-iOS/Sources/Authentication/Helpers/AuthenticationFlowStep+ClientsDeletion.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Helpers/AuthenticationFlowStep+ClientsDeletion.swift
@@ -21,7 +21,7 @@ import WireSyncEngine
 
 extension AuthenticationFlowStep {
 
-    static func makeClientManagementStep(from error: NSError, credentials: ZMCredentials?, statusProvider: AuthenticationStatusProvider?) -> AuthenticationFlowStep? {
+    static func makeClientManagementStep(from error: NSError, statusProvider: AuthenticationStatusProvider?) -> AuthenticationFlowStep? {
         guard let userClientIDs = error.userInfo[ZMClientsKey] as? [NSManagedObjectID] else {
             return nil
         }
@@ -38,7 +38,7 @@ extension AuthenticationFlowStep {
             return object as? UserClient
         }
 
-        return .clientManagement(clients: clients, credentials: credentials)
+        return .clientManagement(clients: clients)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
@@ -34,19 +34,8 @@ final class RemoveClientStepViewController: UIViewController, AuthenticationCoor
 
     // MARK: - Initialization
 
-    init(clients: [UserClient],
-         credentials: ZMCredentials?) {
-        let emailCredentials: ZMEmailCredentials? = credentials.flatMap {
-            guard let email = $0.email, let password = $0.password else {
-                return nil
-            }
-
-            return ZMEmailCredentials(email: email, password: password)
-        }
-
-        clientListController = RemoveClientsViewController(
-            clientsList: clients,
-            credentials: emailCredentials)
+    init(clients: [UserClient]) {
+        clientListController = RemoveClientsViewController(clientsList: clients)
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewController.swift
@@ -138,6 +138,7 @@ final class RemoveClientsViewController: UIViewController,
                     continuation.resume(returning: password)
                 })
             guard let alertController = requestPasswordController?.alertController else {
+                continuation.resume(returning: nil)
                 return
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewModel.swift
@@ -54,7 +54,7 @@ extension RemoveClientsViewController {
             }
 
             try await removeUserClientUseCase?.invoke(clientId: clientId,
-                                                      credentials: EmailCredentials(email: "", password: password))
+                                                      password: password)
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewModel.swift
@@ -22,12 +22,9 @@ import WireCommonComponents
 extension RemoveClientsViewController {
     final class ViewModel: NSObject {
         private let removeUserClientUseCase: RemoveUserClientUseCaseProtocol?
-        private let credentials: ZMEmailCredentials?
         private(set) var clients: [UserClient] = []
 
-        init(clientsList: [UserClient],
-             credentials: ZMEmailCredentials?) {
-            self.credentials = credentials
+        init(clientsList: [UserClient]) {
             self.removeUserClientUseCase = ZMUserSession.shared()?.removeUserClient
 
             super.init()
@@ -48,25 +45,16 @@ extension RemoveClientsViewController {
                 })
         }
 
-        func removeUserClient(_ userClient: UserClient) async throws {
+        func removeUserClient(_ userClient: UserClient, password: String) async throws {
             let clientId = await userClient.managedObjectContext?.perform {
                 return userClient.remoteIdentifier
             }
             guard let clientId else {
                 throw RemoveUserClientError.clientDoesNotExistLocally
             }
-            try await removeUserClientUseCase?.invoke(clientId: clientId, credentials: credentials?.emailCredentials)
-        }
-    }
-}
 
-private extension ZMEmailCredentials {
-    var emailCredentials: EmailCredentials? {
-        guard let email,
-              let password
-        else {
-            return nil
+            try await removeUserClientUseCase?.invoke(clientId: clientId,
+                                                      credentials: EmailCredentials(email: "", password: password))
         }
-        return EmailCredentials(email: email, password: password)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9372" title="WPB-9372" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9372</a>  [iOS] Beta unable to import backup from Production
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->

### Issue
If a user who already has 7 active clients wants to restore a backup created from an app version with an old database version, the app will stuck on the landing screen.

### Solution
After migration, create a new `AuthenticationCoordinator` and go to the `.createCredentials` authentication step. Since we are creating a new authentication coordinator, we no longer have the password from the first step and need to prompt for a password to remove one of the clients. 

**Note:** we didn't ask for a password to delete clients during login, but it wasn't consistent with other platforms. QA and product agree to ask a password each time.

### Testing
1. Create a backup with the previous version of the database.
2. You should have 7 clients for the user you are going to use.
3. Import backup.

**Expected:**
- There should be a screen "Too many devices".
- After deleting one of the clients, the login process should be completed.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

