### PR TITLE
fix: cancel all queued processing tasks when processing throws WPB-9221

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -91,8 +91,10 @@ actor EventProcessor: UpdateEventProcessor {
     }
 
     private func enqueueTask(_ block: @escaping @Sendable () async throws -> Void) async throws {
+        defer { processingTask = nil }
+
         processingTask = Task { [processingTask] in
-            _ = await processingTask?.result
+            _ = try await processingTask?.value
             return try await block()
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9221" title="WPB-9221" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9221</a>  Missing messages during sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If we we call 

```
EventProcessor.processEvent([event1, event2])
EventProcessor.processEvent([event3, event4])
```

and we run out of processing time while processing `[event1, event2]` we would immediately continue with processing the second batch (`[event3, event4]`).

This was happening because we were swallowing any error thrown while waiting for the previous task to finish.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

