### PR TITLE
chore: use carthage 0.40.0 - no ticket

### DIFF
--- a/scripts/carthage.sh
+++ b/scripts/carthage.sh
@@ -20,19 +20,20 @@ set -Eeuo pipefail
 #
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-CARTHAGE_URL="https://github.com/Carthage/Carthage/releases/download/0.39.1/Carthage.pkg"
+CARTHAGE_URL="https://github.com/Carthage/Carthage/releases/download/0.40.0/Carthage.pkg"
 CARTHAGE_DIR="$REPO_ROOT/Carthage"
-CARTHAGE="$CARTHAGE_DIR/carthage"
+CARTHAGE="$CARTHAGE_DIR/carthage-0.40.0"
 
 if [[ ! -f "$CARTHAGE" ]]; then
     (
         mkdir -pv "$CARTHAGE_DIR"
         cd "$CARTHAGE_DIR"
         curl -LO "$CARTHAGE_URL"
+        echo "48431b41db5da40998b84dfb4171f759bb9bb06b88d509818c3ad6b0e874113bb8bdd70eec7a81d0313a6f64127aac4e0f55ffed2379222544f98c945534f64c  Carthage.pkg" | shasum -a 512 -c
         pkgutil --expand-full ./Carthage.pkg ./Carthage_pkg
         mv -v \
             ./Carthage_pkg/CarthageApp.pkg/Payload/usr/local/bin/carthage \
-            ./carthage
+            "$CARTHAGE"
         rm -rvf ./Carthage.pkg ./Carthage_pkg
     )
 fi


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Changes

This PR updates the carthage.sh script to use version 0.40.0.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
