### PR TITLE
fix: bypass Danger's PR check - WPB-9872

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -162,6 +162,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-system.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireSystem" --verbose
 
       - name: Test WireSystem
@@ -186,6 +187,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-testing.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireTesting" --verbose
 
       - name: Test WireTesting
@@ -210,6 +212,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-utilities.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireUtilities" --verbose
 
       - name: Test WireUtilities
@@ -234,6 +237,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-cryptobox.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireCryptobox" --verbose
 
       - name: Test WireCryptobox
@@ -258,6 +262,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-transport.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireTransport" --verbose
 
       - name: Test WireTransport
@@ -282,6 +287,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-link-preview.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireLinkPreview" --verbose
 
       - name: Test WireLinkPreview
@@ -306,6 +312,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-images.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireImages" --verbose
 
       - name: Test WireImages
@@ -330,6 +337,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-protos.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireProtos" --verbose
 
       - name: Test WireProtos
@@ -354,6 +362,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-mocktransport.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireMockTransport" --verbose
 
       - name: Test WireMockTransport
@@ -378,6 +387,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-data-model.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDataModel" --verbose
 
       - name: Test WireDataModel
@@ -401,6 +411,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-api.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireAPI" --verbose
 
       - name: Test WireAPI
@@ -425,6 +436,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-domain.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDomain" --verbose
 
       - name: Test WireDomain
@@ -449,6 +461,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-request-strategy.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireRequestStrategy" --verbose
 
       - name: Test WireRequestStrategy
@@ -473,6 +486,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-share-engine.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireShareEngine" --verbose
 
       - name: Test WireShareEngine
@@ -497,6 +511,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-sync-engine.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireSyncEngine" --verbose
 
       - name: Test WireSyncEngine
@@ -521,6 +536,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-design.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireDesign" --verbose
 
       - name: Test WireDesign
@@ -545,6 +561,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-reusable-ui-components.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireReusableUIComponents" --verbose
 
       - name: Test WireReusableUIComponents
@@ -569,6 +586,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for Wire-iOS" --verbose
 
       - name: Test Wire-iOS
@@ -610,6 +628,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XCRESULT_PATH: xcodebuild-wire-ios-notification-engine.xcresult
         run: |
+          export GITHUB_EVENT_NAME="pull_request" # bypass PR check
           bundle exec danger --dangerfile=Dangerfile.warning-workaround --danger_id="Run Danger for WireNotificationEngine" --verbose
 
       - name: Test WireNotificationEngine

--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -12,18 +12,19 @@ concurrency:
 
 jobs:
   SwiftFormat:
-      runs-on: ubuntu-latest
-      container:
-        image: ghcr.io/nicklockwood/swiftformat:0.54.0
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/nicklockwood/swiftformat:0.54.0
 
-      steps:
-        - uses: actions/checkout@v4
-        - name: GitHub Action for SwiftFormat
-          run: >
-            swiftformat --lint
-            ./SourceryPlugin
-            ./WireAPI
-            ./WireAnalytics
-            ./WireDomain
-            ./WireUI
-            --reporter github-actions-log
+    steps:
+      - uses: actions/checkout@v4
+      - name: GitHub Action for SwiftFormat
+        run: >
+          swiftformat --lint
+          ./SourceryPlugin
+          ./WireAPI
+          ./WireAnalytics
+          ./WireDomain
+          ./WireUI
+          --reporter github-actions-log

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -12,12 +12,13 @@ concurrency:
 
 jobs:
   SwiftLint:
-      runs-on: ubuntu-latest
-      container:
-        image: ghcr.io/realm/swiftlint:0.55.1
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/realm/swiftlint:0.55.1
 
-      steps:
-        - uses: actions/checkout@v4
-        - name: GitHub Action for SwiftLint
-          run: |
-            swiftlint --reporter github-actions-logging --strict --quiet
+    steps:
+      - uses: actions/checkout@v4
+      - name: GitHub Action for SwiftLint
+        run: |
+          swiftlint --reporter github-actions-logging --strict --quiet


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9872" title="WPB-9872" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9872</a>  Show xcodebuild warnings on GitHub
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Danger aborts execution if `GITHUB_EVENT_NAME` is not `pull_request` or `pull_request_target` [danger/lib/danger/ci_source /github_actions.rb](https://github.com/danger/danger/blob/7beacabf477447587aa229e1c7cf1d73acb2661b/lib/danger/ci_source/github_actions.rb#L18)

This PR overrides the value to always contain `pull_request`.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
