### PR TITLE
fix: Biometrics app lock - WPB-11014

### DIFF
--- a/wire-ios/Wire-iOS Tests/AppLockModuleViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppLockModuleViewTests.swift
@@ -50,7 +50,7 @@ final class AppLockModuleViewTests: XCTestCase {
         sut.viewDidAppear(false)
 
         // Then
-        XCTAssertEqual(presenter.events, [.viewDidAppear])
+        XCTAssertEqual(presenter.events, [.viewDidFirstAppear])
     }
 
     // @SF.Locking @TSFI.FS-IOS @S0.1

--- a/wire-ios/Wire-iOS UnitTests/AppLockModuleInteractorTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/AppLockModuleInteractorTests.swift
@@ -64,20 +64,20 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.requireCustomAppLockPasscode = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: false)])
     }
 
-    func test_InitiaAuthentication_NeedsToCreateCustomPasscode_NotRequired() {
+    func test_InitiateAuthentication_NeedsToCreateCustomPasscode_NotRequired() {
         // Given
         session.isCustomAppLockPasscodeSet = false
         session.requireCustomAppLockPasscode = false
         authenticationType.current = .unavailable
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: false)])
@@ -90,7 +90,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.needsToNotifyUserOfAppLockConfiguration = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: true)])
@@ -101,7 +101,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.isCustomAppLockPasscodeSet = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
@@ -113,7 +113,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.needsToNotifyUserOfAppLockConfiguration = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: true)])
@@ -126,7 +126,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         authenticationType.current = .unavailable
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
@@ -137,36 +137,11 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.lock = .none
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(session.evaluateAuthentication.count, 0)
         XCTAssertEqual(session.openApp.count, 1)
-    }
-
-    func test_InitiateAuthentication_RequireForegroundApp_ReturnsNothingIfAppIsInBackground() {
-        // Given
-        applicationStateProvider.applicationState = .background
-        session.isCustomAppLockPasscodeSet = true
-
-        // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: true))
-
-        // Then
-        XCTAssertEqual(presenter.results, [])
-    }
-
-    func test_InitiateAuthentication_NeedsToCreateCustomPasscodeAndRequireForegroundApp_ReturnsNothingIfAppIsInBackground() {
-        // Given
-        applicationStateProvider.applicationState = .background
-        session.isCustomAppLockPasscodeSet = false
-        session.requireCustomAppLockPasscode = true
-
-        // When
-        sut.executeRequest(.initiateAuthentication(requireForegroundApp: true))
-
-        // Then
-        XCTAssertEqual(presenter.results, [])
     }
 
     // MARK: - Evaluate authentication

--- a/wire-ios/Wire-iOS UnitTests/AppLockModuleInteractorTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/AppLockModuleInteractorTests.swift
@@ -64,7 +64,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.requireCustomAppLockPasscode = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: false)])
@@ -77,7 +77,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         authenticationType.current = .unavailable
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: false)])
@@ -90,7 +90,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.needsToNotifyUserOfAppLockConfiguration = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: true)])
@@ -101,7 +101,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.isCustomAppLockPasscodeSet = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
@@ -113,7 +113,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.needsToNotifyUserOfAppLockConfiguration = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: true)])
@@ -126,7 +126,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         authenticationType.current = .unavailable
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
@@ -137,33 +137,33 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.lock = .none
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         // Then
         XCTAssertEqual(session.evaluateAuthentication.count, 0)
         XCTAssertEqual(session.openApp.count, 1)
     }
 
-    func test_InitiateAuthentication_RequireActiveApp_ReturnsNothingIfAppIsInBackground() {
+    func test_InitiateAuthentication_RequireForegroundApp_ReturnsNothingIfAppIsInBackground() {
         // Given
         applicationStateProvider.applicationState = .background
         session.isCustomAppLockPasscodeSet = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: true))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: true))
 
         // Then
         XCTAssertEqual(presenter.results, [])
     }
 
-    func test_InitiateAuthentication_NeedsToCreateCustomPasscodeAndRequireActiveApp_ReturnsNothingIfAppIsInBackground() {
+    func test_InitiateAuthentication_NeedsToCreateCustomPasscodeAndRequireForegroundApp_ReturnsNothingIfAppIsInBackground() {
         // Given
         applicationStateProvider.applicationState = .background
         session.isCustomAppLockPasscodeSet = false
         session.requireCustomAppLockPasscode = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: true))
+        sut.executeRequest(.initiateAuthentication(requireForegroundApp: true))
 
         // Then
         XCTAssertEqual(presenter.results, [])

--- a/wire-ios/Wire-iOS UnitTests/AppLockModulePresenterTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/AppLockModulePresenterTests.swift
@@ -111,12 +111,12 @@ final class AppLockModulePresenterTests: XCTestCase {
 
     // MARK: - Process Event
 
-    func test_ViewDidAppear() {
+    func test_ViewDidFirstAppear() {
         // When
-        sut.processEvent(.viewDidAppear)
+        sut.processEvent(.viewDidFirstAppear)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireForegroundApp: true)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication])
     }
 
     func test_UnlockButtonTapped() {
@@ -124,7 +124,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.unlockButtonTapped)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireForegroundApp: true)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication])
     }
 
     func test_PasscodeSetupCompleted() {
@@ -164,7 +164,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.applicationWillEnterForeground)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireForegroundApp: false)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication])
     }
 
 }

--- a/wire-ios/Wire-iOS UnitTests/AppLockModulePresenterTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/AppLockModulePresenterTests.swift
@@ -116,7 +116,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.viewDidAppear)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireActiveApp: true)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireForegroundApp: true)])
     }
 
     func test_UnlockButtonTapped() {
@@ -124,7 +124,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.unlockButtonTapped)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireActiveApp: true)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireForegroundApp: true)])
     }
 
     func test_PasscodeSetupCompleted() {
@@ -164,7 +164,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.applicationWillEnterForeground)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireActiveApp: false)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireForegroundApp: false)])
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
@@ -97,7 +97,7 @@ extension AppLockModule.Interactor: AppLockInteractorPresenterInterface {
 
     func executeRequest(_ request: AppLockModule.Request) {
         switch request {
-        case .initiateAuthentication(requireActiveApp: true) where applicationState != .active:
+        case .initiateAuthentication(requireForegroundApp: true) where applicationState != .active:
             return
 
         case .initiateAuthentication where !isAuthenticationNeeded:

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
@@ -97,9 +97,6 @@ extension AppLockModule.Interactor: AppLockInteractorPresenterInterface {
 
     func executeRequest(_ request: AppLockModule.Request) {
         switch request {
-        case .initiateAuthentication(requireForegroundApp: true) where applicationState == .background:
-            return
-
         case .initiateAuthentication where !isAuthenticationNeeded:
             openAppLock()
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
@@ -97,7 +97,7 @@ extension AppLockModule.Interactor: AppLockInteractorPresenterInterface {
 
     func executeRequest(_ request: AppLockModule.Request) {
         switch request {
-        case .initiateAuthentication(requireForegroundApp: true) where applicationState != .active:
+        case .initiateAuthentication(requireForegroundApp: true) where applicationState == .background:
             return
 
         case .initiateAuthentication where !isAuthenticationNeeded:

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
@@ -69,11 +69,8 @@ extension AppLockModule.Presenter: AppLockPresenterViewInterface {
         switch event {
         // In iOS 14, it was found that 'viewDidAppear' may be invoked even when the app is in the background.
         // To prevent re-authentication when the app is in the background, there is the 'requireForegroundApp' parameter.
-        case .viewDidAppear, .unlockButtonTapped:
-            interactor.executeRequest(.initiateAuthentication(requireForegroundApp: true))
-
-        case .applicationWillEnterForeground:
-            interactor.executeRequest(.initiateAuthentication(requireForegroundApp: false))
+        case .viewDidFirstAppear, .unlockButtonTapped, .applicationWillEnterForeground:
+            interactor.executeRequest(.initiateAuthentication)
 
         case .passcodeSetupCompleted, .customPasscodeVerified:
             interactor.executeRequest(.openAppLock)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
@@ -67,12 +67,13 @@ extension AppLockModule.Presenter: AppLockPresenterViewInterface {
 
     func processEvent(_ event: AppLockModule.Event) {
         switch event {
-        // In iOS 14, it was found that 'viewDidAppear' may be invoked even when the app is in the background. To prevent re-authentication when the app is in the background, there is the 'requireActiveApp' parameter.
+        // In iOS 14, it was found that 'viewDidAppear' may be invoked even when the app is in the background.
+        // To prevent re-authentication when the app is in the background, there is the 'requireForegroundApp' parameter.
         case .viewDidAppear, .unlockButtonTapped:
-            interactor.executeRequest(.initiateAuthentication(requireActiveApp: true))
+            interactor.executeRequest(.initiateAuthentication(requireForegroundApp: true))
 
         case .applicationWillEnterForeground:
-            interactor.executeRequest(.initiateAuthentication(requireActiveApp: false))
+            interactor.executeRequest(.initiateAuthentication(requireForegroundApp: false))
 
         case .passcodeSetupCompleted, .customPasscodeVerified:
             interactor.executeRequest(.openAppLock)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
@@ -24,6 +24,7 @@ extension AppLockModule {
 
         // MARK: - Properties
 
+        private var hasViewAppeared = false
         var presenter: AppLockPresenterViewInterface!
 
         override var prefersStatusBarHidden: Bool {
@@ -37,12 +38,16 @@ extension AppLockModule {
         override func viewDidLoad() {
             super.viewDidLoad()
             setUpViews()
-            setUpObserver()
         }
 
         override func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
-            presenter.processEvent(.viewDidAppear)
+
+            if !hasViewAppeared {
+                presenter.processEvent(.viewDidFirstAppear)
+                hasViewAppeared = true
+                observeViewWillEnterForeground()
+            }
         }
 
         // MARK: - Methods
@@ -53,8 +58,13 @@ extension AppLockModule {
             lockView.fitIn(view: view)
         }
 
-        private func setUpObserver() {
-            NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        private func observeViewWillEnterForeground() {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(applicationWillEnterForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
         }
 
         @objc

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
@@ -58,7 +58,7 @@ extension AppLockModule {
 
     enum Request: Equatable {
 
-        case initiateAuthentication(requireActiveApp: Bool)
+        case initiateAuthentication(requireForegroundApp: Bool)
         case evaluateAuthentication
         case openAppLock
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
@@ -46,7 +46,7 @@ extension AppLockModule {
 
     enum Event: Equatable {
 
-        case viewDidAppear
+        case viewDidFirstAppear
         case applicationWillEnterForeground
         case unlockButtonTapped
         case openDeviceSettingsButtonTapped
@@ -58,7 +58,7 @@ extension AppLockModule {
 
     enum Request: Equatable {
 
-        case initiateAuthentication(requireForegroundApp: Bool)
+        case initiateAuthentication
         case evaluateAuthentication
         case openAppLock
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11014" title="WPB-11014" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11014</a>  [iOS] : When  biometry (passcode) protection enabled - Have to close and restart to use Wire
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a user has password `Lock With Passcode` enabled, and the `AppLock` shows when returning from the background, we filter out calls to initiate authentication if the application state is not [UIApplicationStateActive](https://developer.apple.com/documentation/uikit/uiapplicationstate/uiapplicationstateactive?language=objc). This was a fix for another bug where users may be presented with the authentication UI twice, once caused by the appearance of the app lock and once in response to a `UIApplication.willEnterForegroundNotification` notification - at least this I my assumption based on the code and code comments. Unfortunately the bugfix PR and tickets are not available as this was an old code fix. 

However, in my tests the initiate authentication action due to viewDidAppear is filtered out as the application state at that point on my device / os version is [UIApplicationStateInactive](https://developer.apple.com/documentation/uikit/uiapplicationstate/uiapplicationstateinactive?language=objc) (which is still a foreground state). 

My assumption is that this bug might be iOS version dependent. Therefore with this PR I change how things work a little:

- We only considerer the first `viewDidAppear` when showing the authentication due to `viewDidAppear`.
- We begin observing `UIApplication.willEnterForegroundNotification` after  `viewDidAppear`.

I hope with these changes that we always show the authentication when required, but don't show it twice.

One thing I was not sure about is where to add the logic for this new behavior - is this view following Viper? I haven't really worked with Viper before. Is my implementation OK or should the logic be moved to the presenter or interactor?


### Testing

**Please try both on devices with `Face ID` and `Touch ID` and with multiple `iOS` versions.**

#### Test Case 1

1. Enable `Lock With Passcode` in Account > Settings > Options
2. Put the app in the background
3. Wait over 1 minute
4. Bring the app to the foreground -> `Face/Touch ID` is shown
5. Authenticate with `Face/Touch ID`

#### Test Case 2

Try to break things related to  `Face/Touch ID`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

