### PR TITLE
fix: video calls fail immediately - WPB-10762

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -433,7 +433,11 @@ extension WireCallCenterV3 {
     /// Call this method when the callParticipants changed and avs calls the handler `wcall_participant_changed_h`
     func callParticipantsChanged(conversationId: AVSIdentifier, participants: [AVSCallMember]) {
         guard isEnabled else { return }
-        guard !shouldEndCall(conversationId: conversationId, participants: participants) else {
+        let shouldEndCall = shouldEndCall(
+            conversationId: conversationId,
+            previousParticipants: callSnapshots[conversationId]?.callParticipants.members.array ?? [],
+            newParticipants: participants)
+        guard !shouldEndCall else {
             endAllCalls()
             return
         }
@@ -456,15 +460,18 @@ extension WireCallCenterV3 {
 
 }
 
-// MARK: - Call ending helpers
+// MARK: - Call ending for oneOnOne conversations
 
 extension WireCallCenterV3 {
 
-    /// This is a short term solution for 1:1 calls via SFT.
     /// We treat 1:1 calls as conferences (via SFT) if `useSFTForOneToOneCalls` from the `conferenceCalling` feature is `true`.
     /// If the other user hangs up, we should end the call for the self user.
     /// More info (Option 1): https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT
-    private func shouldEndCall(conversationId: AVSIdentifier, participants: [AVSCallMember]) -> Bool {
+    private func shouldEndCall(
+        conversationId: AVSIdentifier,
+        previousParticipants: [AVSCallMember],
+        newParticipants: [AVSCallMember]
+    ) -> Bool {
         guard let context = uiMOC,
               let conversation = ZMConversation.fetch(
                 with: conversationId.identifier,
@@ -478,23 +485,36 @@ extension WireCallCenterV3 {
 
         switch conversation.messageProtocol {
         case .mls:
-            return shouldEndCallForMLS(participants: participants)
+            return shouldEndCallForMLS(
+                previousParticipants: previousParticipants,
+                newParticipants: newParticipants)
         case .mixed, .proteus:
-            return shouldEndCallForProteus(participants: participants)
+            return shouldEndCallForProteus(
+                previousParticipants: previousParticipants,
+                newParticipants: newParticipants)
         }
     }
 
-    private func shouldEndCallForMLS(participants: [AVSCallMember]) -> Bool {
+    private func shouldEndCallForMLS(
+        previousParticipants: [AVSCallMember],
+        newParticipants: [AVSCallMember]
+    ) -> Bool {
         /// We assume that the 2nd participant is the other user, and if the other user's audio state is connecting, the call should end.
-        guard participants.count == 2,
-              participants[1].audioState == .connecting else {
+        guard
+            previousParticipants.count == 2,
+            newParticipants.count == 2,
+            newParticipants[1].audioState == .connecting
+        else {
             return false
         }
         return true
     }
 
-    private func shouldEndCallForProteus(participants: [AVSCallMember]) -> Bool {
-        return participants.count == 1
+    private func shouldEndCallForProteus(
+        previousParticipants: [AVSCallMember],
+        newParticipants: [AVSCallMember]
+    ) -> Bool {
+        return previousParticipants.count == 2 && newParticipants.count == 1
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10762" title="WPB-10762" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10762</a>  [iOS] Video calls fail immediately
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR is cherry-picked based on the following PR:

https://github.com/wireapp/wire-ios/pull/1877

**Original PR description:**
The video call in 1:1 ends after a couple of seconds.

**Solution**
The issues was introduces when we implemented "[1:1 calls over SFT](https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT)".
Since 1:1 calls should be treated as group calls (if the feature flag for the team is enabled), we implemented a way to drop the call if one (out of two, since it is a 1:1 call) of the participants has already ended it.
One requirement was missing, we need to check that the previous participant count was 2, the new one is 1 and the call is established. This requirement has been added in this PR.

### Testing


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
