### PR TITLE
fix: enable danger again - WPB-9872

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -164,13 +164,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireSystem" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-system || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-system.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireSystem
         if: ${{ inputs.wire-ios-system || inputs.all }}
         run: |
@@ -194,13 +187,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-testing.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireTesting" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-testing || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-testing.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireTesting
         if: ${{ inputs.wire-ios-testing || inputs.all }}
@@ -226,13 +212,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireUtilities" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-utilities || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-utilities.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireUtilities
         if: ${{ inputs.wire-ios-utilities || inputs.all }}
         run: |
@@ -256,13 +235,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-cryptobox.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireCryptobox" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-cryptobox || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-cryptobox.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireCryptobox
         if: ${{ inputs.wire-ios-cryptobox || inputs.all }}
@@ -288,13 +260,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireTransport" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-transport || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-transport.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireTransport
         if: ${{ inputs.wire-ios-transport || inputs.all }}
         run: |
@@ -318,13 +283,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-link-preview.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireLinkPreview" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-link-preview || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-link-preview.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireLinkPreview
         if: ${{ inputs.wire-ios-link-preview || inputs.all }}
@@ -350,13 +308,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireImages" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-images || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-images.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireImages
         if: ${{ inputs.wire-ios-images || inputs.all }}
         run: |
@@ -380,13 +331,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-protos.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireProtos" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-protos || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-protos.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireProtos
         if: ${{ inputs.wire-ios-protos || inputs.all }}
@@ -412,13 +356,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireMockTransport" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-mocktransport || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-mocktransport.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireMockTransport
         if: ${{ inputs.wire-ios-mocktransport || inputs.all }}
         run: |
@@ -443,13 +380,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDataModel" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-data-model || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-data-model.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireDataModel
         if: ${{ inputs.wire-ios-data-model || inputs.all }}
         run: |
@@ -472,13 +402,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-api.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireAPI" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-api || inputs.all }}
-        with:
-          results: xcodebuild-wire-api.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireAPI
         if: ${{ inputs.wire-api || inputs.all }}
@@ -504,13 +427,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDomain" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-domain || inputs.all }}
-        with:
-          results: xcodebuild-wire-domain.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireDomain
         if: ${{ inputs.wire-domain || inputs.all }}
         run: |
@@ -534,13 +450,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-request-strategy.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireRequestStrategy" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-request-strategy || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-request-strategy.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireRequestStrategy
         if: ${{ inputs.wire-ios-request-strategy || inputs.all }}
@@ -566,13 +475,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireShareEngine" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-share-engine || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-share-engine.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireShareEngine
         if: ${{ inputs.wire-ios-share-engine || inputs.all }}
         run: |
@@ -596,13 +498,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-sync-engine.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireSyncEngine" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-sync-engine || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-sync-engine.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireSyncEngine
         if: ${{ inputs.wire-ios-sync-engine || inputs.all }}
@@ -628,13 +523,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDesign" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-design || inputs.all }}
-        with:
-          results: xcodebuild-wire-design.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireDesign
         if: ${{ inputs.wire-design || inputs.all }}
         run: |
@@ -659,13 +547,6 @@ jobs:
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireReusableUIComponents" --verbose
 
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-reusable-ui-components || inputs.all }}
-        with:
-          results: xcodebuild-wire-reusable-ui-components.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Test WireReusableUIComponents
         if: ${{ inputs.wire-reusable-ui-components || inputs.all }}
         run: |
@@ -689,13 +570,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for Wire-iOS" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test Wire-iOS
         if: ${{ inputs.wire-ios || inputs.all }}
@@ -737,13 +611,6 @@ jobs:
           XCRESULT_PATH: xcodebuild-wire-ios-notification-engine.xcresult
         run: |
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireNotificationEngine" --verbose
-
-      - uses: kronenthaler/analyze-xcoderesults-action@0.1.9
-        if: ${{ inputs.wire-ios-notification-engine || inputs.all }}
-        with:
-          results: xcodebuild-wire-ios-notification-engine.xcresult
-          warningAnnotations: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test WireNotificationEngine
         if: ${{ inputs.wire-ios-notification-engine || inputs.all }}

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: Danger.results
-          key: ${{ github.event.pull_request.base.ref }}-${{ runner.os }}-xcode${{ steps.xcode-version.outputs.XCODE_VERSION }}-Danger.results
+          key: ${{ github.event.before || github.event.pull_request.base.sha }}-Danger.results
 
       - name: Bootstrap Carthage if no cache
         if: steps.cache-carthage.outputs.cache-hit != 'true'
@@ -771,10 +771,12 @@ jobs:
           xcodebuild test -retry-tests-on-failure -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee -a xcodebuild-wire-ios-notification-engine.log | bundle exec xcpretty --report junit --output build/reports/WireNotificationEngine.junit
           exit ${PIPESTATUS[0]}
 
-      - uses: actions/cache/save@v4
+      - name: Save cache with warning counts
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v4
         with:
           path: Danger.results
-          key: ${{ steps.restore-danger-results.outputs.cache-primary-key }}
+          key: ${{ github.event.head_commit.id || github.event.pull_request.merge_commit_sha ||github.event.pull_request.head.sha }}-Danger.results
 
       - name: Upload Test Reports as Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -625,7 +625,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: Danger.results
-          key: ${{ github.event.head_commit.id || github.event.pull_request.merge_commit_sha ||github.event.pull_request.head.sha }}-Danger.results
+          key: ${{ github.event.head_commit.id || github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}-Danger.results
 
       - name: Upload Test Reports as Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -620,7 +620,8 @@ jobs:
           exit ${PIPESTATUS[0]}
 
       - name: Save cache with warning counts
-        if: ${{ !cancelled() }}
+        # This step should only run for the test_develop.yml workflow
+        if: ${{ !cancelled() && github.event.action == 'push' }}
         uses: actions/cache/save@v4
         with:
           path: Danger.results

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -157,8 +157,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireSystem -resultBundlePath xcodebuild-wire-ios-system.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-system.log | bundle exec xcpretty
 
       - name: Run Danger for WireSystem
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-system || inputs.all }}
+        if: ${{ inputs.wire-ios-system || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-system.xcresult
@@ -189,8 +188,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireTesting -resultBundlePath xcodebuild-wire-ios-testing.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-testing.log | bundle exec xcpretty
 
       - name: Run Danger for WireTesting
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-testing || inputs.all }}
+        if: ${{ inputs.wire-ios-testing || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-testing.xcresult
@@ -221,8 +219,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireUtilities -resultBundlePath xcodebuild-wire-ios-utilities.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-utilities.log | bundle exec xcpretty
 
       - name: Run Danger for WireUtilities
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-utilities || inputs.all }}
+        if: ${{ inputs.wire-ios-utilities || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-utilities.xcresult
@@ -253,8 +250,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireCryptobox -resultBundlePath xcodebuild-wire-ios-cryptobox.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-cryptobox.log | bundle exec xcpretty
 
       - name: Run Danger for WireCryptobox
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-cryptobox || inputs.all }}
+        if: ${{ inputs.wire-ios-cryptobox || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-cryptobox.xcresult
@@ -285,8 +281,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireTransport -resultBundlePath xcodebuild-wire-ios-transport.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-transport.log | bundle exec xcpretty
 
       - name: Run Danger for WireTransport
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-transport || inputs.all }}
+        if: ${{ inputs.wire-ios-transport || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-transport.xcresult
@@ -317,8 +312,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireLinkPreview -resultBundlePath xcodebuild-wire-ios-link-preview.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-link-preview.log | bundle exec xcpretty
 
       - name: Run Danger for WireLinkPreview
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-link-preview || inputs.all }}
+        if: ${{ inputs.wire-ios-link-preview || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-link-preview.xcresult
@@ -349,8 +343,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireImages -resultBundlePath xcodebuild-wire-ios-images.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-images.log | bundle exec xcpretty
 
       - name: Run Danger for WireImages
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-images || inputs.all }}
+        if: ${{ inputs.wire-ios-images || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-images.xcresult
@@ -381,8 +374,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireProtos -resultBundlePath xcodebuild-wire-ios-protos.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-protos.log | bundle exec xcpretty
 
       - name: Run Danger for WireProtos
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-protos || inputs.all }}
+        if: ${{ inputs.wire-ios-protos || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-protos.xcresult
@@ -413,8 +405,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireMockTransport -resultBundlePath xcodebuild-wire-ios-mocktransport.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-mocktransport.log | bundle exec xcpretty
 
       - name: Run Danger for WireMockTransport
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-mocktransport || inputs.all }}
+        if: ${{ inputs.wire-ios-mocktransport || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-mocktransport.xcresult
@@ -445,8 +436,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireDataModel -resultBundlePath xcodebuild-wire-ios-data-model.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-data-model.log | bundle exec xcpretty
 
       - name: Run Danger for WireDataModel
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-data-model || inputs.all }}
+        if: ${{ inputs.wire-ios-data-model || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-data-model.xcresult
@@ -476,8 +466,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireAPI -resultBundlePath xcodebuild-wire-api.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-api.log | bundle exec xcpretty
 
       - name: Run Danger for WireAPI
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-api || inputs.all }}
+        if: ${{ inputs.wire-api || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-api.xcresult
@@ -508,8 +497,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireDomain -resultBundlePath xcodebuild-wire-domain.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-domain.log | bundle exec xcpretty
 
       - name: Run Danger for WireDomain
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-domain || inputs.all }}
+        if: ${{ inputs.wire-domain || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-domain.xcresult
@@ -540,8 +528,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireRequestStrategy -resultBundlePath xcodebuild-wire-ios-request-strategy.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-request-strategy.log | bundle exec xcpretty
 
       - name: Run Danger for WireRequestStrategy
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-request-strategy || inputs.all }}
+        if: ${{ inputs.wire-ios-request-strategy || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-request-strategy.xcresult
@@ -572,8 +559,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireShareEngine -resultBundlePath xcodebuild-wire-ios-share-engine.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-share-engine.log | bundle exec xcpretty
 
       - name: Run Danger for WireShareEngine
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-share-engine || inputs.all }}
+        if: ${{ inputs.wire-ios-share-engine || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-share-engine.xcresult
@@ -604,8 +590,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireSyncEngine -resultBundlePath xcodebuild-wire-ios-sync-engine.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-sync-engine.log | bundle exec xcpretty
 
       - name: Run Danger for WireSyncEngine
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-sync-engine || inputs.all }}
+        if: ${{ inputs.wire-ios-sync-engine || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-sync-engine.xcresult
@@ -636,8 +621,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireDesign -resultBundlePath xcodebuild-wire-design.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-design.log | bundle exec xcpretty
 
       - name: Run Danger for WireDesign
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-design || inputs.all }}
+        if: ${{ inputs.wire-design || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-design.xcresult
@@ -668,8 +652,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireReusableUIComponents -resultBundlePath xcodebuild-wire-reusable-ui-components.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-reusable-ui-components.log | bundle exec xcpretty
 
       - name: Run Danger for WireReusableUIComponents
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-reusable-ui-components || inputs.all }}
+        if: ${{ inputs.wire-reusable-ui-components || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-reusable-ui-components.xcresult
@@ -700,8 +683,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme Wire-iOS -resultBundlePath xcodebuild-wire-ios.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios.log | bundle exec xcpretty
 
       - name: Run Danger for Wire-iOS
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios || inputs.all }}
+        if: ${{ inputs.wire-ios || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios.xcresult
@@ -749,8 +731,7 @@ jobs:
           xcodebuild build-for-testing -workspace wire-ios-mono.xcworkspace -scheme WireNotificationEngine -resultBundlePath xcodebuild-wire-ios-notification-engine.xcresult -destination 'platform=iOS Simulator,OS=${{ env.IOS_VERSION }},name=${{ env.IPHONE_MODEL }}' | tee xcodebuild-wire-ios-notification-engine.log | bundle exec xcpretty
 
       - name: Run Danger for WireNotificationEngine
-        # TODO: WPB-9872 revert after fixing Dangerfile
-        if: false # ${{ inputs.wire-ios-notification-engine || inputs.all }}
+        if: ${{ inputs.wire-ios-notification-engine || inputs.all }}
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-notification-engine.xcresult

--- a/wire-ios-system/Source/ZMSDispatchGroup.swift
+++ b/wire-ios-system/Source/ZMSDispatchGroup.swift
@@ -29,9 +29,12 @@ public final class ZMSDispatchGroup: NSObject {
         self.init(dispatchGroup: .init(), label: label)
     }
 
+
     public init(dispatchGroup group: DispatchGroup, label: String) {
         self.group = group
         self.label = label
+
+        var x = 10
     }
 
     public func enter() {

--- a/wire-ios-system/Source/ZMSDispatchGroup.swift
+++ b/wire-ios-system/Source/ZMSDispatchGroup.swift
@@ -29,12 +29,9 @@ public final class ZMSDispatchGroup: NSObject {
         self.init(dispatchGroup: .init(), label: label)
     }
 
-
     public init(dispatchGroup group: DispatchGroup, label: String) {
         self.group = group
         self.label = label
-
-        var x = 10
     }
 
     public func enter() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9872" title="WPB-9872" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9872</a>  Show xcodebuild warnings on GitHub
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes workaround of PR https://github.com/wireapp/wire-ios/pull/1671

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
