### PR TITLE
chore:  Add logging and remove some unnecessary mutability around SessionManager - WPB-10462

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -791,6 +791,7 @@ public final class SessionManager: NSObject, SessionManagerType {
     /// removed. See [WPB-10404].
     fileprivate func logoutCurrentSession(deleteCookie: Bool, deleteAccount: Bool, error: Error?) {
         guard let account = accountManager.selectedAccount else {
+            WireLogger.sessionManager.critical("No selected account")
             return
         }
 
@@ -801,6 +802,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         self.createUnauthenticatedSession(accountId: deleteAccount ? nil : account.userIdentifier)
 
         guard let activeUserSession else {
+            WireLogger.sessionManager.critical("No active user session")
             delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: nil)
 
             if deleteAccount {
@@ -809,17 +811,18 @@ public final class SessionManager: NSObject, SessionManagerType {
             return
         }
 
-        delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: { [weak self] in
-            let group = self?.dispatchGroup
-            group?.enter()
+        requireInternal(activeUserSession.userId == account.userIdentifier, "User session and account are different")
+
+        delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: { [dispatchGroup] in
+            dispatchGroup.enter()
 
             activeUserSession.close(deleteCookie: deleteCookie) {
                 if deleteAccount {
-                    self?.deleteAccountData(for: account)
+                    self.deleteAccountData(for: account)
                 }
-                group?.leave()
+                dispatchGroup.leave()
             }
-            self?.activeUserSession = nil
+            self.activeUserSession = nil
         })
     }
 

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -31,14 +31,14 @@ final class AppRootRouter: NSObject {
 
     // MARK: - Private Property
 
-    private var appStateCalculator: AppStateCalculator
-    private var urlActionRouter: URLActionRouter
+    private let appStateCalculator: AppStateCalculator
+    private let urlActionRouter: URLActionRouter
 
     private var authenticationCoordinator: AuthenticationCoordinator?
-    private var switchingAccountRouter: SwitchingAccountRouter
-    private var sessionManagerLifeCycleObserver: SessionManagerLifeCycleObserver
+    private let switchingAccountRouter: SwitchingAccountRouter
+    private let sessionManagerLifeCycleObserver: SessionManagerLifeCycleObserver
     private let foregroundNotificationFilter: ForegroundNotificationFilter
-    private var quickActionsManager: QuickActionsManager
+    private let quickActionsManager: QuickActionsManager
     private var authenticatedRouter: AuthenticatedRouter? {
         didSet {
             setupAnalyticsSharing()
@@ -51,11 +51,11 @@ final class AppRootRouter: NSObject {
 
     // MARK: - Private Set Property
 
-    private(set) var sessionManager: SessionManager
+    let sessionManager: SessionManager
 
     // swiftlint:disable:next todo_requires_jira_link
     // TODO: This should be private
-    private(set) var rootViewController: RootViewController
+    let rootViewController: RootViewController
 
     private var lastLaunchOptions: LaunchOptions?
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10462" title="WPB-10462" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10462</a>  [iOS] Issues around login & logout behavior
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

In trying to catch what could be causing https://wearezeta.atlassian.net/browse/WPB-10462. So far I'm not sure. This PR:

- Adds some logging around strange state when logging out in `SessionManager`.
- Ensures `SessionManager` is not deallocated before completing a log out as it is necessary for clean up.
- Makes some properties of `AppRootRouter` `let` instead of `var` for clarity.

### Testing

There are no changes that can be manually tested here.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.