### PR TITLE
fix: Don’t attach URLs for non existing files when sharing logs - WPB-9948

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTechnicalReportViewController.swift
@@ -155,7 +155,7 @@ extension SendTechnicalReportPresenter where Self: UIViewController {
         let mailRecipient = WireEmail.shared.callingSupportEmail
 
         guard MFMailComposeViewController.canSendMail() else {
-            DebugAlert.displayFallbackActivityController(logPaths: DebugLogSender.debugLogs, email: mailRecipient, from: self, sourceView: sourceView)
+            DebugAlert.displayFallbackActivityController(logPaths: DebugLogSender.existingDebugLogs, email: mailRecipient, from: self, sourceView: sourceView)
             return
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9948" title="WPB-9948" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9948</a>  Sending logs - when email client is not configured
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently when sending logs via a share sheet we attempt to attach all logging URLs derived from `LogFileDestination` and `ZMSLog`. However in some cases no logs have actually been created, which unsurprisingly can cause sending logs to fail.

This PR:
- Updates `DebugLogSender.debugLogs` to filter out urls for files that do not exist. It also renames it to `existingDebugLogs` to emphasize this.

This is a temporary workaround to get a fix into the release branch. It will be superseded by https://github.com/wireapp/wire-ios/pull/1678 which unifies how we gather logs for sharing but depends on https://github.com/wireapp/wire-ios/pull/1658 which is not quite ready.

### Testing

1. Clean install app, don't have Mail.app configured, have Gmail installed.
2. Login.
3. Go to Account > Settings > Advanced > Debug Report.
4. Tap "Send report to Wire".
5. Tap "OK" on alert informing you that no mail clients are set up.
6. Select Gmail.
7. Gmail compose email sheet appears with bug reports attached.

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

