### PR TITLE
fix: account name overflows in top bar  - WPB-7281

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Availability/TitleView.swift
@@ -42,11 +42,11 @@ class TitleView: UIView, DynamicTypeCapable {
         }
 
         createViews()
+        createConstraints()
     }
 
     // MARK: - Private methods
     private func createConstraints() {
-        [titleButton, stackView, subtitleLabel].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
 
         stackView.fitIn(view: self)
     }
@@ -93,7 +93,6 @@ class TitleView: UIView, DynamicTypeCapable {
         subtitleLabel.text = subtitle
         subtitleLabel.font = .smallLightFont
 
-        createConstraints()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -29,15 +29,18 @@ final class ConversationListTopBarViewController: UIViewController {
 
     /// Name, availability and verification info about the self user.
     public var selfUserStatus = UserStatus() {
-        didSet { updateTitleView() }
+        didSet { 
+            guard viewIfLoaded != nil else { return }
+            updateTitleView()
+        }
     }
 
     private let selfUser: SelfUserType
     private var userSession: UserSession
     private var observerToken: NSObjectProtocol?
 
-    var topBar: TopBar? {
-        view as? TopBar
+    private var topBar: TopBar? {
+        viewIfLoaded as? TopBar
     }
 
     private weak var userStatusViewController: UserStatusViewController?
@@ -85,7 +88,7 @@ final class ConversationListTopBarViewController: UIViewController {
 
     // MARK: - Title View
 
-    func updateTitleView() {
+    private func updateTitleView() {
         if selfUser.isTeamMember {
             defer { userStatusViewController?.userStatus = selfUserStatus }
             guard userStatusViewController == nil else { return }
@@ -169,7 +172,7 @@ final class ConversationListTopBarViewController: UIViewController {
         return button
     }
 
-    func updateAccountView() {
+    private func updateAccountView() {
         topBar?.leftView = createAccountView()
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ConversationListTopBarViewController.swift
@@ -29,7 +29,7 @@ final class ConversationListTopBarViewController: UIViewController {
 
     /// Name, availability and verification info about the self user.
     public var selfUserStatus = UserStatus() {
-        didSet { 
+        didSet {
             guard viewIfLoaded != nil else { return }
             updateTitleView()
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-7281" title="WPB-7281" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-7281</a>  [iOS] : Overlapping Account name and icon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

On a cold start, it happens the name in the top bar overflows especially when adding status.

Modify when some views get implicitly loaded and when constraints are set

### Testing
| Before        | After           |
| ------------- |:-------------:|
|  ![IMG_8260](https://github.com/wireapp/wire-ios/assets/254198/6a55cc56-28d3-46b3-8f1f-110b055e534c)   | ![IMG_D202A6BABC63-1](https://github.com/wireapp/wire-ios/assets/254198/153da5ca-1140-400a-9420-a274f2478bb5) |

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

