### PR TITLE
feat: Disable location sharing for C1 - WPB-9749

### DIFF
--- a/wire-ios/Configuration/Security-Flags.xcconfig
+++ b/wire-ios/Configuration/Security-Flags.xcconfig
@@ -26,6 +26,7 @@ CUSTOM_BACKEND_ENABLED=1
 CAMERA_ROLL_ENABLED=1
 BACKUP_ENABLED=1
 FILE_SHARING_ENABLED=1
+LOCATION_SHARING_ENABLED=1
 
 /// Whether encryption at rest is enabled and can't be disabled.
 

--- a/wire-ios/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/Bundle+SecurityFlags.swift
@@ -27,6 +27,7 @@ public enum SecurityFlags {
     case backup
     case maxNumberAccounts
     case fileSharing
+    case locationSharing
     case forceCallKitDisabled
     case clipboard
 
@@ -56,6 +57,8 @@ public enum SecurityFlags {
             return "ForceEncryptionAtRestEnabled"
         case .fileSharing:
             return "FileSharingEnabled"
+        case .locationSharing:
+            return "LocationSharingEnabled"
         case .forceCallKitDisabled:
             return "ForceCallKitDisabled"
         case .minTLSVersion:

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -253,7 +253,7 @@ final class ConversationInputBarViewController: UIViewController,
             buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
         }
 
-        // Remove locationButton if feature flag does not allow it
+        // Remove locationButton if security flag does not allow it
         if shouldExcludeLocationButton {
             if let index = buttonsArray.firstIndex(of: locationButton) {
                 buttonsArray.remove(at: index)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 import WireSyncEngine
 import avs
 import AVFoundation
+import WireCommonComponents
 
 enum ConversationInputBarViewControllerMode {
     case textInput
@@ -252,7 +253,18 @@ final class ConversationInputBarViewController: UIViewController,
             buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
         }
 
+        // Remove locationButton if feature flag does not allow it
+        if shouldExcludeLocationButton {
+            if let index = buttonsArray.firstIndex(of: locationButton) {
+                buttonsArray.remove(at: index)
+            }
+        }
+
         return buttonsArray
+    }
+
+    private var shouldExcludeLocationButton: Bool {
+        !SecurityFlags.locationSharing.isEnabled
     }
 
     var mode: ConversationInputBarViewControllerMode = .textInput {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -253,7 +253,6 @@ final class ConversationInputBarViewController: UIViewController,
             buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
         }
 
-        // Remove locationButton if security flag does not allow it
         if shouldExcludeLocationButton {
             if let index = buttonsArray.firstIndex(of: locationButton) {
                 buttonsArray.remove(at: index)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -263,6 +263,7 @@ final class ConversationInputBarViewController: UIViewController,
         return buttonsArray
     }
 
+    /// Remove locationButton if security flag does not allow it
     private var shouldExcludeLocationButton: Bool {
         !SecurityFlags.locationSharing.isEnabled
     }

--- a/wire-ios/Wire-iOS/Wire-Info.plist
+++ b/wire-ios/Wire-iOS/Wire-Info.plist
@@ -96,6 +96,8 @@
 	<string>${DEVELOPER_MODE_ENABLED}</string>
 	<key>FileSharingEnabled</key>
 	<string>${FILE_SHARING_ENABLED}</string>
+	<key>LocationSharingEnabled</key>
+	<string>${LOCATION_SHARING_ENABLED}</string>
 	<key>ForceCBREnabled</key>
 	<string>${FORCE_CBR_ENABLED}</string>
 	<key>ForceCallKitDisabled</key>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9749" title="WPB-9749" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9749</a>  [iOS] Location sharing should be disabled in C1 builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
Disable location sharing for C1

**Needs releases with:**
https://github.com/wireapp/wire-ios-build-assets/pull/114

### Testing
If `LOCATION_SHARING_ENABLED` is false, the user shouldn't see the location button.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

