### PR TITLE
fix: conversation otr unit tests message expire [WPB-10147]

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/E2EE/ConversationTests+OTR.m
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/ConversationTests+OTR.m
@@ -262,10 +262,7 @@
 {
     // given
     XCTAssertTrue([self login]);
-    
-    NSTimeInterval defaultExpirationTime = [ZMMessage defaultExpirationTime];
-    [ZMMessage setDefaultExpirationTime:0.3];
-    
+
     self.mockTransportSession.doNotRespondToRequests = YES;
     
     ZMConversation *conversation = [self conversationForMockConversation:self.selfToUser1Conversation];
@@ -276,16 +273,12 @@
     [self.userSession performChanges:^{
         message = (id)[conversation appendImageFromData:[self verySmallJPEGData] nonce:[NSUUID createUUID]];
     }];
-    
-    [self spinMainQueueWithTimeout:0.5];
-    
-    // then
-    XCTAssertTrue(message.isExpired);
-    XCTAssertEqual(message.deliveryState, ZMDeliveryStateFailedToSend);
-    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorExpiredMessage);
 
-    [ZMMessage setDefaultExpirationTime:defaultExpirationTime];
-    
+    // then
+    XCTAssertTrue(message.shouldExpire);
+    XCTAssertEqual(message.deliveryState, ZMDeliveryStatePending);
+    XCTAssertEqual(conversation.conversationListIndicator, ZMConversationListIndicatorNone);
+
     WaitForAllGroupsToBeEmpty(0.5);
 }
 

--- a/wire-ios-sync-engine/Tests/Source/Integration/LoginFlowTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/LoginFlowTests.m
@@ -271,9 +271,9 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     DebugLoginFailureTimerOverride = 0;
 }
 
-@end
 
-@implementation LoginFlowTests (PhoneLogin)
+// MARK: - PhoneLogin
+
 
 - (void)testThatWeCanLogInWithPhoneNumber
 {
@@ -374,10 +374,9 @@ extern NSTimeInterval DebugLoginFailureTimerOverride;
     XCTAssertTrue(self.mockLoginDelegete.didCallAuthenticationDidFail);
 }
 
-@end
 
+// MARK: - ClientRegistration_Errors
 
-@implementation LoginFlowTests (ClientRegistration_Errors)
 
 - (void)testThatItFetchesSelfUserBeforeRegisteringSelfClient
 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10147" title="WPB-10147" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10147</a>  Sending asset regression
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes the expectations that a message is already expired by just testing `shouldExpire`. The message is now processed later since we merged https://github.com/wireapp/wire-ios/pull/1692.

### Testing

- Run `ConversationTestsOTR`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

