### PR TITLE
fix: crash accessing self client id - WPB-9939

### DIFF
--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.h
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.h
@@ -33,17 +33,16 @@
 @property (nonatomic, readonly) ZMSingleRequestProgress status;
 
 /// Date of last call to `resetFetching`
-@property (nonatomic, readonly) NSDate *lastResetFetchDate;
+@property (nonatomic, readonly, nullable) NSDate *lastResetFetchDate;
 
 
-- (instancetype)initWithBasePath:(NSString *)basePath
-                        startKey:(NSString *)startKey
-                        pageSize:(NSUInteger)pageSize
-            managedObjectContext:(NSManagedObjectContext *)moc
-                    selfClientID:(NSString *)selfClientID
-                      transcoder:(id<ZMSimpleListRequestPaginatorSync>)transcoder;
+- (nonnull instancetype)initWithBasePath:(nonnull NSString *)basePath
+                                startKey:(nonnull NSString *)startKey
+                                pageSize:(NSUInteger)pageSize
+                    managedObjectContext:(nonnull NSManagedObjectContext *)moc
+                              transcoder:(nullable id<ZMSimpleListRequestPaginatorSync>)transcoder;
 
-- (ZMTransportRequest *)nextRequestForAPIVersion:(APIVersion)apiVersion;
+- (nullable ZMTransportRequest *)nextRequestForAPIVersion:(APIVersion)apiVersion;
 
 /// this will cause the fetch to restart at the nextPaginatedRequest
 - (void)resetFetching;
@@ -54,26 +53,28 @@
 
 @protocol ZMSimpleListRequestPaginatorSync <NSObject>
 
+- (nullable NSString *)selfClientID;
+
 /// returns the next UUID to be used as the starting point for the next request
-- (NSUUID *)nextUUIDFromResponse:(ZMTransportResponse *)response forListPaginator:(ZMSimpleListRequestPaginator *)paginator;
+- (nullable NSUUID *)nextUUIDFromResponse:(nonnull ZMTransportResponse *)response forListPaginator:(nonnull ZMSimpleListRequestPaginator *)paginator;
 
 
 /// Returns an NSUUID to start with after calling resetFetching
 @optional
-- (NSUUID *)startUUID;
+- (nullable NSUUID *)startUUID;
 
 /// Returns YES, if the error response for a specific statusCode should be parsed (e.g. if the payload contains content that needs to be processed)
 @optional
-- (BOOL)shouldParseErrorForResponse:(ZMTransportResponse*)response;
+- (BOOL)shouldParseErrorForResponse:(nonnull ZMTransportResponse*)response;
 
 @optional
-- (void)parseTemporaryErrorForResponse:(ZMTransportResponse*)response;
+- (void)parseTemporaryErrorForResponse:(nonnull ZMTransportResponse*)response;
 
 @optional
 - (void)startSlowSync;
 
 @optional
-- (BOOL)shouldStartSlowSync:(ZMTransportResponse *)response;
+- (BOOL)shouldStartSlowSync:(nonnull ZMTransportResponse *)response;
 
 @end
 

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.h
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.h
@@ -40,7 +40,7 @@
                         startKey:(NSString *)startKey
                         pageSize:(NSUInteger)pageSize
             managedObjectContext:(NSManagedObjectContext *)moc
-                 includeClientID:(BOOL)includeClientID
+                    selfClientID:(NSString *)selfClientID
                       transcoder:(id<ZMSimpleListRequestPaginatorSync>)transcoder;
 
 - (ZMTransportRequest *)nextRequestForAPIVersion:(APIVersion)apiVersion;

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.m
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.m
@@ -35,8 +35,6 @@
 @property (nonatomic) NSUUID *lastUUIDOfPreviousPage;
 @property (nonatomic) NSDate *lastResetFetchDate;
 
-@property (nonatomic, copy) NSString *selfClientID;
-
 @property (nonatomic, weak) id<ZMSimpleListRequestPaginatorSync> transcoder;
 
 @end
@@ -50,7 +48,6 @@ ZM_EMPTY_ASSERTING_INIT()
                         startKey:(NSString *)startKey
                         pageSize:(NSUInteger)pageSize
             managedObjectContext:(NSManagedObjectContext *)moc
-                    selfClientID:(NSString *)selfClientID
                       transcoder:(id<ZMSimpleListRequestPaginatorSync>)transcoder;
 {
     Require(startKey != nil);
@@ -62,7 +59,6 @@ ZM_EMPTY_ASSERTING_INIT()
         self.startKey = startKey;
         self.pageSize = pageSize;
         self.moc = moc;
-        self.selfClientID = selfClientID;
         self.transcoder = transcoder;
         self.singleRequestSync = [[ZMSingleRequestSync alloc] initWithSingleRequestTranscoder:self groupQueue:self.moc];
     }
@@ -93,8 +89,15 @@ ZM_EMPTY_ASSERTING_INIT()
     if (self.lastUUIDOfPreviousPage != nil) {
         [queryItems addObject:[NSURLQueryItem queryItemWithName:self.startKey value:self.lastUUIDOfPreviousPage.transportString]];
     }
-    if (self.selfClientID) {
-        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"client" value:self.selfClientID]];
+
+    NSString *selfClientID;
+    id strongTranscoder = self.transcoder;
+    if ([strongTranscoder respondsToSelector:@selector(selfClientID)]) {
+        selfClientID = [strongTranscoder selfClientID];
+    }
+
+    if (selfClientID) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"client" value:selfClientID]];
     }
 
     NSURLComponents *components = [NSURLComponents componentsWithString:self.basePath];
@@ -111,7 +114,6 @@ ZM_EMPTY_ASSERTING_INIT()
             return;
         }
 
-        id strongTranscoder = self.transcoder;
         if ([strongTranscoder respondsToSelector:@selector(parseTemporaryErrorForResponse:)]) {
             [strongTranscoder parseTemporaryErrorForResponse:response];
         }

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.m
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginator.m
@@ -35,7 +35,7 @@
 @property (nonatomic) NSUUID *lastUUIDOfPreviousPage;
 @property (nonatomic) NSDate *lastResetFetchDate;
 
-@property (nonatomic) BOOL includeClientID;
+@property (nonatomic, copy) NSString *selfClientID;
 
 @property (nonatomic, weak) id<ZMSimpleListRequestPaginatorSync> transcoder;
 
@@ -50,7 +50,7 @@ ZM_EMPTY_ASSERTING_INIT()
                         startKey:(NSString *)startKey
                         pageSize:(NSUInteger)pageSize
             managedObjectContext:(NSManagedObjectContext *)moc
-                 includeClientID:(BOOL)includeClientID
+                    selfClientID:(NSString *)selfClientID
                       transcoder:(id<ZMSimpleListRequestPaginatorSync>)transcoder;
 {
     Require(startKey != nil);
@@ -62,7 +62,7 @@ ZM_EMPTY_ASSERTING_INIT()
         self.startKey = startKey;
         self.pageSize = pageSize;
         self.moc = moc;
-        self.includeClientID = includeClientID;
+        self.selfClientID = selfClientID;
         self.transcoder = transcoder;
         self.singleRequestSync = [[ZMSingleRequestSync alloc] initWithSingleRequestTranscoder:self groupQueue:self.moc];
     }
@@ -93,13 +93,8 @@ ZM_EMPTY_ASSERTING_INIT()
     if (self.lastUUIDOfPreviousPage != nil) {
         [queryItems addObject:[NSURLQueryItem queryItemWithName:self.startKey value:self.lastUUIDOfPreviousPage.transportString]];
     }
-    if (self.includeClientID) {
-        UserClient *selfClient = [ZMUser selfUserInContext:self.moc].selfClient;
-        if (selfClient.remoteIdentifier != nil) {
-            [queryItems addObject:[NSURLQueryItem queryItemWithName:@"client" value:selfClient.remoteIdentifier]];
-        } else {
-            return nil;
-        }
+    if (self.selfClientID) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"client" value:self.selfClientID]];
     }
 
     NSURLComponents *components = [NSURLComponents componentsWithString:self.basePath];

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginatorTests.m
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginatorTests.m
@@ -58,7 +58,7 @@
     self.transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [self verifyMockLater:self.transcoder];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:self.transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext transcoder:self.transcoder];
 
     self.singleRequestSync = [OCMockObject mockForClass:ZMSingleRequestSync.class];
     [self verifyMockLater:self.singleRequestSync];
@@ -91,7 +91,7 @@
 - (void)testThatItCreatesASingleRequestSyncByDefault
 {
     // when
-    ZMSimpleListRequestPaginator *sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:@"foo" startKey:@"bar" pageSize:10 managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:nil];
+    ZMSimpleListRequestPaginator *sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:@"foo" startKey:@"bar" pageSize:10 managedObjectContext:self.coreDataStack.syncContext transcoder:nil];
 
     // then
     XCTAssertNotNil(sut.singleRequestSync);
@@ -218,7 +218,7 @@
     id transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [[[transcoder expect] andReturn:startUUID] startUUID];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:startKey pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:startKey pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext transcoder:transcoder];
 
     [[self.singleRequestSync stub] readyForNextRequest];
     [self.sut resetFetching];
@@ -239,8 +239,9 @@
     [self.coreDataStack.syncContext performGroupedBlock:^{
         // given
         NSString *selfClientID = [self createSelfClient].remoteIdentifier;
+        [[[self.transcoder expect] andReturn:selfClientID] selfClientID];
 
-        self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"foo" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext selfClientID:selfClientID transcoder:nil];
+        self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"foo" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext  transcoder:self.transcoder];
 
         [[self.singleRequestSync stub] readyForNextRequest];
         [self.sut resetFetching];
@@ -425,7 +426,7 @@
     id transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [[transcoder reject] nextUUIDFromResponse:OCMOCK_ANY forListPaginator:OCMOCK_ANY];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext transcoder:transcoder];
     [[self.singleRequestSync stub] readyForNextRequest];
     [self.sut resetFetching];
 
@@ -446,7 +447,7 @@
     id transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [[transcoder expect] nextUUIDFromResponse:OCMOCK_ANY forListPaginator:OCMOCK_ANY];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext  transcoder:transcoder];
     [[self.singleRequestSync stub] readyForNextRequest];
     [self.sut resetFetching];
 
@@ -521,7 +522,7 @@
     [[[transcoder expect] andReturn:[self returnFullPageWithLastIdentifier:lastIdentifier]] nextUUIDFromResponse:OCMOCK_ANY forListPaginator:OCMOCK_ANY];
     [[[transcoder expect] andReturn:startIdentifier] startUUID];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext transcoder:transcoder];
     self.sut.singleRequestSync = self.singleRequestSync;
 
     [self.sut resetFetching];

--- a/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginatorTests.m
+++ b/wire-ios-request-strategy/Sources/Helpers/ZMSimpleListRequestPaginatorTests.m
@@ -58,7 +58,7 @@
     self.transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [self verifyMockLater:self.transcoder];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext includeClientID:NO transcoder:self.transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:self.transcoder];
 
     self.singleRequestSync = [OCMockObject mockForClass:ZMSingleRequestSync.class];
     [self verifyMockLater:self.singleRequestSync];
@@ -91,7 +91,7 @@
 - (void)testThatItCreatesASingleRequestSyncByDefault
 {
     // when
-    ZMSimpleListRequestPaginator *sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:@"foo" startKey:@"bar" pageSize:10 managedObjectContext:self.coreDataStack.syncContext includeClientID:NO transcoder:nil];
+    ZMSimpleListRequestPaginator *sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:@"foo" startKey:@"bar" pageSize:10 managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:nil];
 
     // then
     XCTAssertNotNil(sut.singleRequestSync);
@@ -218,7 +218,7 @@
     id transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [[[transcoder expect] andReturn:startUUID] startUUID];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:startKey pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext includeClientID:NO transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:startKey pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
 
     [[self.singleRequestSync stub] readyForNextRequest];
     [self.sut resetFetching];
@@ -240,7 +240,7 @@
         // given
         NSString *selfClientID = [self createSelfClient].remoteIdentifier;
 
-        self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"foo" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext includeClientID:YES transcoder:nil];
+        self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"foo" pageSize:self.pageSize managedObjectContext:self.coreDataStack.syncContext selfClientID:selfClientID transcoder:nil];
 
         [[self.singleRequestSync stub] readyForNextRequest];
         [self.sut resetFetching];
@@ -425,7 +425,7 @@
     id transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [[transcoder reject] nextUUIDFromResponse:OCMOCK_ANY forListPaginator:OCMOCK_ANY];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext includeClientID:NO transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
     [[self.singleRequestSync stub] readyForNextRequest];
     [self.sut resetFetching];
 
@@ -446,7 +446,7 @@
     id transcoder = [OCMockObject niceMockForProtocol:@protocol(ZMSimpleListRequestPaginatorSync)];
     [[transcoder expect] nextUUIDFromResponse:OCMOCK_ANY forListPaginator:OCMOCK_ANY];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext includeClientID:NO transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
     [[self.singleRequestSync stub] readyForNextRequest];
     [self.sut resetFetching];
 
@@ -521,7 +521,7 @@
     [[[transcoder expect] andReturn:[self returnFullPageWithLastIdentifier:lastIdentifier]] nextUUIDFromResponse:OCMOCK_ANY forListPaginator:OCMOCK_ANY];
     [[[transcoder expect] andReturn:startIdentifier] startUUID];
 
-    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext includeClientID:NO transcoder:transcoder];
+    self.sut = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:self.basePath startKey:@"start" pageSize:self.pageSize  managedObjectContext:self.coreDataStack.syncContext selfClientID: nil transcoder:transcoder];
     self.sut.singleRequestSync = self.singleRequestSync;
 
     [self.sut resetFetching];

--- a/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
@@ -41,8 +41,11 @@ public class NotificationStreamSync: NSObject, ZMRequestGenerator, ZMSimpleListR
         super.init()
         managedObjectContext = moc
 
-        let selfUser = ZMUser.selfUser(in: moc)
-        let selfClientID = selfUser.selfClient()?.remoteIdentifier
+        var selfClientID: String?
+        moc.performAndWait {
+            let selfUser = ZMUser.selfUser(in: moc)
+            selfClientID = selfUser.selfClient()?.remoteIdentifier
+        }
 
         listPaginator = ZMSimpleListRequestPaginator(
             basePath: "/notifications",

--- a/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/NotificationStreamSync.swift
@@ -40,12 +40,19 @@ public class NotificationStreamSync: NSObject, ZMRequestGenerator, ZMSimpleListR
         self.lastEventIDRepository = eventIDRespository
         super.init()
         managedObjectContext = moc
-        listPaginator = ZMSimpleListRequestPaginator.init(basePath: "/notifications",
-                                                          startKey: "since",
-                                                          pageSize: 500,
-                                                          managedObjectContext: moc,
-                                                          includeClientID: true,
-                                                          transcoder: self)
+
+        let selfUser = ZMUser.selfUser(in: moc)
+        let selfClientID = selfUser.selfClient()?.remoteIdentifier
+
+        listPaginator = ZMSimpleListRequestPaginator(
+            basePath: "/notifications",
+            startKey: "since",
+            pageSize: 500,
+            managedObjectContext: moc,
+            selfClientID: selfClientID,
+            transcoder: self
+        )
+
         self.notificationsTracker = notificationsTracker
         notificationStreamSyncDelegate = delegate
     }

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -78,14 +78,10 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
         self.useLegacyPushNotifications = useLegacyPushNotifications;
         self.lastEventIDRepository = lastEventIDRepository;
 
-        ZMUser* selfUser = [ZMUser selfUserInContext:managedObjectContext];
-        NSString* selfClientID = [[selfUser selfClient] remoteIdentifier];
-
         self.listPaginator = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:NotificationsPath
                                                                            startKey:StartKey
                                                                            pageSize:ZMMissingUpdateEventsTranscoderListPageSize
-                                                                managedObjectContext:self.managedObjectContext
-                                                                       selfClientID:selfClientID
+                                                               managedObjectContext:self.managedObjectContext
                                                                          transcoder:self];
     }
     return self;
@@ -317,6 +313,12 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
 
 
 @implementation ZMMissingUpdateEventsTranscoder (Pagination)
+
+- (NSString *)selfClientID
+{
+    ZMUser* selfUser = [ZMUser selfUserInContext:super.managedObjectContext];
+    return [[selfUser selfClient] remoteIdentifier];
+}
 
 - (NSUUID *)nextUUIDFromResponse:(ZMTransportResponse *)response forListPaginator:(ZMSimpleListRequestPaginator *)paginator
 {

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMMissingUpdateEventsTranscoder.m
@@ -77,11 +77,15 @@ NSUInteger const ZMMissingUpdateEventsTranscoderListPageSize = 500;
         self.operationStatus = operationStatus;
         self.useLegacyPushNotifications = useLegacyPushNotifications;
         self.lastEventIDRepository = lastEventIDRepository;
+
+        ZMUser* selfUser = [ZMUser selfUserInContext:managedObjectContext];
+        NSString* selfClientID = [[selfUser selfClient] remoteIdentifier];
+
         self.listPaginator = [[ZMSimpleListRequestPaginator alloc] initWithBasePath:NotificationsPath
                                                                            startKey:StartKey
                                                                            pageSize:ZMMissingUpdateEventsTranscoderListPageSize
                                                                 managedObjectContext:self.managedObjectContext
-                                                                    includeClientID:YES
+                                                                       selfClientID:selfClientID
                                                                          transcoder:self];
     }
     return self;

--- a/wire-ios-sync-engine/Tests/Source/Integration/APNSTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Integration/APNSTests.m
@@ -37,6 +37,7 @@
     
     ZMUser *selfUser = [self userForMockUser:self.selfUser];
     XCTAssertEqual(selfUser.clients.count, 1u);
+    XCTAssertNotNil(selfUser.selfClient);
 
     __block NSDictionary *conversationTransportData;
     


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9939" title="WPB-9939" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-9939</a>  Crash accessing selfUser in NSE - Beta
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

There is a crash when accessing the self client in the notification service extension. It's not clear by exactly what is causing the crash. The top of the stack trace is:

```
0
libobjc.A.dylib
object_getMethodImplementation
1
CoreFoundation
_NSIsNSSet
2
CoreFoundation
-[NSMutableSet unionSet:]
3
CoreData
-[_NSFaultingMutableSet willReadWithContents:]
4
CoreData
-[_NSFaultingMutableSet allObjects]
5
WireDataModel
-[ZMUser selfClient] (ZMUser.m:221)
6
WireRequestStrategy
-[ZMSimpleListRequestPaginator requestForSingleRequestSync:apiVersion:] (ZMSimpleListRequestPaginator.m:97)
```

`object_getMethodImplementation` is causing a segmentation fault which is likely because the object it references has been released. There are a couple other threads that appear to wait on a file lock for safe core crypto access. It is possible that this could be interfering with Core Data because the file lock is on the account directory which encloses both the Core Crypto database and the Core Data database.

We are trying to see if we can move the Core Crypto database so the file lock doesn't include the Core Data database, but it's not so easy.

In the meantime however, I thought that one way we could avoid this particular crash is to avoid accessing the self client when trying to fetch events, and instead inject the self client id (just a string) where needed. I don't know if this will fix the crash, so we'll need to monitor crashes and see if it makes a difference.

### Testing

Use the app and check for crashes.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
