### PR TITLE
fix: upcoming feature settings in package targets - WPB-10949

### DIFF
--- a/WireAPI/Package.swift
+++ b/WireAPI/Package.swift
@@ -18,13 +18,11 @@ let package = Package(
     targets: [
         .target(
             name: "WireAPI",
-            dependencies: ["WireUtilitiesPackage"],
-            swiftSettings: swiftSettings
+            dependencies: ["WireUtilitiesPackage"]
         ),
         .target(
             name: "WireAPISupport",
             dependencies: ["WireAPI"],
-            swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "SourceryPlugin", package: "SourceryPlugin")
             ]
@@ -48,14 +46,15 @@ let package = Package(
                 .process("APIs/UserPropertiesAPI/Resources"),
                 .process("APIs/SelfUserAPI/Resources"),
                 .process("Network/PushChannel/Resources")
-            ],
-            swiftSettings: swiftSettings
+            ]
         )
     ]
 )
 
-let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency")
-]
+for target in package.targets {
+    target.swiftSettings = [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("GlobalConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/WireAPI/Package.swift
+++ b/WireAPI/Package.swift
@@ -52,6 +52,9 @@ let package = Package(
 )
 
 for target in package.targets {
+    // remove this once we updated the Sourcery stencil to support existential any
+    guard target.name != "WireAPISupport" else { continue }
+
     target.swiftSettings = [
         .enableUpcomingFeature("ExistentialAny"),
         .enableUpcomingFeature("GlobalConcurrency"),

--- a/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
@@ -24,9 +24,9 @@ class ConnectionsAPIV0: ConnectionsAPI, VersionedAPI {
         static let batchSize = 500
     }
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPIV0.swift
@@ -30,11 +30,11 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
 
     var apiVersion: APIVersion { .v0 }
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
     // MARK: - Initialize
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/FeatureConfigsAPI/FeatureConfigsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/FeatureConfigsAPI/FeatureConfigsAPIV0.swift
@@ -20,9 +20,9 @@ import Foundation
 
 class FeatureConfigsAPIV0: FeatureConfigsAPI, VersionedAPI {
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/SelfUserAPI/SelfUserAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/SelfUserAPI/SelfUserAPIV0.swift
@@ -20,9 +20,9 @@ import Foundation
 
 class SelfUserAPIV0: SelfUserAPI, VersionedAPI {
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
@@ -20,9 +20,9 @@ import Foundation
 
 class TeamsAPIV0: TeamsAPI, VersionedAPI {
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Event decoding/UpdateEventDecodingProxyError.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Event decoding/UpdateEventDecodingProxyError.swift
@@ -28,7 +28,7 @@ public struct UpdateEventDecodingProxyError: Error, CustomStringConvertible {
 
     /// The error that occurred when decoding.
 
-    public let decodingError: Error
+    public let decodingError: any Error
 
     /// A textual representation of the error.
 

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
@@ -20,9 +20,9 @@ import Foundation
 
 class UpdateEventsAPIV0: UpdateEventsAPI, VersionedAPI {
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/UserPropertiesAPI/UserPropertiesAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UserPropertiesAPI/UserPropertiesAPIV0.swift
@@ -20,9 +20,9 @@ import Foundation
 
 class UserPropertiesAPIV0: UserPropertiesAPI, VersionedAPI {
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/UsersAPI/UsersAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UsersAPI/UsersAPIV0.swift
@@ -20,9 +20,9 @@ import Foundation
 
 class UsersAPIV0: UsersAPI, VersionedAPI {
 
-    let httpClient: HTTPClient
+    let httpClient: any HTTPClient
 
-    init(httpClient: HTTPClient) {
+    init(httpClient: any HTTPClient) {
         self.httpClient = httpClient
     }
 

--- a/WireAPI/Sources/WireAPI/Components/ResponseParser.swift
+++ b/WireAPI/Sources/WireAPI/Components/ResponseParser.swift
@@ -73,7 +73,7 @@ struct ResponseParser<Success> {
     func failure(
         code: HTTPStatusCode,
         label: String = "",
-        error: Error
+        error: any Error
     ) -> ResponseParser<Success> {
         var copy = self
         copy.parseBlocks.append { _, data in

--- a/WireAPI/Sources/WireAPI/Network/APIService/PushChannelService.swift
+++ b/WireAPI/Sources/WireAPI/Network/APIService/PushChannelService.swift
@@ -125,7 +125,7 @@ extension PushChannelService: URLSessionDataDelegate {
     public func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
-        didCompleteWithError error: Error?
+        didCompleteWithError error: (any Error)?
     ) {
         // When does this get called? My guess is that it's for the initial request.
         if let error {

--- a/WireAPI/Sources/WireAPI/Network/PushChannel/PushChannel.swift
+++ b/WireAPI/Sources/WireAPI/Network/PushChannel/PushChannel.swift
@@ -21,7 +21,7 @@ import WireUtilitiesPkg
 
 final class PushChannel: PushChannelProtocol {
 
-    typealias Stream = AsyncThrowingStream<UpdateEventEnvelope, Error>
+    typealias Stream = AsyncThrowingStream<UpdateEventEnvelope, any Error>
 
     private let request: URLRequest
     private let webSocket: any WebSocketProtocol

--- a/WireAPI/Sources/WireAPI/Network/PushChannel/PushChannelProtocol.swift
+++ b/WireAPI/Sources/WireAPI/Network/PushChannel/PushChannelProtocol.swift
@@ -26,7 +26,7 @@ public protocol PushChannelProtocol {
     ///
     /// - Returns: An async stream of live update event envelopes.
 
-    func open() throws -> AsyncThrowingStream<UpdateEventEnvelope, Error>
+    func open() throws -> AsyncThrowingStream<UpdateEventEnvelope, any Error>
 
     /// Close the push channel and stop receiving update events.
 

--- a/WireAPI/Sources/WireAPI/Network/PushChannel/WebSocketProtocol.swift
+++ b/WireAPI/Sources/WireAPI/Network/PushChannel/WebSocketProtocol.swift
@@ -21,7 +21,7 @@ import Foundation
 // sourcery: AutoMockable
 protocol WebSocketProtocol {
 
-    func open() throws -> AsyncThrowingStream<URLSessionWebSocketTask.Message, Error>
+    func open() throws -> AsyncThrowingStream<URLSessionWebSocketTask.Message, any Error>
 
     func close()
 

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/ConnectionsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/ConnectionsAPITests.swift
@@ -26,7 +26,7 @@ class ConnectionsAPITests: XCTestCase {
     /// Verifies generation of request for each API versions
     func testGetConnectionsRequest() async throws {
         // given
-        let apiSnapshotHelper = APISnapshotHelper<ConnectionsAPI> { httpClient, apiVersion in
+        let apiSnapshotHelper = APISnapshotHelper<any ConnectionsAPI> { httpClient, apiVersion in
             let builder = ConnectionsAPIBuilder(httpClient: httpClient)
             return builder.makeAPI(for: apiVersion)
         }

--- a/WireAPI/Tests/WireAPITests/APIs/ConversationsAPI/ConversationsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/ConversationsAPI/ConversationsAPITests.swift
@@ -23,7 +23,7 @@ import XCTest
 final class ConversationsAPITests: XCTestCase {
 
     private var httpRequestSnapshotHelper: HTTPRequestSnapshotHelper!
-    private var apiSnapshotHelper: APISnapshotHelper<ConversationsAPI>!
+    private var apiSnapshotHelper: APISnapshotHelper<any ConversationsAPI>!
 
     // MARK: - Setup
 
@@ -31,7 +31,7 @@ final class ConversationsAPITests: XCTestCase {
         super.setUp()
 
         httpRequestSnapshotHelper = HTTPRequestSnapshotHelper()
-        apiSnapshotHelper = APISnapshotHelper<ConversationsAPI> { httpClient, apiVersion in
+        apiSnapshotHelper = APISnapshotHelper<any ConversationsAPI> { httpClient, apiVersion in
             let builder = ConversationsAPIBuilder(httpClient: httpClient)
             return builder.makeAPI(for: apiVersion)
         }

--- a/WireAPI/Tests/WireAPITests/APIs/FeatureConfigsAPI/FeatureConfigsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/FeatureConfigsAPI/FeatureConfigsAPITests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 final class FeatureConfigsAPITests: XCTestCase {
 
-    private var apiSnapshotHelper: APISnapshotHelper<FeatureConfigsAPI>!
+    private var apiSnapshotHelper: APISnapshotHelper<any FeatureConfigsAPI>!
 
     // MARK: - Setup
 
@@ -403,7 +403,7 @@ extension FeatureConfigsAPITests {
 
 private extension APIVersion {
 
-    func buildAPI(client: any HTTPClient) -> FeatureConfigsAPI {
+    func buildAPI(client: any HTTPClient) -> any FeatureConfigsAPI {
         let builder = FeatureConfigsAPIBuilder(httpClient: client)
         return builder.makeAPI(for: self)
     }

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/SelfUserAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/SelfUserAPITests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 final class SelfUserAPITests: XCTestCase {
 
-    private var apiSnapshotHelper: APISnapshotHelper<SelfUserAPI>!
+    private var apiSnapshotHelper: APISnapshotHelper<any SelfUserAPI>!
 
     // MARK: - Setup
 
@@ -249,7 +249,7 @@ extension SelfUserAPITests {
 }
 
 private extension APIVersion {
-    func buildAPI(client: any HTTPClient) -> SelfUserAPI {
+    func buildAPI(client: any HTTPClient) -> any SelfUserAPI {
         let builder = SelfUserAPIBuilder(httpClient: client)
         return builder.makeAPI(for: self)
     }

--- a/WireAPI/Tests/WireAPITests/APIs/TeamsAPI/TeamsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/TeamsAPI/TeamsAPITests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 final class TeamsAPITests: XCTestCase {
 
-    private var apiSnapshotHelper: APISnapshotHelper<TeamsAPI>!
+    private var apiSnapshotHelper: APISnapshotHelper<any TeamsAPI>!
 
     // MARK: - Setup
 

--- a/WireAPI/Tests/WireAPITests/APIs/UpdateEventsAPI/UpdateEventsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UpdateEventsAPI/UpdateEventsAPITests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 final class UpdateEventsAPITests: XCTestCase {
 
-    private func createSnapshotter() -> APISnapshotHelper<UpdateEventsAPI> {
+    private func createSnapshotter() -> APISnapshotHelper<any UpdateEventsAPI> {
         APISnapshotHelper { httpClient, apiVersion in
             UpdateEventsAPIBuilder(httpClient: httpClient)
                 .makeAPI(for: apiVersion)

--- a/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/UserPropertiesAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/UserPropertiesAPITests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 final class UserPropertiesAPITests: XCTestCase {
 
-    private var apiSnapshotHelper: APISnapshotHelper<UserPropertiesAPI>!
+    private var apiSnapshotHelper: APISnapshotHelper<any UserPropertiesAPI>!
 
     // MARK: - Setup
 

--- a/WireAPI/Tests/WireAPITests/APIs/UsersAPI/UsersAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UsersAPI/UsersAPITests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 final class UsersAPITests: XCTestCase {
 
-    private var apiSnapshotHelper: APISnapshotHelper<UsersAPI>!
+    private var apiSnapshotHelper: APISnapshotHelper<any UsersAPI>!
 
     // MARK: - Setup
 

--- a/WireAnalytics/Package.swift
+++ b/WireAnalytics/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
     targets: [
         .target(
             name: "WireAnalytics",
-            dependencies: resolveWireAnalyticsDependencies(),
-            swiftSettings: swiftSettings
+            dependencies: resolveWireAnalyticsDependencies()
         ),
         .target(
             name: "WireDatadog",
@@ -27,8 +26,7 @@ let package = Package(
                 .product(name: "DatadogLogs", package: "dd-sdk-ios"),
                 .product(name: "DatadogRUM", package: "dd-sdk-ios"),
                 .product(name: "DatadogTrace", package: "dd-sdk-ios")
-            ],
-            swiftSettings: swiftSettings
+            ]
         )
     ]
 )
@@ -50,8 +48,10 @@ func hasEnvironmentVariable(_ name: String, _ value: String? = nil) -> Bool {
     }
 }
 
-let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency")
-]
+for target in package.targets {
+    target.swiftSettings = [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("GlobalConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/WireDomain/Package.swift
+++ b/WireDomain/Package.swift
@@ -16,14 +16,13 @@ let package = Package(
         .package(name: "WireAPI", path: "../WireAPI")
     ],
     targets: [
-        .target(name: "WireDomainPkg", dependencies: ["WireAPI"], path: "./Sources/Package", swiftSettings: swiftSettings),
+        .target(name: "WireDomainPkg", dependencies: ["WireAPI"], path: "./Sources/Package"),
         .testTarget(name: "WireDomainPkgTests", dependencies: ["WireDomainPkg"], path: "./Tests/PackageTests"),
 
         .target(
             name: "WireDomainPkgSupport",
             dependencies: ["WireDomainPkg"],
             path: "./Sources/PackageSupport",
-            swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "SourceryPlugin", package: "SourceryPlugin")
             ]
@@ -31,8 +30,10 @@ let package = Package(
     ]
 )
 
-let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency")
-]
+for target in package.targets {
+    target.swiftSettings = [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("GlobalConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/WireSystem/Package.swift
+++ b/WireSystem/Package.swift
@@ -15,14 +15,13 @@ let package = Package(
         .package(path: "../SourceryPlugin")
     ],
     targets: [
-        .target(name: "WireSystemPackage", path: "./Sources/WireSystem", swiftSettings: swiftSettings),
+        .target(name: "WireSystemPackage", path: "./Sources/WireSystem"),
         .testTarget(name: "WireSystemPackageTests", dependencies: ["WireSystemPackage"], path: "./Tests/WireSystemTests"),
 
         .target(
             name: "WireSystemPackageSupport",
             dependencies: ["WireSystemPackage"],
             path: "./Sources/WireSystemSupport",
-            swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "SourceryPlugin", package: "SourceryPlugin")
             ]
@@ -30,8 +29,10 @@ let package = Package(
     ]
 )
 
-let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency")
-]
+for target in package.targets {
+    target.swiftSettings = [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("GlobalConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/WireTesting/Package.swift
+++ b/WireTesting/Package.swift
@@ -21,15 +21,16 @@ let package = Package(
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
                 .product(name: "WireSystemPackageSupport", package: "WireSystemPackage")
             ],
-            path: "./Sources/WireTesting",
-            swiftSettings: swiftSettings
+            path: "./Sources/WireTesting"
         ),
         .testTarget(name: "WireTestingPkgTests", dependencies: ["WireTestingPkg"], path: "./Tests/WireTestingTests")
     ]
 )
 
-let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency")
-]
+for target in package.targets {
+    target.swiftSettings = [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("GlobalConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/WireUtilities/Package.swift
+++ b/WireUtilities/Package.swift
@@ -16,14 +16,13 @@ let package = Package(
         .package(name: "WireSystemPackage", path: "../WireSystem")
     ],
     targets: [
-        .target(name: "WireUtilitiesPkg", dependencies: ["WireSystemPackage"], path: "./Sources/WireUtilities", swiftSettings: swiftSettings),
-        .testTarget(name: "WireUtilitiesPkgTests", dependencies: ["WireUtilitiesPkg"], path: "./Tests/WireUtilitiesTests", swiftSettings: swiftSettings),
+        .target(name: "WireUtilitiesPkg", dependencies: ["WireSystemPackage"], path: "./Sources/WireUtilities"),
+        .testTarget(name: "WireUtilitiesPkgTests", dependencies: ["WireUtilitiesPkg"], path: "./Tests/WireUtilitiesTests"),
 
         .target(
             name: "WireUtilitiesPkgSupport",
             dependencies: ["WireUtilitiesPkg"],
             path: "./Sources/WireUtilitiesSupport",
-            swiftSettings: swiftSettings,
             plugins: [
                 .plugin(name: "SourceryPlugin", package: "SourceryPlugin")
             ]
@@ -31,8 +30,10 @@ let package = Package(
     ]
 )
 
-let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("GlobalConcurrency"),
-    .enableExperimentalFeature("StrictConcurrency")
-]
+for target in package.targets {
+    target.swiftSettings = [
+        .enableUpcomingFeature("ExistentialAny"),
+        .enableUpcomingFeature("GlobalConcurrency"),
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/WireUtilities/Sources/WireUtilities/AsyncSequence+ToStream.swift
+++ b/WireUtilities/Sources/WireUtilities/AsyncSequence+ToStream.swift
@@ -24,7 +24,7 @@ public extension AsyncSequence {
     ///
     /// - Returns: An `AsyncThrowingStream` of the same element.
 
-    func toStream() -> AsyncThrowingStream<Element, Error> {
+    func toStream() -> AsyncThrowingStream<Element, any Error> {
         var iterator = makeAsyncIterator()
         return AsyncThrowingStream {
             try await iterator.next()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10949" title="WPB-10949" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10949</a>  Fix Swift compilation settings in packages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Enabling `ExistentialAny`, `GlobalConcurrency` and `StrictConcurrency` for our Swift packages didn't seem to work properly.
This PR takes a different approach:
Instead of passing a "swiftSettings" argument now a loop adds the settings to all targets of a package.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
