### PR TITLE
feat: Remove call to deleteSubConversation after ending a 1:1 SFT call - WPB-11123

### DIFF
--- a/wire-ios-data-model/Source/UseCases/ObserveMLSGroupVerificationStatusUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/ObserveMLSGroupVerificationStatusUseCase.swift
@@ -64,7 +64,7 @@ public final class ObserveMLSGroupVerificationStatusUseCase: ObserveMLSGroupVeri
                     guard let conversation = await syncContext.perform({
                         ZMConversation.fetch(with: groupID, in: syncContext)
                     }) else {
-                        return WireLogger.e2ei.warn("failed to fetch the conversation by mlsGroupID \(groupID)")
+                        return
                     }
 
                     try await updateMLSGroupVerificationStatusUseCase.invoke(for: conversation, groupID: groupID)

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+MLS.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+MLS.swift
@@ -171,32 +171,6 @@ extension WireCallCenterV3 {
         }
     }
 
-    func deleteSubconversation(conversationID: AVSIdentifier) {
-        guard
-            let viewContext = uiMOC,
-            let syncContext = viewContext.zm_sync,
-            let parentIDs = mlsParentIDS(for: conversationID)
-        else {
-            return
-        }
-
-        syncContext.perform {
-            guard let mlsService = syncContext.mlsService else {
-                WireLogger.calling.error("failed to delete subconversation: mlsService is missing")
-                assertionFailure("mlsService is nil")
-                return
-            }
-
-            Task {
-                do {
-                    try await mlsService.deleteSubgroup(parentQualifiedID: parentIDs.qualifiedID)
-                } catch {
-                    WireLogger.calling.error("failed to delete subconversation: \(String(reflecting: error))")
-                }
-            }
-        }
-    }
-
 }
 
 extension CallParticipantState {

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -819,17 +819,6 @@ extension WireCallCenterV3 {
             snapshot?.mlsConferenceStaleParticipantsRemover?.stopSubscribing()
             snapshot?.mlsConferenceStaleParticipantsRemover = nil
 
-            guard let viewContext = uiMOC,
-                  let conversation = ZMConversation.fetch(
-                    with: mlsParentIDs.qualifiedID.uuid,
-                    domain: mlsParentIDs.qualifiedID.domain,
-                    in: viewContext),
-                  conversation.conversationType == .group
-            else {
-                deleteSubconversation(conversationID: conversationId)
-                return
-            }
-
             leaveSubconversation(
                 parentQualifiedID: mlsParentIDs.0,
                 parentGroupID: mlsParentIDs.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11123" title="WPB-11123" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11123</a>  [iOS] Remove call to deleteSubConversation after ending a 1:1 SFT call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue
We need to remove the call to `DELETE /conversations/:domain/:uuid/subconversations/conference` and revert the call to leaveMlsConference after ending a 1:1 call on SFT.
This was implemented as a [Short term solution](https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT#Do-not-leave-the-subconversation:~:text=The%20client%20should%20no%20longer%20leave%20the%20MLS%20subconversation.%20Instead%2C%20when%20a%20client%20hangs%20up%2C%20it%20calls%20DELETE%20/conversations/%3Adomain/%3Auuid/subconversations/conference%20(conference%20is%20the%20ID%20of%20the%20subconversation%2C%20this%20is%20always%20hardcoded%20to%20be%20conference).) and we don't need it anymore.

### Testing


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
