### PR TITLE
feat: set ciphersuites when replacing KeyPackages WPB-10253

### DIFF
--- a/wire-ios-data-model/Source/MLS/Actions/ReplaceSelfMLSKeyPackagesAction.swift
+++ b/wire-ios-data-model/Source/MLS/Actions/ReplaceSelfMLSKeyPackagesAction.swift
@@ -55,16 +55,19 @@ public class ReplaceSelfMLSKeyPackagesAction: EntityAction {
     public var resultHandler: ResultHandler?
     public var clientID: String
     public var keyPackages: [String]
+    public let ciphersuite: MLSCipherSuite
 
     // MARK: - Life cycle
 
     public init(
         clientID: String,
         keyPackages: [String],
+        ciphersuite: MLSCipherSuite,
         resultHandler: ResultHandler? = nil
     ) {
         self.clientID = clientID
         self.keyPackages = keyPackages
+        self.ciphersuite = ciphersuite
         self.resultHandler = resultHandler
     }
 }

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2EIKeyPackageRotatorTests.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2EIKeyPackageRotatorTests.swift
@@ -29,6 +29,7 @@ class E2EIKeyPackageRotatorTests: MessagingTestBase {
     private var mockCoreCryptoProvider: MockCoreCryptoProviderProtocol!
     private var mockCommitSender: MockCommitSending!
     private var mockConversationEventProcessor: MockConversationEventProcessorProtocol!
+    private var mockFeatureRepository: MockFeatureRepositoryInterface!
     private var sut: E2EIKeyPackageRotator!
 
     override func setUp() {
@@ -39,13 +40,15 @@ class E2EIKeyPackageRotatorTests: MessagingTestBase {
         mockConversationEventProcessor = MockConversationEventProcessorProtocol()
         mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
         mockCoreCryptoProvider.coreCrypto_MockValue = MockSafeCoreCrypto(coreCrypto: mockCoreCrypto)
+        mockFeatureRepository = .init()
 
         sut = E2EIKeyPackageRotator(
             coreCryptoProvider: mockCoreCryptoProvider,
             conversationEventProcessor: mockConversationEventProcessor,
             context: syncMOC,
             onNewCRLsDistributionPointsSubject: .init(),
-            commitSender: mockCommitSender
+            commitSender: mockCommitSender,
+            featureRepository: mockFeatureRepository
         )
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ReplaceSelfMLSKeyPackagesActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ReplaceSelfMLSKeyPackagesActionHandler.swift
@@ -37,7 +37,7 @@ class ReplaceSelfMLSKeyPackagesActionHandler: ActionHandler<ReplaceSelfMLSKeyPac
         }
 
         return ZMTransportRequest(
-            path: "/mls/key-packages/self/\(action.clientID)",
+            path: "/mls/key-packages/self/\(action.clientID)?ciphersuites=\(action.ciphersuite.rawValue)",
             method: .put,
             payload: ["key_packages": action.keyPackages] as ZMTransportData,
             apiVersion: apiVersion.rawValue

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ReplaceSelfMLSKeyPackagesActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/ReplaceSelfMLSKeyPackagesActionHandlerTests.swift
@@ -24,10 +24,14 @@ class ReplaceSelfMLSKeyPackagesActionHandlerTests: ActionHandlerTestBase<Replace
 
     let clientId = UUID().transportString()
     let keyPackages = ["a2V5IHBhY2thZ2UgZGF0YQo="]
+    let ciphersuite = MLSCipherSuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
 
     override func setUp() {
         super.setUp()
-        action = ReplaceSelfMLSKeyPackagesAction(clientID: clientId, keyPackages: keyPackages)
+        action = ReplaceSelfMLSKeyPackagesAction(
+            clientID: clientId,
+            keyPackages: keyPackages,
+            ciphersuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
         handler = ReplaceSelfMLSKeyPackagesActionHandler(context: syncMOC)
     }
 
@@ -36,7 +40,7 @@ class ReplaceSelfMLSKeyPackagesActionHandlerTests: ActionHandlerTestBase<Replace
     func test_itGeneratesARequest_APIV5() throws {
         try test_itGeneratesARequest(
             for: action,
-            expectedPath: "/v5/mls/key-packages/self/\(clientId)",
+            expectedPath: "/v5/mls/key-packages/self/\(clientId)?ciphersuites=\(ciphersuite.rawValue)",
             expectedPayload: ["key_packages": keyPackages],
             expectedMethod: .put,
             apiVersion: .v5
@@ -55,7 +59,7 @@ class ReplaceSelfMLSKeyPackagesActionHandlerTests: ActionHandlerTestBase<Replace
 
         // when there are empty parameters
         test_itDoesntGenerateARequest(
-            action: ReplaceSelfMLSKeyPackagesAction(clientID: "", keyPackages: []),
+            action: ReplaceSelfMLSKeyPackagesAction(clientID: "", keyPackages: [], ciphersuite: ciphersuite),
             apiVersion: .v5,
             expectedError: .invalidParameters
         )

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -345,7 +345,8 @@ public final class ZMUserSession: NSObject {
             coreCryptoProvider: coreCryptoProvider,
             conversationEventProcessor: conversationEventProcessor,
             context: syncContext,
-            onNewCRLsDistributionPointsSubject: onNewCRLsDistributionPointsSubject
+            onNewCRLsDistributionPointsSubject: onNewCRLsDistributionPointsSubject,
+            featureRepository: featureRepository
         )
 
         let e2eiRepository = E2EIRepository(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10253" title="WPB-10253" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10253</a>  [iOS] When enabling e2ei after user is logged in, certificate generation fails
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
After finding some issues on the backend, now it's mandatory to set the CipherSuite when replacing keypackages after E2EI.

### Testing
- create a team on bund-next-column-1
- enable MLS and add users to keycloak
- login with any member
- in web, go to team management and enable e2ei for the team
- go back to the app and try to generate the certificate

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
