### PR TITLE
fix: Avoid and log account deletion failures - WPB-10462

### DIFF
--- a/wire-ios-data-model/Source/Model/Account.swift
+++ b/wire-ios-data-model/Source/Model/Account.swift
@@ -117,3 +117,13 @@ extension Account {
     }
 
 }
+
+// MARK: - SafeForLoggingStringConvertible
+
+extension Account: SafeForLoggingStringConvertible {
+
+    public var safeForLoggingDescription: String {
+        userIdentifier.safeForLoggingDescription
+    }
+
+}

--- a/wire-ios-data-model/Source/Model/AccountManager.swift
+++ b/wire-ios-data-model/Source/Model/AccountManager.swift
@@ -35,7 +35,7 @@ fileprivate extension UserDefaults {
 }
 
 /// Class used to safely access and change stored accounts and the current selected account.
-@objcMembers public final class AccountManager: NSObject {
+public final class AccountManager: NSObject {
 
     private let defaults = UserDefaults.shared()
     private(set) public var accounts = [Account]()
@@ -50,35 +50,35 @@ fileprivate extension UserDefaults {
 
     /// Creates a new `AccountManager`.
     /// - parameter sharedDirectory: The directory of the shared container.
-    @objc(initWithSharedDirectory:) public init(sharedDirectory: URL) {
+    public init(sharedDirectory: URL) {
         store = AccountStore(root: sharedDirectory)
         super.init()
         updateAccounts()
     }
 
     /// Deletes all content stored by an `AccountManager` on disk at the given URL, including the selected account.
-    @objc (deleteAtRoot:) static public func delete(at root: URL) {
+    static public func delete(at root: URL) {
         AccountStore.delete(at: root)
         UserDefaults.shared().selectedAccountIdentifier = nil
     }
 
     /// Adds an account to the manager and persists it.
     /// - parameter account: The account to add.
-    @objc(addOrUpdateAccount:) public func addOrUpdate(_ account: Account) {
+    public func addOrUpdate(_ account: Account) {
         store.add(account)
         updateAccounts()
     }
 
     /// Adds an account to the mananger and immediately and selects it.
     /// - parameter account: The account to add and select.
-    @objc(addAndSelectAccount:) public func addAndSelect(_ account: Account) {
+    public func addAndSelect(_ account: Account) {
         addOrUpdate(account)
         select(account)
     }
 
     /// Removes an account from the manager and the persistence layer.
     /// - parameter account: The account to remove.
-    @objc(removeAccount:) public func remove(_ account: Account) {
+    public func remove(_ account: Account) {
         store.remove(account)
         if selectedAccount == account {
             defaults?.selectedAccountIdentifier = nil
@@ -88,7 +88,7 @@ fileprivate extension UserDefaults {
 
     /// Selects a new account.
     /// - parameter account: The account to select.
-    @objc(selectAccount:) public func select(_ account: Account) {
+    public func select(_ account: Account) {
         precondition(accounts.contains(account), "Selecting an account without first adding it is not allowed")
         guard account != selectedAccount else { return }
         defaults?.selectedAccountIdentifier = account.userIdentifier

--- a/wire-ios-data-model/Source/Model/AccountStore.swift
+++ b/wire-ios-data-model/Source/Model/AccountStore.swift
@@ -77,7 +77,6 @@ public final class AccountStore: NSObject {
     /// - returns: Whether or not the operation was successful.
     @discardableResult func remove(_ account: Account) -> Bool {
         do {
-            guard contains(account) else { return false }
             try fileManager.removeItem(at: url(for: account))
             return true
         } catch {
@@ -97,13 +96,6 @@ public final class AccountStore: NSObject {
             log.error("Unable to remove all accounts at \(root): \(error)")
             return false
         }
-    }
-
-    /// Check if an `Account` is already stored in this `AccountStore`.
-    /// - parameter account: The account which should be deleted.
-    /// - returns: Whether or not the account is stored in this `AccountStore`.
-    func contains(_ account: Account) -> Bool {
-        return fileManager.fileExists(atPath: url(for: account).path)
     }
 
     // MARK: - Private Helper

--- a/wire-ios-data-model/Tests/Source/Model/AccountStoreTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/AccountStoreTests.swift
@@ -227,32 +227,6 @@ final class AccountStoreTests: ZMConversationTestsBase {
         XCTAssertNil(store.load(.create()))
     }
 
-    func testThatItReturnsTrueForAccountsContainedInTheStore() {
-        // given
-        let store = AccountStore(root: url)
-        let uuid = UUID.create()
-
-        // when
-        let account = Account(userName: "Mike", userIdentifier: uuid)
-        XCTAssert(store.add(account))
-
-        // then
-        XCTAssert(store.contains(account))
-    }
-
-    func testThatItReturnsFalseForAccountsNotContainedInTheStore() {
-        // given
-        let store = AccountStore(root: url)
-
-        // when
-        let account1 = Account(userName: "Jacob", userIdentifier: .create())
-        let account2 = Account(userName: "Dasha", userIdentifier: .create())
-        XCTAssert(store.add(account1))
-
-        // then
-        XCTAssertFalse(store.contains(account2))
-    }
-
     func testThatASecondAccountAtTheSameLocationShowsTheSameAccounts() {
         // given
         let account1 = Account(userName: "John", userIdentifier: .create())

--- a/wire-ios-system/Source/Extensions/Foundation/Error+SafeForLoggingStringConvertible.swift
+++ b/wire-ios-system/Source/Extensions/Foundation/Error+SafeForLoggingStringConvertible.swift
@@ -1,0 +1,27 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension NSError: SafeForLoggingStringConvertible {
+
+    public var safeForLoggingDescription: String {
+        "<domain: \(domain), code: \(code)>"
+    }
+
+}

--- a/wire-ios-system/WireSystem Project.xcodeproj/project.pbxproj
+++ b/wire-ios-system/WireSystem Project.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		59FDA2572C47B0BF00E14FF7 /* PopoverPresentationControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FDA2562C47B0BF00E14FF7 /* PopoverPresentationControllerConfiguration.swift */; };
 		8701221620F64171001E6342 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8701221520F64171001E6342 /* Cache.swift */; };
 		8701221920F641BE001E6342 /* CacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8701221720F641A4001E6342 /* CacheTests.swift */; };
+		CB79AC2F2C69F1D8003CF5F4 /* Error+SafeForLoggingStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB79AC2E2C69F1D8003CF5F4 /* Error+SafeForLoggingStringConvertible.swift */; };
 		D59F3A1B206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */; };
 		D59F3A1D206A47E80023474F /* DispatchQueueHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */; };
 		E66F22ED2C2ADC6B005FD57E /* WireLogger+Instances.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66F22EC2C2ADC6B005FD57E /* WireLogger+Instances.swift */; };
@@ -139,6 +140,7 @@
 		59FDA2562C47B0BF00E14FF7 /* PopoverPresentationControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverPresentationControllerConfiguration.swift; sourceTree = "<group>"; };
 		8701221520F64171001E6342 /* Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		8701221720F641A4001E6342 /* CacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheTests.swift; sourceTree = "<group>"; };
+		CB79AC2E2C69F1D8003CF5F4 /* Error+SafeForLoggingStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+SafeForLoggingStringConvertible.swift"; sourceTree = "<group>"; };
 		D59F3A1A206A448F0023474F /* DispatchQueue+ZMSDispatchGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+ZMSDispatchGroup.swift"; sourceTree = "<group>"; };
 		D59F3A1C206A47E80023474F /* DispatchQueueHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHelperTests.swift; sourceTree = "<group>"; };
 		E66F22EC2C2ADC6B005FD57E /* WireLogger+Instances.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WireLogger+Instances.swift"; sourceTree = "<group>"; };
@@ -366,6 +368,7 @@
 			isa = PBXGroup;
 			children = (
 				59D985EC2B5FCE14009B99F0 /* NSAttributedStringExtensions.swift */,
+				CB79AC2E2C69F1D8003CF5F4 /* Error+SafeForLoggingStringConvertible.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -598,6 +601,7 @@
 				F19E554522AA8748005C792D /* SafeForLoggingStringConvertible.swift in Sources */,
 				595052972C4785AE0020B1A1 /* UIModalPresentationStyle+CustomDebugStringConvertible.swift in Sources */,
 				54DB81631DBF66CF00AF495D /* ZMSLog+Levels.swift in Sources */,
+				CB79AC2F2C69F1D8003CF5F4 /* Error+SafeForLoggingStringConvertible.swift in Sources */,
 				16AAA62A2C21903200080A06 /* ExpiringActivity.swift in Sources */,
 				54D5736A1DBFBAFA00D6C2C4 /* ZMSLog+Recording.swift in Sources */,
 				599C83222C453FF600D33A0D /* ZMSDispatchGroup.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10462" title="WPB-10462" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10462</a>  [iOS] Issues around login & logout behavior
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

There are issues when logging out and logging in. From the ticket:

> It Iooks like data wasn't wiped and the app behaves erratically. Sometimes getting session expired, sometimes getting a prompt to enter password again which disappears

I have not been able to reproduce the issue. However one danger area that could cause this issue is this:

When deleting an account we delete its file from disc. During this process we check whether it exists on disk via a call to [fileExists(atPath:isDirectory:)](https://developer.apple.com/documentation/foundation/filemanager/1410277-fileexists). Apple states that this is a bad idea in it's documentation:

> Attempting to predicate behavior based on the current state of the file system or a particular file on the file system is not recommended. Doing so can cause odd behavior or race conditions.

To address this issue, this PR:

- No longer checks whether an `Account` file exists on disk before attempting to delete it. I think this is better behavior anyway as attempting to delete an no existent account feels like an error.
- Change `AccountStore` to log using `WireLogger`. This means we will be aware of account deleting issues via DataDog. This is necessary as local logs are deleted during logout so cannot be inspected. 

### Testing

Try to reproduce the original issue by logging in and logging out repeatably. I was unable to reproduce the error original issue before this _fix_ but it is still worth trying.

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
