### PR TITLE
fix: Improvement of conversation scrolling performance - WPB-10042

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -87,7 +87,7 @@ final class ConversationTableViewDataSource: NSObject {
         }
     }
 
-    var messages: [ConversationMessage] {
+    var messages: [ZMMessage] {
         // NOTE: We limit the number of messages to the `lastFetchedObjectCount` since the
         // NSFetchResultsController will add objects to `fetchObjects` if they are modified after
         // the initial fetch, which results in unwanted table view updates. This is normally what


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10042" title="WPB-10042" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10042</a>  [iOS] App freezes when scrolling back into conversation history
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The app currently suffers very poor scrolling performance in the conversation view in cases where there are many messages.

This PR provides a quick win improvement with scrolling simply by changing `ConversationTableViewDataSource.getter:messages` to return an array of the concrete `ZMMessage` rather than a protocol, `ConversationMessage`.

I'm yet to fully understand the reasons for this improvement but it seems a worthwhile and low risk to put it in our upcoming release. As such it should only be considered a partial fix - there are further underlying issues to resolve.

Some ideas I have of why this works and which I will investigate further:

- Using `ConversationMessage` instead of `ZMMessage` is unintentionally causing core data faults to fire.
- In some cases `messages` is being called a very large number of times. Perhaps this change is just removing some of the cost of this.

**Old**

https://github.com/user-attachments/assets/4c19d873-2b91-40c8-8c49-3e3e74261b10

**New**

https://github.com/user-attachments/assets/75752d18-7072-4c52-93e7-fdde66ab30b4

### Testing

1. Open a conversation with a large number of messages. In the videos above I have around 800
2. Scroll to the oldest message
3. Scroll to the latest message
4. Post a message

Result: Performance should be noticeably better than the current release cycle version.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

