### PR TITLE
fix: decoding MLS feature config on v3 fails - WPB-10439

### DIFF
--- a/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
+++ b/wire-ios-data-model/Source/Model/FeatureConfig/MLS/Feature.MLS.swift
@@ -62,7 +62,7 @@ public extension Feature {
 
             public let defaultCipherSuite: MLSCipherSuite
 
-            /// The list of supported message protocols
+            /// The list of supported message protocols.
 
             public let supportedProtocols: Set<MessageProtocol>
 
@@ -78,6 +78,17 @@ public extension Feature {
                 self.allowedCipherSuites = allowedCipherSuites
                 self.defaultCipherSuite = defaultCipherSuite
                 self.supportedProtocols = supportedProtocols
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container: KeyedDecodingContainer<Feature.MLS.Config.CodingKeys> = try decoder.container(keyedBy: Feature.MLS.Config.CodingKeys.self)
+                self.protocolToggleUsers = try container.decode([UUID].self, forKey: Feature.MLS.Config.CodingKeys.protocolToggleUsers)
+                self.defaultProtocol = try container.decode(Feature.MLS.Config.MessageProtocol.self, forKey: Feature.MLS.Config.CodingKeys.defaultProtocol)
+                self.allowedCipherSuites = try container.decode([Feature.MLS.Config.MLSCipherSuite].self, forKey: Feature.MLS.Config.CodingKeys.allowedCipherSuites)
+                self.defaultCipherSuite = try container.decode(Feature.MLS.Config.MLSCipherSuite.self, forKey: Feature.MLS.Config.CodingKeys.defaultCipherSuite)
+
+                // Supported protocols was added in v4 so we decode if present and provide a default if it's not there.
+                self.supportedProtocols = try container.decodeIfPresent(Set<Feature.MLS.Config.MessageProtocol>.self, forKey: Feature.MLS.Config.CodingKeys.supportedProtocols) ?? [.proteus]
             }
 
             public enum MessageProtocol: String, Codable {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/GetFeatureConfigsActionHandlerTests.swift
@@ -331,6 +331,49 @@ final class GetFeatureConfigsActionHandlerTests: MessagingTestBase {
         XCTAssert(waitForCustomExpectations(withTimeout: 0.5))
     }
 
+    func test_ItDecodesMLSFeatureConfig_V3() throws {
+        // There was a bug where we couldn't decode the mls feature config for v3 because
+        // 'supportedProtocols' was missing.
+        syncMOC.performAndWait {
+            // Given
+            let sut = GetFeatureConfigsActionHandler(context: self.syncMOC)
+            var action = GetFeatureConfigsAction()
+
+            // Expectation
+            let gotResult = self.customExpectation(description: "gotResult")
+
+            action.onResult { result in
+                switch result {
+                case .success:
+                    break
+
+                default:
+                    XCTFail("Expected 'success'")
+                }
+
+                gotResult.fulfill()
+            }
+
+            let payloadString = JSONPayload.mlsConfigV3
+
+            // When
+            sut.handleResponse(self.mockResponse(status: 200, payload: payloadString as ZMTransportData), action: action)
+            XCTAssert(self.waitForCustomExpectations(withTimeout: 0.5))
+
+            // Then
+            let featureRepository = FeatureRepository(context: self.syncMOC)
+
+            let mls = featureRepository.fetchMLS()
+            XCTAssertEqual(mls.status, .enabled)
+            XCTAssertEqual(mls.config.protocolToggleUsers, [UUID(uuidString: "881b1824-a6e1-4a60-8cc3-14feabf6dec0")!])
+            XCTAssertEqual(mls.config.defaultProtocol, .proteus)
+            XCTAssertEqual(mls.config.allowedCipherSuites, [.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519])
+            XCTAssertEqual(mls.config.supportedProtocols, [.proteus])
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+    }
+
 }
 
 // MARK: - JSONPayload
@@ -404,4 +447,19 @@ private enum JSONPayload {
     }
 }
 """
+
+    static let mlsConfigV3 =
+    """
+    {
+        "mls": {
+            "status": "enabled",
+            "config": {
+                "defaultCipherSuite": 1,
+                "protocolToggleUsers": ["881b1824-a6e1-4a60-8cc3-14feabf6dec0"],
+                "allowedCipherSuites": [1],
+                "defaultProtocol": "proteus"
+            }
+        }
+    }
+    """
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10439" title="WPB-10439" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10439</a>  [iOS] Request loop on feature configs when logging in
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If the client resolves API v3 with the backend, it will fail to decode the MLS feature config when feature configs are fetched. This is because `supportedProtocols` was added as a required field in v4, and the decoding did not consider the versioning. To make decoding backwards compatible, `supportedProtocols` is decoded if present, otherwise defaults to `[.proteus]`.

The affect of this was that after registering a client we fetch feature configs but fail, and in response we will try again, resulting in a loop. This would block the user to successfully log in.

### Testing

Log in to a v3 backend and assert you reach the conversation list.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
