### PR TITLE
feat: add an URL action for importing external events - WPB-11075

### DIFF
--- a/wire-ios-sync-engine/Source/DeepLink/URL+DeepLink.swift
+++ b/wire-ios-sync-engine/Source/DeepLink/URL+DeepLink.swift
@@ -23,5 +23,6 @@ extension URL {
         static let user = "user"
         static let conversation = "conversation"
         static let conversationJoin = "conversation-join"
+        static let importEvents = "import-events"
     }
 }

--- a/wire-ios-sync-engine/Source/SessionManager/URLActions.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/URLActions.swift
@@ -44,6 +44,9 @@ public enum URLAction: Equatable {
     /// Switch to a custom backend
     case accessBackend(configurationURL: URL)
 
+    /// Import external events
+    case importEvents
+
     public var causesLogout: Bool {
         switch self {
         case .startCompanyLogin: return true
@@ -56,7 +59,8 @@ public enum URLAction: Equatable {
         case .joinConversation,
              .openConversation,
              .openUserProfile,
-             .connectBot:
+             .connectBot,
+             .importEvents:
              return true
         default: return false
         }
@@ -115,6 +119,9 @@ extension URLAction {
             } else {
                 throw DeepLinkRequestError.invalidConversationLink
             }
+
+        case URL.DeepLink.importEvents:
+            self = .importEvents
 
         case URL.Host.startSSO:
             if let uuidCode = url.pathComponents.last.flatMap(CompanyLoginRequestDetector.requestCode) {

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ImportEventsURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ImportEventsURLActionProcessor.swift
@@ -1,0 +1,88 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+enum ImportEventsError: Error {
+    case fileNotFound(String)
+}
+
+class ImportEventsURLActionProcessor: URLActionProcessor {
+
+    private let eventProcessor: UpdateEventProcessor
+
+    init(eventProcessor: UpdateEventProcessor) {
+        self.eventProcessor = eventProcessor
+    }
+
+    func process(urlAction: URLAction, delegate: (any PresentationDelegate)?) {
+        guard case .importEvents = urlAction else {
+            return
+        }
+
+        Task {
+            do {
+                try await handleImportEvents(urlAction: urlAction, delegate: delegate)
+                await MainActor.run {
+                    delegate?.completedURLAction(urlAction)
+                }
+            } catch {
+                await MainActor.run {
+                    delegate?.failedToPerformAction(urlAction, error: error)
+                }
+            }
+        }
+    }
+
+    private func handleImportEvents(
+        urlAction: URLAction,
+        delegate: PresentationDelegate?
+    ) async throws {
+        let eventsFile = FileManager.default.temporaryDirectory.appendingPathComponent("events", conformingTo: .plainText)
+
+        guard let eventsData = FileManager.default.contents(atPath: eventsFile.path) else {
+            delegate?.failedToPerformAction(urlAction, error: ImportEventsError.fileNotFound(eventsFile.path))
+            return
+        }
+
+        let events = updateEventsFromJSON(eventsData)
+        let start = DispatchTime.now()
+        try await eventProcessor.processEvents(events)
+        let end = DispatchTime.now()
+        let elapsedTimeInMilliSeconds = Double(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+
+        WireLogger.eventProcessing.info("It took \(elapsedTimeInMilliSeconds) ms to import \(events.count) event(s)")
+    }
+
+    private func updateEventsFromJSON(_ eventsData: Data) -> [ZMUpdateEvent] {
+        let eventsRaw = String(decoding: eventsData, as: UTF8.self)
+        let eventsDicts = ((eventsRaw as ZMTransportData)
+            .asDictionary() as? NSDictionary)?
+            .optionalArray(forKey: "notifications")?
+            .compactMap { $0 as? ZMTransportData }
+
+        guard let events = eventsDicts?.compactMap({
+            ZMUpdateEvent.eventsArray(from: $0, source: .download)
+        }) else {
+            return []
+        }
+
+        return Array(events.joined())
+    }
+
+}

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ImportEventsURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ImportEventsURLActionProcessor.swift
@@ -24,6 +24,14 @@ enum ImportEventsError: Error {
 
 class ImportEventsURLActionProcessor: URLActionProcessor {
 
+    private static var isRunningOnSimulator: Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
+    }
+
     private let eventProcessor: UpdateEventProcessor
 
     init(eventProcessor: UpdateEventProcessor) {
@@ -31,7 +39,7 @@ class ImportEventsURLActionProcessor: URLActionProcessor {
     }
 
     func process(urlAction: URLAction, delegate: (any PresentationDelegate)?) {
-        guard case .importEvents = urlAction else {
+        guard case .importEvents = urlAction, Self.isRunningOnSimulator else {
             return
         }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -532,6 +532,9 @@ public final class ZMUserSession: NSObject {
 
     private func createURLActionProcessors() -> [URLActionProcessor] {
         return [
+            ImportEventsURLActionProcessor(
+                eventProcessor: updateEventProcessor!
+            ),
             DeepLinkURLActionProcessor(
                 contextProvider: coreDataStack,
                 transportSession: transportSession,

--- a/wire-ios-sync-engine/Tests/Source/SessionManager/URLActionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/SessionManager/URLActionTests.swift
@@ -99,6 +99,17 @@ class URLActionTests: ZMTBaseTest {
         XCTAssertEqual(action, URLAction.openUserProfile(id: uuid))
     }
 
+    func testThatItParsesImportEventsLink() throws {
+        // given
+        let url = URL(string: "wire://import-events")!
+
+        // when
+        let action = try URLAction(url: url)
+
+        // then
+        XCTAssertEqual(action, URLAction.importEvents)
+    }
+
     func testThatItDiscardsInvalidJoinConversationLink() throws {
         // given
         let key = "KpvjjQSDgp9aniYGUXqi"

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		1662B0F723D9B29C00B8C7C5 /* UnauthenticatedSession+DomainLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662B0F623D9B29C00B8C7C5 /* UnauthenticatedSession+DomainLookup.swift */; };
 		1662B0F923D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1662B0F823D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift */; };
 		166507812459D7CA005300C1 /* UserClientEventConsumer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166507802459D7CA005300C1 /* UserClientEventConsumer.swift */; };
+		1667C4092C93135000AA43A1 /* ImportEventsURLActionProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1667C4082C93135000AA43A1 /* ImportEventsURLActionProcessor.swift */; };
 		166A8BF31E015F3B00F5EEEA /* WireCallCenterV3Factory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */; };
 		166A8BF91E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */; };
 		166B2B5E23E86522003E8581 /* ZMUserSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166B2B5D23E86522003E8581 /* ZMUserSession.swift */; };
@@ -918,6 +919,7 @@
 		1662B0F623D9B29C00B8C7C5 /* UnauthenticatedSession+DomainLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSession+DomainLookup.swift"; sourceTree = "<group>"; };
 		1662B0F823D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnauthenticatedSessionTests+DomainLookup.swift"; sourceTree = "<group>"; };
 		166507802459D7CA005300C1 /* UserClientEventConsumer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserClientEventConsumer.swift; sourceTree = "<group>"; };
+		1667C4082C93135000AA43A1 /* ImportEventsURLActionProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportEventsURLActionProcessor.swift; sourceTree = "<group>"; };
 		166A8BF21E015F3B00F5EEEA /* WireCallCenterV3Factory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireCallCenterV3Factory.swift; sourceTree = "<group>"; };
 		166A8BF81E02C7D500F5EEEA /* ZMHotFix+PendingChanges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMHotFix+PendingChanges.swift"; sourceTree = "<group>"; };
 		166B2B5D23E86522003E8581 /* ZMUserSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserSession.swift; sourceTree = "<group>"; };
@@ -1732,6 +1734,7 @@
 			children = (
 				161ACB2C23F5BA0200ABFF33 /* DeepLinkURLActionProcessor.swift */,
 				161ACB2E23F5BACA00ABFF33 /* ConnectToBotURLActionProcessor.swift */,
+				1667C4082C93135000AA43A1 /* ImportEventsURLActionProcessor.swift */,
 			);
 			path = URLActionProcessors;
 			sourceTree = "<group>";
@@ -3884,6 +3887,7 @@
 				166A8BF31E015F3B00F5EEEA /* WireCallCenterV3Factory.swift in Sources */,
 				16519D38231D3B1700C9D76D /* Conversation+Deletion.swift in Sources */,
 				F1C1F3F01FCF18C5007273E3 /* NSError+Localized.swift in Sources */,
+				1667C4092C93135000AA43A1 /* ImportEventsURLActionProcessor.swift in Sources */,
 				EE2DE5E429250CC400F42F4C /* CallKitCall.swift in Sources */,
 				5467F1C61E0AE421008C1745 /* KeyValueStore+AccessToken.swift in Sources */,
 				639290A7252DEDB500046171 /* WireCallCenterV3+Degradation.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11075" title="WPB-11075" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11075</a>  Add debug tool for importing events from an external file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Add URL action for importing external events for profiling / debugging purposes.

### Testing

1. Generate external using the [kalium CLI](https://github.com/wireapp/kalium?tab=readme-ov-file#running-the-cli)
```
./gradlew :cli:run  --console=plain --quiet --args="login --environment staging --email user@wire.com --password secret generate-events --target-user-id 8791760d-8711-4f93-822d-6b08726b9b6d --target-client-id b15268108810fc2a --conversation-id 93b53516-b89c-4d7b-9232-ebd14ebea973 100 events.txt"
```
2. Launch Wire IOS app in the simulator and import the events
```
cp ~/path/to/generated/events.txt `xcrun simctl get_app_container booted com.wearezeta.zclient.alpha data`/tmp
xcrun simctl openurl booted wire://import-events
```

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
