### PR TITLE
fix: 1-1 conversations already locked - WPB-10416

### DIFF
--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneResolver.swift
@@ -85,12 +85,16 @@ public final class OneOnOneResolver: OneOnOneResolverInterface {
             return try await resolveCommonUserProtocolMLS(with: userID, in: context)
         case .proteus:
             return await resolveCommonUserProtocolProteus(with: userID, in: context)
-        default:
+        case .mixed:
             // This should never happen:
             // Users can only support proteus and mls protocols.
             // Mixed protocol is used by conversations to represent
             // the migration state when migrating from proteus to mls.
             assertionFailure("users should not have mixed protocol")
+            return .noAction
+        default:
+            // if mls not enabled, there is nothing to take action
+            // fixes locked conversations
             return .noAction
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -383,7 +383,7 @@ final class ConversationViewController: UIViewController {
         else {
             return
         }
-        
+
         guard
             let otherUser = conversation.localParticipants.first(where: { !$0.isSelfUser }),
             let otherUserID = otherUser.qualifiedID,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -378,14 +378,12 @@ final class ConversationViewController: UIViewController {
     // MARK: Resolve 1-1 conversations
 
     private func resolveConversationIfOneOnOne() {
-        guard
-            DeveloperFlag.enableMLSSupport.isOn,
-            conversation.conversationType == .oneOnOne,
-            conversation.messageProtocol == .proteus
+        guard conversation.conversationType == .oneOnOne,
+              conversation.messageProtocol == .proteus
         else {
             return
         }
-
+        
         guard
             let otherUser = conversation.localParticipants.first(where: { !$0.isSelfUser }),
             let otherUserID = otherUser.qualifiedID,


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Following previous PR #1755, there is a chance if one user already locked his conversation it cannot unlock it anymore since we disabled the OneonOneResolver.

Solution: allow resolution when opening the conversation, and check if the conversation is proteus and mls is disabled and in case it's readonly unlock it

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
