### PR TITLE
refactor: user legal hold disabled - WPB-10194

### DIFF
--- a/WireAPI/Sources/WireAPI/Models/UpdateEvent/UserEvent/UserLegalholdDisableEvent.swift
+++ b/WireAPI/Sources/WireAPI/Models/UpdateEvent/UserEvent/UserLegalholdDisableEvent.swift
@@ -26,4 +26,8 @@ public struct UserLegalholdDisableEvent: Equatable, Codable {
 
     public let userID: UUID
 
+    public init(userID: UUID) {
+        self.userID = userID
+    }
+
 }

--- a/WireDomain/Project/WireDomain Project.xcodeproj/project.pbxproj
+++ b/WireDomain/Project/WireDomain Project.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		C9E8A3C02C761EDD0093DD5C /* FeatureConfigRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E8A3BF2C761EDD0093DD5C /* FeatureConfigRepositoryTests.swift */; };
 		C9F691192C987DC8008CC41F /* TeamDeleteEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F691162C987DC8008CC41F /* TeamDeleteEventProcessorTests.swift */; };
 		C9F6911A2C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F691172C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift */; };
+		C9F691232C99D3C9008CC41F /* UserLegalHoldDisableEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F691222C99D3C9008CC41F /* UserLegalHoldDisableEventProcessorTests.swift */; };
 		CB7979132C738508006FBA58 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7979122C738508006FBA58 /* WireTransportSupport.framework */; };
 		CB7979162C738547006FBA58 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7979152C738547006FBA58 /* TestSetup.swift */; };
 		EE368CCE2C2DAA87009DBAB0 /* ConversationEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE368CC72C2DAA87009DBAB0 /* ConversationEventProcessor.swift */; };
@@ -164,6 +165,7 @@
 		C9E8A3E72C7F6EA40093DD5C /* ConversationRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationRepositoryTests.swift; sourceTree = "<group>"; };
 		C9F691162C987DC8008CC41F /* TeamDeleteEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamDeleteEventProcessorTests.swift; sourceTree = "<group>"; };
 		C9F691172C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamMemberUpdateEventProcessorTests.swift; sourceTree = "<group>"; };
+		C9F691222C99D3C9008CC41F /* UserLegalHoldDisableEventProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLegalHoldDisableEventProcessorTests.swift; sourceTree = "<group>"; };
 		CB7979122C738508006FBA58 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB7979152C738547006FBA58 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		EE0E117D2C2C4080004BBD29 /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 		C90E8B322C89EBA90017494F /* Event Processing */ = {
 			isa = PBXGroup;
 			children = (
+				C9F691212C99D3AC008CC41F /* UserEventProcessor */,
 				C9F691182C987DC8008CC41F /* TeamEventProcessor */,
 			);
 			path = "Event Processing";
@@ -471,6 +474,14 @@
 				C9F691172C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift */,
 			);
 			path = TeamEventProcessor;
+			sourceTree = "<group>";
+		};
+		C9F691212C99D3AC008CC41F /* UserEventProcessor */ = {
+			isa = PBXGroup;
+			children = (
+				C9F691222C99D3C9008CC41F /* UserLegalHoldDisableEventProcessorTests.swift */,
+			);
+			path = UserEventProcessor;
 			sourceTree = "<group>";
 		};
 		EE0E117C2C2C4076004BBD29 /* Helpers */ = {
@@ -874,6 +885,7 @@
 				EEC410262C60D48900E89394 /* SyncManagerTests.swift in Sources */,
 				EE57A7032C2994420096F242 /* UpdateEventsRepositoryTests.swift in Sources */,
 				C9E8A3C02C761EDD0093DD5C /* FeatureConfigRepositoryTests.swift in Sources */,
+				C9F691232C99D3C9008CC41F /* UserLegalHoldDisableEventProcessorTests.swift in Sources */,
 				CB7979162C738547006FBA58 /* TestSetup.swift in Sources */,
 				162356502C2B223100C6666C /* UserRepositoryTests.swift in Sources */,
 				EE3F97542C2ADC4C00668DF1 /* ProteusMessageDecryptorTests.swift in Sources */,

--- a/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor/UserLegalholdDisableEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor/UserLegalholdDisableEventProcessor.swift
@@ -32,9 +32,10 @@ protocol UserLegalholdDisableEventProcessorProtocol {
 
 struct UserLegalholdDisableEventProcessor: UserLegalholdDisableEventProcessorProtocol {
 
+    let repository: any UserRepositoryProtocol
+
     func processEvent(_: UserLegalholdDisableEvent) async throws {
-        // TODO: [WPB-10194]
-        assertionFailure("not implemented yet")
+        try await repository.disableUserLegalHold()
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
@@ -43,6 +43,10 @@ public protocol UserRepositoryProtocol {
 
     func pullUsers(userIDs: [WireDataModel.QualifiedID]) async throws
 
+    /// Disables user legal hold.
+
+    func disableUserLegalHold() async throws
+
 }
 
 public final class UserRepository: UserRepositoryProtocol {
@@ -86,6 +90,15 @@ public final class UserRepository: UserRepositoryProtocol {
             }
         } catch {
             throw UserRepositoryError.failedToFetchRemotely(error)
+        }
+    }
+
+    public func disableUserLegalHold() async throws {
+        try await context.perform { [context] in
+            let selfUser = ZMUser.selfUser(in: context)
+            selfUser.legalHoldRequestWasCancelled()
+
+            try context.save()
         }
     }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -445,6 +445,26 @@ public class MockUserRepositoryProtocol: UserRepositoryProtocol {
         try await mock(userIDs)
     }
 
+    // MARK: - disableUserLegalHold
+
+    public var disableUserLegalHold_Invocations: [Void] = []
+    public var disableUserLegalHold_MockError: Error?
+    public var disableUserLegalHold_MockMethod: (() async throws -> Void)?
+
+    public func disableUserLegalHold() async throws {
+        disableUserLegalHold_Invocations.append(())
+
+        if let error = disableUserLegalHold_MockError {
+            throw error
+        }
+
+        guard let mock = disableUserLegalHold_MockMethod else {
+            fatalError("no mock for `disableUserLegalHold`")
+        }
+
+        try await mock()
+    }
+
 }
 
 // swiftlint:enable variable_name

--- a/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserLegalHoldDisableEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserLegalHoldDisableEventProcessorTests.swift
@@ -1,0 +1,105 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireAPI
+import WireAPISupport
+import WireDataModel
+import WireDataModelSupport
+import XCTest
+
+@testable import WireDomain
+
+final class UserLegalHoldDisableEventProcessorTests: XCTestCase {
+
+    var sut: UserLegalholdDisableEventProcessor!
+
+    var coreDataStack: CoreDataStack!
+    let coreDataStackHelper = CoreDataStackHelper()
+    let modelHelper = ModelHelper()
+
+    var context: NSManagedObjectContext {
+        coreDataStack.syncContext
+    }
+
+    override func setUp() async throws {
+        coreDataStack = try await coreDataStackHelper.createStack()
+        sut = UserLegalholdDisableEventProcessor(
+            repository: UserRepository(
+                context: context,
+                usersAPI: MockUsersAPI()
+            )
+        )
+        try await super.setUp()
+    }
+
+    override func tearDown() async throws {
+        coreDataStack = nil
+        sut = nil
+        try coreDataStackHelper.cleanupDirectory()
+        try await super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func testProcessEvent_It_Disables_Legal_Hold_Status() async throws {
+        // Given
+
+        await context.perform { [self] in
+            let selfUser = ZMUser.selfUser(in: context)
+            selfUser.remoteIdentifier = Scaffolding.userID
+
+            let legalHoldRequest = Scaffolding.legalHoldRequest
+            selfUser.userDidReceiveLegalHoldRequest(Scaffolding.legalHoldRequest)
+
+            XCTAssertEqual(selfUser.legalHoldStatus, .pending(legalHoldRequest))
+        }
+
+        // When
+
+        try await sut.processEvent(Scaffolding.event)
+
+        // Then
+
+        await context.perform { [context] in
+            let selfUser = ZMUser.selfUser(in: context)
+            XCTAssertEqual(selfUser.legalHoldStatus, .disabled)
+        }
+    }
+
+}
+
+extension UserLegalHoldDisableEventProcessorTests {
+    enum Scaffolding {
+        nonisolated(unsafe) static let event = UserLegalholdDisableEvent(
+            userID: userID
+        )
+
+        static let userID = UUID()
+
+        nonisolated(unsafe) static let legalHoldRequest = LegalHoldRequest(
+            target: userID,
+            requester: UUID(),
+            clientIdentifier: "eca3c87cfe28be49",
+            lastPrekey: LegalHoldRequest.Prekey(
+                id: 65_535,
+                key: Data(base64Encoded: "pQABAQoCoQBYIPEFMBhOtG0dl6gZrh3kgopEK4i62t9sqyqCBckq3IJgA6EAoQBYIC9gPmCdKyqwj9RiAaeSsUI7zPKDZS+CjoN+sfihk/5VBPY=")!
+            )
+        )
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10194" title="WPB-10194" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10194</a>  [iOS] Process UserLegalholdDisableEvent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is part of the quick sync refactoring plan and is related to processing the multiple events we receive from the backend or the push channel.

Specifically, this PR is about porting the existing implementation of the `UserLegalHoldDisable` event.

### Testing

UTs cover the following use cases, ensuring that
- user legal hold is disabled 

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
