### PR TITLE
fix: Push analyticsIdentifier to Countly with a merge when it changes - WPB-10520

### DIFF
--- a/WireAnalytics/Sources/WireAnalytics/AnalyticsManager.swift
+++ b/WireAnalytics/Sources/WireAnalytics/AnalyticsManager.swift
@@ -51,6 +51,11 @@ public struct AnalyticsManager: AnalyticsManagerProtocol {
         self.analyticsService.start(appKey: appKey, host: host)
     }
 
+    public func updateUserAnalyticsIdentifier(_ userProfile: AnalyticsUserProfile, mergeData: Bool) {
+        analyticsService.changeDeviceID(userProfile.analyticsIdentifier, mergeData: mergeData)
+        updateUserProfile(userProfile)
+    }
+
     /// Switches the current user and begins a new analytics session.
     ///
     /// - Parameter userProfile: The profile of the user to switch to.
@@ -58,6 +63,7 @@ public struct AnalyticsManager: AnalyticsManagerProtocol {
     public func switchUser(_ userProfile: AnalyticsUserProfile) -> any AnalyticsSessionProtocol {
         analyticsService.endSession()
         updateUserProfile(userProfile)
+        analyticsService.changeDeviceID(userProfile.analyticsIdentifier, mergeData: false)
         analyticsService.beginSession()
 
         return AnalyticsSession(
@@ -83,8 +89,6 @@ public struct AnalyticsManager: AnalyticsManagerProtocol {
     // MARK: - Private Helper Methods
 
     private func updateUserProfile(_ userProfile: AnalyticsUserProfile) {
-        analyticsService.changeDeviceIDWithoutMerge(userProfile.analyticsIdentifier)
-
         analyticsService.setUserValue(userProfile.teamInfo?.id, forKey: AnalyticsUserKey.teamID.rawValue)
         analyticsService.setUserValue(userProfile.teamInfo?.role, forKey: AnalyticsUserKey.teamRole.rawValue)
         analyticsService.setUserValue(userProfile.teamInfo.map { String($0.size.logRound()) }, forKey: AnalyticsUserKey.teamSize.rawValue)

--- a/WireAnalytics/Sources/WireAnalytics/AnalyticsManager.swift
+++ b/WireAnalytics/Sources/WireAnalytics/AnalyticsManager.swift
@@ -83,7 +83,7 @@ public struct AnalyticsManager: AnalyticsManagerProtocol {
     // MARK: - Private Helper Methods
 
     private func updateUserProfile(_ userProfile: AnalyticsUserProfile) {
-        analyticsService.changeDeviceID(userProfile.analyticsIdentifier)
+        analyticsService.changeDeviceIDWithoutMerge(userProfile.analyticsIdentifier)
 
         analyticsService.setUserValue(userProfile.teamInfo?.id, forKey: AnalyticsUserKey.teamID.rawValue)
         analyticsService.setUserValue(userProfile.teamInfo?.role, forKey: AnalyticsUserKey.teamRole.rawValue)

--- a/WireAnalytics/Sources/WireAnalytics/AnalyticsManagerProtocol.swift
+++ b/WireAnalytics/Sources/WireAnalytics/AnalyticsManagerProtocol.swift
@@ -18,6 +18,13 @@
 
 public protocol AnalyticsManagerProtocol {
 
+    /// Updates the user analytics identifier and merges data from the previous identifier.
+    ///
+    /// - Parameters:
+    ///   - userProfile: The updated profile of the user.
+    ///   - mergeData: A Boolean indicating whether to merge data from the previous identifier.
+    func updateUserAnalyticsIdentifier(_ userProfile: AnalyticsUserProfile, mergeData: Bool)
+
     /// Switches the current analytics user and starts a new session.
     /// - Parameter userProfile: The profile of the user to switch to.
     /// - Returns: A new analytics session for the switched user.

--- a/WireAnalytics/Sources/WireAnalytics/AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/AnalyticsService.swift
@@ -38,12 +38,12 @@ protocol AnalyticsService {
     ///
     /// - Parameters:
     ///   - id: The new device ID to be used.
-    ///   - withMerge: A Boolean indicating whether to merge the data associated with the previous device ID into the new device ID.
+    ///   - mergeData: A Boolean indicating whether to merge the data associated with the previous device ID into the new device ID.
     ///     - If `true`, the data from the old device ID will be merged with the new device ID.
     ///     - If `false`, the data will not be merged, and the new device ID will start with separate data.
     ///
     /// - Note: If the `withMerge` parameter is set to `false`, the data associated with the previous device ID will not be transferred to the new device ID, resulting in separate analytics tracking.
-    func changeDeviceID(_ id: String, withMerge: Bool)
+    func changeDeviceID(_ id: String, mergeData: Bool)
 
     /// Sets a user value for a given key in the analytics service.
     ///

--- a/WireAnalytics/Sources/WireAnalytics/AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/AnalyticsService.swift
@@ -34,15 +34,16 @@ protocol AnalyticsService {
     /// Ends the current analytics session.
     func endSession()
 
-    /// Changes the device ID used for analytics without merging the data.
+    /// Changes the device ID used for analytics.
     ///
-    /// - Parameter id: The new device ID.
-    func changeDeviceIDWithoutMerge(_ id: String)
-
-    /// Changes the device ID used for analytics and merges the data.
+    /// - Parameters:
+    ///   - id: The new device ID to be used.
+    ///   - withMerge: A Boolean indicating whether to merge the data associated with the previous device ID into the new device ID.
+    ///     - If `true`, the data from the old device ID will be merged with the new device ID.
+    ///     - If `false`, the data will not be merged, and the new device ID will start with separate data.
     ///
-    /// - Parameter id: The new device ID.
-    func changeDeviceIDWithMerge(_ id: String)
+    /// - Note: If the `withMerge` parameter is set to `false`, the data associated with the previous device ID will not be transferred to the new device ID, resulting in separate analytics tracking.
+    func changeDeviceID(_ id: String, withMerge: Bool)
 
     /// Sets a user value for a given key in the analytics service.
     ///

--- a/WireAnalytics/Sources/WireAnalytics/AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/AnalyticsService.swift
@@ -34,10 +34,15 @@ protocol AnalyticsService {
     /// Ends the current analytics session.
     func endSession()
 
-    /// Changes the device ID used for analytics.
+    /// Changes the device ID used for analytics without merging the data.
     ///
     /// - Parameter id: The new device ID.
-    func changeDeviceID(_ id: String)
+    func changeDeviceIDWithoutMerge(_ id: String)
+
+    /// Changes the device ID used for analytics and merges the data.
+    ///
+    /// - Parameter id: The new device ID.
+    func changeDeviceIDWithMerge(_ id: String)
 
     /// Sets a user value for a given key in the analytics service.
     ///

--- a/WireAnalytics/Sources/WireAnalytics/Countly+AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Countly+AnalyticsService.swift
@@ -28,8 +28,8 @@ extension Countly: AnalyticsService {
         start(with: config)
     }
 
-    func changeDeviceID(_ id: String, withMerge: Bool) {
-        if withMerge {
+    func changeDeviceID(_ id: String, mergeData: Bool) {
+        if mergeData {
             changeDeviceID(withMerge: id)
         } else {
             changeDeviceIDWithoutMerge(id)

--- a/WireAnalytics/Sources/WireAnalytics/Countly+AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Countly+AnalyticsService.swift
@@ -28,8 +28,12 @@ extension Countly: AnalyticsService {
         start(with: config)
     }
 
-    func changeDeviceIDWithMerge(_ id: String) {
-        changeDeviceIDWithoutMerge(id)
+    func changeDeviceID(_ id: String, withMerge: Bool) {
+        if withMerge {
+            changeDeviceID(withMerge: id)
+        } else {
+            changeDeviceIDWithoutMerge(id)
+        }
     }
 
     func setUserValue(_ value: String?, forKey key: String) {

--- a/WireAnalytics/Sources/WireAnalytics/Countly+AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Countly+AnalyticsService.swift
@@ -28,7 +28,7 @@ extension Countly: AnalyticsService {
         start(with: config)
     }
 
-    func changeDeviceID(_ id: String) {
+    func changeDeviceIDWithMerge(_ id: String) {
         changeDeviceIDWithoutMerge(id)
     }
 

--- a/WireAnalytics/Sources/WireAnalyticsSupport/MockAnalyticsManagerProtocol.swift
+++ b/WireAnalytics/Sources/WireAnalyticsSupport/MockAnalyticsManagerProtocol.swift
@@ -65,4 +65,18 @@ public class MockAnalyticsManagerProtocol: AnalyticsManagerProtocol {
         invokedEnableTrackingParametersList.append((userProfile, ()))
         return stubbedEnableTrackingResult
     }
+
+    // MARK: - updateUserAnalyticsIdentifier
+
+    public var invokedUpdateUserAnalyticsIdentifier = false
+    public var invokedUpdateUserAnalyticsIdentifierCount = 0
+    public var invokedUpdateUserAnalyticsIdentifierParameters: (userProfile: AnalyticsUserProfile, mergeData: Bool)?
+    public var invokedUpdateUserAnalyticsIdentifierParametersList = [(userProfile: AnalyticsUserProfile, mergeData: Bool)]()
+
+    public func updateUserAnalyticsIdentifier(_ userProfile: AnalyticsUserProfile, mergeData: Bool) {
+        invokedUpdateUserAnalyticsIdentifier = true
+        invokedUpdateUserAnalyticsIdentifierCount += 1
+        invokedUpdateUserAnalyticsIdentifierParameters = (userProfile, mergeData)
+        invokedUpdateUserAnalyticsIdentifierParametersList.append((userProfile, mergeData))
+    }
 }

--- a/WireAnalytics/Tests/WireAnalyticsTests/AnalyticsManagerTests.swift
+++ b/WireAnalytics/Tests/WireAnalyticsTests/AnalyticsManagerTests.swift
@@ -37,7 +37,7 @@ class AnalyticsManagerTests: XCTestCase {
         analyticsService.startAppKeyHost_MockMethod = { _, _ in }
         analyticsService.beginSession_MockMethod = {}
         analyticsService.endSession_MockMethod = {}
-        analyticsService.changeDeviceID_MockMethod = { _ in }
+        analyticsService.changeDeviceIDMergeData_MockMethod = { _, _ in }
         analyticsService.setUserValueForKey_MockMethod = { _, _ in }
 
         sut = AnalyticsManager(
@@ -77,11 +77,12 @@ class AnalyticsManagerTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(analyticsService.endSession_Invocations.count, 1)
-        guard analyticsService.changeDeviceID_Invocations.count == 1 else {
-            XCTFail("Expected 1 invocation of changeDeviceID, but got \(analyticsService.changeDeviceID_Invocations.count)")
+        guard analyticsService.changeDeviceIDMergeData_Invocations.count == 1 else {
+            XCTFail("Expected 1 invocation of changeDeviceIDMergeData, but got \(analyticsService.changeDeviceIDMergeData_Invocations.count)")
             return
         }
-        XCTAssertEqual(analyticsService.changeDeviceID_Invocations[0], "testUser123")
+        XCTAssertEqual(analyticsService.changeDeviceIDMergeData_Invocations[0].id, "testUser123")
+        XCTAssertFalse(analyticsService.changeDeviceIDMergeData_Invocations[0].mergeData)
 
         guard analyticsService.setUserValueForKey_Invocations.count == 3 else {
             XCTFail("Expected 3 invocations of setUserValueForKey, but got \(analyticsService.setUserValueForKey_Invocations.count)")
@@ -111,11 +112,12 @@ class AnalyticsManagerTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(analyticsService.endSession_Invocations.count, 1)
-        guard analyticsService.changeDeviceID_Invocations.count == 1 else {
-            XCTFail("Expected 1 invocation of changeDeviceID, but got \(analyticsService.changeDeviceID_Invocations.count)")
+        guard analyticsService.changeDeviceIDMergeData_Invocations.count == 1 else {
+            XCTFail("Expected 1 invocation of changeDeviceIDMergeData, but got \(analyticsService.changeDeviceIDMergeData_Invocations.count)")
             return
         }
-        XCTAssertEqual(analyticsService.changeDeviceID_Invocations[0], "testUser456")
+        XCTAssertEqual(analyticsService.changeDeviceIDMergeData_Invocations[0].id, "testUser456")
+        XCTAssertFalse(analyticsService.changeDeviceIDMergeData_Invocations[0].mergeData)
 
         guard analyticsService.setUserValueForKey_Invocations.count == 3 else {
             XCTFail("Expected 3 invocations of setUserValueForKey, but got \(analyticsService.setUserValueForKey_Invocations.count)")

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1340,6 +1340,16 @@ extension SessionManager: UserObserving {
             }
             updateCurrentAccount(in: managedObjectContext)
         }
+
+        if changeInfo.analyticsIdentifierChanged {
+            guard changeInfo.user.isSelfUser, let userSession = activeUserSession else {
+                return
+            }
+
+            if let userProfile = getUserAnalyticsProfile(for: userSession) {
+                analyticsManager?.updateUserAnalyticsIdentifier(userProfile, mergeData: true)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10520" title="WPB-10520" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10520</a>  [iOS] Push analyticsIdentifier to Countly with a merge when it changes
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


## Overview
This PR implements a mechanism to push the user's `analyticsIdentifier` to Countly when it changes, using a merge strategy to preserve existing data.

## Implementation Details
- Modified the `userDidChange(_:)` method in the user change observer to react to changes in the `analyticsIdentifier`.
- Utilized the existing `getUserAnalyticsProfile(for:)` method to retrieve the updated user profile, including team information.
- Implemented a call to `analyticsManager.updateUserAnalyticsIdentifier(_:mergeData:)` with `mergeData` set to `true` to ensure existing data is preserved during the update.

## Key Changes
1. Updated `userDidChange(_:)` method to check for `analyticsIdentifierChanged`.
2. Added a guard clause to ensure we're dealing with the self user and have an active user session.
3. Integrated `getUserAnalyticsProfile(for:)` to fetch the latest user profile data.
4. Implemented the call to update the analytics identifier in Countly.

## Code Snippet
```swift
if changeInfo.analyticsIdentifierChanged {
    guard changeInfo.user.isSelfUser, let userSession = activeUserSession else {
        return
    }

    if let userProfile = getUserAnalyticsProfile(for: userSession) {
        analyticsManager?.updateUserAnalyticsIdentifier(userProfile, mergeData: true)
    }
}
```

## Testing
- Verified that the `analyticsIdentifier` is correctly pushed to Countly when it changes

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---
