### PR TITLE
chore: add more logs and connect to the websocket when self client is not nil - WPB-9221

### DIFF
--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+Proteus.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+Proteus.swift
@@ -59,7 +59,7 @@ extension EventDecoder {
                     LogAttributesKey.selfClientId.rawValue: selfClient?.safeRemoteIdentifier.safeForLoggingDescription ?? "<nil>",
                     LogAttributesKey.selfUserId.rawValue: selfUser?.remoteIdentifier.safeForLoggingDescription ?? "<nil>"
                 ].merging(event.logAttributes, uniquingKeysWith: { _, new in new })
-                WireLogger.updateEvent.info("decrypting proteus event... failed: is not for self client, dropping...)", attributes: additionalInfo)
+                WireLogger.updateEvent.error("decrypting proteus event... failed: is not for self client, dropping...)", attributes: additionalInfo)
                 return (UserClient?.none, ProteusSessionID?.none)
             }
 

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategy.swift
@@ -87,7 +87,7 @@ final class EvaluateOneOnOneConversationsStrategy: AbstractRequestStrategy {
     }
 
     private func finishCurrentSyncPhase() {
-        WireLogger.conversation.error("EvaluateOneOnOneConversationsStrategy: finishCurrentSyncPhase!")
+        WireLogger.conversation.info("EvaluateOneOnOneConversationsStrategy: finishCurrentSyncPhase!")
         syncProgress.finishCurrentSyncPhase(phase: syncPhase)
     }
 }

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -223,6 +223,7 @@ public extension WireLogger {
     static let ui = WireLogger(tag: "UI")
     static let updateEvent = WireLogger(tag: "update-event")
     static let userClient = WireLogger(tag: "user-client")
+    static let pushChannel = WireLogger(tag: "pushChannel")
 
 }
 

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -223,7 +223,7 @@ public extension WireLogger {
     static let ui = WireLogger(tag: "UI")
     static let updateEvent = WireLogger(tag: "update-event")
     static let userClient = WireLogger(tag: "user-client")
-    static let pushChannel = WireLogger(tag: "pushChannel")
+    static let pushChannel = WireLogger(tag: "push-channel")
 
 }
 

--- a/wire-ios-transport/Source/PushChannel/NativePushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/NativePushChannel.swift
@@ -118,8 +118,8 @@ final class NativePushChannel: NSObject, PushChannelType {
         guard
             keepOpen,
             websocketTask == nil,
-            let accessToken = accessToken,
-            let websocketURL = websocketURL
+            let accessToken,
+            let websocketURL
         else {
             return
         }
@@ -147,6 +147,8 @@ final class NativePushChannel: NSObject, PushChannelType {
     }
 
     var websocketURL: URL? {
+        guard let clientID else { return nil }
+
         let url = environment.backendWSURL.appendingPathComponent("/await")
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
         urlComponents?.queryItems = [URLQueryItem(name: "client", value: clientID)]
@@ -237,13 +239,13 @@ extension NativePushChannel: ZMTimerClient {
 extension NativePushChannel: URLSessionWebSocketDelegate {
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-        WireLogger.pushChannel.debug("Push channel did open with protocol \(`protocol` ?? "n/a")")
+        WireLogger.pushChannel.info("Push channel did open with protocol \(`protocol` ?? "n/a")")
 
         onOpen()
     }
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        WireLogger.pushChannel.debug("Push channel did close with code \(closeCode), reason: \(reason ?? Data())")
+        WireLogger.pushChannel.info("Push channel did close with code \(closeCode), reason: \(reason ?? Data())")
 
         onClose()
     }
@@ -252,7 +254,7 @@ extension NativePushChannel: URLSessionWebSocketDelegate {
 extension NativePushChannel: URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        WireLogger.pushChannel.debug("Websocket open connection task did fail: \(error.map({ String(describing: $0) }) ?? "n/a" )")
+        WireLogger.pushChannel.error("Websocket open connection task did fail: \(error.map({ String(describing: $0) }) ?? "n/a" )")
 
         websocketTask = nil
     }

--- a/wire-ios-transport/Source/PushChannel/NativePushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/NativePushChannel.swift
@@ -23,14 +23,14 @@ final class NativePushChannel: NSObject, PushChannelType {
 
     var clientID: String? {
         didSet {
-            Logging.pushChannel.debug("Setting client ID")
+            WireLogger.pushChannel.debug("Setting client ID")
             scheduleOpen()
         }
     }
 
     var accessToken: AccessToken? {
         didSet {
-            Logging.pushChannel.debug("Setting access token")
+            WireLogger.pushChannel.debug("Setting access token")
         }
     }
 
@@ -88,7 +88,7 @@ final class NativePushChannel: NSObject, PushChannelType {
     }
 
     func close() {
-        Logging.pushChannel.debug("Push channel was closed")
+        WireLogger.pushChannel.info("Push channel was closed")
 
         scheduler.performGroupedBlock { [weak self] in
             self?.websocketTask?.cancel()
@@ -139,10 +139,10 @@ final class NativePushChannel: NSObject, PushChannelType {
 
     private func scheduleOpenInternal() {
         guard canOpenConnection else {
-            Logging.pushChannel.debug("Conditions for scheduling opening not fulfilled, waiting...")
+            WireLogger.pushChannel.debug("Conditions for scheduling opening not fulfilled, waiting...")
             return
         }
-        Logging.pushChannel.debug("Schedule opening..")
+        WireLogger.pushChannel.debug("Schedule opening..")
         scheduler.add(ZMOpenPushChannelRequest())
     }
 
@@ -158,7 +158,7 @@ final class NativePushChannel: NSObject, PushChannelType {
         websocketTask?.receive(completionHandler: { [weak self] (result) in
             switch result {
             case.failure(let error):
-                Logging.pushChannel.debug("Failed to receive message \(error)")
+                WireLogger.pushChannel.debug("Failed to receive message \(error)")
                 self?.onClose()
             case .success(let message):
                 guard
@@ -223,10 +223,10 @@ final class NativePushChannel: NSObject, PushChannelType {
 extension NativePushChannel: ZMTimerClient {
 
     func timerDidFire(_ timer: ZMTimer!) {
-        Logging.pushChannel.debug("Sending ping")
+        WireLogger.pushChannel.debug("Sending ping")
         websocketTask?.sendPing(pongReceiveHandler: { error in
             if let error = error {
-                Logging.pushChannel.debug("Failed to send ping: \(error)")
+                WireLogger.pushChannel.debug("Failed to send ping: \(error)")
             }
         })
         schedulePingTimer()
@@ -237,13 +237,13 @@ extension NativePushChannel: ZMTimerClient {
 extension NativePushChannel: URLSessionWebSocketDelegate {
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-        Logging.pushChannel.debug("Push channel did open with protocol \(`protocol` ?? "n/a")")
+        WireLogger.pushChannel.debug("Push channel did open with protocol \(`protocol` ?? "n/a")")
 
         onOpen()
     }
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        Logging.pushChannel.debug("Push channel did close with code \(closeCode), reason: \(reason ?? Data())")
+        WireLogger.pushChannel.debug("Push channel did close with code \(closeCode), reason: \(reason ?? Data())")
 
         onClose()
     }
@@ -252,7 +252,7 @@ extension NativePushChannel: URLSessionWebSocketDelegate {
 extension NativePushChannel: URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        Logging.pushChannel.debug("Websocket open connection task did fail: \(error.map({ String(describing: $0) }) ?? "n/a" )")
+        WireLogger.pushChannel.debug("Websocket open connection task did fail: \(error.map({ String(describing: $0) }) ?? "n/a" )")
 
         websocketTask = nil
     }

--- a/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
@@ -33,14 +33,14 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
 
     var clientID: String? {
         didSet {
-            Logging.pushChannel.debug("Setting client ID")
+            WireLogger.pushChannel.debug("Setting client ID")
             scheduleOpen()
         }
     }
 
     var accessToken: AccessToken? {
         didSet {
-            Logging.pushChannel.debug("Setting access token")
+            WireLogger.pushChannel.debug("Setting access token")
         }
     }
 
@@ -59,6 +59,8 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
     }
 
     var websocketURL: URL? {
+        guard let clientID else { return nil }
+
         let url = environment.backendWSURL.appendingPathComponent("/await")
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
         urlComponents?.queryItems = [URLQueryItem(name: "client", value: clientID)]
@@ -106,7 +108,7 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
     }
 
     func close() {
-        Logging.pushChannel.debug("Push channel was closed")
+        WireLogger.pushChannel.debug("Push channel was closed")
 
         scheduler.performGroupedBlock {
             self.webSocket?.disconnect()
@@ -117,9 +119,10 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
         guard
             keepOpen,
             webSocket == nil,
-            let accessToken = accessToken,
-            let websocketURL = websocketURL
+            let accessToken,
+            let websocketURL
         else {
+            WireLogger.pushChannel.warn("Can't connect websocket")
             return
         }
 
@@ -152,7 +155,7 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
         }
         webSocket?.connect()
 
-        Logging.pushChannel.debug("Connecting websocket..")
+        WireLogger.pushChannel.debug("Connecting websocket with URL: \(websocketURL)")
     }
 
     func scheduleOpen() {
@@ -168,10 +171,10 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
 
     private func scheduleOpenInternal() {
         guard canOpenConnection else {
-            Logging.pushChannel.debug("Conditions for scheduling opening not fulfilled, waiting...")
+            WireLogger.pushChannel.debug("Conditions for scheduling opening not fulfilled, waiting...")
             return
         }
-        Logging.pushChannel.debug("Schedule opening..")
+        WireLogger.pushChannel.debug("Schedule opening..")
         scheduler.add(ZMOpenPushChannelRequest())
     }
 
@@ -216,7 +219,7 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
 extension StarscreamPushChannel: ZMTimerClient {
 
     func timerDidFire(_ timer: ZMTimer!) {
-        Logging.pushChannel.debug("Sending ping")
+        WireLogger.pushChannel.debug("Sending ping")
         webSocket?.write(ping: Data())
         schedulePingTimer()
     }
@@ -228,19 +231,19 @@ extension StarscreamPushChannel: WebSocketDelegate {
         switch event {
 
         case .connected:
-            Logging.pushChannel.debug("Sending ping")
+            WireLogger.pushChannel.debug("Sending ping")
             onOpen()
         case .disconnected:
-            Logging.pushChannel.debug("Websocket disconnected")
+            WireLogger.pushChannel.debug("Websocket disconnected")
             onClose()
         case .text:
             break
         case .binary(let data):
-            Logging.pushChannel.debug("Received data")
+            WireLogger.pushChannel.debug("Received data")
             guard
                 let transportData = try? JSONSerialization.jsonObject(with: data, options: []) as? ZMTransportData
             else {
-                Logging.pushChannel.safePublic("Received binary data via push channel cannot be deserialized", level: .error)
+                WireLogger.pushChannel.error("Received binary data via push channel cannot be deserialized", attributes: .safePublic)
                 break
             }
 

--- a/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
@@ -155,7 +155,11 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
         }
         webSocket?.connect()
 
-        WireLogger.pushChannel.info("Connecting websocket with URL: \(websocketURL)")
+        let attributes: LogAttributes = [
+            LogAttributesKey.selfClientId.rawValue: clientID?.redactedAndTruncated()
+        ]
+        WireLogger.pushChannel.info("Connecting websocket with URL: \(websocketURL.endpointRemoteLogDescription)",
+                                    attributes: makeAttributesPublic(attributes))
     }
 
     func scheduleOpen() {
@@ -214,6 +218,13 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
         timer?.fire(afterTimeInterval: 30)
         pingTimer = timer
     }
+
+    // MARK: Helpers
+
+    private func makeAttributesPublic(_ attributes: LogAttributes) -> LogAttributes {
+        attributes.merging(.safePublic, uniquingKeysWith: { _, new in new })
+    }
+
 }
 
 extension StarscreamPushChannel: ZMTimerClient {

--- a/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
+++ b/wire-ios-transport/Source/PushChannel/StarscreamPushChannel.swift
@@ -108,7 +108,7 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
     }
 
     func close() {
-        WireLogger.pushChannel.debug("Push channel was closed")
+        WireLogger.pushChannel.info("Push channel was closed")
 
         scheduler.performGroupedBlock {
             self.webSocket?.disconnect()
@@ -155,7 +155,7 @@ final class StarscreamPushChannel: NSObject, PushChannelType {
         }
         webSocket?.connect()
 
-        WireLogger.pushChannel.debug("Connecting websocket with URL: \(websocketURL)")
+        WireLogger.pushChannel.info("Connecting websocket with URL: \(websocketURL)")
     }
 
     func scheduleOpen() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9221" title="WPB-9221" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9221</a>  Missing messages during sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
We connect to the websocket after login when the self client is nil. As a result, we have access to events for all self user clients.

### Solution
Check self client before connecting the websocket and improve logs.

### Testing


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

