### PR TITLE
chore: set avs version to 9.7.21 - WPB-10564

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "wire-avs.json" "9.8.5"
+binary "wire-avs.json" "9.7.21"
 github "wireapp/Down" "v2.3.4_xcframework"
 github "wireapp/HTMLString" "6.0.1_xcframework"
 github "wireapp/ZipArchive" "v2.4.2"

--- a/wire-avs.json
+++ b/wire-avs.json
@@ -1,3 +1,3 @@
 {
-  "9.8.5": "https://github.com/wireapp/wire-avs/releases/download/9.8.5/avs.xcframework.zip",
+  "9.7.21": "https://github.com/wireapp/wire-avs/releases/download/9.7.21/avs.xcframework.zip",
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10564" title="WPB-10564" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10564</a>  Set avs version to 9.7.21 on develop
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

cherry pick avs version 9.7.21 to release/cycle-3.113


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
