### PR TITLE
fix: crash accessing selfClient in NSE - WPB-9939

### DIFF
--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -76,46 +76,6 @@ public class CoreCryptoConfigProvider {
         }
     }
 
-    public func removeOldCoreCryptoFiles(
-        sharedContainerURL: URL,
-        userID: UUID
-    ) {
-        let accountDirectory = CoreDataStack.accountDataFolder(
-            accountIdentifier: userID,
-            applicationContainer: sharedContainerURL
-        )
-
-        let coreCryptoDirectory = accountDirectory.appendingPathComponent(sqliteDirectory)
-
-        do {
-            try FileManager.default.createAndProtectDirectory(at: coreCryptoDirectory)
-            removePreviousCoreCryptoFilesIfNeeded(from: accountDirectory)
-        } catch {
-            WireLogger.coreCrypto.error("Failed to moveCoreCryptoFilesIfNeeded \(String(describing: error))")
-        }
-
-    }
-
-    private func removePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL) {
-        let walFilename = "\(sqliteFilename)-wal"
-        let shmFilename = "\(sqliteFilename)-shm"
-
-        for file in [walFilename, shmFilename, sqliteFilename] {
-            let oldPath = oldDirURL.appendingPathComponent(file).path
-
-            guard FileManager.default.fileExists(atPath: oldPath) else {
-                continue
-            }
-
-            WireLogger.coreCrypto.debug("removing cc file \(oldPath)")
-            do {
-                try FileManager.default.removeItem(atPath: oldPath)
-            } catch {
-                WireLogger.coreCrypto.warn("error removing cc file \(oldPath): \(error)")
-            }
-        }
-    }
-
     public func clientID(of selfUser: ZMUser) throws -> String {
         guard
             let selfClient = selfUser.selfClient(),

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -64,8 +64,6 @@ public class CoreCryptoConfigProvider {
 
         let coreCryptoFile = coreCryptoDirectory.appendingPathComponent(sqliteFilename)
 
-        try movePreviousCoreCryptoFilesIfNeeded(from: accountDirectory, to: coreCryptoDirectory)
-
         do {
             let key = try coreCryptoKeyProvider.coreCryptoKey(createIfNeeded: createKeyIfNeeded)
             return (
@@ -77,8 +75,29 @@ public class CoreCryptoConfigProvider {
             throw ConfigurationSetupFailure.failedToGetCoreCryptoKey
         }
     }
+    
+    public func moveCoreCryptoFilesIfNeeded(
+        sharedContainerURL: URL,
+        userID: UUID
+    ) {
+        let accountDirectory = CoreDataStack.accountDataFolder(
+            accountIdentifier: userID,
+            applicationContainer: sharedContainerURL
+        )
 
-    private func movePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL, to currentDirURL: URL) throws {
+        let coreCryptoDirectory = accountDirectory.appendingPathComponent(sqliteDirectory)
+        let coreCryptoFile = coreCryptoDirectory.appendingPathComponent(sqliteFilename)
+
+        do {
+            try FileManager.default.createAndProtectDirectory(at: coreCryptoDirectory)
+            movePreviousCoreCryptoFilesIfNeeded(from: accountDirectory, to: coreCryptoDirectory)
+        } catch {
+            WireLogger.coreCrypto.error("Failed to moveCoreCryptoFilesIfNeeded \(String(describing: error))")
+        }
+
+    }
+
+    private func movePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL, to currentDirURL: URL) {
         let walFilename = "\(sqliteFilename)-wal"
         let shmFilename = "\(sqliteFilename)-shm"
 

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -76,6 +76,46 @@ public class CoreCryptoConfigProvider {
         }
     }
 
+    public func removeOldCoreCryptoFiles(
+        sharedContainerURL: URL,
+        userID: UUID
+    ) {
+        let accountDirectory = CoreDataStack.accountDataFolder(
+            accountIdentifier: userID,
+            applicationContainer: sharedContainerURL
+        )
+
+        let coreCryptoDirectory = accountDirectory.appendingPathComponent(sqliteDirectory)
+
+        do {
+            try FileManager.default.createAndProtectDirectory(at: coreCryptoDirectory)
+            removePreviousCoreCryptoFilesIfNeeded(from: accountDirectory)
+        } catch {
+            WireLogger.coreCrypto.error("Failed to moveCoreCryptoFilesIfNeeded \(String(describing: error))")
+        }
+
+    }
+
+    private func removePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL) {
+        let walFilename = "\(sqliteFilename)-wal"
+        let shmFilename = "\(sqliteFilename)-shm"
+
+        for file in [walFilename, shmFilename, sqliteFilename] {
+            let oldPath = oldDirURL.appendingPathComponent(file).path
+
+            guard FileManager.default.fileExists(atPath: oldPath) else {
+                continue
+            }
+
+            WireLogger.coreCrypto.debug("removing cc file \(oldPath)")
+            do {
+                try FileManager.default.removeItem(atPath: oldPath)
+            } catch {
+                WireLogger.coreCrypto.warn("error removing cc file \(oldPath): \(error)")
+            }
+        }
+    }
+
     public func clientID(of selfUser: ZMUser) throws -> String {
         guard
             let selfClient = selfUser.selfClient(),

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -86,6 +86,10 @@ public class CoreCryptoConfigProvider {
         let coreCryptoFile = coreCryptoDirectory.appendingPathComponent(sqliteFilename)
 
         try movePreviousCoreCryptoFilesIfNeeded(from: accountDirectory, to: coreCryptoDirectory)
+        
+        FileManager.default.enumerator(atPath: accountDirectory.path)?.forEach({ file in
+            WireLogger.coreCrypto.debug("🕵🏽 file: \(file)")
+        })
 
         do {
             let key = try coreCryptoKeyProvider.coreCryptoKey(createIfNeeded: createKeyIfNeeded)

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -48,27 +48,6 @@ public class CoreCryptoConfigProvider {
 
     // MARK: - Configuration
 
-    public func createFullConfiguration(
-        sharedContainerURL: URL,
-        selfUser: ZMUser,
-        createKeyIfNeeded: Bool
-    ) throws -> CoreCryptoConfiguration {
-
-        let qualifiedClientID = try clientID(of: selfUser)
-
-        let initialConfig = try createInitialConfiguration(
-            sharedContainerURL: sharedContainerURL,
-            userID: selfUser.remoteIdentifier,
-            createKeyIfNeeded: createKeyIfNeeded
-        )
-
-        return CoreCryptoConfiguration(
-            path: initialConfig.path,
-            key: initialConfig.key,
-            clientID: qualifiedClientID
-        )
-    }
-
     public func createInitialConfiguration(
         sharedContainerURL: URL,
         userID: UUID,

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -75,7 +75,7 @@ public class CoreCryptoConfigProvider {
             throw ConfigurationSetupFailure.failedToGetCoreCryptoKey
         }
     }
-    
+
     public func moveCoreCryptoFilesIfNeeded(
         sharedContainerURL: URL,
         userID: UUID
@@ -86,7 +86,6 @@ public class CoreCryptoConfigProvider {
         )
 
         let coreCryptoDirectory = accountDirectory.appendingPathComponent(sqliteDirectory)
-        let coreCryptoFile = coreCryptoDirectory.appendingPathComponent(sqliteFilename)
 
         do {
             try FileManager.default.createAndProtectDirectory(at: coreCryptoDirectory)

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -86,10 +86,6 @@ public class CoreCryptoConfigProvider {
         let coreCryptoFile = coreCryptoDirectory.appendingPathComponent(sqliteFilename)
 
         try movePreviousCoreCryptoFilesIfNeeded(from: accountDirectory, to: coreCryptoDirectory)
-        
-        FileManager.default.enumerator(atPath: accountDirectory.path)?.forEach({ file in
-            WireLogger.coreCrypto.debug("🕵🏽 file: \(file)")
-        })
 
         do {
             let key = try coreCryptoKeyProvider.coreCryptoKey(createIfNeeded: createKeyIfNeeded)
@@ -104,7 +100,6 @@ public class CoreCryptoConfigProvider {
     }
 
     private func movePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL, to currentDirURL: URL) throws {
-        WireLogger.coreCrypto.debug("🕵🏽 movePreviousCoreCryptoFileIfNeeded start")
         let walFilename = "\(sqliteFilename)-wal"
         let shmFilename = "\(sqliteFilename)-shm"
 
@@ -118,13 +113,11 @@ public class CoreCryptoConfigProvider {
 
             WireLogger.coreCrypto.debug("moving cc file \(oldPath) to \(newPath)")
             do {
-                try FileManager.default.moveItem(atPath: oldPath, toPath: currentDirURL.path)
+                try FileManager.default.moveItem(atPath: oldPath, toPath: newPath)
             } catch {
-                WireLogger.coreCrypto.warn("could not move cc file \(oldPath) to \(newPath)")
+                WireLogger.coreCrypto.warn("could not move cc file \(oldPath) to \(newPath): error \(error)")
             }
         }
-
-        WireLogger.coreCrypto.debug("🕵🏽 movePreviousCoreCryptoFileIfNeeded end")
     }
 
     public func clientID(of selfUser: ZMUser) throws -> String {

--- a/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoConfiguration.swift
@@ -76,7 +76,7 @@ public class CoreCryptoConfigProvider {
         }
     }
 
-    public func moveCoreCryptoFilesIfNeeded(
+    public func removeOldCoreCryptoFiles(
         sharedContainerURL: URL,
         userID: UUID
     ) {
@@ -89,30 +89,29 @@ public class CoreCryptoConfigProvider {
 
         do {
             try FileManager.default.createAndProtectDirectory(at: coreCryptoDirectory)
-            movePreviousCoreCryptoFilesIfNeeded(from: accountDirectory, to: coreCryptoDirectory)
+            removePreviousCoreCryptoFilesIfNeeded(from: accountDirectory)
         } catch {
             WireLogger.coreCrypto.error("Failed to moveCoreCryptoFilesIfNeeded \(String(describing: error))")
         }
 
     }
 
-    private func movePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL, to currentDirURL: URL) {
+    private func removePreviousCoreCryptoFilesIfNeeded(from oldDirURL: URL) {
         let walFilename = "\(sqliteFilename)-wal"
         let shmFilename = "\(sqliteFilename)-shm"
 
         for file in [walFilename, shmFilename, sqliteFilename] {
             let oldPath = oldDirURL.appendingPathComponent(file).path
-            let newPath = currentDirURL.appendingPathComponent(file).path
 
             guard FileManager.default.fileExists(atPath: oldPath) else {
                 continue
             }
 
-            WireLogger.coreCrypto.debug("moving cc file \(oldPath) to \(newPath)")
+            WireLogger.coreCrypto.debug("removing cc file \(oldPath)")
             do {
-                try FileManager.default.moveItem(atPath: oldPath, toPath: newPath)
+                try FileManager.default.removeItem(atPath: oldPath)
             } catch {
-                WireLogger.coreCrypto.warn("could not move cc file \(oldPath) to \(newPath): error \(error)")
+                WireLogger.coreCrypto.warn("error removing cc file \(oldPath): \(error)")
             }
         }
     }

--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -143,11 +143,13 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
     func createCoreCrypto() async throws -> SafeCoreCrypto {
         let provider = CoreCryptoConfigProvider()
 
-        let configuration = try provider.createInitialConfiguration(
-            sharedContainerURL: sharedContainerURL,
-            userID: selfUserID,
-            createKeyIfNeeded: allowCreation
-        )
+        let configuration = try await MainActor.run {
+            try provider.createInitialConfiguration(
+                sharedContainerURL: sharedContainerURL,
+                userID: selfUserID,
+                createKeyIfNeeded: allowCreation
+            )
+        }
 
         let coreCrypto = try await SafeCoreCrypto(
             path: configuration.path,

--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -40,10 +40,9 @@ public protocol CoreCryptoProviderProtocol {
     ///   - certificateChain: the resulting certificate chain from the end to end identity enrollment
     func initialiseMLSWithEndToEndIdentity(enrollment: E2eiEnrollment, certificateChain: String) async throws -> CRLsDistributionPoints?
 
-    
     /// Move CC files to dedicated folder
     /// - Note: This is a patch from v3.112.2 and below
-    func moveExistingCoreCryptoFilesIfNeeded()
+    func removeExistingCoreCryptoFilesIfNeeded()
 }
 
 public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
@@ -105,9 +104,9 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         }
     }
 
-    nonisolated public func moveExistingCoreCryptoFilesIfNeeded() {
+    nonisolated public func removeExistingCoreCryptoFilesIfNeeded() {
         let provider = CoreCryptoConfigProvider()
-        provider.moveCoreCryptoFilesIfNeeded(sharedContainerURL: sharedContainerURL,
+        provider.removeOldCoreCryptoFiles(sharedContainerURL: sharedContainerURL,
                                              userID: selfUserID)
     }
 

--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -40,6 +40,10 @@ public protocol CoreCryptoProviderProtocol {
     ///   - certificateChain: the resulting certificate chain from the end to end identity enrollment
     func initialiseMLSWithEndToEndIdentity(enrollment: E2eiEnrollment, certificateChain: String) async throws -> CRLsDistributionPoints?
 
+    
+    /// Move CC files to dedicated folder
+    /// - Note: This is a patch from v3.112.2 and below
+    func moveExistingCoreCryptoFilesIfNeeded()
 }
 
 public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
@@ -69,7 +73,6 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         self.allowCreation = allowCreation
         self.cryptoboxMigrationManager = cryptoboxMigrationManager
         self.featureRespository = FeatureRepository(context: syncContext)
-        self.moveExistingCoreCryptoFilesIfNeeded()
     }
 
     public func coreCrypto() async throws -> SafeCoreCryptoProtocol {
@@ -102,7 +105,7 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         }
     }
 
-    private func moveExistingCoreCryptoFilesIfNeeded() {
+    nonisolated public func moveExistingCoreCryptoFilesIfNeeded() {
         let provider = CoreCryptoConfigProvider()
         provider.moveCoreCryptoFilesIfNeeded(sharedContainerURL: sharedContainerURL,
                                              userID: selfUserID)

--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -40,9 +40,10 @@ public protocol CoreCryptoProviderProtocol {
     ///   - certificateChain: the resulting certificate chain from the end to end identity enrollment
     func initialiseMLSWithEndToEndIdentity(enrollment: E2eiEnrollment, certificateChain: String) async throws -> CRLsDistributionPoints?
 
+    
     /// Move CC files to dedicated folder
     /// - Note: This is a patch from v3.112.2 and below
-    func removeExistingCoreCryptoFilesIfNeeded()
+    func moveExistingCoreCryptoFilesIfNeeded()
 }
 
 public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
@@ -104,9 +105,9 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         }
     }
 
-    nonisolated public func removeExistingCoreCryptoFilesIfNeeded() {
+    nonisolated public func moveExistingCoreCryptoFilesIfNeeded() {
         let provider = CoreCryptoConfigProvider()
-        provider.removeOldCoreCryptoFiles(sharedContainerURL: sharedContainerURL,
+        provider.moveCoreCryptoFilesIfNeeded(sharedContainerURL: sharedContainerURL,
                                              userID: selfUserID)
     }
 

--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -39,10 +39,6 @@ public protocol CoreCryptoProviderProtocol {
     ///   - enrollment: enrollment instance which was used to establish end to end identity
     ///   - certificateChain: the resulting certificate chain from the end to end identity enrollment
     func initialiseMLSWithEndToEndIdentity(enrollment: E2eiEnrollment, certificateChain: String) async throws -> CRLsDistributionPoints?
-
-    /// Move CC files to dedicated folder
-    /// - Note: This is a patch from v3.112.2 and below
-    func removeExistingCoreCryptoFilesIfNeeded()
 }
 
 public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
@@ -102,12 +98,6 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
             try await generateClientPublicKeys(with: coreCrypto, credentialType: .x509)
             return CRLsDistributionPoints(from: crlsDistributionPoints)
         }
-    }
-
-    nonisolated public func removeExistingCoreCryptoFilesIfNeeded() {
-        let provider = CoreCryptoConfigProvider()
-        provider.removeOldCoreCryptoFiles(sharedContainerURL: sharedContainerURL,
-                                             userID: selfUserID)
     }
 
     // Create an CoreCrypto instance with guranteees that only one task is performing

--- a/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/MLS/CoreCryptoProvider.swift
@@ -39,6 +39,10 @@ public protocol CoreCryptoProviderProtocol {
     ///   - enrollment: enrollment instance which was used to establish end to end identity
     ///   - certificateChain: the resulting certificate chain from the end to end identity enrollment
     func initialiseMLSWithEndToEndIdentity(enrollment: E2eiEnrollment, certificateChain: String) async throws -> CRLsDistributionPoints?
+
+    /// Move CC files to dedicated folder
+    /// - Note: This is a patch from v3.112.2 and below
+    func removeExistingCoreCryptoFilesIfNeeded()
 }
 
 public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
@@ -98,6 +102,12 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
             try await generateClientPublicKeys(with: coreCrypto, credentialType: .x509)
             return CRLsDistributionPoints(from: crlsDistributionPoints)
         }
+    }
+
+    nonisolated public func removeExistingCoreCryptoFilesIfNeeded() {
+        let provider = CoreCryptoConfigProvider()
+        provider.removeOldCoreCryptoFiles(sharedContainerURL: sharedContainerURL,
+                                             userID: selfUserID)
     }
 
     // Create an CoreCrypto instance with guranteees that only one task is performing

--- a/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
@@ -35,7 +35,7 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
 
     private let coreCrypto: CoreCryptoProtocol
     private let safeContext: SafeFileContext
-    private let databaseFolderPath: String
+    private let databasePath: String
 
     public convenience init(path: String, key: String) async throws {
         let coreCrypto = try await coreCryptoDeferredInit(
@@ -47,18 +47,18 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
 
         try await coreCrypto.setCallbacks(callbacks: CoreCryptoCallbacksImpl())
 
-        self.init(coreCrypto: coreCrypto, databaseFolderPath: path)
+        self.init(coreCrypto: coreCrypto, databasePath: path)
     }
 
-    init(coreCrypto: CoreCryptoProtocol, databaseFolderPath: String) {
+    init(coreCrypto: CoreCryptoProtocol, databasePath: String) {
         self.coreCrypto = coreCrypto
-        self.databaseFolderPath = databaseFolderPath
-        let directoryPathUrl = URL(fileURLWithPath: databaseFolderPath)
+        self.databasePath = databasePath
+        let directoryPathUrl = URL(fileURLWithPath: databasePath).deletingLastPathComponent()
         self.safeContext = SafeFileContext(fileURL: directoryPathUrl)
     }
 
     public func tearDown() throws {
-        _ = try FileManager.default.removeItem(atPath: databaseFolderPath)
+        _ = try FileManager.default.removeItem(atPath: databasePath)
     }
 
     public func perform<T>(_ block: (CoreCryptoProtocol) async throws -> T) async rethrows -> T {

--- a/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
+++ b/wire-ios-data-model/Source/MLS/SafeCoreCrypto.swift
@@ -35,7 +35,7 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
 
     private let coreCrypto: CoreCryptoProtocol
     private let safeContext: SafeFileContext
-    private let databasePath: String
+    private let databaseFolderPath: String
 
     public convenience init(path: String, key: String) async throws {
         let coreCrypto = try await coreCryptoDeferredInit(
@@ -47,18 +47,18 @@ public class SafeCoreCrypto: SafeCoreCryptoProtocol {
 
         try await coreCrypto.setCallbacks(callbacks: CoreCryptoCallbacksImpl())
 
-        self.init(coreCrypto: coreCrypto, databasePath: path)
+        self.init(coreCrypto: coreCrypto, databaseFolderPath: path)
     }
 
-    init(coreCrypto: CoreCryptoProtocol, databasePath: String) {
+    init(coreCrypto: CoreCryptoProtocol, databaseFolderPath: String) {
         self.coreCrypto = coreCrypto
-        self.databasePath = databasePath
-        let directoryPathUrl = URL(fileURLWithPath: databasePath).deletingLastPathComponent()
+        self.databaseFolderPath = databaseFolderPath
+        let directoryPathUrl = URL(fileURLWithPath: databaseFolderPath)
         self.safeContext = SafeFileContext(fileURL: directoryPathUrl)
     }
 
     public func tearDown() throws {
-        _ = try FileManager.default.removeItem(atPath: databasePath)
+        _ = try FileManager.default.removeItem(atPath: databaseFolderPath)
     }
 
     public func perform<T>(_ block: (CoreCryptoProtocol) async throws -> T) async rethrows -> T {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -475,7 +475,7 @@ public final class ZMUserSession: NSObject {
             cryptoboxMigrationManager: cryptoboxMigrationManager)
 
         // should be done only once
-        self.coreCryptoProvider.removeExistingCoreCryptoFilesIfNeeded()
+        self.coreCryptoProvider.moveExistingCoreCryptoFilesIfNeeded()
 
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -473,6 +473,10 @@ public final class ZMUserSession: NSObject {
             accountDirectory: coreDataStack.accountContainer,
             syncContext: coreDataStack.syncContext,
             cryptoboxMigrationManager: cryptoboxMigrationManager)
+
+        // should be done only once
+        self.coreCryptoProvider.moveExistingCoreCryptoFilesIfNeeded()
+
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,
             sharedUserDefaults: sharedUserDefaults

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -475,7 +475,7 @@ public final class ZMUserSession: NSObject {
             cryptoboxMigrationManager: cryptoboxMigrationManager)
 
         // should be done only once
-        self.coreCryptoProvider.moveExistingCoreCryptoFilesIfNeeded()
+        self.coreCryptoProvider.removeExistingCoreCryptoFilesIfNeeded()
 
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -474,6 +474,9 @@ public final class ZMUserSession: NSObject {
             syncContext: coreDataStack.syncContext,
             cryptoboxMigrationManager: cryptoboxMigrationManager)
 
+        // should be done only once
+        self.coreCryptoProvider.removeExistingCoreCryptoFilesIfNeeded()
+
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,
             sharedUserDefaults: sharedUserDefaults

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -474,9 +474,6 @@ public final class ZMUserSession: NSObject {
             syncContext: coreDataStack.syncContext,
             cryptoboxMigrationManager: cryptoboxMigrationManager)
 
-        // should be done only once
-        self.coreCryptoProvider.removeExistingCoreCryptoFilesIfNeeded()
-
         self.lastEventIDRepository = LastEventIDRepository(
             userID: userId,
             sharedUserDefaults: sharedUserDefaults

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -147,6 +147,7 @@ public enum LogAttributesKey: String {
     case syncPhase = "sync_phase"
     case eventSource = "event_source"
     case processId = "process_id"
+    case processName = "process_name"
 }
 
 public extension LogAttributes {

--- a/wire-ios-system/Source/Logging/WireLogger.swift
+++ b/wire-ios-system/Source/Logging/WireLogger.swift
@@ -146,6 +146,7 @@ public enum LogAttributesKey: String {
     case conversationId = "conversation_id"
     case syncPhase = "sync_phase"
     case eventSource = "event_source"
+    case processId = "process_id"
 }
 
 public extension LogAttributes {

--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -114,6 +114,7 @@ public final class DatadogWrapper {
             level: defaultLevel,
             message: "Datadog startMonitoring for device: \(datadogUserId)"
         )
+        addTag(.processId, value: "\(ProcessInfo.processInfo.processName) - \(ProcessInfo.processInfo.processIdentifier)")
     }
 
     public func log(

--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -110,11 +110,12 @@ public final class DatadogWrapper {
         Datadog.setUserInfo(id: datadogUserId)
         RemoteMonitoring.remoteLogger = self
 
+        addTag(.processId, value: "\(ProcessInfo.processInfo.processIdentifier)")
+        addTag(.processName, value: ProcessInfo.processInfo.processName)
         log(
             level: defaultLevel,
             message: "Datadog startMonitoring for device: \(datadogUserId)"
         )
-        addTag(.processId, value: "\(ProcessInfo.processInfo.processName) - \(ProcessInfo.processInfo.processIdentifier)")
     }
 
     public func log(


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

When we setup CoreCrypto (CC), we add a safeContext on its database enclosing directory to protect multiple processes to access CC at the same time. The issue is that the directory is the shared account folder containing also the database for messages and events. The protection using flock might block the access to the CoreData stack resulting in a crash.


### Solution

* Change location of CoreCrypto database to another folder `CC` which would be protected by SafeContext.
* Add process name and id to logs to identify multiple processes in Datadog


### Note

Originally, I thought we would need to move the files to a specific folder to protect them with flock, but [moving the CC files](https://github.com/wireapp/wire-ios/pull/1717/commits/11bbe22e0efc633a47dc7caa32b31b1daf2b78a7) always ended up to corrupt the session (Error 204 or 3).

### Testing

1. Install previous build
2. send message
3. update to new build
4. check that sending / receiving message still works

### TODO

- [ ] check no more crash is produced
- [ ] flock check
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

