### PR TITLE
fix(actions): prevent command injection - WPB-9709

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,11 +12,11 @@ on:
       changelog-name:
         description: "The name of the changelog file"
         value: ${{ jobs.changelog.outputs.changelog-name }}
-    
+
 
 env: # https://docs.fastlane.tools/getting-started/ios/setup/
   LC_ALL: en_US.UTF-8
-  LANG: en_US.UTF-8     
+  LANG: en_US.UTF-8
 
 jobs:
   changelog:
@@ -32,14 +32,16 @@ jobs:
       - name: 'Tag regex'
         id: regex
         run: |
-          if ${{ inputs.is_cloud_build }}; then
+          if [ "true" == "${IS_CLOUD_BUILD}" ]; then
             echo "regex='appstore/[0-9]+\.[0-9]+\.[0-9]*'" >> $GITHUB_ENV
-          else 
+          else
             echo "regex='bk_build/[0-9]+\.[0-9]+\.[0-9]*'" >> $GITHUB_ENV
           fi
+        env:
+          IS_CLOUD_BUILD: ${{ inputs.is_cloud_build }}
       - name: 'Calculate diff between HEAD and latest tag'
         run: echo "HEAD_TAG_DIFF=$(git diff HEAD $(git tag | grep -E '${{ env.regex }}' | tail -n 1) | wc -l | xargs)" >> "$GITHUB_ENV"
-      
+
       - name: 'Set current Git tag to HEAD'
         if: "${{ env.HEAD_TAG_DIFF != '0' }}"
         run: echo "CURRENT_TAG=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
@@ -66,9 +68,9 @@ jobs:
           npx generate-changelog@1.8.0 -t "$PREVIOUS_TAG...$CURRENT_TAG"
 
       - name: 'Set date variable'
-        id: date          
+        id: date
         run: echo "date=$(date +%s%N)" >> $GITHUB_OUTPUT
-  
+
       - name: 'Upload changelog'
         id: upload-file
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9709" title="WPB-9709" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9709</a>  Fix GHA pipeline command injection vulnerabilities
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Unsanitized user input could be used to execute arbitrary code in the context of the workflow.

related:
- https://wearezeta.atlassian.net/wiki/spaces/SC/pages/1216053328/How+to+avoid+Command+Injection+via+Github+Actions+or+CI+jobs+in+general
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.

