### PR TITLE
fix: show user image at the conversation list top instead of team image - WPB-11052

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar.swift
@@ -43,7 +43,7 @@ extension ConversationListViewController {
 
         let user = ZMUser.selfUser(inUserSession: session)
 
-        let accountView = AccountViewBuilder(account: viewModel.account, user: user, displayContext: .conversationListHeader).build()
+        let accountView = PersonalAccountView(account: viewModel.account, user: user, displayContext: .conversationListHeader)
         accountView.unreadCountStyle = .current
         accountView.autoUpdateSelection = false
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11052" title="WPB-11052" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11052</a>  Extract getting the image of the user account use case
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In the iOS app we have been showing the team image at the top of the conversation list.
This PR changes it to the user's image and keeps the team image for the account switcher.

### Testing

Log into one or more accounts.
The conversation list should always show the user's image or initials.
Only for switching accounts the team image is visible.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
