### PR TITLE
chore: bump avs to 9.8.19 - no ticket

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "wire-avs.json" "9.8.18"
+binary "wire-avs.json" "9.8.19"
 github "wireapp/Down" "v2.3.4_xcframework"
 github "wireapp/HTMLString" "6.0.1_xcframework"
 github "wireapp/ZipArchive" "v2.4.2"

--- a/wire-avs.json
+++ b/wire-avs.json
@@ -1,3 +1,3 @@
 {
-  "9.8.18": "https://github.com/wireapp/wire-avs/releases/download/9.8.18/avs.xcframework.zip",
+  "9.8.19": "https://github.com/wireapp/wire-avs/releases/download/9.8.19/avs.xcframework.zip",
 }


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

bump avs to 9.8.19


