### PR TITLE
fix: crowdin action always fails - WPB-9959

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Crowdin action
-        uses: crowdin/github-action@1.20.4
+        uses: crowdin/github-action@v2
         with:
           # For more info: https://github.com/crowdin/github-action/blob/master/action.yml
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}          


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9959" title="WPB-9959" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9959</a>  [iOS] Crowdin action always fails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The Crowdin action is failing due to error: 

```
Unable to resolve action `crowdin/github-action@1.20.4`, unable to find version '1.20.4'
```

The version tag is `v1.20.4`. There is a new `v2.0.0` release available, so but the version to that.

### Testing

Run the action and check that it succeeds.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

