### PR TITLE
fix: delete stored events using await - WPB-10177

### DIFF
--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -358,14 +358,16 @@ extension EventDecoder {
 
         await block(filterInvalidEvents(from: events))
 
-        eventMOC.performGroupedBlockAndWait {
-
+        await eventMOC.perform { [eventMOC] in
             storedEvents.forEach { storedEvent in
-                self.eventMOC.delete(storedEvent)
-                WireLogger.eventProcessing.info("delete stored event", attributes: [LogAttributesKey.eventId.rawValue: storedEvent.uuidString?.redactedAndTruncated() ?? "<nil>"])
+                eventMOC.delete(storedEvent)
+                WireLogger.eventProcessing.info(
+                    "delete stored event",
+                    attributes: [LogAttributesKey.eventId.rawValue: storedEvent.uuidString?.redactedAndTruncated() ?? "<nil>"]
+                )
             }
             do {
-                try self.eventMOC.save()
+                try eventMOC.save()
             } catch {
                 WireLogger.eventProcessing.critical("failed to save eventMoc after deleting stored events: \(error.localizedDescription)")
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10177" title="WPB-10177" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10177</a>  [iOS] Process ConversationRenameEvent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We managed to reproduce duplicate events and observed in the logs that each event was correctly received, decrypted, and stored once, but were processed multiple times.

After inspecting the processing code, we found that the code that decrypts, stores, and processes received events is enqueued in a mutually exclusive task by:

```swift
private func enqueueTask(_ block: @escaping @Sendable () async throws -> Void) async throws {
    defer { processingTask = nil }

    processingTask = Task { [processingTask] in
        _ = try await processingTask?.value
        return try await block()
    }

    // throw error if any
    _ = try await processingTask?.value
}
```

Inside `block`, during event processing, we fetch stored update events from the database, process them, then delete them. The deletion of events was wrapped inside

```swift
eventMOC.performGroupedBlockAndWait {
  // delete events...
}
```

We suspect that this may not work as expected within an `async` Task. Perhaps it results in this deletion code from running outside of the mutually exclusive task. If this is true, then it is possible to enqueue several tasks that process messages, each fetching stored update events that should have been deleted but weren't (yet), resulting in duplicate processing of events.

This PR replaces the blocking call and instead uses `await eventMOC.perform { ... }` . We're not sure that this will fix the issue but we should use the await api anyway.

### Testing

It's hard to reproduce duplicate messages, but all signs point to accumulating lots of messages (possibly with notifications disabled), opening the app, experiencing a very slow quick sync, and putting the app in the BG and FG while the sync is ongoing.

I was able to reproduce the issue while my phone was incredibly slow due to high temperatures.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
