### PR TITLE
feat: Track analytic events related to video audio and file messages - WPB-10953

### DIFF
--- a/wire-ios-sync-engine/Source/Use cases/AppendFileMessageUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/AppendFileMessageUseCase.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAnalytics
+import WireDataModel
+
+public protocol AppendFileMessageUseCaseProtocol {
+    func invoke<Conversation: MessageAppendableConversation>(
+        with fileMetadata: ZMFileMetadata,
+        in conversation: Conversation
+    ) throws
+}
+
+public struct AppendFileMessageUseCase: AppendFileMessageUseCaseProtocol {
+    let analyticsSession: AnalyticsSessionProtocol?
+
+    public init(analyticsSession: AnalyticsSessionProtocol?) {
+        self.analyticsSession = analyticsSession
+    }
+
+    public func invoke<Conversation: MessageAppendableConversation>(
+        with fileMetadata: ZMFileMetadata,
+        in conversation: Conversation
+    ) throws {
+        let message = try conversation.appendFile(with: fileMetadata, nonce: UUID())
+
+        var contributionType: ContributionType = .fileMessage
+
+        if let fileMessageData = message.fileMessageData {
+            if fileMessageData.isVideo {
+                contributionType = .videoMessage
+            } else if fileMessageData.isAudio {
+                contributionType = .audioMessage
+            } else if fileMessageData.isPDF {
+                contributionType = .fileMessage
+            }
+            
+        }
+
+        analyticsSession?.trackEvent(
+            ConversationContributionAnalyticsEvent(
+                contributionType: contributionType,
+                conversationType: .init(
+                    conversation.conversationType
+                ),
+                conversationSize: UInt(
+                    conversation.localParticipants.count
+                )
+            )
+        )
+    }
+}

--- a/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
@@ -40,6 +40,12 @@ public protocol MessageAppendableConversation {
     @discardableResult
     func appendLocation(with locationData: LocationData, nonce: UUID) throws -> ZMConversationMessage
 
+    @discardableResult
+    func appendFile(
+        with fileMetadata: ZMFileMetadata,
+        nonce: UUID
+    ) throws -> ZMConversationMessage
+
 }
 
 extension ZMConversation: MessageAppendableConversation {

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -274,6 +274,8 @@ public protocol UserSession: AnyObject {
 
     func makeAppendLocationMessageUseCase() -> any AppendLocationMessagekUseCaseProtocol
 
+    func makeAppendFileMessageUseCase() -> any AppendFileMessageUseCaseProtocol
+
     func fetchSelfConversationMLSGroupID() async -> MLSGroupID?
 
     func e2eIdentityUpdateCertificateUpdateStatus() -> E2EIdentityCertificateUpdateStatusUseCaseProtocol?

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -371,6 +371,10 @@ extension ZMUserSession: UserSession {
         return AppendLocationMessageUseCase(analyticsSession: analyticsSession)
     }
 
+    public func makeAppendFileMessageUseCase() -> AppendFileMessageUseCaseProtocol {
+        return AppendFileMessageUseCase(analyticsSession: analyticsSession)
+    }
+
 }
 
 extension UInt64 {

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -225,4 +225,28 @@ public class MockMessageAppendableConversation: MessageAppendableConversation {
             fatalError("no mock for `appendLocation`")
         }
     }
+
+    // MARK: - appendFile
+
+       public var appendFile_Invocations: [(fileMetadata: ZMFileMetadata, nonce: UUID)] = []
+       public var appendFile_MockError: Error?
+       public var appendFile_MockMethod: ((ZMFileMetadata, UUID) throws -> ZMConversationMessage)?
+       public var appendFile_MockValue: ZMConversationMessage?
+
+       @discardableResult
+       public func appendFile(with fileMetadata: ZMFileMetadata, nonce: UUID) throws -> ZMConversationMessage {
+           appendFile_Invocations.append((fileMetadata: fileMetadata, nonce: nonce))
+
+           if let error = appendFile_MockError {
+               throw error
+           }
+
+           if let mock = appendFile_MockMethod {
+               return try mock(fileMetadata, nonce)
+           } else if let mock = appendFile_MockValue {
+               return mock
+           } else {
+               fatalError("no mock for `appendFile`")
+           }
+       }
 }

--- a/wire-ios-sync-engine/Tests/Source/Use cases/AppendFileMessageUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/AppendFileMessageUseCaseTests.swift
@@ -49,7 +49,7 @@ final class AppendFileMessageUseCaseTests: XCTestCase {
         mockAnalyticsSessionProtocol = nil
     }
 
-    func testInvoke_AppendFileInGroupConversation_TracksEventCorrectly() throws {
+    func testInvoke_AppendsFileToGroupConversation_TracksEventCorrectly() throws {
         // GIVEN
         mockConversation.conversationType = .group
         mockConversation.localParticipants = []

--- a/wire-ios-sync-engine/Tests/Source/Use cases/AppendFileMessageUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/AppendFileMessageUseCaseTests.swift
@@ -1,0 +1,79 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAnalytics
+import WireAnalyticsSupport
+import WireDataModel
+import WireDataModelSupport
+import WireSyncEngineSupport
+import XCTest
+
+@testable import WireSyncEngine
+
+final class AppendFileMessageUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var mockAnalyticsSessionProtocol: MockAnalyticsSessionProtocol!
+    private var mockConversation: MockMessageAppendableConversation!
+    private var sut: AppendFileMessageUseCase!
+
+    // MARK: - setUp
+
+    override func setUp() {
+        mockAnalyticsSessionProtocol = .init()
+        mockConversation = .init()
+        sut = AppendFileMessageUseCase(analyticsSession: mockAnalyticsSessionProtocol)
+    }
+
+    // MARK: - tearDown
+
+    override func tearDown() {
+        sut = nil
+        mockConversation = nil
+        mockAnalyticsSessionProtocol = nil
+    }
+
+    func testInvoke_AppendFileInGroupConversation_TracksEventCorrectly() throws {
+        // GIVEN
+        mockConversation.conversationType = .group
+        mockConversation.localParticipants = []
+        mockConversation.appendFile_MockMethod = { _, _ in
+            MockZMConversationMessage()
+        }
+        mockAnalyticsSessionProtocol.trackEvent_MockMethod = { _ in }
+
+        let fileMetadata = ZMFileMetadata(fileURL: URL(fileURLWithPath: "/path/to/file.pdf"), thumbnail: nil)
+
+        // WHEN
+        try sut.invoke(
+            with: fileMetadata,
+            in: mockConversation
+        )
+
+        // THEN
+        XCTAssertEqual(mockConversation.appendFile_Invocations.count, 1)
+        let appendFileInvocation = try XCTUnwrap(mockConversation.appendFile_Invocations.first)
+        XCTAssertEqual(appendFileInvocation.fileMetadata, fileMetadata)
+
+        XCTAssertEqual(mockAnalyticsSessionProtocol.trackEvent_Invocations.count, 1)
+        let trackEventInvocation = try XCTUnwrap(mockAnalyticsSessionProtocol.trackEvent_Invocations.first as? ConversationContributionAnalyticsEvent)
+        XCTAssertEqual(trackEventInvocation.contributionType, .fileMessage)
+        XCTAssertEqual(trackEventInvocation.conversationType, .group)
+    }
+}

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -581,6 +581,7 @@
 		E965B10C2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E965B10B2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift */; };
 		E967757F2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E967757E2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift */; };
 		E96970562C8F2F68009F037C /* AppendFileMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96970552C8F2F68009F037C /* AppendFileMessageUseCase.swift */; };
+		E96970592C8F354F009F037C /* AppendFileMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96970572C8F3546009F037C /* AppendFileMessageUseCaseTests.swift */; };
 		E97296252C4A784300C4F1DB /* MessageAppendableConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97296242C4A784300C4F1DB /* MessageAppendableConversation.swift */; };
 		E97296282C4AA7D300C4F1DB /* AppendImageMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97296262C4AA72100C4F1DB /* AppendImageMessageUseCaseTests.swift */; };
 		E98E5DFC2B8DF45100A2CFF5 /* ResolveOneOnOneConversationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98E5DFB2B8DF45100A2CFF5 /* ResolveOneOnOneConversationsUseCaseTests.swift */; };
@@ -1445,6 +1446,7 @@
 		E965B10B2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendLocationMessageUseCase.swift; sourceTree = "<group>"; };
 		E967757E2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAllowGuestAndServicesUseCase.swift; sourceTree = "<group>"; };
 		E96970552C8F2F68009F037C /* AppendFileMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendFileMessageUseCase.swift; sourceTree = "<group>"; };
+		E96970572C8F3546009F037C /* AppendFileMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendFileMessageUseCaseTests.swift; sourceTree = "<group>"; };
 		E97296242C4A784300C4F1DB /* MessageAppendableConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAppendableConversation.swift; sourceTree = "<group>"; };
 		E97296262C4AA72100C4F1DB /* AppendImageMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendImageMessageUseCaseTests.swift; sourceTree = "<group>"; };
 		E98E5DFB2B8DF45100A2CFF5 /* ResolveOneOnOneConversationsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolveOneOnOneConversationsUseCaseTests.swift; sourceTree = "<group>"; };
@@ -1754,6 +1756,7 @@
 				E97296262C4AA72100C4F1DB /* AppendImageMessageUseCaseTests.swift */,
 				E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */,
 				E9DA6FF42C5CDF9A00BF8298 /* DisableAnalyticsSharingUseCaseTests.swift */,
+				E96970572C8F3546009F037C /* AppendFileMessageUseCaseTests.swift */,
 			);
 			path = "Use cases";
 			sourceTree = "<group>";
@@ -3652,6 +3655,7 @@
 				F19F4F4D1E646C3C00F4D8FF /* UserProfileImageUpdateStatusTests.swift in Sources */,
 				167BCB902603CAB200E9D7E3 /* AnalyticsTests.swift in Sources */,
 				1679D1CD1EF97387007B0DF5 /* ZMUserSessionTestsBase+Calling.swift in Sources */,
+				E96970592C8F354F009F037C /* AppendFileMessageUseCaseTests.swift in Sources */,
 				167F383D23E04A93006B6AA9 /* UnauthenticatedSessionTests+SSO.swift in Sources */,
 				63C4B3C82C36A4C900C09A93 /* FetchShareableConversationUseCaseTests.swift in Sources */,
 				16519D6D231EAAF300C9D76D /* Conversation+DeletionTests.swift in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 		E955D3E32C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E955D3E22C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift */; };
 		E965B10C2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E965B10B2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift */; };
 		E967757F2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E967757E2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift */; };
+		E96970562C8F2F68009F037C /* AppendFileMessageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E96970552C8F2F68009F037C /* AppendFileMessageUseCase.swift */; };
 		E97296252C4A784300C4F1DB /* MessageAppendableConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97296242C4A784300C4F1DB /* MessageAppendableConversation.swift */; };
 		E97296282C4AA7D300C4F1DB /* AppendImageMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97296262C4AA72100C4F1DB /* AppendImageMessageUseCaseTests.swift */; };
 		E98E5DFC2B8DF45100A2CFF5 /* ResolveOneOnOneConversationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98E5DFB2B8DF45100A2CFF5 /* ResolveOneOnOneConversationsUseCaseTests.swift */; };
@@ -1443,6 +1444,7 @@
 		E955D3E22C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendKnockMessageUseCaseTests.swift; sourceTree = "<group>"; };
 		E965B10B2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendLocationMessageUseCase.swift; sourceTree = "<group>"; };
 		E967757E2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAllowGuestAndServicesUseCase.swift; sourceTree = "<group>"; };
+		E96970552C8F2F68009F037C /* AppendFileMessageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendFileMessageUseCase.swift; sourceTree = "<group>"; };
 		E97296242C4A784300C4F1DB /* MessageAppendableConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageAppendableConversation.swift; sourceTree = "<group>"; };
 		E97296262C4AA72100C4F1DB /* AppendImageMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendImageMessageUseCaseTests.swift; sourceTree = "<group>"; };
 		E98E5DFB2B8DF45100A2CFF5 /* ResolveOneOnOneConversationsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolveOneOnOneConversationsUseCaseTests.swift; sourceTree = "<group>"; };
@@ -2961,6 +2963,7 @@
 				E9A71BD42C33EE080027EC01 /* AppendImageMessageUseCase.swift */,
 				E9A71BD62C33F4850027EC01 /* AppendKnockMessagekUseCase.swift */,
 				E965B10B2C3431EC009BEAB3 /* AppendLocationMessageUseCase.swift */,
+				E96970552C8F2F68009F037C /* AppendFileMessageUseCase.swift */,
 				63C4B3C12C35B07A00C09A93 /* FetchShareableConversationUseCase.swift */,
 				63C4B3C52C35B56A00C09A93 /* ShareFileUseCase.swift */,
 				E97296242C4A784300C4F1DB /* MessageAppendableConversation.swift */,
@@ -4038,6 +4041,7 @@
 				634976F8268A200C00824A05 /* AVSClient.swift in Sources */,
 				D522571E2062552800562561 /* AssetDeletionRequestStrategy.swift in Sources */,
 				060C06682B7619E300B484C6 /* SelfClientCertificateProvider.swift in Sources */,
+				E96970562C8F2F68009F037C /* AppendFileMessageUseCase.swift in Sources */,
 				161ACB1623F1AFB000ABFF33 /* SessionManager+CallKitManagerDelegate.swift in Sources */,
 				6349770A268A250E00824A05 /* Encodable+JSONString.swift in Sources */,
 				1671F7502B6A7DF500C2D8A3 /* ZMAuthenticationStatus.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -94,7 +94,7 @@ extension ConversationInputBarViewController {
 
             guard let self else { return }
 
-            self.impactFeedbackGenerator.prepare()
+            impactFeedbackGenerator.prepare()
 
             userSession.perform { [weak self] in
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -94,13 +94,17 @@ extension ConversationInputBarViewController {
 
             guard let self else { return }
 
-            impactFeedbackGenerator.prepare()
-            ZMUserSession.shared()?.perform {
+            self.impactFeedbackGenerator.prepare()
+
+            userSession.perform { [weak self] in
+
+                guard let self else { return }
 
                 self.impactFeedbackGenerator.impactOccurred()
 
                 do {
-                    try conversation.appendFile(with: metadata)
+                    let useCase = self.userSession.makeAppendFileMessageUseCase()
+                    try useCase.invoke(with: metadata, in: conversation)
                 } catch {
                     Logging.messageProcessing.warn("Failed to append file. Reason: \(error.localizedDescription)")
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10953" title="WPB-10953" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10953</a>  [iOS] Analytic events related to sending videos are not shown in Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


This PR introduces a new AppendFileMessageUseCase and its associated unit tests. Additionally, it enhances file tracking by recording analytics events based on the file type, ensuring better insights and performance tracking for file-related activities within conversations.

## Key Changes

- Added the AppendFileMessageUseCase to handle appending files to conversations.
- Implemented comprehensive unit tests to ensure robustness and correctness of the new use case.
- Integrated file analytics tracking to capture and log events based on the type of file being appended.


## Benefits

- Improves the maintainability and scalability of file-related actions within conversations.
- Ensures more detailed and accurate file tracking through type-based analytics, enabling better monitoring and decision-making.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---