### PR TITLE
fix: explicitly skip localizing strings on the developer tools screen - WPB-11020

### DIFF
--- a/WireUI/Sources/WireUIFoundation/Main/MainTabBarController.swift
+++ b/WireUI/Sources/WireUIFoundation/Main/MainTabBarController.swift
@@ -33,7 +33,7 @@ public final class MainTabBarController: UITabBarController {
         viewControllers![tab.rawValue] as! UINavigationController
     }
 
-    public var selectedTab: Tab {
+    public var currentTab: Tab {
         get { Tab(rawValue: selectedIndex) ?? .conversations }
         set { selectedIndex = newValue.rawValue }
     }
@@ -118,7 +118,7 @@ func MainTabBarController_Preview() -> MainTabBarController {
     for tab in MainTabBarController.Tab.allCases {
         tabBarController[tab: tab].viewControllers = [PlaceholderViewController()]
     }
-    tabBarController.selectedTab = .conversations
+    tabBarController.currentTab = .conversations
     return tabBarController
 }
 

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsView.swift
@@ -29,7 +29,7 @@ struct DeveloperToolsView: View {
 
     var body: some View {
         List(viewModel.sections, rowContent: sectionView(for:))
-            .navigationTitle("Developer tools")
+            .navigationTitle(Text(verbatim: "Developer tools"))
             .navigationBarItems(trailing: dismissButton)
             .alert(isPresented: $viewModel.isPresentingAlert) {
                 Alert(
@@ -80,7 +80,7 @@ struct DeveloperToolsView: View {
     private var dismissButton: some View {
         Button(
             action: { viewModel.handleEvent(.dismissButtonTapped) },
-            label: { Text("Close") }
+            label: { Text(verbatim: "Close") }
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11020" title="WPB-11020" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11020</a>  Accent colors and title changed after WPB-10282 PR #1854
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When the app is run with the `NSShowNonLocalizedStrings` argument to `YES`, the navigation title and the close button are written uppercased.
This PR fixes it by declaring them as non-localised.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
