### PR TITLE
fix: can't see screen share - WPB-9909

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallGridView/CallParticipantViews/CallParticipantView.swift
@@ -122,6 +122,10 @@ final class CallParticipantView: BaseCallParticipantView {
         self.videoContainerView?.removeFromSuperview()
         self.videoContainerView = videoContainerView
 
+        let videoView = makeVideoView()
+        self.videoView = videoView
+        videoContainerView.setupVideoView(videoView)
+
         // Adding the preview into a container allows smoother scaling
         let scalableView = ScalableView(isScalingEnabled: shouldEnableScaling)
         scalableView.addSubview(videoContainerView)
@@ -162,15 +166,6 @@ final class CallParticipantView: BaseCallParticipantView {
     // MARK: Override Base
 
     override func updateVideoShouldFill(_ shouldFill: Bool) {
-        if shouldFill, videoView == nil {
-            // [WPB-8954] Setup video only when the video really starts to avoid
-            // calls crashing on the iOS 17 simulator.
-            let videoView = makeVideoView()
-            self.videoView = videoView
-
-            videoContainerView?.setupVideoView(videoView)
-        }
-
         videoView?.shouldFill = shouldFill
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9909" title="WPB-9909" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9909</a>  Cannot see screen share
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

While in a call, if another person shares their screen (without having first enabled their video) then the self user would not see the screen share.

This is due to another fix (https://wearezeta.atlassian.net/browse/WPB-8954) that only created the video view (used for both camera and screen share) for another participant when they enabled their camera. This was to prevent a crash on iOS 17 simulators.

The fix is to always create the video view. 

In my testing, I was not able to reproduce any crash on iOS 17 simulators. I did observe though that when answering a call on simulator, the call is immediately dismissed the first time, but succeeds the second time. Also, if another user enables video or screen share, then this is never visible on the simulator, even if we always create the video view.

### Testing

1. Be in a group call.
2. Other participants enable screen share.
3. Assert eh self user can see the screen share.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

I'm not sure how to add a unit test for this, if you have any ideas let me know.

