### PR TITLE
fix: prevent duplicate event processing - WPB-10403

### DIFF
--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -23,8 +23,24 @@ import WireUtilities
 
 private let zmLog = ZMSLog(tag: "EventDecoder")
 
+// sourcery: AutoMockable
+public protocol EventDecoderProtocol {
+
+    func decryptAndStoreEvents(
+        _ events: [ZMUpdateEvent],
+        publicKeys: EARPublicKeys?
+    ) async throws -> [ZMUpdateEvent]
+
+    func processStoredEvents(
+        with privateKeys: EARPrivateKeys?,
+        callEventsOnly: Bool,
+        _ block: @escaping ([ZMUpdateEvent]) async -> Void
+    ) async
+
+}
+
 /// Decodes and stores events from various sources to be processed later
-@objcMembers public final class EventDecoder: NSObject {
+public final class EventDecoder: NSObject, EventDecoderProtocol {
 
     public typealias ConsumeBlock = (([ZMUpdateEvent]) async -> Void)
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEvent.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/StoreUpdateEvent.swift
@@ -279,6 +279,8 @@ public final class StoredUpdateEvent: NSManagedObject {
                 decryptedEvent.appendDebugInformation(debugInfo)
             }
 
+            decryptedEvent.contentHash = storedEvent.eventHash
+
             return .success(decryptedEvent)
 
         } catch DecryptionFailure.privateKeyUnavailable {

--- a/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -588,6 +588,53 @@ public class MockEnrollE2EICertificateUseCaseProtocol: EnrollE2EICertificateUseC
 
 }
 
+public class MockEventDecoderProtocol: EventDecoderProtocol {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - decryptAndStoreEvents
+
+    public var decryptAndStoreEventsPublicKeys_Invocations: [(events: [ZMUpdateEvent], publicKeys: EARPublicKeys?)] = []
+    public var decryptAndStoreEventsPublicKeys_MockError: Error?
+    public var decryptAndStoreEventsPublicKeys_MockMethod: (([ZMUpdateEvent], EARPublicKeys?) async throws -> [ZMUpdateEvent])?
+    public var decryptAndStoreEventsPublicKeys_MockValue: [ZMUpdateEvent]?
+
+    public func decryptAndStoreEvents(_ events: [ZMUpdateEvent], publicKeys: EARPublicKeys?) async throws -> [ZMUpdateEvent] {
+        decryptAndStoreEventsPublicKeys_Invocations.append((events: events, publicKeys: publicKeys))
+
+        if let error = decryptAndStoreEventsPublicKeys_MockError {
+            throw error
+        }
+
+        if let mock = decryptAndStoreEventsPublicKeys_MockMethod {
+            return try await mock(events, publicKeys)
+        } else if let mock = decryptAndStoreEventsPublicKeys_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `decryptAndStoreEventsPublicKeys`")
+        }
+    }
+
+    // MARK: - processStoredEvents
+
+    public var processStoredEventsWithCallEventsOnly_Invocations: [(privateKeys: EARPrivateKeys?, callEventsOnly: Bool, block: ([ZMUpdateEvent]) async -> Void)] = []
+    public var processStoredEventsWithCallEventsOnly_MockMethod: ((EARPrivateKeys?, Bool, @escaping ([ZMUpdateEvent]) async -> Void) async -> Void)?
+
+    public func processStoredEvents(with privateKeys: EARPrivateKeys?, callEventsOnly: Bool, _ block: @escaping ([ZMUpdateEvent]) async -> Void) async {
+        processStoredEventsWithCallEventsOnly_Invocations.append((privateKeys: privateKeys, callEventsOnly: callEventsOnly, block: block))
+
+        guard let mock = processStoredEventsWithCallEventsOnly_MockMethod else {
+            fatalError("no mock for `processStoredEventsWithCallEventsOnly`")
+        }
+
+        await mock(privateKeys, callEventsOnly, block)
+    }
+
+}
+
 class MockMLSClientIDsProviding: MLSClientIDsProviding {
 
     // MARK: - Life cycle

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -27,12 +27,14 @@ actor EventProcessor: UpdateEventProcessor {
     private let syncContext: NSManagedObjectContext
     private let eventContext: NSManagedObjectContext
     private var bufferedEvents: [ZMUpdateEvent]
-    private let eventDecoder: EventDecoder
+    private let eventDecoder: any EventDecoderProtocol
     private let eventProcessingTracker: EventProcessingTrackerProtocol
     private let earService: EARServiceInterface
     private var processingTask: Task<Void, Error>?
     private let eventConsumers: [ZMEventConsumer]
     private let eventAsyncConsumers: [ZMEventAsyncConsumer]
+
+    private let processedEventList = ProcessedEventList()
 
     // MARK: Life Cycle
 
@@ -44,13 +46,33 @@ actor EventProcessor: UpdateEventProcessor {
         eventAsyncConsumers: [ZMEventAsyncConsumer],
         lastEventIDRepository: LastEventIDRepositoryInterface
     ) {
-        self.syncContext = storeProvider.syncContext
-        self.eventContext = storeProvider.eventContext
-        self.eventDecoder = EventDecoder(
-            eventMOC: eventContext,
-            syncMOC: syncContext,
+        let eventDecoder = EventDecoder(
+            eventMOC: storeProvider.eventContext,
+            syncMOC: storeProvider.syncContext,
             lastEventIDRepository: lastEventIDRepository
         )
+        
+        self.init(
+            storeProvider: storeProvider,
+            eventDecoder: eventDecoder,
+            eventProcessingTracker: eventProcessingTracker,
+            earService: earService,
+            eventConsumers: eventConsumers,
+            eventAsyncConsumers: eventAsyncConsumers
+        )
+    }
+
+    init(
+        storeProvider: CoreDataStack,
+        eventDecoder: any EventDecoderProtocol,
+        eventProcessingTracker: EventProcessingTrackerProtocol,
+        earService: EARServiceInterface,
+        eventConsumers: [ZMEventConsumer],
+        eventAsyncConsumers: [ZMEventAsyncConsumer]
+    ) {
+        self.syncContext = storeProvider.syncContext
+        self.eventContext = storeProvider.eventContext
+        self.eventDecoder = eventDecoder
         self.eventProcessingTracker = eventProcessingTracker
         self.earService = earService
         self.bufferedEvents = []
@@ -140,7 +162,7 @@ actor EventProcessor: UpdateEventProcessor {
         }
     }
 
-    private func processStoredUpdateEvents(
+    func processStoredUpdateEvents(
         with privateKeys: EARPrivateKeys? = nil,
         callEventsOnly: Bool = false
     ) async {
@@ -169,6 +191,18 @@ actor EventProcessor: UpdateEventProcessor {
             for event in decryptedUpdateEvents {
                 WireLogger.updateEvent.info("process decrypted event", attributes: event.logAttributes)
 
+                // Workaround: there's a concurrency bug where a stored event was fetched
+                // and processed, then before it could be deleted, a second pass refetched
+                // the same event and processed it again. It's not known why this happens,
+                // but in the meantime we will avoid processing an event more than once.
+                guard await !self.processedEventList.containsEvent(event) else {
+                    WireLogger.updateEvent.warn(
+                        "event already processed, skipping...",
+                        attributes: event.logAttributes
+                    )
+                    continue
+                }
+
                 await syncContext.perform {
                     for eventConsumer in self.eventConsumers {
                         eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
@@ -180,6 +214,8 @@ actor EventProcessor: UpdateEventProcessor {
                 for eventConsumer in self.eventAsyncConsumers {
                     await eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
                 }
+
+                await self.processedEventList.addEvent(event)
             }
 
             await syncContext.perform {
@@ -224,4 +260,33 @@ extension Notification.Name {
 
     /// Published after the last event has been processed.
     static let eventProcessorDidFinishProcessingEventsNotification = Self("EventProcessorDidFinishProcessingEvents")
+}
+
+private actor ProcessedEventList {
+
+    private var hashes = Set<Int64>()
+
+    // A full list would coontain approx 80kB.
+    private let capacity = 10_000
+
+    func addEvent(_ event: ZMUpdateEvent) {
+        guard let hash = event.contentHash else {
+            return
+        }
+
+        if hashes.count >= capacity, let randomElement = hashes.randomElement() {
+            hashes.remove(randomElement)
+        }
+
+        hashes.insert(hash)
+    }
+
+    func containsEvent(_ event: ZMUpdateEvent) -> Bool {
+        guard let hash = event.contentHash else {
+            return false
+        }
+        
+        return hashes.contains(hash)
+    }
+
 }

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -271,6 +271,7 @@ private actor ProcessedEventList {
 
     func addEvent(_ event: ZMUpdateEvent) {
         guard let hash = event.contentHash else {
+            assertionFailure("events for processing should have a content hash")
             return
         }
 
@@ -283,6 +284,7 @@ private actor ProcessedEventList {
 
     func containsEvent(_ event: ZMUpdateEvent) -> Bool {
         guard let hash = event.contentHash else {
+            assertionFailure("events for processing should have a content hash")
             return false
         }
 

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -51,7 +51,7 @@ actor EventProcessor: UpdateEventProcessor {
             syncMOC: storeProvider.syncContext,
             lastEventIDRepository: lastEventIDRepository
         )
-        
+
         self.init(
             storeProvider: storeProvider,
             eventDecoder: eventDecoder,
@@ -285,7 +285,7 @@ private actor ProcessedEventList {
         guard let hash = event.contentHash else {
             return false
         }
-        
+
         return hashes.contains(hash)
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -266,7 +266,7 @@ private actor ProcessedEventList {
 
     private var hashes = Set<Int64>()
 
-    // A full list would coontain approx 80kB.
+    // A full list would contain approx 80kB.
     private let capacity = 10_000
 
     func addEvent(_ event: ZMUpdateEvent) {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireRequestStrategySupport
 import XCTest
 
 @testable import WireDataModelSupport
@@ -70,15 +71,33 @@ final class EventProcessorTests: MessagingTest {
     // MARK: - Helpers
 
     func createSampleEvents(conversationID: UUID = UUID(), messageNonce: UUID = UUID()) -> [ZMUpdateEvent] {
-        let payload1: [String: Any] = ["type": "conversation.member-join",
-                                       "conversation": conversationID]
-        let payload2: [String: Any] = ["type": "conversation.message-add",
-                                       "data": ["content": "www.wire.com",
-                                                "nonce": messageNonce],
-                                       "conversation": conversationID]
+        let payload1: [String: Any] = [
+            "type": "conversation.member-join",
+            "conversation": conversationID
+        ]
+        
+        let payload2: [String: Any] = [
+            "type": "conversation.message-add",
+            "data": [
+                "content": "www.wire.com",
+                "nonce": messageNonce
+            ],
+            "conversation": conversationID
+        ]
 
-        let event1 = ZMUpdateEvent(fromEventStreamPayload: payload1 as ZMTransportData, uuid: UUID())!
-        let event2 = ZMUpdateEvent(fromEventStreamPayload: payload2 as ZMTransportData, uuid: UUID())!
+        let event1 = ZMUpdateEvent(
+            fromEventStreamPayload: payload1 as ZMTransportData,
+            uuid: UUID()
+        )!
+
+        event1.contentHash = 1234
+
+        let event2 = ZMUpdateEvent(
+            fromEventStreamPayload: payload2 as ZMTransportData,
+            uuid: UUID()
+        )!
+
+        event2.contentHash = 2345
 
         return [event1, event2]
     }
@@ -193,6 +212,42 @@ final class EventProcessorTests: MessagingTest {
         let messageNonceSet: NSSet = [messageNonce]
         XCTAssertEqual(batchFetchRequest.remoteIdentifiersToFetch, conversationIdSet)
         XCTAssertEqual(batchFetchRequest.noncesToFetch, messageNonceSet)
+    }
+
+    func testItProcessesEventsOnlyOnce() async throws {
+        // Given
+        let events = createSampleEvents()
+        let eventDecoder = MockEventDecoderProtocol()
+
+        // Simulate trying to process same events multiple times.
+        eventDecoder.processStoredEventsWithCallEventsOnly_MockMethod = { _, _, processBlock in
+            await processBlock(events)
+            await processBlock(events)
+            await processBlock(events)
+        }
+
+        sut = EventProcessor(
+            storeProvider: coreDataStack,
+            eventDecoder: eventDecoder,
+            eventProcessingTracker: eventProcessingTracker,
+            earService: earService,
+            eventConsumers: mockEventsConsumers,
+            eventAsyncConsumers: mockEventAsyncConsumers
+        )
+
+        // When
+        await sut.processStoredUpdateEvents()
+
+        // Then each consumer processed the events once.
+        mockEventsConsumers.forEach { mockEventConsumer in
+            XCTAssertEqual(mockEventConsumer.eventsProcessed.count, events.count)
+            XCTAssertEqual(mockEventConsumer.eventsProcessed, events)
+        }
+
+        mockEventAsyncConsumers.forEach { mockEventConsumer in
+            XCTAssertEqual(mockEventConsumer.eventsProcessed.count, events.count)
+            XCTAssertEqual(mockEventConsumer.eventsProcessed, events)
+        }
     }
 }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -75,7 +75,7 @@ final class EventProcessorTests: MessagingTest {
             "type": "conversation.member-join",
             "conversation": conversationID
         ]
-        
+
         let payload2: [String: Any] = [
             "type": "conversation.message-add",
             "data": [

--- a/wire-ios-transport/Source/Public/ZMUpdateEvent.swift
+++ b/wire-ios-transport/Source/Public/ZMUpdateEvent.swift
@@ -216,6 +216,10 @@ open class ZMUpdateEvent: NSObject {
     open var source: ZMUpdateEventSource
     open var uuid: UUID?
 
+    // A hash of the event content. This is used to keep track of events
+    // that we have already processed.
+    public var contentHash: Int64?
+
     var debugInformationArray: [String] = []
     /// True if the event will not appear in the notification stream
     open var isTransient: Bool


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10403" title="WPB-10403" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10403</a>  [iOS] Prevent processing an event more than once
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

There's a concurrency bug where we might fetch a stored update event that should have been deleted, and then process that even for a second time. We don't still don't know why this happens, but in the meantime we will avoid to process events more than once.

To achieve this, before processing an event, we use its content hash (which uniquely identifies the event) to check if it has already been added to a thread safe list of hashes. If not, we will process it, then add it to the list. If it is already in the list, we will not process it.

### Testing

The bug is not easy to reproduce, but it's most likely to happen when there are many events to process (i.e the app has been offline and there has been a lot of activity in conversations the self user is a member of) and the phone is under immense load (for me it happened when the device was very hot due to the weather and was likely throttled severely).

I suggest to run this in an internal beta for at least a week and keep an eye out for duplicate messages / logs that an event has skipped processing a second time.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
