### PR TITLE
fix: Update Modal Copy for Analytics Sharing - WPB-10650

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5581,17 +5581,17 @@ internal enum L10n {
           /// Send anonymous usage data
           internal static let title = L10n.tr("Localizable", "self.settings.privacy_analytics.title", fallback: "Send anonymous usage data")
           internal enum Alert {
-            /// Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy (link). You can revoke your consent at any time.
-            internal static let message = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.message", fallback: "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy (link). You can revoke your consent at any time.")
+            /// Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy. You can revoke your consent at any time.
+            internal static let message = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.message", fallback: "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy. You can revoke your consent at any time.")
             /// Consent to share user data
             internal static let title = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.title", fallback: "Consent to share user data")
             internal enum Button {
               /// Agree
-              internal static let accept = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.accept", fallback: "Agree")
+              internal static let agree = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.agree", fallback: "Agree")
+              /// Decline
+              internal static let decline = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.decline", fallback: "Decline")
               /// Privacy Policy
               internal static let privacyPolicy = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.privacyPolicy", fallback: "Privacy Policy")
-              /// Decline
-              internal static let reject = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.reject", fallback: "Decline")
             }
           }
         }

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5581,17 +5581,17 @@ internal enum L10n {
           /// Send anonymous usage data
           internal static let title = L10n.tr("Localizable", "self.settings.privacy_analytics.title", fallback: "Send anonymous usage data")
           internal enum Alert {
-            /// With your consent, we use technologies to analyse the use of Wire Messenger in order to improve and develop it based on user needs. Information about your use of Wire Messenger, such as whether and when an error occurs or a particular function is used (so-called events), and other technical information (e.g., IP address, app version, device type, operating system) is collected using a pseudonymous ID. The collected data cannot be assigned to you. The data is not linked to your personal information or shared with third parties beside Zeta Project Germany GmbH. The ID is deleted from your device after [28] days after the last activity at the latest. The statistical analysis of the collected information helps us to troubleshoot and improve the Wire Messenger. Further information can be found in our privacy policy. You can revoke or change your consent at any time with effect for the future.
-            internal static let message = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.message", fallback: "With your consent, we use technologies to analyse the use of Wire Messenger in order to improve and develop it based on user needs. Information about your use of Wire Messenger, such as whether and when an error occurs or a particular function is used (so-called events), and other technical information (e.g., IP address, app version, device type, operating system) is collected using a pseudonymous ID. The collected data cannot be assigned to you. The data is not linked to your personal information or shared with third parties beside Zeta Project Germany GmbH. The ID is deleted from your device after [28] days after the last activity at the latest. The statistical analysis of the collected information helps us to troubleshoot and improve the Wire Messenger. Further information can be found in our privacy policy. You can revoke or change your consent at any time with effect for the future.")
-            /// Consent to the Analysis of Your User Behaviour
-            internal static let title = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.title", fallback: "Consent to the Analysis of Your User Behaviour")
+            /// Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy (link). You can revoke your consent at any time.
+            internal static let message = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.message", fallback: "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy (link). You can revoke your consent at any time.")
+            /// Consent to share user data
+            internal static let title = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.title", fallback: "Consent to share user data")
             internal enum Button {
-              /// Accept
-              internal static let accept = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.accept", fallback: "Accept")
+              /// Agree
+              internal static let accept = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.accept", fallback: "Agree")
               /// Privacy Policy
               internal static let privacyPolicy = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.privacyPolicy", fallback: "Privacy Policy")
-              /// Reject
-              internal static let reject = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.reject", fallback: "Reject")
+              /// Decline
+              internal static let reject = L10n.tr("Localizable", "self.settings.privacy_analytics.alert.button.reject", fallback: "Decline")
             }
           }
         }

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1160,10 +1160,10 @@
 "self.settings.receiveNews_and_offers.title" = "Receive Newsletter";
 "self.settings.receiveNews_and_offers.description.title" = "Receive news and product updates from Wire via email.";
 
-"self.settings.privacy_analytics.alert.title" = "Consent to the Analysis of Your User Behaviour";
-"self.settings.privacy_analytics.alert.message" = "With your consent, we use technologies to analyse the use of Wire Messenger in order to improve and develop it based on user needs. Information about your use of Wire Messenger, such as whether and when an error occurs or a particular function is used (so-called events), and other technical information (e.g., IP address, app version, device type, operating system) is collected using a pseudonymous ID. The collected data cannot be assigned to you. The data is not linked to your personal information or shared with third parties beside Zeta Project Germany GmbH. The ID is deleted from your device after [28] days after the last activity at the latest. The statistical analysis of the collected information helps us to troubleshoot and improve the Wire Messenger. Further information can be found in our privacy policy. You can revoke or change your consent at any time with effect for the future.";
-"self.settings.privacy_analytics.alert.button.accept" = "Accept";
-"self.settings.privacy_analytics.alert.button.reject" = "Reject";
+"self.settings.privacy_analytics.alert.title" = "Consent to share user data";
+"self.settings.privacy_analytics.alert.message" = "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy (link). You can revoke your consent at any time.";
+"self.settings.privacy_analytics.alert.button.accept" = "Agree";
+"self.settings.privacy_analytics.alert.button.reject" = "Decline";
 "self.settings.privacy_analytics.alert.button.privacyPolicy" = "Privacy Policy";
 
 // Change Username

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -1161,9 +1161,9 @@
 "self.settings.receiveNews_and_offers.description.title" = "Receive news and product updates from Wire via email.";
 
 "self.settings.privacy_analytics.alert.title" = "Consent to share user data";
-"self.settings.privacy_analytics.alert.message" = "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy (link). You can revoke your consent at any time.";
-"self.settings.privacy_analytics.alert.button.accept" = "Agree";
-"self.settings.privacy_analytics.alert.button.reject" = "Decline";
+"self.settings.privacy_analytics.alert.message" = "Help to improve Wire by sharing your usage data via a pseudonymous ID. The data is neither linked to your personal information nor shared with third parties besides Zeta Project Germany GmbH. It includes, for example, when you use a feature, your app version, device type, or your operating system. The ID will be deleted at the latest from your device after 365 days after the last activity. Find further details in our Privacy Policy. You can revoke your consent at any time.";
+"self.settings.privacy_analytics.alert.button.agree" = "Agree";
+"self.settings.privacy_analytics.alert.button.decline" = "Decline";
 "self.settings.privacy_analytics.alert.button.privacyPolicy" = "Privacy Policy";
 
 // Change Username

--- a/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager+UIAlertController.swift
+++ b/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager+UIAlertController.swift
@@ -36,8 +36,8 @@ extension TrackingManager {
         )
 
         let actions: [(title: String, style: UIAlertAction.Style, handler: (UIAlertAction) -> Void)] = [
-            (AlertLocale.Button.accept, .default, { _ in completion(true) }),
-            (AlertLocale.Button.reject, .cancel, { _ in completion(false) }),
+            (AlertLocale.Button.agree, .default, { _ in completion(true) }),
+            (AlertLocale.Button.decline, .cancel, { _ in completion(false) }),
             (AlertLocale.Button.privacyPolicy, .default, { [weak self] _ in
                 self?.presentPrivacyPolicy()
                 completion(false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10650" title="WPB-10650" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10650</a>  [iOS] Update copy for the user consent modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->



This PR updates the text displayed in the modal when a user opts to share their analytics data. The revised copy is clearer and according to the latest changes coming from product.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---