### PR TITLE
hackathon: add basic backup models

### DIFF
--- a/wire-ios-data-model/Source/Universal backup/Model/ConversationBackupModel.swift
+++ b/wire-ios-data-model/Source/Universal backup/Model/ConversationBackupModel.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public struct ConversationBackupModel {
+
+    public let qualifiedID: QualifiedID
+
+    public let name: String
+
+    public let participants: Set<QualifiedID>
+
+    public init(
+        qualifiedID: QualifiedID,
+        name: String,
+        participants: Set<QualifiedID>
+    ) {
+        self.qualifiedID = qualifiedID
+        self.name = name
+        self.participants = participants
+    }
+
+}

--- a/wire-ios-data-model/Source/Universal backup/Model/TextMessageBackupModel.swift
+++ b/wire-ios-data-model/Source/Universal backup/Model/TextMessageBackupModel.swift
@@ -1,0 +1,43 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public struct TextMessageBackupModel {
+
+    public let nonce: UUID
+
+    public let content: String
+
+    public let conversationID: QualifiedID
+
+    public let senderUserID: QualifiedID
+
+    public init(
+        nonce: UUID,
+        content: String,
+        conversationID: QualifiedID,
+        senderUserID: QualifiedID
+    ) {
+        self.nonce = nonce
+        self.content = content
+        self.conversationID = conversationID
+        self.senderUserID = senderUserID
+    }
+
+}

--- a/wire-ios-data-model/Source/Universal backup/Model/UserBackupModel.swift
+++ b/wire-ios-data-model/Source/Universal backup/Model/UserBackupModel.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public struct UserBackupModel {
+
+    public let qualifiedID: QualifiedID
+
+    public let name: String
+
+    public init(
+        qualifiedID: QualifiedID,
+        name: String
+    ) {
+        self.qualifiedID = qualifiedID
+        self.name = name
+    }
+
+}

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -667,6 +667,9 @@
 		EEF09CA42B1DBC8700D729A1 /* OneOnOneResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF09CA32B1DBC8700D729A1 /* OneOnOneResolver.swift */; };
 		EEF0BC3128EEC02400ED16CA /* MockSyncStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */; };
 		EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF4010623A9213B007B1A97 /* UserType+Team.swift */; };
+		EEF46F162C3E8E0A00FE4FDB /* ConversationBackupModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF46F152C3E8E0A00FE4FDB /* ConversationBackupModel.swift */; };
+		EEF46F182C3E8EC600FE4FDB /* UserBackupModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF46F172C3E8EC600FE4FDB /* UserBackupModel.swift */; };
+		EEF46F1A2C3E8EEF00FE4FDB /* TextMessageBackupModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF46F192C3E8EEF00FE4FDB /* TextMessageBackupModel.swift */; };
 		EEF6E3CA28D89251001C1799 /* StaleMLSKeyDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */; };
 		EEFAAC3528DDE2B1009940E7 /* CoreCryptoCallbacksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */; };
 		EEFC3EE72208311200D3091A /* ZMConversation+HasMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */; };
@@ -1636,6 +1639,9 @@
 		EEF09CA32B1DBC8700D729A1 /* OneOnOneResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneOnOneResolver.swift; sourceTree = "<group>"; };
 		EEF0BC3028EEC02400ED16CA /* MockSyncStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSyncStatus.swift; sourceTree = "<group>"; };
 		EEF4010623A9213B007B1A97 /* UserType+Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+Team.swift"; sourceTree = "<group>"; };
+		EEF46F152C3E8E0A00FE4FDB /* ConversationBackupModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationBackupModel.swift; sourceTree = "<group>"; };
+		EEF46F172C3E8EC600FE4FDB /* UserBackupModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserBackupModel.swift; sourceTree = "<group>"; };
+		EEF46F192C3E8EEF00FE4FDB /* TextMessageBackupModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMessageBackupModel.swift; sourceTree = "<group>"; };
 		EEF6E3C928D89251001C1799 /* StaleMLSKeyDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleMLSKeyDetectorTests.swift; sourceTree = "<group>"; };
 		EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreCryptoCallbacksTests.swift; sourceTree = "<group>"; };
 		EEFC3EE62208311200D3091A /* ZMConversation+HasMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+HasMessages.swift"; sourceTree = "<group>"; };
@@ -2722,6 +2728,24 @@
 			path = OneOnOne;
 			sourceTree = "<group>";
 		};
+		EEF46F132C3E8DC800FE4FDB /* Universal backup */ = {
+			isa = PBXGroup;
+			children = (
+				EEF46F142C3E8DF900FE4FDB /* Model */,
+			);
+			path = "Universal backup";
+			sourceTree = "<group>";
+		};
+		EEF46F142C3E8DF900FE4FDB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				EEF46F152C3E8E0A00FE4FDB /* ConversationBackupModel.swift */,
+				EEF46F172C3E8EC600FE4FDB /* UserBackupModel.swift */,
+				EEF46F192C3E8EEF00FE4FDB /* TextMessageBackupModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		F1103BD82135471A00EB9ED6 /* Calling */ = {
 			isa = PBXGroup;
 			children = (
@@ -3515,6 +3539,7 @@
 		F9C9A4FE1CAD5DF10039E10C /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				EEF46F132C3E8DC800FE4FDB /* Universal backup */,
 				E6E504332BC542C5004948E7 /* Authentication */,
 				069BCC4F2B30945500DF4EC2 /* E2EIdentity */,
 				638941EC2AF4FD170051ABFD /* UseCases */,
@@ -4064,6 +4089,7 @@
 				F9A706AE1CAEE01D00C2F5FE /* SetSnapshot.swift in Sources */,
 				162A81DD202DA4BC00F6200C /* AssetCache.swift in Sources */,
 				EE9AEC822BD1570E00F7853F /* WireDataModel.docc in Sources */,
+				EEF46F182C3E8EC600FE4FDB /* UserBackupModel.swift in Sources */,
 				EEBACDAB25B9C4B0000210AC /* AppLockAuthenticationResult.swift in Sources */,
 				638805652410FE920043B641 /* ButtonState.swift in Sources */,
 				63B1335A29A503D100009D84 /* MLSActionExecutor.swift in Sources */,
@@ -4103,6 +4129,7 @@
 				EE28991E26B4422800E7BAF0 /* Feature.ConferenceCalling.swift in Sources */,
 				63B1336A29A503D100009D84 /* ClaimMLSKeyPackageAction.swift in Sources */,
 				639971AE2B2732E6009DD5CF /* CommitSender.swift in Sources */,
+				EEF46F1A2C3E8EEF00FE4FDB /* TextMessageBackupModel.swift in Sources */,
 				6308F8A62A273CB70072A177 /* FetchMLSConversationGroupInfoAction.swift in Sources */,
 				E999AC402BC9467E00569E79 /* CreateConversationGuestLinkAction.swift in Sources */,
 				63B1335929A503D100009D84 /* MLSGroupID.swift in Sources */,
@@ -4130,6 +4157,7 @@
 				013887A22B9A5C6000323DD0 /* CleanupModels107PreAction.swift in Sources */,
 				16030DB021AD765D00F8032E /* ZMConversation+Confirmations.swift in Sources */,
 				6313CF2F2B6A8CDB00B41A33 /* CRLsDistributionPoints.swift in Sources */,
+				EEF46F162C3E8E0A00FE4FDB /* ConversationBackupModel.swift in Sources */,
 				F9A7065C1CAEE01D00C2F5FE /* ZMConnection.m in Sources */,
 				066795902B8C9E4700FF6A25 /* UpdateMLSGroupVerificationStatusUseCase.swift in Sources */,
 				EF2CBDA720061E2D0004F65E /* ServiceUser.swift in Sources */,


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Add basic backup models. We'll parse the raw backup file into these models, then these models can be used to populate the database.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

