### PR TITLE
fix: user property read receipt with apiVersion v6 - WPB-11262

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
@@ -24,7 +24,7 @@ private enum UserProperty: CaseIterable {
 }
 
 extension UserProperty {
-    static let propertiesPath = "properties"
+    static let propertiesPath = "/properties"
 
     var propertyName: String {
         switch self {

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategyTests.swift
@@ -132,9 +132,32 @@ extension UserPropertyRequestStrategyTests {
 
             XCTAssertNotNil(request)
             XCTAssertEqual(request!.method, .get)
-            XCTAssertEqual(request!.path, "properties/WIRE_RECEIPT_MODE")
+            XCTAssertEqual(request!.path, "/properties/WIRE_RECEIPT_MODE")
 
             let response = ZMTransportResponse(payload: "1" as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
+
+            self.sut.didReceive(response, forSingleRequest: self.sut.downstreamSync)
+
+            // then
+            XCTAssertFalse(selfUser.needsPropertiesUpdate)
+            XCTAssertTrue(selfUser.readReceiptsEnabled)
+            XCTAssertFalse(selfUser.readReceiptsEnabledChangedRemotely)
+        }
+    }
+
+    func testThatItIsFetchingPropertyValue_withV6() {
+        self.syncMOC.performGroupedAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+
+            // when
+            let request = self.sut.nextRequestIfAllowed(for: .v6)
+
+            XCTAssertNotNil(request)
+            XCTAssertEqual(request!.method, .get)
+            XCTAssertEqual(request!.path, "/v6/properties/WIRE_RECEIPT_MODE")
+
+            let response = ZMTransportResponse(payload: "1" as ZMTransportData, httpStatus: 200, transportSessionError: nil, apiVersion: APIVersion.v6.rawValue)
 
             self.sut.didReceive(response, forSingleRequest: self.sut.downstreamSync)
 
@@ -155,9 +178,32 @@ extension UserPropertyRequestStrategyTests {
 
             XCTAssertNotNil(request)
             XCTAssertEqual(request!.method, .get)
-            XCTAssertEqual(request!.path, "properties/WIRE_RECEIPT_MODE")
+            XCTAssertEqual(request!.path, "/properties/WIRE_RECEIPT_MODE")
 
             let response = ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil, apiVersion: APIVersion.v0.rawValue)
+
+            self.sut.didReceive(response, forSingleRequest: self.sut.downstreamSync)
+
+            // then
+            XCTAssertFalse(selfUser.needsPropertiesUpdate)
+            XCTAssertFalse(selfUser.readReceiptsEnabled)
+            XCTAssertFalse(selfUser.readReceiptsEnabledChangedRemotely)
+        }
+    }
+
+    func testThatItIsFetchingPropertyValue_404_apiV6() {
+        self.syncMOC.performGroupedAndWait {
+            // given
+            let selfUser = ZMUser.selfUser(in: syncMOC)
+
+            // when
+            let request = self.sut.nextRequestIfAllowed(for: .v6)
+
+            XCTAssertNotNil(request)
+            XCTAssertEqual(request!.method, .get)
+            XCTAssertEqual(request!.path, "/v6/properties/WIRE_RECEIPT_MODE")
+
+            let response = ZMTransportResponse(payload: nil, httpStatus: 404, transportSessionError: nil, apiVersion: APIVersion.v6.rawValue)
 
             self.sut.didReceive(response, forSingleRequest: self.sut.downstreamSync)
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11262" title="WPB-11262" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11262</a>  [iOS] Read receipt option not persisted / synced on API v6
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR is a manual cherry-pick for the hotfix release 3.113.1 see PR #1966.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
