### PR TITLE
fix: disable call quality survey - WPB-10935

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -321,8 +321,7 @@ platform :ios do
             enable_datadog_args = [
             "DATADOG_IMPORT=1",
             "DATADOG_APP_ID=#{ENV['DATADOG_APP_ID']}",
-            "DATADOG_CLIENT_TOKEN=#{ENV['DATADOG_CLIENT_TOKEN']}",
-            "OTHER_PREPROCESSOR_FLAGS=$OTHER_PREPROCESSOR_FLAGS"
+            "DATADOG_CLIENT_TOKEN=#{ENV['DATADOG_CLIENT_TOKEN']}"
             ]
 
             xcargs = ["BUILD_NUMBER=#{build.build_number}"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -322,7 +322,7 @@ platform :ios do
             "DATADOG_IMPORT=1",
             "DATADOG_APP_ID=#{ENV['DATADOG_APP_ID']}",
             "DATADOG_CLIENT_TOKEN=#{ENV['DATADOG_CLIENT_TOKEN']}",
-            "OTHER_PREPROCESSOR_FLAGS='DATADOG_IMPORT'"
+            "OTHER_PREPROCESSOR_FLAGS=$OTHER_PREPROCESSOR_FLAGS"
             ]
 
             xcargs = ["BUILD_NUMBER=#{build.build_number}"]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10935" title="WPB-10935" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10935</a>  [iOS] Column builds shouldn't collect call feedback
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

1. We shouldn't override `OTHER_PREPROCESSOR_FLAGS`.
2. There's a new version of [wire-ios-build-assets](https://github.com/wireapp/wire-ios-build-assets/pull/118) that contains `DATADOG_IMPORT`.

❗️ Don't move it to the **develop** branch! ❗️

### Testing

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
