### PR TITLE
fix: unit test message to be expired

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -262,10 +262,7 @@
 {
     // given
     XCTAssertTrue([self login]);
-    
-    NSTimeInterval defaultExpirationTime = [ZMMessage defaultExpirationTime];
-    [ZMMessage setDefaultExpirationTime:0.3];
-    
+
     self.mockTransportSession.doNotRespondToRequests = YES;
     
     ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
@@ -276,16 +273,12 @@
     [self.userSession performChanges:^{
         message = (id)[conversation appendImageFromData:[self verySmallJPEGData] nonce:[NSUUID createUUID]];
     }];
-    
-    [self spinMainQueueWithTimeout:0.5];
-    
-    // then
-    XCTAssertTrue(message.isExpired);
-    XCTAssertEqual(message.deliveryState, ZMDeliveryStateFailedToSend);
-    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorExpiredMessage);
 
-    [ZMMessage setDefaultExpirationTime:defaultExpirationTime];
-    
+    // then
+    XCTAssertTrue(message.shouldExpire);
+    XCTAssertEqual(message.deliveryState, ZMDeliveryStatePending);
+    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorNone);
+
     WaitForAllGroupsToBeEmpty(0.5);
 }
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Fixes the expectations that a message is already expired by just testing `shouldExpire`. The message is now processed later since we merged https://github.com/wireapp/wire-ios/pull/1692.


### Testing

- Run `ConversationTestsOTR`.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

