### PR TITLE
chore: cherrypick link preview fixes - WPB-10622 WPB-10495

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
+++ b/wire-ios-data-model/Source/Model/Message/FileAssetCache.swift
@@ -694,6 +694,19 @@ public final class FileAssetCache: NSObject {
         encryptionKey: Data,
         sha256Digest: Data
     ) -> Data? {
+        // Workaround: when decrypting data for the link preview, the key
+        // and digest are sometimes empty (not sure why). An empty digest
+        // will always fail the digest check and result in deleting the
+        // asset forever. As a workaround, just return nil with these
+        // invalid empty inputs, so next time the asset is fetched with
+        // valid inputs it will succeed.
+        guard
+            !encryptionKey.isEmpty,
+            !sha256Digest.isEmpty
+        else {
+            return nil
+        }
+
         guard let encryptedData = cache.assetData(key) else {
             return nil
         }

--- a/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/FileAssetCacheTests.swift
@@ -265,6 +265,25 @@ class FileAssetCacheTests: XCTestCase {
         XCTAssertFalse(sut.hasEncryptedMediumImageData(for: message))
     }
 
+    func testThatItDoesNotDecryptAFileIfSHA256IsEmpty() {
+
+        // given
+        let message = createMessageForCaching()
+        sut.storeEncryptedMediumImage(data: testData(), for: message)
+        XCTAssertTrue(sut.hasEncryptedMediumImageData(for: message))
+
+        // when
+        let result = sut.decryptedMediumImageData(
+            for: message,
+            encryptionKey: .randomEncryptionKey(),
+            sha256Digest: Data()
+        )
+
+        // then
+        XCTAssertNil(result)
+        XCTAssertTrue(sut.hasEncryptedMediumImageData(for: message))
+    }
+
     // @SF.Messages @TSFI.RESTfulAPI @S0.1 @S0.2 @S0.3
     func testThatItDoesNotDecryptAndDeletesAFileWithWrongSHA256() {
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategy.swift
@@ -64,7 +64,7 @@ extension LinkPreviewUpdateRequestStrategy: ModifiedKeyObjectSyncTranscoder {
                 WireLogger.calling.error("failed to send message: \(String(reflecting: error))")
             }
             await managedObjectContext.perform {
-                object.linkPreviewState = .done
+                object.markAsSent()
                 completion()
             }
             managedObjectContext.leaveAllGroups(groups)

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
@@ -91,17 +91,25 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
     func testThatItDoesCreateARequestInState_Uploaded() {
         apiVersion = .v1
 
+        var message: ZMClientMessage!
+
         self.syncMOC.performGroupedAndWait { _ in
             // Given
             self.mockMessageSender.sendMessageMessage_MockMethod = { _ in }
-            let message = self.insertMessage(with: .uploaded)
+            message = self.insertMessage(with: .uploaded)
 
             // When
             self.process(message)
         }
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
+        // THEN
         XCTAssertEqual(1, mockMessageSender.sendMessageMessage_Invocations.count)
+
+        self.syncMOC.performGroupedAndWait { _ in
+            XCTAssertEqual(message.linkPreviewState, .done)
+            XCTAssertNil(message.expirationDate)
+        }
     }
 
     func testThatItDoesNotCreateARequestAfterGettingsAResponseForIt() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10622" title="WPB-10622" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10622</a>  [iOS] Link preview image sometimes doesn't upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cherry pick link preview fixes.
- https://github.com/wireapp/wire-ios/pull/1806
- https://github.com/wireapp/wire-ios/pull/1808

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
