### PR TITLE
fix:  Blank screen when navigating back from conversation via contacts - WPB-10392

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -77,6 +77,7 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
                 toView?.alpha = 1
             }, completion: { _ in
                 fromView?.transform = .identity
+                fromView?.alpha = 1
                 transitionContext.completeTransition(true)
             })
         })

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Transitions/SwizzleTransition.swift
@@ -68,6 +68,7 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
         }
         toView?.alpha = 0
 
+        let originalFromViewAlpha = fromView?.alpha
         UIView.animate(easing: .easeInQuad, duration: durationPhase1, animations: {
             fromView?.alpha = 0
             fromView?.transform = self.direction == .horizontal ? CGAffineTransform(translationX: 48, y: 0) : verticalTransform
@@ -77,7 +78,7 @@ final class SwizzleTransition: NSObject, UIViewControllerAnimatedTransitioning {
                 toView?.alpha = 1
             }, completion: { _ in
                 fromView?.transform = .identity
-                fromView?.alpha = 1
+                fromView?.alpha = originalFromViewAlpha ?? 1
                 transitionContext.completeTransition(true)
             })
         })

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -421,7 +421,7 @@ final class ZClientViewController: UIViewController {
                     }
                 }
 
-                presentedViewController.dismiss(animated: false, completion: callback)
+                presentedViewController.dismiss(animated: true, completion: callback)
             } else if self.presentedViewController != nil {
                 self.dismiss(animated: false, completion: callback)
             } else {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10392" title="WPB-10392" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10392</a>  [iOS] : Blank screen - while navigating to contacts - click on contact - now click on back button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When navigating to a conversation from contacts, then back again, the conversation ends up on a blank screen. See video:

https://github.com/user-attachments/assets/0137ea54-2fea-4e47-8835-8d507deab0c0

The issue was introduced in a refactor to use `UITabBarController` - https://github.com/wireapp/wire-ios/pull/1427/files#diff-a4cedd4bc25df5a4862f4840f1414020664739b34a74dc4222929334d5dba0fa - but the underlying issue is how our `SwizzleTransition` works. It sets the `fromView`'s alpha to `0` but never returns it to `1`. I guess this is a risky behavior although may sometimes be desired. 

In the case of this bug, the contacts view is displayed modally over the conversation list. It is animated there using the `SwizzleTransition`. When we navigate to a conversation, the contacts list is dismissed modally then the conversation list pushes the conversation onto is navigation stack. Due to the original `SwizzleTransition` when presenting the contacts list, the conversation list's alpha is still 0. When we navigate back from the conversation there is a blank screen.

When we navigate back the contacts list still has an `alpha` of `0`.

This PR fixes this issue by:

1. Returning the `fromView`'s alpha to it's original values once the transition completes.
2. Enables `animation` when dismissing modal views in `ZClientViewController`. This is done to avoid a flash to the conversation view when it suddenly becomes visible when navigating to a conversation from a modal view such as contacts. See video which is similar in behavior to the current production apps. Note that there are now two visible transitions - dismissing the contacts and navigating to the conversation. I'm sure this can be improved but don't want to break things further - navigation is quite complex it seems.



https://github.com/user-attachments/assets/725585fc-be0d-40e5-bd5a-48f27beaf9a7



### Testing

Please test on both iPhone and iPad as the issue affects both platforms

1. Tap `Contacts` tab
2. Tap on a contact for **who you have an existing conversation**
3. Tap back
4. You should be navigated back to the `Conversations` tab

This is a small change that can affect navigation all over the app. Please also try navigating around much of the app to see if anything is broken.

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
