### PR TITLE
fix: refilling prekeys always start from index 0 - WPB-9806

### DIFF
--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -236,7 +236,7 @@ public final class ProteusService: ProteusServiceInterface {
     }
 
     public func generatePrekey(id: UInt16) async throws -> String {
-        logger.info("generating prekey")
+        logger.info("generating prekey with id: \(id)")
 
         do {
             return try await coreCrypto.perform { try await $0.proteusNewPrekey(prekeyId: id).base64EncodedString() }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestStrategy.swift
@@ -323,10 +323,11 @@ public final class UserClientRequestStrategy: ZMObjectSyncStrategy, ZMObjectStra
                 return false
             } else if clientUpdateStatus?.currentPhase == .waitingForPrekeys {
                 clientUpdateStatus?.willGeneratePrekeys()
+                let nextPrekeyIndex = UInt16(userClient.preKeysRangeMax) + 1
                 let groups = managedObjectContext?.enterAllGroupsExceptSecondary()
                 Task {
                     do {
-                        let prekeys = try await prekeyGenerator.generatePrekeys()
+                        let prekeys = try await prekeyGenerator.generatePrekeys(startIndex: nextPrekeyIndex)
                         await managedObjectContext?.perform {
                             self.clientUpdateStatus?.didGeneratePrekeys(prekeys)
                         }

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestStrategyTests.swift
@@ -426,6 +426,7 @@ extension UserClientRequestStrategyTests {
             let client = self.createSelfClient(self.sut.managedObjectContext!)
             client.remoteIdentifier = UUID.create().transportString()
             client.numberOfKeysRemaining = Int32(self.sut.minNumberOfRemainingKeys - 1)
+            client.preKeysRangeMax = 5
             client.setLocallyModifiedKeys([ZMUserClientNumberOfKeysRemainingKey])
             self.sut.managedObjectContext!.saveOrRollback()
             self.sut.notifyChangeTrackers(client)
@@ -438,6 +439,7 @@ extension UserClientRequestStrategyTests {
         syncMOC.performGroupedBlockAndWait {
             // then
             XCTAssertNotNil(self.clientUpdateStatus.prekeys)
+            XCTAssertEqual(self.clientUpdateStatus.prekeys?.first?.id, 6)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9806" title="WPB-9806" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9806</a>  When refilling prekeys the iOS client is always starting from index 0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When re-filling prekeys we were always starting from index 0. If not all local prekeys have been used they would be over-written, and if someone had been holding on to an old prekey and tries use it this will result in a decryption error.

#### Solution

Generate new prekeys after the previous range to avoid any change of overwriting old prekeys.

### Testing

Run out of prekeys and watch the logs to see that the new prekeys have an index higher than the previously generated prekeys.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

