### PR TITLE
fix: System message icon color - WPB-10936

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationFailedToAddParticipantsSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationFailedToAddParticipantsSystemMessageCellDescription.swift
@@ -45,7 +45,7 @@ final class ConversationFailedToAddParticipantsSystemMessageCellDescription: Con
             title: ConversationFailedToAddParticipantsSystemMessageCellDescription.configureTitle(for: failedUsers),
             content: ConversationFailedToAddParticipantsSystemMessageCellDescription.configureContent(for: failedUsers),
             isCollapsed: isCollapsed,
-            icon: Asset.Images.attention.image,
+            icon: Asset.Images.attention.image.withRenderingMode(.alwaysOriginal),
             buttonAction: buttonAction
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10936" title="WPB-10936" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-10936</a>  [iOS] System message colors are wrong per design doc
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The icon has a wrong color:
<img width="428" alt="Screenshot 2024-09-13 at 14 41 19" src="https://github.com/user-attachments/assets/13816178-d6c0-46c8-a252-fa6dc03eb4ed">

[Expected:](https://www.figma.com/design/NzVYqBBPH097XIg36zEIgn/5.5.1.-Backend-offline-handling?node-id=1160-47969&node-type=FRAME&t=7CHa1SHXUpk3baJF-0)
<img width="375" alt="Screenshot 2024-09-13 at 14 42 55" src="https://github.com/user-attachments/assets/d339c666-6053-4774-84e5-e0749b8e0574">

### Testing

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
