### PR TITLE
fix: subconference parsing - WPB-11057

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -309,7 +309,7 @@ jobs:
           compare_to_earlier_commit: false
             
       - name: Archiving DerivedData Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: derived-data-xcode

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1596,7 +1596,7 @@ public final class MLSService: MLSServiceInterface {
     ) async throws {
         do {
             logger.info("creating subgroup with id (\(id.safeForLoggingDescription))")
-            try await createGroup(for: id, parentGroupID: parentID)
+            _ = try await createGroup(for: id, parentGroupID: parentID)
             try await updateKeyMaterial(for: id)
         } catch {
             logger.error("failed to create subgroup with id (\(id.safeForLoggingDescription)): \(String(describing: error))")

--- a/wire-ios-data-model/Source/MLS/MLSSubgroup.swift
+++ b/wire-ios-data-model/Source/MLS/MLSSubgroup.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public struct MLSSubgroup: Equatable {
 
-    public let cipherSuite: Int
+    public let cipherSuite: Int?
     public let epoch: Int
     public let epochTimestamp: Date?
     public let groupID: MLSGroupID
@@ -28,7 +28,7 @@ public struct MLSSubgroup: Equatable {
     public let parentQualifiedID: QualifiedID
 
     public init(
-        cipherSuite: Int,
+        cipherSuite: Int?,
         epoch: Int,
         epochTimestamp: Date?,
         groupID: MLSGroupID,

--- a/wire-ios-request-strategy/Sources/Payloads/Payload+Coding.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload+Coding.swift
@@ -74,7 +74,7 @@ extension Decodable {
         do {
             self = try decoder.decode(Self.self, from: payloadData)
         } catch let error {
-            Logging.network.warn("Failed to decode \(Self.self) from payload: \(error)")
+            WireLogger.network.warn("Failed to decode \(Self.self) from payload: \(error)")
             return nil
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandler.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandler.swift
@@ -97,7 +97,7 @@ extension FetchSubgroupActionHandler {
             case subconvID = "subconv_id"
         }
 
-        let cipherSuite: Int
+        let cipherSuite: Int?
         let epoch: Int
         let epochTimestamp: Date?
         let groupID: String

--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandlerTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/Actions/FetchSubgroupActionHandlerTests.swift
@@ -107,6 +107,29 @@ class FetchSubroupActionHandlerTests: ActionHandlerTestBase<FetchSubgroupAction,
         XCTAssertEqual(mlsSubgroup, payload.mlsSubgroup)
     }
 
+    func test_itHandlesSuccess_WhenNoCipherSuiteOrEpochTimestamp() {
+        // Given
+        let payload = ResponsePayload(
+            cipherSuite: nil,
+            epoch: 0,
+            epochTimestamp: nil,
+            groupID: Data.secureRandomData(length: 8).base64String(),
+            members: [.init(
+                userID: UUID(),
+                clientID: UUID().transportString(),
+                domain: "domain.com"
+            )],
+            parentQualifiedID: .init(id: UUID(), domain: "domain.com"),
+            subconvID: UUID().transportString()
+        )
+
+        // When
+        let mlsSubgroup = test_itHandlesSuccess(status: 200, payload: transportData(for: payload))
+
+        // Then
+        XCTAssertEqual(mlsSubgroup, payload.mlsSubgroup)
+    }
+
     func test_itHandlesSuccess_MalformedResponse() {
         // Given
         let payload = ResponsePayload(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11057" title="WPB-11057" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11057</a>  Caller in MLS group cannot participate in the call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When calling on MLS group, at the moment to fetch the mls subgroup, we failed parsing the server's response returning a malformedResponse error.

According to [swagger](https://nginz-https.anta.wire.link/v6/api/swagger-ui/#/default/get_conversations__cnv_domain___cnv__subconversations__subconv_), the ciphersuite in the response is optional.

**Solution**

Make the ciphersuite attribute of MLSSubgroup optional

### Testing

1. Call in a MLS group
2. caller should see the participants in the call
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
