### PR TITLE
chore: Migrate from deprecated random string methods - WPB-11016

### DIFF
--- a/wire-ios-data-model/Source/Model/QualifiedID.swift
+++ b/wire-ios-data-model/Source/Model/QualifiedID.swift
@@ -96,6 +96,8 @@ public extension Collection where Element == ZMConversation {
 
 }
 
+// TODO: [WPB-11016] Move this test code from production targets
+#if DEBUG
 public extension QualifiedID {
 
     static func random() -> QualifiedID {
@@ -106,3 +108,4 @@ public extension QualifiedID {
     }
 
 }
+#endif

--- a/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
@@ -50,7 +50,7 @@ extension ZMBaseManagedObjectTest {
         }
 
         let userClient = UserClient.insertNewObject(in: moc)
-        userClient.remoteIdentifier = String.createLegacyAlphanumerical()
+        userClient.remoteIdentifier = String.randomClientIdentifier()
         userClient.user = user
 
         if createSessionWithSelfUser {

--- a/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
+++ b/wire-ios-data-model/Tests/Source/Model/ZMBaseManagedObjectTest.swift
@@ -43,7 +43,7 @@ extension ZMBaseManagedObjectTest {
         return message
     }
 
-    @objc( createClientForUser:createSessionWithSelfUser:onMOC:)
+    @objc(createClientForUser:createSessionWithSelfUser:onMOC:)
     func createClient(for user: ZMUser, createSessionWithSelfUser: Bool, onMOC moc: NSManagedObjectContext) -> UserClient {
         if user.remoteIdentifier == nil {
             user.remoteIdentifier = UUID.create()

--- a/wire-ios-mocktransport/Source/Clients and OTR/MockUserClient.swift
+++ b/wire-ios-mocktransport/Source/Clients and OTR/MockUserClient.swift
@@ -117,7 +117,7 @@ extension MockUserClient {
         let newClient = NSEntityDescription.insertNewObject(forEntityName: "UserClient", into: context) as! MockUserClient
         newClient.label = label
         newClient.type = type
-        newClient.identifier = String.createLegacyAlphanumerical()
+        newClient.identifier = String.randomClientIdentifier()
         newClient.mackey = mackey
         newClient.enckey = enckey
         newClient.deviceClass = deviceClass
@@ -147,7 +147,7 @@ extension MockUserClient {
         let newClient = NSEntityDescription.insertNewObject(forEntityName: "UserClient", into: context) as! MockUserClient
 
         newClient.user = user
-        newClient.identifier = String.createLegacyAlphanumerical()
+        newClient.identifier = String.randomClientIdentifier()
         newClient.label = label
         newClient.type = type
         newClient.deviceClass = deviceClass

--- a/wire-ios-utilities/Source/Public/NSString+Random.swift
+++ b/wire-ios-utilities/Source/Public/NSString+Random.swift
@@ -20,6 +20,8 @@ import Foundation
 
 extension NSString {
 
+    // TODO: [WPB-11016] Move this test code from production targets
+    #if DEBUG
     @objc static func randomAlphanumerical(length: UInt) -> String {
         String.randomAlphanumerical(length: length)
     }
@@ -31,4 +33,5 @@ extension NSString {
     @objc public static func randomRemoteIdentifier() -> String {
         String.randomRemoteIdentifier()
     }
+    #endif
 }

--- a/wire-ios-utilities/Source/Public/NSString+Random.swift
+++ b/wire-ios-utilities/Source/Public/NSString+Random.swift
@@ -32,12 +32,3 @@ extension NSString {
         String.randomRemoteIdentifier()
     }
 }
-
-// MARK: - Legacy
-
-public extension NSString {
-    @available(*, deprecated, message: "Better use one of the newer random string methods!")
-    @objc static func createLegacyAlphanumerical() -> String {
-        String.createLegacyAlphanumerical()
-    }
-}

--- a/wire-ios-utilities/Source/Public/String+Random.swift
+++ b/wire-ios-utilities/Source/Public/String+Random.swift
@@ -33,8 +33,8 @@ public extension String {
         return s
     }
 
-    static func randomClientIdentifier(length: UInt = 16) -> String {
-        randomAlphanumerical(length: length)
+    static func randomClientIdentifier() -> String {
+        randomHexadecimal()
     }
 
     static func randomDomain(hostLength: UInt = 5) -> String {
@@ -44,20 +44,9 @@ public extension String {
     static func randomRemoteIdentifier(length: UInt = 16) -> String {
         randomAlphanumerical(length: length)
     }
-}
 
-// MARK: - Legacy
-
-public extension String {
-
-    // https://github.com/wireapp/wire-ios/pull/920
-    // Replacing all random strings didn't work for the some places,
-    // so we reverted the change to keep the legacy random func.
-    //
-    // ClientMessageTests_OTR and ClientMessageTests_OTR_Legacy seem to use rely on a "%llx",
-    // but the underlying logic is not clear to me at this point.
-    @available(*, deprecated, message: "Better use one of the newer random string methods!")
-    static func createLegacyAlphanumerical() -> String {
-        String(format: "%llx", arc4random()) // swiftlint:disable:this legacy_random
+    private static func randomHexadecimal() -> String {
+        let value = UInt.random(in: UInt.min...UInt.max)
+        return String(value, radix: 16)
     }
 }

--- a/wire-ios-utilities/Source/Public/String+Random.swift
+++ b/wire-ios-utilities/Source/Public/String+Random.swift
@@ -33,6 +33,8 @@ public extension String {
         return s
     }
 
+    // TODO: [WPB-11016] Move this test code from production targets
+    #if DEBUG
     static func randomClientIdentifier() -> String {
         randomHexadecimal()
     }
@@ -49,4 +51,5 @@ public extension String {
         let value = UInt.random(in: UInt.min...UInt.max)
         return String(value, radix: 16)
     }
+    #endif
 }

--- a/wire-ios-utilities/Source/Public/String+Random.swift
+++ b/wire-ios-utilities/Source/Public/String+Random.swift
@@ -48,7 +48,7 @@ public extension String {
     }
 
     private static func randomHexadecimal() -> String {
-        let value = UInt.random(in: UInt.min...UInt.max)
+        let value = UInt32.random(in: UInt32.min...UInt32.max)
         return String(value, radix: 16)
     }
     #endif

--- a/wire-ios-utilities/Tests/Public/StringRandomTests.swift
+++ b/wire-ios-utilities/Tests/Public/StringRandomTests.swift
@@ -68,7 +68,7 @@ final class StringRandomTests: XCTestCase {
             let string = String.randomClientIdentifier()
 
             // then
-            XCTAssertNotNil(UInt(string, radix: 16), "\(string) is not hexadecimal")
+            XCTAssertNotNil(UInt32(string, radix: 16), "\(string) is not hexadecimal")
         }
     }
 
@@ -95,7 +95,7 @@ final class StringRandomTests: XCTestCase {
     func test_randomRemoteIdentifier_withDefaultLength() {
         // given
         // when
-        let string = String.randomClientIdentifier()
+        let string = String.randomRemoteIdentifier()
 
         // then
         XCTAssertEqual(string.count, 16)

--- a/wire-ios-utilities/Tests/Public/StringRandomTests.swift
+++ b/wire-ios-utilities/Tests/Public/StringRandomTests.swift
@@ -61,25 +61,18 @@ final class StringRandomTests: XCTestCase {
         })
     }
 
-    func test_randomClientIdentifier_withDefaultLength() {
-        // given
-        // when
-        let string = String.randomClientIdentifier()
+    func test_randomClientIdentifier_isHexadecimalString() {
+        for _ in 1..<10 {
+            // given
+            // when
+            let string = String.randomClientIdentifier()
 
-        // then
-        XCTAssertEqual(string.count, 16)
+            // then
+            XCTAssertNotNil(UInt(string, radix: 16), "\(string) is not hexadecimal")
+        }
     }
 
-    func test_randomClientIdentifier_withLength8() {
-        // given
-        // when
-        let string = String.randomClientIdentifier(length: 8)
-
-        // then
-        XCTAssertEqual(string.count, 8)
-    }
-
-    func test_randomDomain_withDefaultLenght() {
+    func test_randomDomain_withDefaultLength() {
         // given
         // when
         let string = String.randomDomain()
@@ -111,7 +104,7 @@ final class StringRandomTests: XCTestCase {
     func test_randomRemoteIdentifier_withLength8() {
         // given
         // when
-        let string = String.randomClientIdentifier(length: 8)
+        let string = String.randomRemoteIdentifier(length: 8)
 
         // then
         XCTAssertEqual(string.count, 8)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11016" title="WPB-11016" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11016</a>  [iOS] Migrate off `createLegacyAlphanumerical()` deprecated methods
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR migrates from and removes the following deprecated methods:

- `String.createLegacyAlphanumerical()`
- `NSString.createLegacyAlphanumerical()`

The reason why these methods exist is due to a misunderstanding of what a client ID is - it is not a random alpha numeric string but a hexadecimal string. Therefore to remove them, this PR updates `String.randomClientIdentifier()` to return a hexadecimal string. 

All this code is actually test support code but it lives in production targets. Therefore I've also wrapped this code in `#if DEBUG` statements for safety and added some todos with tickets to migrate the code to a better place.

### Testing

Run automated tests

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
