### PR TITLE
fix: sending assets expiration timer - WPB-10147

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Message.swift
@@ -281,6 +281,14 @@ extension ZMConversation {
                         expires: Bool,
                         prepareMessage: (ZMAssetClientMessage) -> Void) throws -> ZMAssetClientMessage {
 
+        let logAttributes: LogAttributes = [
+            LogAttributesKey.conversationId.rawValue: self.qualifiedID?.safeForLoggingDescription ?? "<nil>",
+            LogAttributesKey.messageType.rawValue: "asset"
+        ].merging(LogAttributes.safePublic, uniquingKeysWith: { _, new in new })
+
+        WireLogger.messaging.debug("appending message to conversation",
+                                   attributes: logAttributes)
+
         guard let moc = managedObjectContext else {
             throw AppendMessageError.missingManagedObjectContext
         }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Message.swift
@@ -302,9 +302,10 @@ extension ZMConversation {
 
         message.sender = ZMUser.selfUser(in: moc)
 
-        if expires {
-            message.setExpirationDate()
-        }
+//        if expires {
+//            message.setExpirationDate()
+//        }
+        message.shouldExpire = expires
 
         append(message)
         unarchiveIfNeeded()

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Message.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Message.swift
@@ -309,10 +309,6 @@ extension ZMConversation {
         }
 
         message.sender = ZMUser.selfUser(in: moc)
-
-//        if expires {
-//            message.setExpirationDate()
-//        }
         message.shouldExpire = expires
 
         append(message)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -59,10 +59,24 @@ extension ConversationContentViewController {
         switch actionId {
         case .cancel:
             userSession.enqueue({
+                WireLogger.messaging.info(
+                    "cancel message",
+                    attributes: [
+                        LogAttributesKey.conversationId.rawValue: message.conversation?.qualifiedID?.safeForLoggingDescription ?? "<nil>"
+                    ].merging(.safePublic, uniquingKeysWith: { new, _ in new })
+                )
+
                 message.fileMessageData?.cancelTransfer()
             })
         case .resend:
             userSession.enqueue({
+                WireLogger.messaging.info(
+                    "resend message",
+                    attributes: [
+                        LogAttributesKey.conversationId.rawValue: message.conversation?.qualifiedID?.safeForLoggingDescription ?? "<nil>"
+                    ].merging(.safePublic, uniquingKeysWith: { new, _ in new })
+                )
+
                 message.resend()
             })
         case .delete:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10147" title="WPB-10147" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10147</a>  Sending asset regression
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The asset sending had the same misbehaviour of setting the expiration timer too early as https://github.com/wireapp/wire-ios/pull/1636, but wasn't fixed there.

### Testing

- TODO: Test to cancel the sending
- Regression test


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

