### PR TITLE
fix: wire sync engine disable treat warnings as errors - WPB-9517

### DIFF
--- a/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
 import WireTransport
+import WireDataModel
 
 private let zmLog = ZMSLog(tag: "Dependencies")
 

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -4346,6 +4346,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0994E1E31B835C4900A51721 /* project-debug.xcconfig */;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				HEADER_SEARCH_PATHS = "$(SDKROOT)/usr/include/libxml2";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 			};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9517" title="WPB-9517" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9517</a>  [iOS] Assets frequently fail to send
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

After merging #1637 tests started to fail without obvious reason. Let's set the compiler setting like it is used in other targets like `WireDataModel`.

### Testing

- Build and run `ConversationTestsOTR`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

