### PR TITLE
fix: Unable to tab to Contacts - WPB-10514

### DIFF
--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 		BFFD439E1DE47FFA00505C8C /* UIView+RightToLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */; };
 		BFFE943C1E7839D10025AD75 /* ConversationRenamedCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE943B1E7839D10025AD75 /* ConversationRenamedCellTests.swift */; };
 		BFFE943E1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE943D1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift */; };
+		CB51204B2C6F6C84000C8FEC /* TabBarChangeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51204A2C6F6C84000C8FEC /* TabBarChangeHandler.swift */; };
 		CE2402811E0A992200665A91 /* AnalyticsConsoleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */; };
 		CEEEAF071CB562BF00111759 /* PlaceholderConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEEAF061CB562BF00111759 /* PlaceholderConversationView.swift */; };
 		D30880FB292CD8F200DDEAB0 /* CallingBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30880FA292CD8F200DDEAB0 /* CallingBottomSheetViewController.swift */; };
@@ -3282,6 +3283,7 @@
 		BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+RightToLeft.swift"; sourceTree = "<group>"; };
 		BFFE943B1E7839D10025AD75 /* ConversationRenamedCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationRenamedCellTests.swift; sourceTree = "<group>"; };
 		BFFE943D1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataSnapshotTestCase.swift; sourceTree = "<group>"; };
+		CB51204A2C6F6C84000C8FEC /* TabBarChangeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarChangeHandler.swift; sourceTree = "<group>"; };
 		CE06C93E1DF5C3D900497685 /* AVAsset+VideoConvert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVAsset+VideoConvert.swift"; sourceTree = "<group>"; };
 		CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsConsoleProvider.swift; sourceTree = "<group>"; };
 		CE8E4FA91DF066750009F437 /* FileMetaDataGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileMetaDataGenerator.swift; sourceTree = "<group>"; };
@@ -8399,6 +8401,7 @@
 				EF3CBC092147D81700566295 /* ConversationListViewController+PushPermissions.swift */,
 				EF6E9FE323193439000B7785 /* ConversationListViewController+State.swift */,
 				BFAAB2421DEDB21E00CBC096 /* ConversationListViewController+Transitions.swift */,
+				CB51204A2C6F6C84000C8FEC /* TabBarChangeHandler.swift */,
 				EF471BE023265305008E11A5 /* ViewModel */,
 			);
 			path = Container;
@@ -10290,6 +10293,7 @@
 				87BEB0441D3E478500DE9575 /* AssetLibrary.swift in Sources */,
 				D30880FE292E521D00DDEAB0 /* CallingActionsInfoViewController.swift in Sources */,
 				16D74BEA2B5895C900160298 /* AuthenticationMissingUsernameErrorHandler.swift in Sources */,
+				CB51204B2C6F6C84000C8FEC /* TabBarChangeHandler.swift in Sources */,
 				EE593F9C2B73C3F0008D1109 /* DeepLinksView.swift in Sources */,
 				E90B7DB628117DED001831FB /* DynamicFontLabel.swift in Sources */,
 				EECA90AA287449EC0024B301 /* DeveloperFlagsView.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -38,8 +38,6 @@ final class ConversationListViewController: UIViewController {
     /// internal View Model
     var state: ConversationListState = .conversationList
 
-    private var previouslySelectedTabIndex = MainTabBarControllerTab.conversations
-
     /// private
     private var viewDidAppearCalled = false
     private static let contentControllerBottomInset: CGFloat = 16
@@ -184,8 +182,6 @@ final class ConversationListViewController: UIViewController {
 
         if !viewDidAppearCalled {
             viewDidAppearCalled = true
-
-            tabBarController?.delegate = self
 
             zClientViewController?.showAvailabilityBehaviourChangeAlertIfNeeded()
         }
@@ -338,30 +334,6 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
 
     func conversationListViewControllerViewModel(_ viewModel: ViewModel, didUpdate selfUserStatus: UserStatus) {
         updateTitleView()
-    }
-}
-
-// MARK: - UITabBarControllerDelegate
-
-extension ConversationListViewController: UITabBarControllerDelegate {
-
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        guard let selectedIndex = MainTabBarControllerTab(rawValue: tabBarController.selectedIndex) else {
-            fatalError("unexpected selected tab index")
-        }
-
-        switch selectedIndex {
-        case .contacts:
-            presentPeoplePicker { [self] in
-                tabBarController.selectedIndex = previouslySelectedTabIndex.rawValue
-            }
-        case .conversations, .folders:
-            previouslySelectedTabIndex = selectedIndex
-        case .archive:
-            setState(.archived, animated: true) { [self] in
-                tabBarController.selectedIndex = previouslySelectedTabIndex.rawValue
-            }
-        }
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -346,22 +346,21 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
 extension ConversationListViewController: UITabBarControllerDelegate {
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let selectedIndex = MainTabBarControllerTab(rawValue: tabBarController.selectedIndex) else {
+            fatalError("unexpected selected tab index")
+        }
 
-        switch MainTabBarControllerTab(rawValue: tabBarController.selectedIndex) {
+        switch selectedIndex {
         case .contacts:
             presentPeoplePicker { [self] in
                 tabBarController.selectedIndex = previouslySelectedTabIndex.rawValue
             }
         case .conversations, .folders:
-            previouslySelectedTabIndex = .init(rawValue: tabBarController.selectedIndex) ?? .conversations
+            previouslySelectedTabIndex = selectedIndex
         case .archive:
             setState(.archived, animated: true) { [self] in
                 tabBarController.selectedIndex = previouslySelectedTabIndex.rawValue
             }
-        case .none:
-            fallthrough
-        default:
-            fatalError("unexpected selected tab index")
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/TabBarChangeHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/TabBarChangeHandler.swift
@@ -38,7 +38,7 @@ final class TabBarChangeHandler: NSObject, UITabBarControllerDelegate {
     private let conversationsViewController: ConversationListViewController
     private let foldersViewController: ConversationListViewController
     private var principleTab: PrincipleTab
-    
+
     /// Initializes a `TabBarChangeHandler`.
     /// - Parameters:
     ///   - conversationsViewController: The view controller corresponding the `Conversations` tab.

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/TabBarChangeHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/TabBarChangeHandler.swift
@@ -1,0 +1,96 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+/// Responds to selected tab changes, ensuring the correct _principle_ tab is selected and `Contacts` or `Archive` views
+/// are shown.
+///
+/// Currently we abuse our main `UITabBarController`. Two tabs (`Conversations` & `Folders`) contain
+/// `ConversationListViewController` instances with real content. These are considered `PrincipleTab`s. The other two
+/// tabs (`Contacts` & `Archive`) contain **empty** `UIViewController` instances. We use these empty tabs as buttons.
+/// When either of these tabs are tapped we switch back to the currently selected _principle tab_ and request it to
+/// present the corresponding `Contacts` or `Archive` view.
+///
+/// - Warning: This solution is only temporary and should be removed in the ongoing navigation overhaul. [WPB-6647]
+final class TabBarChangeHandler: NSObject, UITabBarControllerDelegate {
+
+    enum PrincipleTab {
+        case conversations
+        case folders
+    }
+
+    private let conversationsViewController: ConversationListViewController
+    private let foldersViewController: ConversationListViewController
+    private var principleTab: PrincipleTab
+    
+    /// Initializes a `TabBarChangeHandler`.
+    /// - Parameters:
+    ///   - conversationsViewController: The view controller corresponding the `Conversations` tab.
+    ///   - foldersViewController: The view controller corresponding the `Folders` tab.
+    ///   - selectedTab: The initially selected tab.
+    init(
+        conversationsViewController: ConversationListViewController,
+        foldersViewController: ConversationListViewController,
+        selectedTab: PrincipleTab
+    ) {
+        self.conversationsViewController = conversationsViewController
+        self.foldersViewController = foldersViewController
+        self.principleTab = selectedTab
+    }
+
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        guard let selectedIndex = MainTabBarControllerTab(rawValue: tabBarController.selectedIndex) else {
+            fatalError("unexpected selected tab index")
+        }
+
+        switch selectedIndex {
+        case .contacts:
+            principleViewController.presentPeoplePicker { [self] in
+                tabBarController.selectedIndex = principleTabIndex
+            }
+        case .conversations:
+            principleTab = .conversations
+        case .folders:
+            principleTab = .folders
+        case .archive:
+            principleViewController.setState(.archived, animated: true) { [self] in
+                tabBarController.selectedIndex = principleTabIndex
+            }
+        }
+    }
+
+    private var principleViewController: ConversationListViewController {
+        switch principleTab {
+        case .conversations:
+            conversationsViewController
+        case .folders:
+            foldersViewController
+        }
+    }
+
+    private var principleTabIndex: Int {
+        switch principleTab {
+        case .conversations:
+            MainTabBarControllerTab.conversations.rawValue
+        case .folders:
+            MainTabBarControllerTab.folders.rawValue
+        }
+    }
+
+}

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -198,7 +198,7 @@ final class ZClientViewController: UIViewController {
             archive: .init()
         )
         wireSplitViewController.leftViewController = mainTabBarController
-        
+
         // TODO [WPB-6647]: Remove in navigation overhaul
         // `selectedTab` must be in sync with tab set in MainTabBarController(contacts:conversations:folders:archive:)
         tabBarChangeHandler = TabBarChangeHandler(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -37,6 +37,8 @@ final class ZClientViewController: UIViewController {
     // TODO [WPB-9867]: make private or remove this property
     private(set) var mediaPlaybackManager: MediaPlaybackManager?
     private(set) var mainTabBarController: UITabBarController!
+    // TODO [WPB-6647]: Remove in navigation overhaul
+    private var tabBarChangeHandler: TabBarChangeHandler!
 
     private var selfProfileViewControllerBuilder: SelfProfileViewControllerBuilder {
         .init(
@@ -196,6 +198,15 @@ final class ZClientViewController: UIViewController {
             archive: .init()
         )
         wireSplitViewController.leftViewController = mainTabBarController
+        
+        // TODO [WPB-6647]: Remove in navigation overhaul
+        // `selectedTab` must be in sync with tab set in MainTabBarController(contacts:conversations:folders:archive:)
+        tabBarChangeHandler = TabBarChangeHandler(
+            conversationsViewController: conversationListViewController,
+            foldersViewController: conversationListWithFoldersViewController,
+            selectedTab: .conversations
+        )
+        mainTabBarController.delegate = tabBarChangeHandler
 
         if pendingInitialStateRestore {
             restoreStartupState()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10514" title="WPB-10514" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10514</a>  [iOS] Difficulty with contacts screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an unreleased bug that prevents showing the contacts view when the navigation is in a certain state. For example the following would occur prior to this fix 100% of the time:

1. Quit app
2. Launch app
3. Tap `Folders`
4. Tap `Contacts` 
5. Tap close on contacts
6. Tap `Contacts` - Nothing happens no matter how many times the user taps `Contacts`.

The root cause of the issue is that currently `ConversationListViewController` is the delegate of the `UITabBarController` and we have two instances of `ConversationListViewController` - used for `Conversations` & `Folders` tabs - which both set themselves as the delegate of `UITabBarController` and respond to taps on the `Contacts` & `Archive` tabs by presenting a corresponding view controller on `self` - i.e whichever `ConversationListViewController` instance is the true delegate of `UITabBarController`. This can lead to some messed up state.

The above is necessary because how we are currently (maybe) misusing our `UITabBarController` - Two tabs (`Conversations` & `Folders`) contain `ConversationListViewController` instances with real content. The other two tabs (`Contacts` & `Archive`) contain **empty** `UIViewController` instances. We use these empty tabs as buttons and have the `UITabBarControllerDelegate` perform actions depending on which tab is selected.

To address this issue, this PR introduces `TabBarChangeHandler` which becomes the **single** delegate of the main `UITabBarController` instance. It tracks the currently selected **real** content tab (i.e `Conversations` or `Folders`) and makes sure to present content for `Contacts` & `Archive` on the correct **real** content tab.

The solution is not pretty but seems to work and is **temporary**. This work will all be discarded in our ongoing navigation overhaul https://github.com/wireapp/wire-ios/pull/1361. I have attempted to minimize changes to avoid conflicts with https://github.com/wireapp/wire-ios/pull/1361.

### Testing

1. Quit app
2. Launch app
3. Tap `Folders`
4. Tap `Contacts` 
5. Tap close on contacts
6. Tap `Contacts` - This should work
7. Keep tapping on all tabs trying to break things.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
