### PR TITLE
fix: crash starting video call - WPB-10382

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversation+Calling.swift
@@ -98,7 +98,8 @@ extension ZMConversation {
             return
         }
 
-        let networkInfo = NetworkInfo(serverConnection: sessionManager.environment.reachability)
+        let reachability = sessionManager.environment.reachability
+        let networkInfo = NetworkInfo(serverConnection: reachability)
         if networkInfo.qualityType() == .type2G {
 
             let badConnectionController = UIAlertController(
@@ -116,6 +117,8 @@ extension ZMConversation {
         } else {
             handler(false)
         }
+
+        reachability.tearDown()
     }
 
     func warnAboutNoInternetConnection() -> Bool {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10382" title="WPB-10382" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10382</a>  [iOS] : Crashes on calls consistently
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In `warnAboutSlowConnection` we instantiate a `NetworkInfo` object. The init takes a `ZMReachability` instance. 
When we reach the end of the method, the `NetworkInfo` instance is deallocated, along with the `ZMReachability` instance.
In the `dealloc` of `ZMReachability` we then hit `RequireString(self.tornDownFlag.rawValue != 0, "Object was never torn down.");` which causes the app to crash intentionally.

### Solution

Call `tearDown` before the `ZMReachability` gets deallocated

### Testing

Start a video call

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.


