### PR TITLE
fix: decouple remaining tests that mutate `BackendInfo` - WPB-10065

### DIFF
--- a/WireDomain/Tests/WireDomainTests/Helpers/TestSetup.swift
+++ b/WireDomain/Tests/WireDomainTests/Helpers/TestSetup.swift
@@ -25,7 +25,7 @@ final class TestSetup: NSObject, XCTestObservation {
         super.init()
 
         XCTestObservationCenter.shared.addTestObserver(
-            makeBackendInfoTestObservation(
+            makeBackendInfoTestObserver(
                 apiVersion: .v0,
                 preferredAPIVersion: nil,
                 domain: "wire.com",

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -50,7 +50,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     let defaultCipherSuite: Feature.MLS.Config.MLSCipherSuite = .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
 
     override func setUp() {
-        BackendInfo.storage = .temporary()
         BackendInfo.domain = "example.com"
 
         super.setUp()
@@ -124,7 +123,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         privateUserDefaults = nil
         userDefaultsTestSuite = nil
         super.tearDown()
-        BackendInfo.storage = .standard
     }
 
     // MARK: - Helpers
@@ -2667,8 +2665,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     // MARK: - Self group
 
     func test_itCreatesSelfGroup_WithNoKeyPackages_Successfully() async throws {
-        BackendInfo.domain = "example.com"
-
         // Given a group.
         let groupID = MLSGroupID.random()
         let expectation1 = self.customExpectation(description: "CreateConversation should be called")
@@ -2700,8 +2696,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     }
 
     func test_itCreatesSelfGroup_WithKeyPackages_Successfully() async throws {
-        BackendInfo.domain = "example.com"
-
         // Given a group.
         let expectation1 = self.customExpectation(description: "CreateConversation should be called")
         let expectation2 = self.customExpectation(description: "AddMembers should be called")
@@ -2846,8 +2840,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_startProteusToMLSMigration_succeeds() async throws {
         // Given
-        BackendInfo.storage = .temporary()
-        BackendInfo.domain = "example.com"
         let mlsGroupID = MLSGroupID.random()
         let conversation = await uiMOC.perform { [self] in
             let selfUser = ZMUser.selfUser(in: uiMOC)
@@ -2938,8 +2930,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_startProteusToMLSMigration_staleMessageErrorWipesGroup() async throws {
         // Given
-        BackendInfo.storage = .temporary()
-        BackendInfo.domain = "example.com"
         let mlsGroupID = MLSGroupID.random()
         await uiMOC.perform { [self] in
             let selfUser = ZMUser.selfUser(in: uiMOC)

--- a/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/ProteusToMLSMigrationCoordinatorTests.swift
@@ -58,7 +58,6 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
         mockMLSService.joinGroupWith_MockMethod = { _ in }
         mockFeatureRepository.fetchMLSMigration_MockValue = .init()
 
-        BackendInfo.storage = .temporary()
         DeveloperFlag.storage = .temporary()
     }
 
@@ -70,7 +69,6 @@ final class ProteusToMLSMigrationCoordinatorTests: ZMBaseManagedObjectTest {
         mockFeatureRepository = nil
         mockActionsProvider = nil
         mockMLSService = nil
-        BackendInfo.storage = .standard
         DeveloperFlag.storage = .standard
         super.tearDown()
     }

--- a/wire-ios-data-model/Tests/Resources/Info.plist
+++ b/wire-ios-data-model/Tests/Resources/Info.plist
@@ -18,5 +18,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>$(PRODUCT_NAME).TestSetup</string>
 </dict>
 </plist>

--- a/wire-ios-data-model/Tests/Source/Helper/TestSetup.swift
+++ b/wire-ios-data-model/Tests/Source/Helper/TestSetup.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireTransport
+import WireTransportSupport
+import XCTest
+
+final class TestSetup: NSObject, XCTestObservation {
+    override init() {
+        super.init()
+
+        XCTestObservationCenter.shared.addTestObserver(
+            makeBackendInfoTestObservation(
+                apiVersion: .v0,
+                preferredAPIVersion: nil,
+                domain: "wire.com",
+                isFederationEnabled: false
+            )
+        )
+    }
+
+}

--- a/wire-ios-data-model/Tests/Source/Helper/TestSetup.swift
+++ b/wire-ios-data-model/Tests/Source/Helper/TestSetup.swift
@@ -25,7 +25,7 @@ final class TestSetup: NSObject, XCTestObservation {
         super.init()
 
         XCTestObservationCenter.shared.addTestObserver(
-            makeBackendInfoTestObservation(
+            makeBackendInfoTestObserver(
                 apiVersion: .v0,
                 preferredAPIVersion: nil,
                 domain: "wire.com",

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+OTR.swift
@@ -63,7 +63,6 @@ final class ClientMessageTests_OTR: BaseZMClientMessageTests {
         mockProteusService = nil
 
         DeveloperFlag.storage = UserDefaults.standard
-        BackendInfo.domain = nil
         super.tearDown()
     }
 
@@ -340,7 +339,6 @@ final class ClientMessageTests_OTR: BaseZMClientMessageTests {
 
     func testThatItCreatesPayloadForZMLastReadMessages() async throws {
         // Given
-        BackendInfo.storage = .temporary()
         BackendInfo.domain = "example.domain.com"
 
         let message = try await self.syncMOC.perform {

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+OTR_Legacy.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMClientMessageTests+OTR_Legacy.swift
@@ -23,12 +23,12 @@
 
     override func setUp() {
         DeveloperFlag.proteusViaCoreCrypto.enable(false, storage: .temporary())
+        BackendInfo.domain = nil
         super.setUp()
     }
 
     override func tearDown() {
         super.tearDown()
-        BackendInfo.domain = nil
         DeveloperFlag.storage = UserDefaults.standard
     }
 
@@ -293,7 +293,6 @@ extension ClientMessageTests_OTR_Legacy {
 
     func testThatItCreatesPayloadForZMLastReadMessages() async throws {
         // Given
-        BackendInfo.storage = .temporary()
         BackendInfo.domain = "example.domain.com"
 
         let message = try await self.syncMOC.perform {

--- a/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
+++ b/wire-ios-data-model/Tests/Source/Utils/LegacyPersistedDataPatchesTests.swift
@@ -131,6 +131,12 @@ class LegacyPersistedDataPatchesTests: ZMBaseManagedObjectTest {
         DeveloperFlag.storage = UserDefaults.standard
     }
 
+    override func setUp() {
+        super.setUp()
+
+        BackendInfo.domain = nil
+    }
+
     func testThatItApplyPatchesWhenNoVersion() {
 
         // GIVEN

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -508,6 +508,8 @@
 		BFF8AE8520E4E12A00988700 /* ZMMessage+ShouldDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF8AE8420E4E12A00988700 /* ZMMessage+ShouldDisplay.swift */; };
 		BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */; };
 		BFFBFD951D59E49D0079773E /* ZMClientMessageTests+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */; };
+		CB7979182C747652006FBA58 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7979172C747652006FBA58 /* WireTransportSupport.framework */; };
+		CB79791B2C7476AC006FBA58 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB79791A2C7476AC006FBA58 /* TestSetup.swift */; };
 		CE4EDC091D6D9A3D002A20AA /* Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4EDC081D6D9A3D002A20AA /* Reaction.swift */; };
 		CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */; };
 		CE58A3FF1CD3B3580037B626 /* ConversationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE58A3FE1CD3B3580037B626 /* ConversationMessage.swift */; };
@@ -1454,6 +1456,8 @@
 		BFF8AE8420E4E12A00988700 /* ZMMessage+ShouldDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+ShouldDisplay.swift"; sourceTree = "<group>"; };
 		BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationMessage+Deletion.swift"; sourceTree = "<group>"; };
 		BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Deletion.swift"; sourceTree = "<group>"; };
+		CB7979172C747652006FBA58 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB79791A2C7476AC006FBA58 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		CE4EDC081D6D9A3D002A20AA /* Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reaction.swift; path = Reaction/Reaction.swift; sourceTree = "<group>"; };
 		CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationMessage+Reaction.swift"; sourceTree = "<group>"; };
 		CE58A3FE1CD3B3580037B626 /* ConversationMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationMessage.swift; sourceTree = "<group>"; };
@@ -1916,6 +1920,7 @@
 				59D1C30E2B1DEC300016F6B2 /* WireDataModelSupport.framework in Frameworks */,
 				5996E8C72C1A0000007A52F0 /* OCMock.xcframework in Frameworks */,
 				5996E8B42C19F482007A52F0 /* WireTesting.framework in Frameworks */,
+				CB7979182C747652006FBA58 /* WireTransportSupport.framework in Frameworks */,
 				F9C9A5071CAD5DF10039E10C /* WireDataModel.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3287,6 +3292,7 @@
 				16E70F97270F1F5700718E5D /* ZMConnection+Helper.h */,
 				16E70FA6270F212000718E5D /* ZMConnection+Helper.m */,
 				5987962F2B45880400A6FC63 /* ZMUpdateEvent+allTypes.swift */,
+				CB79791A2C7476AC006FBA58 /* TestSetup.swift */,
 			);
 			name = Helper;
 			path = Tests/Source/Helper;
@@ -3568,6 +3574,7 @@
 		F9C9A6701CAD779E0039E10C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CB7979172C747652006FBA58 /* WireTransportSupport.framework */,
 				F9C9A66E1CAD77930039E10C /* CoreData.framework */,
 				EE8DA9662954A02B00F58B79 /* WireCryptobox.framework */,
 				EE8DA96F2954A03E00F58B79 /* WireImages.framework */,
@@ -4755,6 +4762,7 @@
 				E6A239932B7F6F82004E48C2 /* MockActorOneOnOneProtocolSelector.swift in Sources */,
 				5E454C60210638E300DB4501 /* PushTokenTests.swift in Sources */,
 				55C40BD722B0F78500EFD8BD /* ZMUserLegalHoldTests.swift in Sources */,
+				CB79791B2C7476AC006FBA58 /* TestSetup.swift in Sources */,
 				EE6CB3DE24E2D24F00B0EADD /* ZMGenericMessageDataTests.swift in Sources */,
 				F9C348861E2CC27D0015D69D /* NewUnreadMessageObserverTests.swift in Sources */,
 				63F376DA2834FF7200FE1F05 /* NSManagedObjectContextTests+Federation.swift in Sources */,

--- a/wire-ios-request-strategy/Tests/Helpers/TestSetup.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/TestSetup.swift
@@ -26,7 +26,7 @@ final class TestSetup: NSObject {
         super.init()
 
         XCTestObservationCenter.shared.addTestObserver(
-            makeBackendInfoTestObservation(
+            makeBackendInfoTestObserver(
                 apiVersion: .v0,
                 preferredAPIVersion: nil,
                 domain: "wire.com",

--- a/wire-ios-share-engine/WireShareEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-share-engine/WireShareEngine.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		166DCD9E2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166DCD9D2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift */; };
 		5470D3F31D76E1B000FDE440 /* WireShareEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */; };
 		BFA18BD41D806050005C281B /* BaseSharingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */; };
+		CB79791D2C748580006FBA58 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB79791C2C748580006FBA58 /* TestSetup.swift */; };
 		CE7FBFC41E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */; };
 		CEB50AEC1DF9BADF00211B30 /* OperationLoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB50AEB1DF9BADF00211B30 /* OperationLoopTests.swift */; };
 		E6E504522BC58ACD004948E7 /* WireDataModelSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6E504512BC58ACD004948E7 /* WireDataModelSupport.framework */; };
@@ -96,6 +97,7 @@
 		5470D42B1D770CEE00FDE440 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		5470D42C1D770CEE00FDE440 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseSharingSessionTests.swift; sourceTree = "<group>"; };
+		CB79791C2C748580006FBA58 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestGeneratorStoreTests.swift; sourceTree = "<group>"; };
 		CEB50AEB1DF9BADF00211B30 /* OperationLoopTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationLoopTests.swift; sourceTree = "<group>"; };
 		E6E504512BC58ACD004948E7 /* WireDataModelSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDataModelSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -189,6 +191,7 @@
 				166DCD9D2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift */,
 				CEB50AEB1DF9BADF00211B30 /* OperationLoopTests.swift */,
 				CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */,
+				CB79791C2C748580006FBA58 /* TestSetup.swift */,
 			);
 			path = WireShareEngineTests;
 			sourceTree = "<group>";
@@ -432,6 +435,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE7FBFC41E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift in Sources */,
+				CB79791D2C748580006FBA58 /* TestSetup.swift in Sources */,
 				BFA18BD41D806050005C281B /* BaseSharingSessionTests.swift in Sources */,
 				CEB50AEC1DF9BADF00211B30 /* OperationLoopTests.swift in Sources */,
 				166DCD9E2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift in Sources */,

--- a/wire-ios-share-engine/WireShareEngineTests/Info.plist
+++ b/wire-ios-share-engine/WireShareEngineTests/Info.plist
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>$(PRODUCT_NAME).TestSetup</string>
 </dict>
 </plist>

--- a/wire-ios-share-engine/WireShareEngineTests/TestSetup.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/TestSetup.swift
@@ -1,0 +1,37 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireTransport
+import WireTransportSupport
+import XCTest
+
+final class TestSetup: NSObject, XCTestObservation {
+    override init() {
+        super.init()
+
+        XCTestObservationCenter.shared.addTestObserver(
+            makeBackendInfoTestObservation(
+                apiVersion: .v0,
+                preferredAPIVersion: nil,
+                domain: "wire.com",
+                isFederationEnabled: false
+            )
+        )
+    }
+
+}

--- a/wire-ios-share-engine/WireShareEngineTests/TestSetup.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/TestSetup.swift
@@ -25,7 +25,7 @@ final class TestSetup: NSObject, XCTestObservation {
         super.init()
 
         XCTestObservationCenter.shared.addTestObserver(
-            makeBackendInfoTestObservation(
+            makeBackendInfoTestObserver(
                 apiVersion: .v0,
                 preferredAPIVersion: nil,
                 domain: "wire.com",

--- a/wire-ios-sync-engine/Tests/Source/TestSetup.swift
+++ b/wire-ios-sync-engine/Tests/Source/TestSetup.swift
@@ -25,7 +25,7 @@ final class TestSetup: NSObject, XCTestObservation {
         super.init()
 
         XCTestObservationCenter.shared.addTestObserver(
-            makeBackendInfoTestObservation(
+            makeBackendInfoTestObserver(
                 apiVersion: .v0,
                 preferredAPIVersion: nil,
                 domain: "wire.com",

--- a/wire-ios-transport/WireTransportSupport/BackendInfoTestObserver.swift
+++ b/wire-ios-transport/WireTransportSupport/BackendInfoTestObserver.swift
@@ -19,7 +19,7 @@
 import WireTransport
 import XCTest
 
-public func makeBackendInfoTestObservation(
+public func makeBackendInfoTestObserver(
     apiVersion: APIVersion?,
     preferredAPIVersion: APIVersion?,
     domain: String?,

--- a/wire-ios/Wire-iOS Tests/Utils/TestSetup.swift
+++ b/wire-ios/Wire-iOS Tests/Utils/TestSetup.swift
@@ -29,7 +29,7 @@ final class TestSetup: NSObject {
         super.init()
 
         XCTestObservationCenter.shared.addTestObserver(
-            makeBackendInfoTestObservation(
+            makeBackendInfoTestObserver(
                 apiVersion: .v0,
                 preferredAPIVersion: nil,
                 domain: "wire.com",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10065" title="WPB-10065" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10065</a>  iOS: fix unit tests without backend info
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR follows on from [fix/unit-tests-using-backend-info-test-observer](https://github.com/wireapp/wire-ios/pull/1837). It adds a `BackendInfoTestObserver` to the remaining Test bundles that have tests that directly mutate `BackendInfo`. If merged I will finally consider [`WPB-10065`](https://wearezeta.atlassian.net/browse/WPB-10065) done.

### Testing

No manual tests are necessary. Only running automated tests.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
