### PR TITLE
chore: skip bundle install in setup.sh on failure - no ticket

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -84,7 +84,7 @@ if [[ -n "${CI-}" ]]; then # skip cache bootstrap for CI
     echo "Skipping install since CI is defined"
 else
     which bundle || gem install bundler
-    bundle check || bundle install || echo "⚠️  Skipping bundle install since no or an old ruby version is installed"
+    bundle check || bundle install || echo "⚠️  Skipping bundle install, please check if you have the required ruby version installed"
 fi
 echo ""
 

--- a/setup.sh
+++ b/setup.sh
@@ -84,7 +84,7 @@ if [[ -n "${CI-}" ]]; then # skip cache bootstrap for CI
     echo "Skipping install since CI is defined"
 else
     which bundle || gem install bundler
-    bundle check || bundle install
+    bundle check || bundle install || echo "⚠️  Skipping bundle install since no or an old ruby version is installed"
 fi
 echo ""
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Currently setup.sh fails hard when no proper ruby version is installed.
This PR instead adds a printed warning and continues with the script.

<img width="504" alt="Screenshot 2024-06-20 at 09 37 59" src="https://github.com/wireapp/wire-ios/assets/15628584/6e9fa94e-0424-4d61-a059-e929dd9e1f44">

### Testing

Gems should be installed when a proper ruby version is available, otherwise a clear warning must be shown.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

