### PR TITLE
refactor: add update event processor stubs - WPB-8742

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor.swift
@@ -37,7 +37,7 @@ protocol ConversationEventProcessorProtocol {
 struct ConversationEventProcessor {
 
     func processEvent(_ event: ConversationEvent) async throws {
-        assertionFailure("not implemented")
+        assertionFailure("not implemented yet")
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+
+/// Process conversation update events.
+
+protocol ConversationEventProcessorProtocol {
+    
+    /// Process a conversation update event.
+    ///
+    /// Processing an event is the app's only chance to consume
+    /// some remote changes to update its local state.
+    ///
+    /// - Parameter event: A conversation update event.
+
+    func processEvent(_ event: ConversationEvent) async throws
+
+}
+
+struct ConversationEventProcessor {
+
+    func processEvent(_ event: ConversationEvent) async throws {
+        assertionFailure("not implemented")
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor.swift
@@ -22,7 +22,7 @@ import WireAPI
 /// Process conversation update events.
 
 protocol ConversationEventProcessorProtocol {
-    
+
     /// Process a conversation update event.
     ///
     /// Processing an event is the app's only chance to consume

--- a/WireDomain/Sources/WireDomain/Event Processing/FeatureConfigEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FeatureConfigEventProcessor.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+
+/// Process feature config update events.
+
+protocol FeatureConfigEventProcessorProtocol {
+
+    /// Process a feature config update event.
+    ///
+    /// Processing an event is the app's only chance to consume
+    /// some remote changes to update its local state.
+    ///
+    /// - Parameter event: A feature config update event.
+
+    func processEvent(_ event: FeatureConfigEvent) async throws
+
+}
+
+struct FeatureConfigEventProcessor {
+
+    func processEvent(_ event: FeatureConfigEvent) async throws {
+        assertionFailure("not implemented")
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Event Processing/FeatureConfigEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FeatureConfigEventProcessor.swift
@@ -37,7 +37,7 @@ protocol FeatureConfigEventProcessorProtocol {
 struct FeatureConfigEventProcessor {
 
     func processEvent(_ event: FeatureConfigEvent) async throws {
-        assertionFailure("not implemented")
+        assertionFailure("not implemented yet")
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+
+/// Process federation update events.
+
+protocol FederationEventProcessorProtocol {
+
+    /// Process a federation update event.
+    ///
+    /// Processing an event is the app's only chance to consume
+    /// some remote changes to update its local state.
+    ///
+    /// - Parameter event: A federation update event.
+
+    func processEvent(_ event: FederationEvent) async throws
+
+}
+
+struct FederationEventProcessor {
+
+    func processEvent(_ event: FederationEvent) async throws {
+        assertionFailure("not implemented")
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/FederationEventProcessor.swift
@@ -37,7 +37,7 @@ protocol FederationEventProcessorProtocol {
 struct FederationEventProcessor {
 
     func processEvent(_ event: FederationEvent) async throws {
-        assertionFailure("not implemented")
+        assertionFailure("not implemented yet")
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/TeamEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/TeamEventProcessor.swift
@@ -37,7 +37,7 @@ protocol TeamEventProcessorProtocol {
 struct TeamEventProcessor {
 
     func processEvent(_ event: TeamEvent) async throws {
-        assertionFailure("not implemented")
+        assertionFailure("not implemented yet")
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/TeamEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/TeamEventProcessor.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+
+/// Process team update events.
+
+protocol TeamEventProcessorProtocol {
+
+    /// Process a team update event.
+    ///
+    /// Processing an event is the app's only chance to consume
+    /// some remote changes to update its local state.
+    ///
+    /// - Parameter event: A team update event.
+
+    func processEvent(_ event: TeamEvent) async throws
+
+}
+
+struct TeamEventProcessor {
+
+    func processEvent(_ event: TeamEvent) async throws {
+        assertionFailure("not implemented")
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Event Processing/UpdateEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UpdateEventProcessor.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+
+/// Process update events.
+
+protocol UpdateEventProcessorProtocol {
+
+    /// Process an update event.
+    ///
+    /// Processing an event is the app's only chance to consume
+    /// some remote changes to update its local state.
+    ///
+    /// - Parameter event: An update event.
+
+    func processEvent(_ event: UpdateEvent) async throws
+
+}
+
+struct UpdateEventProcessor {
+
+    let conversationEventProcessor: ConversationEventProcessor
+    let featureconfigEventProcessor: FeatureConfigEventProcessor
+    let federationEventProcessor: FederationEventProcessor
+    let userEventProcessor: UserEventProcessor
+    let teamEventProcessor: TeamEventProcessor
+
+    func processEvent(_ event: UpdateEvent) async throws {
+        switch event {
+        case let .conversation(event):
+            try await conversationEventProcessor.processEvent(event)
+
+        case let .featureConfig(event):
+            try await featureconfigEventProcessor.processEvent(event)
+
+        case let .federation(event):
+            try await federationEventProcessor.processEvent(event)
+
+        case let .user(event):
+            try await userEventProcessor.processEvent(event)
+
+        case let .team(event):
+            try await teamEventProcessor.processEvent(event)
+
+        case let .unknown(event):
+            print("can not process unknown event: \(event)")
+        }
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Event Processing/UpdateEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UpdateEventProcessor.swift
@@ -36,11 +36,11 @@ protocol UpdateEventProcessorProtocol {
 
 struct UpdateEventProcessor {
 
-    let conversationEventProcessor: ConversationEventProcessor
-    let featureconfigEventProcessor: FeatureConfigEventProcessor
-    let federationEventProcessor: FederationEventProcessor
-    let userEventProcessor: UserEventProcessor
-    let teamEventProcessor: TeamEventProcessor
+    let conversationEventProcessor: any ConversationEventProcessorProtocol
+    let featureconfigEventProcessor: any FeatureConfigEventProcessorProtocol
+    let federationEventProcessor: any FederationEventProcessorProtocol
+    let userEventProcessor: any UserEventProcessorProtocol
+    let teamEventProcessor: any TeamEventProcessorProtocol
 
     func processEvent(_ event: UpdateEvent) async throws {
         switch event {

--- a/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor.swift
@@ -37,7 +37,7 @@ protocol UserEventProcessorProtocol {
 struct UserEventProcessor {
 
     func processEvent(_ event: UserEvent) async throws {
-        assertionFailure("not implemented")
+        assertionFailure("not implemented yet")
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+
+/// Process user update events.
+
+protocol UserEventProcessorProtocol {
+
+    /// Process a user update event.
+    ///
+    /// Processing an event is the app's only chance to consume
+    /// some remote changes to update its local state.
+    ///
+    /// - Parameter event: A user update event.
+
+    func processEvent(_ event: UserEvent) async throws
+
+}
+
+struct UserEventProcessor {
+
+    func processEvent(_ event: UserEvent) async throws {
+        assertionFailure("not implemented")
+    }
+
+}

--- a/WireDomain/WireDomain.xcodeproj/project.pbxproj
+++ b/WireDomain/WireDomain.xcodeproj/project.pbxproj
@@ -24,6 +24,12 @@
 		01D0DCC62C1C8CD90076CB1C /* WireTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01D0DCC52C1C8CD90076CB1C /* WireTransport.framework */; };
 		01D0DD012C1C90E90076CB1C /* WireAPI in Frameworks */ = {isa = PBXBuildFile; productRef = 01D0DD002C1C90E90076CB1C /* WireAPI */; };
 		01D0DD032C1C90E90076CB1C /* WireAPISupport in Frameworks */ = {isa = PBXBuildFile; productRef = 01D0DD022C1C90E90076CB1C /* WireAPISupport */; };
+		EE0E11982C2D6899004BBD29 /* ConversationEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E11912C2D6899004BBD29 /* ConversationEventProcessor.swift */; };
+		EE0E11992C2D6899004BBD29 /* FeatureConfigEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E11922C2D6899004BBD29 /* FeatureConfigEventProcessor.swift */; };
+		EE0E119A2C2D6899004BBD29 /* FederationEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E11932C2D6899004BBD29 /* FederationEventProcessor.swift */; };
+		EE0E119B2C2D6899004BBD29 /* TeamEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E11942C2D6899004BBD29 /* TeamEventProcessor.swift */; };
+		EE0E119C2C2D6899004BBD29 /* UpdateEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E11952C2D6899004BBD29 /* UpdateEventProcessor.swift */; };
+		EE0E119D2C2D6899004BBD29 /* UserEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E11962C2D6899004BBD29 /* UserEventProcessor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +68,12 @@
 		01D0DCC52C1C8CD90076CB1C /* WireTransport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		01D0DCE92C1C8EA10076CB1C /* WireDomain.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = WireDomain.docc; sourceTree = "<group>"; };
 		01D0DCFC2C1C8F9B0076CB1C /* WireDomain.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = WireDomain.xctestplan; sourceTree = "<group>"; };
+		EE0E11912C2D6899004BBD29 /* ConversationEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationEventProcessor.swift; sourceTree = "<group>"; };
+		EE0E11922C2D6899004BBD29 /* FeatureConfigEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureConfigEventProcessor.swift; sourceTree = "<group>"; };
+		EE0E11932C2D6899004BBD29 /* FederationEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FederationEventProcessor.swift; sourceTree = "<group>"; };
+		EE0E11942C2D6899004BBD29 /* TeamEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamEventProcessor.swift; sourceTree = "<group>"; };
+		EE0E11952C2D6899004BBD29 /* UpdateEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateEventProcessor.swift; sourceTree = "<group>"; };
+		EE0E11962C2D6899004BBD29 /* UserEventProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserEventProcessor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +141,7 @@
 		017F67A32C20802300B6E02D /* WireDomain */ = {
 			isa = PBXGroup;
 			children = (
+				EE0E11972C2D6899004BBD29 /* Event Processing */,
 				017F67A22C20802300B6E02D /* Repositories */,
 			);
 			path = WireDomain;
@@ -207,6 +220,19 @@
 				017F679A2C20801800B6E02D /* WireDomain */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		EE0E11972C2D6899004BBD29 /* Event Processing */ = {
+			isa = PBXGroup;
+			children = (
+				EE0E11912C2D6899004BBD29 /* ConversationEventProcessor.swift */,
+				EE0E11922C2D6899004BBD29 /* FeatureConfigEventProcessor.swift */,
+				EE0E11932C2D6899004BBD29 /* FederationEventProcessor.swift */,
+				EE0E11942C2D6899004BBD29 /* TeamEventProcessor.swift */,
+				EE0E11952C2D6899004BBD29 /* UpdateEventProcessor.swift */,
+				EE0E11962C2D6899004BBD29 /* UserEventProcessor.swift */,
+			);
+			path = "Event Processing";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -394,12 +420,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE0E11992C2D6899004BBD29 /* FeatureConfigEventProcessor.swift in Sources */,
+				EE0E119A2C2D6899004BBD29 /* FederationEventProcessor.swift in Sources */,
+				EE0E119B2C2D6899004BBD29 /* TeamEventProcessor.swift in Sources */,
 				017F67AA2C20802C00B6E02D /* TeamRepositoryError.swift in Sources */,
 				0163EE812C20D71C00B37260 /* WireDomain.docc in Sources */,
 				017F67AB2C20802C00B6E02D /* ConnectionsRepositiory.swift in Sources */,
 				017F67AC2C20802C00B6E02D /* TeamRepository.swift in Sources */,
 				017F67AD2C20802C00B6E02D /* ConnectionsRepositoryError.swift in Sources */,
+				EE0E119D2C2D6899004BBD29 /* UserEventProcessor.swift in Sources */,
+				EE0E119C2C2D6899004BBD29 /* UpdateEventProcessor.swift in Sources */,
 				017F67AE2C20802C00B6E02D /* UserRepository.swift in Sources */,
+				EE0E11982C2D6899004BBD29 /* ConversationEventProcessor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8742" title="WPB-8742" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-8742</a>  Create UpdateEventRepository
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds stubs for event processing:
- One root update event processor (`UpdateEventProcessor`) receives one event at a time
- It switches over the event, forwards it to a more specialized event processor, e.g `ConversationEventProcessor`.
- The specialized processor may switch over the event, and forward it to even still more specialized processors.
- All event processing throws and is async

### Testing

Nothing to test yet.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

