### PR TITLE
fix(ci): semantic-commit linter remove validate single commit - no ticket

### DIFF
--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -53,7 +53,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           
           subjectPattern: ^(.*) - ((WPB-\d+)|(no ticket))$
           # If `subjectPattern` is configured, you can use this property to override


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

PRs will sometimes get fix PR title badge because the single commit does not match the title of the PR. This is unecessary check since Github defaults to the PR title when we squash and merge.

![Screenshot 2024-07-09 at 10 24 21](https://github.com/wireapp/wire-ios/assets/254198/808ebc2f-3910-4b48-9e88-ca0750f92156)

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

