### PR TITLE
chore: Remove pre iOS 14 UIDocumentPickerViewController code - WPB-6803

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
@@ -80,7 +80,7 @@ final class BackupRestoreController: NSObject {
             forOpeningContentTypes: BackupRestoreController.WireBackupUTIs.compactMap { UTType($0) },
             asCopy: true
         )
-        
+
         picker.delegate = self
         target.present(picker, animated: true)
     }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Backup/BackupRestoreController.swift
@@ -76,15 +76,11 @@ final class BackupRestoreController: NSObject {
     }
 
     private func showFilePicker() {
-        let picker: UIDocumentPickerViewController
-        if #available(iOS 14.0, *) {
-            picker = UIDocumentPickerViewController(
-                forOpeningContentTypes: BackupRestoreController.WireBackupUTIs.compactMap { UTType($0) },
-                asCopy: true)
-        } else {
-            picker = UIDocumentPickerViewController(documentTypes: BackupRestoreController.WireBackupUTIs, in: .import)
-        }
-
+        let picker = UIDocumentPickerViewController(
+            forOpeningContentTypes: BackupRestoreController.WireBackupUTIs.compactMap { UTType($0) },
+            asCopy: true
+        )
+        
         picker.delegate = self
         target.present(picker, animated: true)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-6803" title="WPB-6803" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-6803</a>  [iOS] Can't select backup file in Google Drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR just removes some pre iOS 14 code.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

