### PR TITLE
chore: Delete deprecated properties from UIApplication & ApplicationProtocol - WPB-11154

### DIFF
--- a/wire-ios/Wire-iOS/Settings+ColorScheme.swift
+++ b/wire-ios/Wire-iOS/Settings+ColorScheme.swift
@@ -32,7 +32,11 @@ enum SettingsColorScheme: Int, CaseIterable {
         case .dark:
             return .dark
         case .system:
-            return UIApplication.userInterfaceStyle == .dark ? .dark : .light
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let currentStyle = windowScene.windows.first(where: { $0.isKeyWindow })?.traitCollection.userInterfaceStyle {
+                return currentStyle == .dark ? .dark : .light
+            }
+            return .light
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/Components/ApplicationProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/ApplicationProtocol.swift
@@ -20,9 +20,6 @@ import UIKit
 
 protocol ApplicationProtocol {
 
-    @available(*, deprecated, message: "Use the interfaceOrientation property of the window scene instead.")
-    var statusBarOrientation: UIInterfaceOrientation { get }
-
     static func wr_requestOrWarnAboutPhotoLibraryAccess(_ grantedHandler: @escaping (Bool) -> Void)
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/NetworkStatus/NetworkStatusViewController.swift
@@ -194,7 +194,11 @@ extension NetworkStatusViewController {
         guard isIPadRegular(device: device) else { return true }
         guard let delegate else { return true }
 
-        let newOrientation = application.statusBarOrientation
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return true
+        }
+
+        let newOrientation = windowScene.interfaceOrientation
 
         return delegate.showInIPad(networkStatusViewController: self, with: newOrientation)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+UITextViewDelegate.swift
@@ -29,7 +29,7 @@ extension CharacterSet {
 extension ConversationInputBarViewController {
     func hideLeftView() {
         let currentDevice = DeviceWrapper(device: .current)
-        guard self.isIPadRegularPortrait(device: currentDevice, application: UIApplication.shared) else { return }
+        guard self.isIPadRegularPortrait(device: currentDevice) else { return }
         guard let splitViewController = wr_splitViewController, splitViewController.isLeftViewControllerRevealed else { return }
 
         splitViewController.setLeftViewControllerRevealed(false, animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIApplication+StatusBar.swift
@@ -38,13 +38,4 @@ extension UIApplication {
 
         return topController
     }
-
-    @available(*, deprecated, message: "Don't use this property!")
-    static var userInterfaceStyle: UIUserInterfaceStyle? {
-        return (UIApplication.shared.delegate as? AppDelegate)?
-            .mainWindow?
-            .rootViewController?
-            .traitCollection
-            .userInterfaceStyle
-    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UITraitEnvironment+SizeClass.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UITraitEnvironment+SizeClass.swift
@@ -30,9 +30,11 @@ extension UITraitEnvironment {
     }
 
     func isIPadRegularPortrait(
-        device: DeviceAbstraction = DeviceWrapper(device: .current),
-        application: ApplicationProtocol = UIApplication.shared
+        device: DeviceAbstraction = DeviceWrapper(device: .current)
     ) -> Bool {
-        return isIPadRegular(device: device) && application.statusBarOrientation.isPortrait
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return false
+        }
+        return isIPadRegular(device: device) && windowScene.interfaceOrientation.isPortrait
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11154" title="WPB-11154" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11154</a>  [iOS] Delete deprecated properties from UIApplication & ApplicationProtocol
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


---

#### Summary:

This PR removes two deprecated properties from the `ApplicationProtocol` & UIApplication extension. 
The properties removed are:

1. **`userInterfaceStyle`:**  

   - **Removed Code:** 
     ```swift
     @available(*, deprecated, message: "Don't use this property!")
     static var userInterfaceStyle: UIUserInterfaceStyle? {
         return (UIApplication.shared.delegate as? AppDelegate)?
             .mainWindow?
             .rootViewController?
             .traitCollection
             .userInterfaceStyle
     }
     ```
  
3. **`statusBarOrientation`:**  
   - **Removed Code:** 
     ```swift
     @available(*, deprecated, message: "Use the interfaceOrientation property of the window scene instead.")
     var statusBarOrientation: UIInterfaceOrientation { get }
     ```

#### Testing:
- Ensured that the UI behaves correctly after these properties' removal.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---
