### PR TITLE
fix: replace danger action for disabling warnings temporarily - WPB-9872

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -157,12 +157,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireSystem -resultBundlePath xcodebuild-wire-ios-system.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-system.log | bundle exec xcpretty
 
       - name: Run Danger for WireSystem
-        if: ${{ inputs.wire-ios-system || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-system || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-system.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireSystem" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-system || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-system.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireSystem
         if: ${{ inputs.wire-ios-system || inputs.all }}
@@ -181,12 +189,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireTesting -resultBundlePath xcodebuild-wire-ios-testing.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-testing.log | bundle exec xcpretty
 
       - name: Run Danger for WireTesting
-        if: ${{ inputs.wire-ios-testing || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-testing || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-testing.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireTesting" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-testing || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-testing.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireTesting
         if: ${{ inputs.wire-ios-testing || inputs.all }}
@@ -205,12 +221,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireUtilities -resultBundlePath xcodebuild-wire-ios-utilities.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-utilities.log | bundle exec xcpretty
 
       - name: Run Danger for WireUtilities
-        if: ${{ inputs.wire-ios-utilities || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-utilities || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-utilities.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireUtilities" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-utilities || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-utilities.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireUtilities
         if: ${{ inputs.wire-ios-utilities || inputs.all }}
@@ -229,12 +253,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireCryptobox -resultBundlePath xcodebuild-wire-ios-cryptobox.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-cryptobox.log | bundle exec xcpretty
 
       - name: Run Danger for WireCryptobox
-        if: ${{ inputs.wire-ios-cryptobox || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-cryptobox || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-cryptobox.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireCryptobox" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-cryptobox || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-cryptobox.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireCryptobox
         if: ${{ inputs.wire-ios-cryptobox || inputs.all }}
@@ -253,12 +285,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireTransport -resultBundlePath xcodebuild-wire-ios-transport.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-transport.log | bundle exec xcpretty
 
       - name: Run Danger for WireTransport
-        if: ${{ inputs.wire-ios-transport || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-transport || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-transport.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireTransport" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-transport || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-transport.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireTransport
         if: ${{ inputs.wire-ios-transport || inputs.all }}
@@ -277,12 +317,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireLinkPreview -resultBundlePath xcodebuild-wire-ios-link-preview.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-link-preview.log | bundle exec xcpretty
 
       - name: Run Danger for WireLinkPreview
-        if: ${{ inputs.wire-ios-link-preview || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-link-preview || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-link-preview.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireLinkPreview" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-link-preview || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-link-preview.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireLinkPreview
         if: ${{ inputs.wire-ios-link-preview || inputs.all }}
@@ -301,12 +349,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireImages -resultBundlePath xcodebuild-wire-ios-images.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-images.log | bundle exec xcpretty
 
       - name: Run Danger for WireImages
-        if: ${{ inputs.wire-ios-images || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-images || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-images.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireImages" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-images || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-images.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireImages
         if: ${{ inputs.wire-ios-images || inputs.all }}
@@ -325,12 +381,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireProtos -resultBundlePath xcodebuild-wire-ios-protos.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-protos.log | bundle exec xcpretty
 
       - name: Run Danger for WireProtos
-        if: ${{ inputs.wire-ios-protos || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-protos || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-protos.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireProtos" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-protos || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-protos.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireProtos
         if: ${{ inputs.wire-ios-protos || inputs.all }}
@@ -349,12 +413,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireMockTransport -resultBundlePath xcodebuild-wire-ios-mocktransport.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-mocktransport.log | bundle exec xcpretty
 
       - name: Run Danger for WireMockTransport
-        if: ${{ inputs.wire-ios-mocktransport || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-mocktransport || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-mocktransport.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireMockTransport" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-mocktransport || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-mocktransport.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireMockTransport
         if: ${{ inputs.wire-ios-mocktransport || inputs.all }}
@@ -373,12 +445,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireDataModel -resultBundlePath xcodebuild-wire-ios-data-model.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-data-model.log | bundle exec xcpretty
 
       - name: Run Danger for WireDataModel
-        if: ${{ inputs.wire-ios-data-model || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-data-model || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-data-model.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDataModel" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-data-model || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-data-model.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireDataModel
         if: ${{ inputs.wire-ios-data-model || inputs.all }}
@@ -396,12 +476,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireAPI -resultBundlePath xcodebuild-wire-api.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-api.log | bundle exec xcpretty
 
       - name: Run Danger for WireAPI
-        if: ${{ inputs.wire-api || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-api || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-api.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireAPI" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-api || inputs.all }}
+        with:
+          results: xcodebuild-wire-api.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireAPI
         if: ${{ inputs.wire-api || inputs.all }}
@@ -420,12 +508,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireDomain -resultBundlePath xcodebuild-wire-domain.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-domain.log | bundle exec xcpretty
 
       - name: Run Danger for WireDomain
-        if: ${{ inputs.wire-domain || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-domain || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-domain.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDomain" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-domain || inputs.all }}
+        with:
+          results: xcodebuild-wire-domain.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireDomain
         if: ${{ inputs.wire-domain || inputs.all }}
@@ -444,12 +540,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireRequestStrategy -resultBundlePath xcodebuild-wire-ios-request-strategy.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-request-strategy.log | bundle exec xcpretty
 
       - name: Run Danger for WireRequestStrategy
-        if: ${{ inputs.wire-ios-request-strategy || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-request-strategy || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-request-strategy.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireRequestStrategy" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-request-strategy || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-request-strategy.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireRequestStrategy
         if: ${{ inputs.wire-ios-request-strategy || inputs.all }}
@@ -468,12 +572,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireShareEngine -resultBundlePath xcodebuild-wire-ios-share-engine.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-share-engine.log | bundle exec xcpretty
 
       - name: Run Danger for WireShareEngine
-        if: ${{ inputs.wire-ios-share-engine || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-share-engine || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-share-engine.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireShareEngine" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-share-engine || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-share-engine.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireShareEngine
         if: ${{ inputs.wire-ios-share-engine || inputs.all }}
@@ -492,12 +604,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireSyncEngine -resultBundlePath xcodebuild-wire-ios-sync-engine.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-sync-engine.log | bundle exec xcpretty
 
       - name: Run Danger for WireSyncEngine
-        if: ${{ inputs.wire-ios-sync-engine || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-sync-engine || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-sync-engine.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireSyncEngine" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-sync-engine || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-sync-engine.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireSyncEngine
         if: ${{ inputs.wire-ios-sync-engine || inputs.all }}
@@ -516,12 +636,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireDesign -resultBundlePath xcodebuild-wire-design.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-design.log | bundle exec xcpretty
 
       - name: Run Danger for WireDesign
-        if: ${{ inputs.wire-design || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-design || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-design.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDesign" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-design || inputs.all }}
+        with:
+          results: xcodebuild-wire-design.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireDesign
         if: ${{ inputs.wire-design || inputs.all }}
@@ -540,12 +668,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireReusableUIComponents -resultBundlePath xcodebuild-wire-reusable-ui-components.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-reusable-ui-components.log | bundle exec xcpretty
 
       - name: Run Danger for WireReusableUIComponents
-        if: ${{ inputs.wire-reusable-ui-components || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-reusable-ui-components || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-reusable-ui-components.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireReusableUIComponents" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-reusable-ui-components || inputs.all }}
+        with:
+          results: xcodebuild-wire-reusable-ui-components.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireReusableUIComponents
         if: ${{ inputs.wire-reusable-ui-components || inputs.all }}
@@ -564,12 +700,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -resultBundlePath xcodebuild-wire-ios.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios.log | bundle exec xcpretty
 
       - name: Run Danger for Wire-iOS
-        if: ${{ inputs.wire-ios || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for Wire-iOS" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Wire-iOS
         if: ${{ inputs.wire-ios || inputs.all }}
@@ -605,12 +749,20 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -resultBundlePath xcodebuild-wire-ios-notification-engine.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-notification-engine.log | bundle exec xcpretty
 
       - name: Run Danger for WireNotificationEngine
-        if: ${{ inputs.wire-ios-notification-engine || inputs.all }}
+        # TODO: WPB-9872 revert after fixing Dangerfile
+        if: false # ${{ inputs.wire-ios-notification-engine || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-notification-engine.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireNotificationEngine" --verbose
+
+      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        if: ${{ inputs.wire-ios-notification-engine || inputs.all }}
+        with:
+          results: xcodebuild-wire-ios-notification-engine.xcresult
+          warningAnnotations: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireNotificationEngine
         if: ${{ inputs.wire-ios-notification-engine || inputs.all }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9872" title="WPB-9872" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9872</a>  Show xcodebuild warnings on GitHub
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR disables the danger integration for displaying warnings temporarily until a workings solution for displaying a correct warnings summary is found.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

