### PR TITLE
fix: Exclude build directory from swiftlint - WPB-10070

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -77,6 +77,7 @@ custom_rules:
     severity: warning
 
 excluded:
+  - "**/.build"
   - "**/*/Package.swift"
   - Carthage
   - DerivedData


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10070" title="WPB-10070" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10070</a>  Exclude .build Directory from SwiftLint
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


#### Summary

This pull request updates the SwiftLint configuration to exclude the `.build` directory. This directory is used by Swift Package Manager (Swift PM) to store build artifacts, and linting these files is unnecessary and can generate unwanted warnings.

#### Changes

- Added `.build` to the `excluded` section in the SwiftLint configuration file.

#### Rationale

Excluding the `.build` directory from SwiftLint will help to:
- Prevent linting of generated build files, which are not part of the source code.
- Reduce noise in linting reports by avoiding warnings for files that should not be linted.
- Improve overall development experience by focusing linting efforts on actual source files.

#### Testing

No additional testing is required as this change only affects the configuration of SwiftLint and does not impact the source code or functionality of the project.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

