### PR TITLE
fix: Biometrics app lock - WPB-11014

### DIFF
--- a/wire-ios/Wire-iOS Tests/AppLockModuleViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppLockModuleViewTests.swift
@@ -51,7 +51,7 @@ final class AppLockModuleViewTests: XCTestCase {
         sut.viewDidAppear(false)
 
         // Then
-        XCTAssertEqual(presenter.events, [.viewDidAppear])
+        XCTAssertEqual(presenter.events, [.viewDidFirstAppear])
     }
 
     // @SF.Locking @TSFI.FS-IOS @S0.1

--- a/wire-ios/Wire-iOS UnitTests/AppLockModuleInteractorTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/AppLockModuleInteractorTests.swift
@@ -64,20 +64,20 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.requireCustomAppLockPasscode = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: false)])
     }
 
-    func test_InitiaAuthentication_NeedsToCreateCustomPasscode_NotRequired() {
+    func test_InitiateAuthentication_NeedsToCreateCustomPasscode_NotRequired() {
         // Given
         session.isCustomAppLockPasscodeSet = false
         session.requireCustomAppLockPasscode = false
         authenticationType.current = .unavailable
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: false)])
@@ -90,7 +90,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.needsToNotifyUserOfAppLockConfiguration = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.customPasscodeCreationNeeded(shouldInform: true)])
@@ -101,7 +101,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.isCustomAppLockPasscodeSet = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
@@ -113,7 +113,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.needsToNotifyUserOfAppLockConfiguration = true
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: true)])
@@ -126,7 +126,7 @@ final class AppLockModuleInteractorTests: XCTestCase {
         authenticationType.current = .unavailable
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(presenter.results, [.readyForAuthentication(shouldInform: false)])
@@ -137,36 +137,11 @@ final class AppLockModuleInteractorTests: XCTestCase {
         session.lock = .none
 
         // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        sut.executeRequest(.initiateAuthentication)
 
         // Then
         XCTAssertEqual(session.evaluateAuthentication.count, 0)
         XCTAssertEqual(session.openApp.count, 1)
-    }
-
-    func test_InitiateAuthentication_RequireActiveApp_ReturnsNothingIfAppIsInBackground() {
-        // Given
-        applicationStateProvider.applicationState = .background
-        session.isCustomAppLockPasscodeSet = true
-
-        // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: true))
-
-        // Then
-        XCTAssertEqual(presenter.results, [])
-    }
-
-    func test_InitiateAuthentication_NeedsToCreateCustomPasscodeAndRequireActiveApp_ReturnsNothingIfAppIsInBackground() {
-        // Given
-        applicationStateProvider.applicationState = .background
-        session.isCustomAppLockPasscodeSet = false
-        session.requireCustomAppLockPasscode = true
-
-        // When
-        sut.executeRequest(.initiateAuthentication(requireActiveApp: true))
-
-        // Then
-        XCTAssertEqual(presenter.results, [])
     }
 
     // MARK: - Evaluate authentication

--- a/wire-ios/Wire-iOS UnitTests/AppLockModulePresenterTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/AppLockModulePresenterTests.swift
@@ -111,12 +111,12 @@ final class AppLockModulePresenterTests: XCTestCase {
 
     // MARK: - Process Event
 
-    func test_ViewDidAppear() {
+    func test_ViewDidFirstAppear() {
         // When
-        sut.processEvent(.viewDidAppear)
+        sut.processEvent(.viewDidFirstAppear)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireActiveApp: true)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication])
     }
 
     func test_UnlockButtonTapped() {
@@ -124,7 +124,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.unlockButtonTapped)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireActiveApp: true)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication])
     }
 
     func test_PasscodeSetupCompleted() {
@@ -164,7 +164,7 @@ final class AppLockModulePresenterTests: XCTestCase {
         sut.processEvent(.applicationWillEnterForeground)
 
         // Then
-        XCTAssertEqual(interactor.requests, [.initiateAuthentication(requireActiveApp: false)])
+        XCTAssertEqual(interactor.requests, [.initiateAuthentication])
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Interactor.swift
@@ -97,9 +97,6 @@ extension AppLockModule.Interactor: AppLockInteractorPresenterInterface {
 
     func executeRequest(_ request: AppLockModule.Request) {
         switch request {
-        case .initiateAuthentication(requireActiveApp: true) where applicationState != .active:
-            return
-
         case .initiateAuthentication where !isAuthenticationNeeded:
             openAppLock()
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.Presenter.swift
@@ -67,12 +67,10 @@ extension AppLockModule.Presenter: AppLockPresenterViewInterface {
 
     func processEvent(_ event: AppLockModule.Event) {
         switch event {
-        // In iOS 14, it was found that 'viewDidAppear' may be invoked even when the app is in the background. To prevent re-authentication when the app is in the background, there is the 'requireActiveApp' parameter.
-        case .viewDidAppear, .unlockButtonTapped:
-            interactor.executeRequest(.initiateAuthentication(requireActiveApp: true))
-
-        case .applicationWillEnterForeground:
-            interactor.executeRequest(.initiateAuthentication(requireActiveApp: false))
+        // In iOS 14, it was found that 'viewDidAppear' may be invoked even when the app is in the background.
+        // To prevent re-authentication when the app is in the background, there is the 'requireForegroundApp' parameter.
+        case .viewDidFirstAppear, .unlockButtonTapped, .applicationWillEnterForeground:
+            interactor.executeRequest(.initiateAuthentication)
 
         case .passcodeSetupCompleted, .customPasscodeVerified:
             interactor.executeRequest(.openAppLock)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.View.swift
@@ -24,6 +24,7 @@ extension AppLockModule {
 
         // MARK: - Properties
 
+        private var hasViewAppeared = false
         var presenter: AppLockPresenterViewInterface!
 
         override var prefersStatusBarHidden: Bool {
@@ -37,12 +38,16 @@ extension AppLockModule {
         override func viewDidLoad() {
             super.viewDidLoad()
             setUpViews()
-            setUpObserver()
         }
 
         override func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
-            presenter.processEvent(.viewDidAppear)
+
+            if !hasViewAppeared {
+                presenter.processEvent(.viewDidFirstAppear)
+                hasViewAppeared = true
+                observeViewWillEnterForeground()
+            }
         }
 
         // MARK: - Methods
@@ -53,8 +58,13 @@ extension AppLockModule {
             lockView.fitIn(view: view)
         }
 
-        private func setUpObserver() {
-            NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        private func observeViewWillEnterForeground() {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(applicationWillEnterForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
         }
 
         @objc

--- a/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/App Lock/AppLockModule.swift
@@ -46,7 +46,7 @@ extension AppLockModule {
 
     enum Event: Equatable {
 
-        case viewDidAppear
+        case viewDidFirstAppear
         case applicationWillEnterForeground
         case unlockButtonTapped
         case openDeviceSettingsButtonTapped
@@ -58,7 +58,7 @@ extension AppLockModule {
 
     enum Request: Equatable {
 
-        case initiateAuthentication(requireActiveApp: Bool)
+        case initiateAuthentication
         case evaluateAuthentication
         case openAppLock
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11014" title="WPB-11014" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11014</a>  [iOS] : When  biometry (passcode) protection enabled - Have to close and restart to use Wire
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR cherrypicks https://github.com/wireapp/wire-ios/pull/1956 into `release/cycle-3.113`

### Testing

Please test following instructions from original PR: https://github.com/wireapp/wire-ios/pull/1956

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.
