### PR TITLE
fix: 1-1 conversations locked - WPB-10416

### DIFF
--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
@@ -72,6 +72,10 @@ public final class OneOnOneResolver: OneOnOneResolverInterface {
         with userID: QualifiedID,
         in context: NSManagedObjectContext
     ) async throws -> OneOnOneConversationResolution {
+        guard DeveloperFlag.enableMLSSupport.isOn else {
+            return .noAction
+        }
+        
         WireLogger.conversation.debug("resolving 1-1 conversation with user: \(userID)")
 
         let messageProtocol = try await protocolSelector.getProtocolForUser(with: userID, in: context)

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
@@ -75,7 +75,6 @@ public final class OneOnOneResolver: OneOnOneResolverInterface {
         guard DeveloperFlag.enableMLSSupport.isOn else {
             return .noAction
         }
-        
         WireLogger.conversation.debug("resolving 1-1 conversation with user: \(userID)")
 
         let messageProtocol = try await protocolSelector.getProtocolForUser(with: userID, in: context)

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneResolverTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneResolverTests.swift
@@ -30,10 +30,14 @@ final class OneOnOneResolverTests: XCTestCase {
     private var mockProtocolSelector: MockActorOneOnOneProtocolSelector!
 
     private var syncContext: NSManagedObjectContext { mockCoreDataStack.syncContext }
+    private var oldDeveloperFlagStorage: UserDefaults!
 
     override func setUp() async throws {
         try await super.setUp()
-
+        
+        oldDeveloperFlagStorage = DeveloperFlag.storage
+        DeveloperFlag.enableMLSSupport.enable(true, storage: .temporary())
+        
         coreDataStackHelper = CoreDataStackHelper()
         modelHelper = ModelHelper()
 
@@ -50,6 +54,7 @@ final class OneOnOneResolverTests: XCTestCase {
         try coreDataStackHelper.cleanupDirectory()
         coreDataStackHelper = nil
         modelHelper = nil
+        DeveloperFlag.storage = oldDeveloperFlagStorage
 
         try await super.tearDown()
     }

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneResolverTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneResolverTests.swift
@@ -34,10 +34,10 @@ final class OneOnOneResolverTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        
+
         oldDeveloperFlagStorage = DeveloperFlag.storage
         DeveloperFlag.enableMLSSupport.enable(true, storage: .temporary())
-        
+
         coreDataStackHelper = CoreDataStackHelper()
         modelHelper = ModelHelper()
 

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -178,7 +178,7 @@ struct ConversationEventPayloadProcessor {
                 await mlsEventProcessor.wipeMLSGroup(forConversation: conversation, context: context)
             }
         }
-        
+
         await context.perform {
             if payload.data.reason == .userDeleted {
                 // delete the users locally and/or logout if the self user is affected

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/ConversationEventPayloadProcessor.swift
@@ -173,10 +173,12 @@ struct ConversationEventPayloadProcessor {
             return (isSelfUserRemoved, conversation.messageProtocol)
         }
 
-        if isSelfUserRemoved, messageProtocol.isOne(of: .mls, .mixed) {
-            await mlsEventProcessor.wipeMLSGroup(forConversation: conversation, context: context)
+        if DeveloperFlag.enableMLSSupport.isOn {
+            if isSelfUserRemoved, messageProtocol.isOne(of: .mls, .mixed) {
+                await mlsEventProcessor.wipeMLSGroup(forConversation: conversation, context: context)
+            }
         }
-
+        
         await context.perform {
             if payload.data.reason == .userDeleted {
                 // delete the users locally and/or logout if the self user is affected
@@ -894,6 +896,7 @@ struct ConversationEventPayloadProcessor {
         context: NSManagedObjectContext,
         source: Source
     ) async {
+        guard DeveloperFlag.enableMLSSupport.isOn else { return }
         await mlsEventProcessor.updateConversationIfNeeded(
             conversation: conversation,
             fallbackGroupID: payload.mlsGroupID.map { .init(base64Encoded: $0) } ?? nil,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -29,6 +29,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
 
     override func setUp() {
         super.setUp()
+        DeveloperFlag.enableMLSSupport.enable(true, storage: .temporary())
         conversationService = MockConversationServiceInterface()
         conversationService.syncConversationQualifiedID_MockMethod = { _ in }
         conversationService.syncConversationIfMissingQualifiedID_MockMethod = { _ in }
@@ -56,6 +57,8 @@ final class ConversationEventProcessorTests: MessagingTestBase {
         sut = nil
         conversationService = nil
         mockMLSEventProcessor = nil
+
+        DeveloperFlag.storage = .standard
         super.tearDown()
     }
 

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
@@ -1065,6 +1065,10 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
     // MARK: - MLS: Conversation Create
 
     func testUpdateOrCreateConversation_Group_MLS_AsksToUpdateConversationIfNeeded() async {
+        DeveloperFlag.enableMLSSupport.enable(true, storage: .temporary())
+        defer {
+            DeveloperFlag.storage = .standard
+        }
         // given
         let qualifiedID = await syncMOC.perform {
             self.groupConversation.qualifiedID!
@@ -1236,6 +1240,10 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
     // MARK: - MLS conversation member leave
 
     func test_UpdateConversationMemberLeave_WipesMLSGroup() async {
+        DeveloperFlag.enableMLSSupport.enable(true, storage: .temporary())
+        defer {
+            DeveloperFlag.storage = .standard
+        }
         // Given
         let wipeGroupExpectation = XCTestExpectation(description: "it wipes group")
         mockMLSEventProcessor.wipeMLSGroupForConversationContext_MockMethod = { _, _ in

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -23,6 +23,8 @@ extension ZMUserSession {
 
     var updateProteusToMLSMigrationStatusAction: RecurringAction {
         .init(id: #function, interval: .oneDay) { [weak self] in
+            guard DeveloperFlag.enableMLSSupport.isOn else { return }
+            
             Task { [weak self] in
                 do {
                     try await self?.proteusToMLSMigrationCoordinator.updateMigrationStatus()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -24,7 +24,7 @@ extension ZMUserSession {
     var updateProteusToMLSMigrationStatusAction: RecurringAction {
         .init(id: #function, interval: .oneDay) { [weak self] in
             guard DeveloperFlag.enableMLSSupport.isOn else { return }
-            
+
             Task { [weak self] in
                 do {
                     try await self?.proteusToMLSMigrationCoordinator.updateMigrationStatus()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -379,6 +379,7 @@ final class ConversationViewController: UIViewController {
 
     private func resolveConversationIfOneOnOne() {
         guard
+            DeveloperFlag.enableMLSSupport.isOn,
             conversation.conversationType == .oneOnOne,
             conversation.messageProtocol == .proteus
         else {


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Due to a race condition, the supported. protocols are calculated after we resolve the 1:1 conversations ending up marking the conversation as readonly as there are no common protocols

Solution: don't run the resolver if mls is off

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
