### PR TITLE
fix: can't send messages on API v1 - WPB-10496

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Payload.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload.swift
@@ -374,7 +374,47 @@ public enum Payload {
         let deleted: ClientListByUserID
     }
 
-    public struct MessageSendingStatus: Codable, Equatable {
+    public struct MessageSendingStatusV1: Codable, Equatable {
+
+        enum CodingKeys: String, CodingKey {
+            case time
+            case missing
+            case redundant
+            case deleted
+            case failedToSend = "failed_to_send"
+        }
+
+        /// Time of sending message.
+        let time: Date
+
+        /// Clients that the message should have been encrypted for, but wasn't.
+        let missing: ClientListByQualifiedUserID
+
+        /// Clients that the message was encrypted for, but isn't necessary. For
+        /// example for a client who's user has been removed from the conversation.
+        let redundant: ClientListByQualifiedUserID
+
+        /// Clients that the message was encrypted for, but has since been deleted.
+        let deleted: ClientListByQualifiedUserID
+
+        /// When a message is partially sent contains the list of clients which
+        /// didn't receive the message.
+        let failedToSend: ClientListByQualifiedUserID
+
+        func toAPIModel() -> MessageSendingStatus {
+            MessageSendingStatus(
+                time: time,
+                missing: missing,
+                redundant: redundant,
+                deleted: deleted,
+                failedToSend: failedToSend,
+                failedToConfirm: [:]
+            )
+        }
+
+    }
+
+    public struct MessageSendingStatusV4: Codable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case time
@@ -385,7 +425,48 @@ public enum Payload {
             case failedToConfirm = "failed_to_confirm_clients"
         }
 
-        public init(time: Date, missing: ClientListByQualifiedUserID, redundant: ClientListByQualifiedUserID, deleted: ClientListByQualifiedUserID, failedToSend: ClientListByQualifiedUserID, failedToConfirm: ClientListByQualifiedUserID) {
+        /// Time of sending message.
+        let time: Date
+
+        /// Clients that the message should have been encrypted for, but wasn't.
+        let missing: ClientListByQualifiedUserID
+
+        /// Clients that the message was encrypted for, but isn't necessary. For
+        /// example for a client who's user has been removed from the conversation.
+        let redundant: ClientListByQualifiedUserID
+
+        /// Clients that the message was encrypted for, but has since been deleted.
+        let deleted: ClientListByQualifiedUserID
+
+        /// When a message is partially sent contains the list of clients which
+        /// didn't receive the message.
+        let failedToSend: ClientListByQualifiedUserID
+
+        /// The lists the users for which the client verification could not be performed.
+        let failedToConfirm: ClientListByQualifiedUserID
+
+        func toAPIModel() -> MessageSendingStatus {
+            MessageSendingStatus(
+                time: time,
+                missing: missing,
+                redundant: redundant,
+                deleted: deleted,
+                failedToSend: failedToSend,
+                failedToConfirm: failedToConfirm
+            )
+        }
+    }
+
+    public struct MessageSendingStatus: Equatable {
+
+        public init(
+            time: Date,
+            missing: ClientListByQualifiedUserID,
+            redundant: ClientListByQualifiedUserID,
+            deleted: ClientListByQualifiedUserID,
+            failedToSend: ClientListByQualifiedUserID,
+            failedToConfirm: ClientListByQualifiedUserID
+        ) {
             self.time = time
             self.missing = missing
             self.redundant = redundant

--- a/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
@@ -162,7 +162,6 @@ extension OTREntity {
                 context: context
             )
 
-
         case .v4, .v5, .v6:
             guard let payload = Payload.MessageSendingStatusV4(response) else {
                 return (missingClients: Set(), deletedClients: Set())

--- a/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
+++ b/wire-ios-request-strategy/Sources/Protocols/OTREntity.swift
@@ -149,13 +149,27 @@ extension OTREntity {
                 in: context
             )
 
-        case .v1, .v2, .v3, .v4, .v5, .v6:
-            guard let payload = Payload.MessageSendingStatus(response) else {
+        case .v1, .v2, .v3:
+            guard let payload = Payload.MessageSendingStatusV1(
+                response,
+                decoder: .defaultDecoder
+            ) else {
                 return (missingClients: Set(), deletedClients: Set())
             }
 
             clientListByUser = processor.missingClientListByUser(
-                from: payload,
+                from: payload.toAPIModel(),
+                context: context
+            )
+
+
+        case .v4, .v5, .v6:
+            guard let payload = Payload.MessageSendingStatusV4(response) else {
+                return (missingClients: Set(), deletedClients: Set())
+            }
+
+            clientListByUser = processor.missingClientListByUser(
+                from: payload.toAPIModel(),
                 context: context
             )
         }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
@@ -74,7 +74,6 @@ extension Payload.MessageSendingStatusV4: TransportDataConvertible {
     }
 }
 
-
 class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
 
     var sut: VerifyLegalHoldRequestStrategy!
@@ -173,8 +172,6 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
                 transportData = Payload.MessageSendingStatusV1(missing: [self.otherUser.domain!: clientListByUserID]).transportData
             case .v4, .v5, .v6:
                 transportData = Payload.MessageSendingStatusV4(missing: [self.otherUser.domain!: clientListByUserID]).transportData
-
-
             }
 
             // WHEN

--- a/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User Clients/VerifyLegalHoldRequestStrategyTests.swift
@@ -49,7 +49,19 @@ private struct ClientUpdateResponse: Codable, TransportDataConvertible {
     }
 }
 
-extension Payload.MessageSendingStatus: TransportDataConvertible {
+extension Payload.MessageSendingStatusV1: TransportDataConvertible {
+    fileprivate init(missing: UserListByDomain) {
+        self.init(
+            time: .init(),
+            missing: missing,
+            redundant: .init(),
+            deleted: .init(),
+            failedToSend: .init()
+        )
+    }
+}
+
+extension Payload.MessageSendingStatusV4: TransportDataConvertible {
     fileprivate init(missing: UserListByDomain) {
         self.init(
             time: .init(),
@@ -61,6 +73,7 @@ extension Payload.MessageSendingStatus: TransportDataConvertible {
         )
     }
 }
+
 
 class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
 
@@ -156,8 +169,11 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: clientListByUserID).transportData
-            case .v1, .v2, .v3, .v4, .v5, .v6:
-                transportData = Payload.MessageSendingStatus(missing: [self.otherUser.domain!: clientListByUserID]).transportData
+            case .v1, .v2, .v3:
+                transportData = Payload.MessageSendingStatusV1(missing: [self.otherUser.domain!: clientListByUserID]).transportData
+            case .v4, .v5, .v6:
+                transportData = Payload.MessageSendingStatusV4(missing: [self.otherUser.domain!: clientListByUserID]).transportData
+
 
             }
 
@@ -200,8 +216,10 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: clientListByUserID).transportData
-            case .v1, .v2, .v3, .v4, .v5, .v6:
-                transportData = Payload.MessageSendingStatus(missing: [self.otherUser.domain!: clientListByUserID]).transportData
+            case .v1, .v2, .v3:
+                transportData = Payload.MessageSendingStatusV1(missing: [self.otherUser.domain!: clientListByUserID]).transportData
+            case .v4, .v5, .v6:
+                transportData = Payload.MessageSendingStatusV4(missing: [self.otherUser.domain!: clientListByUserID]).transportData
             }
 
             // WHEN
@@ -241,8 +259,10 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: ClientListByUser()).transportData
-            case .v1, .v2, .v3, .v4, .v5, .v6:
-                transportData = Payload.MessageSendingStatus(missing: UserListByDomain()).transportData
+            case .v1, .v2, .v3:
+                transportData = Payload.MessageSendingStatusV1(missing: UserListByDomain()).transportData
+            case .v4, .v5, .v6:
+                transportData = Payload.MessageSendingStatusV4(missing: UserListByDomain()).transportData
             }
 
             // WHEN
@@ -281,8 +301,10 @@ class VerifyLegalHoldRequestStrategyTests: MessagingTestBase {
             switch apiVersion {
             case .v0:
                 transportData = ClientUpdateResponse(missing: clientListByUserID).transportData
-            case .v1, .v2, .v3, .v4, .v5, .v6:
-                transportData = Payload.MessageSendingStatus(missing: [selfUser.domain!: clientListByUserID]).transportData
+            case .v1, .v2, .v3:
+                transportData = Payload.MessageSendingStatusV1(missing: [selfUser.domain!: clientListByUserID]).transportData
+            case .v4, .v5, .v6:
+                transportData = Payload.MessageSendingStatusV4(missing: [selfUser.domain!: clientListByUserID]).transportData
             }
 
             // WHEN


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10496" title="WPB-10496" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10496</a>  Client experiencing issues with new iOS version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Given an old backend that only supports API v1, when a user tries to send a message, then it will fail and expire.

### Cause

In API v4, the `MessageSendingStatus` payload that is returned from endpoints that send proteus messages got a new required field `failed_to_confirm_clients`. Although this field was added in v4, it was also added to all previous versions on the cloud backend, but would always be an empty set. As a result of this, the iOS client could in fact parse the response expecting the field to be there and it wouldn't fail for API versions before v4. This is exactly what we were doing.

For an old backend though whose max API version is v1 (but could also be v2 or v3), this field would not be present. When using the public iOS client, that always expected the `failed_to_confirm_clients` field, it would fail with a decoding error and then expire the message.

### Solution

Go through the `MessageAPI` and use decode the correct response payloads for all the endpoints:
- MessageSendingStatusV0
- MessageSendingStatusV1
- MessageSendingStatusV4

### Testing

Log in to an old v1 backend and send a message.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
