### PR TITLE
fix: Make `BackendInfo` dependent tests in `Wire-iOS` & `WireDomain Project` more robust - WPB-10065

### DIFF
--- a/WireDomain/Tests/WireDomainTests/Repositories/ConnectionsRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/ConnectionsRepositoryTests.swift
@@ -21,6 +21,8 @@ import WireDataModel
 import WireDataModelSupport
 import WireDomainSupport
 import XCTest
+@_spi(MockBackendInfo)
+import WireTransport
 
 @testable import WireAPI
 @testable import WireDomain
@@ -40,7 +42,8 @@ final class ConnectionsRepositoryTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        BackendInfo.storage = .temporary()
+        BackendInfo.enableMocking()
+        BackendInfo.isFederationEnabled = false
 
         stack = try await coreDataStackHelper.createStack()
         connectionsAPI = MockConnectionsAPI()
@@ -53,7 +56,7 @@ final class ConnectionsRepositoryTests: XCTestCase {
         connectionsAPI = nil
         sut = nil
         try coreDataStackHelper.cleanupDirectory()
-        BackendInfo.storage = .standard
+        BackendInfo.resetMocking()
         try await super.tearDown()
     }
 

--- a/wire-ios/Wire-iOS Tests/AppStateCalculatorTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppStateCalculatorTests.swift
@@ -18,6 +18,8 @@
 
 import WireSyncEngine
 import XCTest
+@_spi(MockBackendInfo)
+import WireTransport
 
 @testable import Wire
 
@@ -35,13 +37,11 @@ final class AppStateCalculatorTests: XCTestCase {
             completion()
         }
         sut.delegate = delegate
-        BackendInfo.apiVersion = .v0
     }
 
     override func tearDown() {
         sut = nil
         delegate = nil
-        BackendInfo.apiVersion = nil
 
         super.tearDown()
     }
@@ -325,6 +325,7 @@ final class AppStateCalculatorTests: XCTestCase {
         // GIVEN
         let userSession = UserSessionMock()
         sut.applicationDidBecomeActive()
+        BackendInfo.enableMocking()
         BackendInfo.apiVersion = nil
 
         let blacklistState = AppState.blacklisted(reason: .clientAPIVersionObsolete)
@@ -335,5 +336,7 @@ final class AppStateCalculatorTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(sut.appState, blacklistState)
+
+        BackendInfo.resetMocking()
     }
 }

--- a/wire-ios/Wire-iOS Tests/ConversationOptionsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationOptionsViewControllerTests.swift
@@ -21,6 +21,8 @@ import WireSyncEngine
 import WireSyncEngineSupport
 import WireUITesting
 import XCTest
+@_spi(MockBackendInfo)
+import WireTransport
 
 @testable import Wire
 
@@ -79,7 +81,7 @@ final class ConversationOptionsViewControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         snapshotHelper = SnapshotHelper()
-        BackendInfo.storage = .temporary()
+        BackendInfo.enableMocking()
         mockConversation = MockConversation()
         mockUserSession = UserSessionMock()
         mockCreateSecuredGuestLinkUseCase = MockCreateConversationGuestLinkUseCaseProtocol()
@@ -89,7 +91,7 @@ final class ConversationOptionsViewControllerTests: XCTestCase {
 
     override func tearDown() {
         snapshotHelper = nil
-        BackendInfo.storage = UserDefaults.standard
+        BackendInfo.resetMocking()
         mockConversation = nil
         mockUserSession = nil
         mockCreateSecuredGuestLinkUseCase = nil

--- a/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -18,6 +18,8 @@
 
 import WireUITesting
 import XCTest
+@_spi(MockBackendInfo)
+import WireTransport
 
 @testable import Wire
 
@@ -58,6 +60,7 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
         )
 
         MockUserRight.isPermitted = true
+        BackendInfo.enableMocking()
     }
 
     // MARK: - tearDown
@@ -72,8 +75,7 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
         selfUser = nil
         SelfUser.provider = nil
         Settings.shared.reset()
-        BackendInfo.storage = .standard
-        BackendInfo.isFederationEnabled = false
+        BackendInfo.resetMocking()
         super.tearDown()
     }
 
@@ -93,7 +95,6 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
         testName: String = #function,
         line: UInt = #line
     ) throws {
-        BackendInfo.storage = UserDefaults(suiteName: UUID().uuidString)!
         BackendInfo.isFederationEnabled = federated
 
         MockUserRight.isPermitted = !disabledEditing

--- a/wire-ios/Wire-iOS Tests/Utils/TestSetup.swift
+++ b/wire-ios/Wire-iOS Tests/Utils/TestSetup.swift
@@ -16,18 +16,41 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import UIKit
+import WireTesting
+import WireTransport
 
 /// This class is set as NSPrincipalClass in test suite info.plist
 /// XCTest makes sure to initialise it only once and we can add all global
 /// test setup code here
-final class TestSetup: NSObject {
+final class TestSetup: NSObject, XCTestObservation {
+    private let defaults: TestUserDefaults
+
     override init() {
+        defaults = TestUserDefaults(suiteName: UUID().uuidString)!
+
         super.init()
+        XCTestObservationCenter.shared.addTestObserver(self)
+
         // The snapshot tests expect to be run with CET time zone
         // We make sure that is the case if e.g. tests run on cloud CI provider
         if let timezone = TimeZone(abbreviation: "CET") {
             NSTimeZone.default = timezone
         }
+    }
+
+    func testBundleWillStart(_ testBundle: Bundle) {
+        BackendInfo.storage = defaults
+        BackendInfo.apiVersion = .v0
+        BackendInfo.domain = "wire.com"
+        BackendInfo.isFederationEnabled = false
+
+        defaults.shouldSet = { _, _ in
+            XCTFail("BackendInfo was mutated outside of mocking")
+            return false
+        }
+    }
+
+    func testBundleDidFinish(_ testBundle: Bundle) {
+        defaults.reset()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10065" title="WPB-10065" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10065</a>  iOS: fix unit tests without backend info
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR continues the work from https://github.com/wireapp/wire-ios/pull/1738 and https://github.com/wireapp/wire-ios/pull/1768 applying changes to the `Wire-iOS` & `WireDomain Project` test targets. See that [PR](https://github.com/wireapp/wire-ios/pull/1738) for details.

### Testing

This PR principally updates unit tests so run them to see they are working.

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.