### PR TITLE
fix: link preview image not uploading - WPB-10622

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
+++ b/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
@@ -694,6 +694,19 @@ public final class FileAssetCache: NSObject {
         encryptionKey: Data,
         sha256Digest: Data
     ) -> Data? {
+        // Workaround: when decrypting data for the link preview, the key
+        // and digest are sometimes empty (not sure why). An empty digest
+        // will always fail the digest check and result in deleting the
+        // asset forever. As a workaround, just return nil with these
+        // invalid empty inputs, so next time the asset is fetched with
+        // valid inputs it will succeed.
+        guard
+            !encryptionKey.isEmpty,
+            !sha256Digest.isEmpty
+        else {
+            return nil
+        }
+        
         guard let encryptedData = cache.assetData(key) else {
             return nil
         }

--- a/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
+++ b/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
@@ -706,7 +706,7 @@ public final class FileAssetCache: NSObject {
         else {
             return nil
         }
-        
+
         guard let encryptedData = cache.assetData(key) else {
             return nil
         }

--- a/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -266,6 +266,25 @@ class FileAssetCacheTests: XCTestCase {
         XCTAssertFalse(sut.hasEncryptedMediumImageData(for: message))
     }
 
+    func testThatItDoesNotDecryptAFileIfSHA256IsEmpty() {
+
+        // given
+        let message = createMessageForCaching()
+        sut.storeEncryptedMediumImage(data: testData(), for: message)
+        XCTAssertTrue(sut.hasEncryptedMediumImageData(for: message))
+
+        // when
+        let result = sut.decryptedMediumImageData(
+            for: message,
+            encryptionKey: .randomEncryptionKey(),
+            sha256Digest: Data()
+        )
+
+        // then
+        XCTAssertNil(result)
+        XCTAssertTrue(sut.hasEncryptedMediumImageData(for: message))
+    }
+
     // @SF.Messages @TSFI.RESTfulAPI @S0.1 @S0.2 @S0.3
     func testThatItDoesNotDecryptAndDeletesAFileWithWrongSHA256() {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10622" title="WPB-10622" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10622</a>  [iOS] Link preview image sometimes doesn't upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When sending a link preview with an image, the image doesn't get uploaded and is not visible to the sender. 

### Cause

The asset is stored encrypted in the file cache, and when we try to retrieve it, we compare it's SHA256 digest with the one passed in (stored on the message) and if it doesn't match we'll delete it from the file cache forever. Most likely due to some concurrency issues, it can happen that when fetching the link preview image to display in the conversation that the decryption key and SHA256 digest are both **empty**. This would result in deleting the encrypted asset, which would prevent it from being uploaded and also from being visible to even the sender.

Why do we pass in an empty key and digest? I don't know, but it may be because these are taken from the message and then cross an async boundary 🤷🏻‍♂️. 

### Solution

The solution is just a workaround: I found that if we simply return nil when the input arguments are empty, it will be invoked again soon after with the non-empty values and succeed. 

I think we should re-visit asset storage and management to try to avoid strange behavior like this.


### Testing

Send several link previews and ensure that the images are uploaded and received on the other side.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
