### PR TITLE
refactor: process user properties delete event - WPB-10198

### DIFF
--- a/WireAPI/Sources/WireAPI/Models/UpdateEvent/UserEvent/UserPropertiesDeleteEvent.swift
+++ b/WireAPI/Sources/WireAPI/Models/UpdateEvent/UserEvent/UserPropertiesDeleteEvent.swift
@@ -21,10 +21,14 @@ import Foundation
 /// An event where one of the self user's persisted
 /// properties was deleted.
 
-public struct UserPropertiesDeleteEvent: Equatable, Codable {
+public struct UserPropertiesDeleteEvent: Equatable, Codable, Sendable {
 
     /// The property key that was deleted.
 
     public let key: String
+
+    public init(key: String) {
+        self.key = key
+    }
 
 }

--- a/WireAPI/Sources/WireAPI/Models/UserProperties/UserProperty.swift
+++ b/WireAPI/Sources/WireAPI/Models/UserProperties/UserProperty.swift
@@ -45,7 +45,7 @@ public extension UserProperty {
 
     /// The user property key.
 
-    enum Key: String {
+    enum Key: String, Sendable {
 
         /// Wire receipt mode
 

--- a/WireDomain/Project/WireDomain Project.xcodeproj/project.pbxproj
+++ b/WireDomain/Project/WireDomain Project.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C93961922C91B12800EA971A /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E117D2C2C4080004BBD29 /* TestError.swift */; };
 		C93961932C91B15B00EA971A /* ConversationRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E8A3E72C7F6EA40093DD5C /* ConversationRepositoryTests.swift */; };
 		C97BCCAA2C98704B004F2D0D /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01D0DCA62C1C8C870076CB1C /* WireDomain.framework */; };
+		C9841A262CA43E9B0062A834 /* UserPropertiesDeleteEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9841A252CA43E9B0062A834 /* UserPropertiesDeleteEventProcessorTests.swift */; };
 		C99322D22C986E3A0065E10F /* TeamRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99322B22C986E3A0065E10F /* TeamRepository.swift */; };
 		C99322D32C986E3A0065E10F /* TeamRepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99322B32C986E3A0065E10F /* TeamRepositoryError.swift */; };
 		C99322D42C986E3A0065E10F /* SelfUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99322B52C986E3A0065E10F /* SelfUserProvider.swift */; };
@@ -54,10 +55,10 @@
 		C9EA76A12C93104C00A7D35C /* PushSupportedProtocolsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EA76A02C93104C00A7D35C /* PushSupportedProtocolsUseCaseTests.swift */; };
 		C9F691192C987DC8008CC41F /* TeamDeleteEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F691162C987DC8008CC41F /* TeamDeleteEventProcessorTests.swift */; };
 		C9F6911A2C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F691172C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift */; };
+		C9F911C72C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F911C52C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift */; };
 		C9F911D42C9DA3E80026B201 /* UserClientAddEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F911D02C9DA3E80026B201 /* UserClientAddEventProcessorTests.swift */; };
 		C9F911D52C9DA3E80026B201 /* UserLegalHoldDisableEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F911D12C9DA3E80026B201 /* UserLegalHoldDisableEventProcessorTests.swift */; };
 		C9F911D62C9DA3E80026B201 /* UserLegalholdRequestEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F911D22C9DA3E80026B201 /* UserLegalholdRequestEventProcessorTests.swift */; };
-		C9F911C72C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F911C52C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift */; };
 		CB7979132C738508006FBA58 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7979122C738508006FBA58 /* WireTransportSupport.framework */; };
 		CB7979162C738547006FBA58 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7979152C738547006FBA58 /* TestSetup.swift */; };
 		EE368CCE2C2DAA87009DBAB0 /* ConversationEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE368CC72C2DAA87009DBAB0 /* ConversationEventProcessor.swift */; };
@@ -141,6 +142,7 @@
 		01D0DCE92C1C8EA10076CB1C /* WireDomain.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = WireDomain.docc; sourceTree = "<group>"; };
 		01D0DCFC2C1C8F9B0076CB1C /* WireDomain.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = WireDomain.xctestplan; sourceTree = "<group>"; };
 		1623564F2C2B223100C6666C /* UserRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRepositoryTests.swift; sourceTree = "<group>"; };
+		C9841A252CA43E9B0062A834 /* UserPropertiesDeleteEventProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPropertiesDeleteEventProcessorTests.swift; sourceTree = "<group>"; };
 		C99322B22C986E3A0065E10F /* TeamRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamRepository.swift; sourceTree = "<group>"; };
 		C99322B32C986E3A0065E10F /* TeamRepositoryError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamRepositoryError.swift; sourceTree = "<group>"; };
 		C99322B52C986E3A0065E10F /* SelfUserProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelfUserProvider.swift; sourceTree = "<group>"; };
@@ -172,10 +174,10 @@
 		C9EA76A02C93104C00A7D35C /* PushSupportedProtocolsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushSupportedProtocolsUseCaseTests.swift; sourceTree = "<group>"; };
 		C9F691162C987DC8008CC41F /* TeamDeleteEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamDeleteEventProcessorTests.swift; sourceTree = "<group>"; };
 		C9F691172C987DC8008CC41F /* TeamMemberUpdateEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeamMemberUpdateEventProcessorTests.swift; sourceTree = "<group>"; };
+		C9F911C52C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureConfigUpdateEventProcessorTests.swift; sourceTree = "<group>"; };
 		C9F911D02C9DA3E80026B201 /* UserClientAddEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserClientAddEventProcessorTests.swift; sourceTree = "<group>"; };
 		C9F911D12C9DA3E80026B201 /* UserLegalHoldDisableEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserLegalHoldDisableEventProcessorTests.swift; sourceTree = "<group>"; };
 		C9F911D22C9DA3E80026B201 /* UserLegalholdRequestEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserLegalholdRequestEventProcessorTests.swift; sourceTree = "<group>"; };
-		C9F911C52C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureConfigUpdateEventProcessorTests.swift; sourceTree = "<group>"; };
 		CB7979122C738508006FBA58 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB7979152C738547006FBA58 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
 		EE0E117D2C2C4080004BBD29 /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
@@ -496,22 +498,23 @@
 			path = TeamEventProcessor;
 			sourceTree = "<group>";
 		};
-		C9F911D32C9DA3E80026B201 /* UserEventProcessor */ = {
-			isa = PBXGroup;
-			children = (
-				C9F911D02C9DA3E80026B201 /* UserClientAddEventProcessorTests.swift */,
-				C9F911D12C9DA3E80026B201 /* UserLegalHoldDisableEventProcessorTests.swift */,
-				C9F911D22C9DA3E80026B201 /* UserLegalholdRequestEventProcessorTests.swift */,
-			);
-			path = UserEventProcessor;
-            sourceTree = "<group>";
-        };
 		C9F911C62C9D5D5F0026B201 /* FeatureConfigEventProcessor */ = {
 			isa = PBXGroup;
 			children = (
 				C9F911C52C9D5D5F0026B201 /* FeatureConfigUpdateEventProcessorTests.swift */,
 			);
 			path = FeatureConfigEventProcessor;
+			sourceTree = "<group>";
+		};
+		C9F911D32C9DA3E80026B201 /* UserEventProcessor */ = {
+			isa = PBXGroup;
+			children = (
+				C9F911D02C9DA3E80026B201 /* UserClientAddEventProcessorTests.swift */,
+				C9F911D12C9DA3E80026B201 /* UserLegalHoldDisableEventProcessorTests.swift */,
+				C9F911D22C9DA3E80026B201 /* UserLegalholdRequestEventProcessorTests.swift */,
+				C9841A252CA43E9B0062A834 /* UserPropertiesDeleteEventProcessorTests.swift */,
+			);
+			path = UserEventProcessor;
 			sourceTree = "<group>";
 		};
 		EE0E117C2C2C4076004BBD29 /* Helpers */ = {
@@ -923,6 +926,7 @@
 				EE3F97542C2ADC4C00668DF1 /* ProteusMessageDecryptorTests.swift in Sources */,
 				EE57A70B2C2A8BAA0096F242 /* UpdateEventDecryptorTests.swift in Sources */,
 				C9E8A3AE2C73878B0093DD5C /* ConnectionsRepositoryTests.swift in Sources */,
+				C9841A262CA43E9B0062A834 /* UserPropertiesDeleteEventProcessorTests.swift in Sources */,
 				C9F911D42C9DA3E80026B201 /* UserClientAddEventProcessorTests.swift in Sources */,
 				C9F911D52C9DA3E80026B201 /* UserLegalHoldDisableEventProcessorTests.swift in Sources */,
 				C9EA76A12C93104C00A7D35C /* PushSupportedProtocolsUseCaseTests.swift in Sources */,

--- a/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessor.swift
@@ -17,6 +17,7 @@
 //
 
 import WireAPI
+import WireSystem
 
 /// Process user properties delete events.
 
@@ -35,7 +36,15 @@ struct UserPropertiesDeleteEventProcessor: UserPropertiesDeleteEventProcessorPro
     let repository: any UserRepositoryProtocol
 
     func processEvent(_ event: UserPropertiesDeleteEvent) async {
-        await repository.deleteUserProperty(withKey: event.key)
+        let userPropertyKey = UserProperty.Key(rawValue: event.key)
+
+        guard let userPropertyKey else {
+            return WireLogger.eventProcessing.error(
+                "Unknown user property key: \(event.key)"
+            )
+        }
+
+        await repository.deleteUserProperty(withKey: userPropertyKey)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessor.swift
@@ -26,15 +26,16 @@ protocol UserPropertiesDeleteEventProcessorProtocol {
     ///
     /// - Parameter event: A user properties delete event.
 
-    func processEvent(_ event: UserPropertiesDeleteEvent) async throws
+    func processEvent(_ event: UserPropertiesDeleteEvent) async
 
 }
 
 struct UserPropertiesDeleteEventProcessor: UserPropertiesDeleteEventProcessorProtocol {
 
-    func processEvent(_: UserPropertiesDeleteEvent) async throws {
-        // TODO: [WPB-10198]
-        assertionFailure("not implemented yet")
+    let repository: any UserRepositoryProtocol
+
+    func processEvent(_ event: UserPropertiesDeleteEvent) async {
+        await repository.deleteUserProperty(withKey: event.key)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
@@ -294,7 +294,7 @@ public final class UserRepository: UserRepositoryProtocol {
             break
 
         case nil:
-            logger.warn("Unknown user property key: \(key)")
+            logger.error("Unknown user property key: \(key)")
         }
     }
 

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
@@ -225,14 +225,18 @@ public final class UserRepository: UserRepositoryProtocol {
                 )
             }
 
+            let selfClient = selfUser.selfClient()
+            let isNotSameId = localClient.remoteIdentifier != selfClient?.remoteIdentifier
             let localClientActivationDate = localClient.activationDate
+            let selfClientActivationDate = selfClient?.activationDate
 
-            if let selfClient = selfUser.selfClient(),
-               localClient.remoteIdentifier != selfClient.remoteIdentifier, isNewClient,
-               let selfClientActivationDate = selfClient.activationDate,
-               localClientActivationDate?.compare(selfClientActivationDate) == .orderedDescending
-            {
-                localClient.needsToNotifyUser = true
+            if let selfClient, isNotSameId, let localClientActivationDate, let selfClientActivationDate {
+                let comparisonResult = localClientActivationDate
+                    .compare(selfClientActivationDate)
+
+                if comparisonResult == .orderedDescending {
+                    localClient.needsToNotifyUser = true
+                }
             }
 
             selfUser.selfClient()?.addNewClientToIgnored(localClient)

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
@@ -290,7 +290,13 @@ public final class UserRepository: UserRepositoryProtocol {
                 selfUser.readReceiptsEnabledChangedRemotely = true
             }
 
-        case .wireTypingIndicatorMode, .labels:
+        case .wireTypingIndicatorMode:
+            // TODO: [WPB-726] feature not implemented yet
+            break
+
+        case .labels:
+            /// Already handled with `user.properties-set` event (adding new labels and removing old ones)
+            /// see `ConversationLabelsRepository`
             break
 
         case nil:

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserRepository.swift
@@ -100,7 +100,7 @@ public protocol UserRepositoryProtocol {
     ///     - key: The user property key to delete.
 
     func deleteUserProperty(
-        withKey key: String
+        withKey key: UserProperty.Key
     ) async
 
 }
@@ -112,7 +112,6 @@ public final class UserRepository: UserRepositoryProtocol {
     private let context: NSManagedObjectContext
     private let usersAPI: any UsersAPI
     private let selfUserAPI: any SelfUserAPI
-    private let logger = WireLogger.eventProcessing
 
     // MARK: - Object lifecycle
 
@@ -231,7 +230,8 @@ public final class UserRepository: UserRepositoryProtocol {
             if let selfClient = selfUser.selfClient(),
                localClient.remoteIdentifier != selfClient.remoteIdentifier, isNewClient,
                let selfClientActivationDate = selfClient.activationDate,
-               localClientActivationDate?.compare(selfClientActivationDate) == .orderedDescending {
+               localClientActivationDate?.compare(selfClientActivationDate) == .orderedDescending
+            {
                 localClient.needsToNotifyUser = true
             }
 
@@ -277,11 +277,9 @@ public final class UserRepository: UserRepositoryProtocol {
     }
 
     public func deleteUserProperty(
-        withKey key: String
+        withKey key: UserProperty.Key
     ) async {
-        let userPropertyKey = UserProperty.Key(rawValue: key)
-
-        switch userPropertyKey {
+        switch key {
         case .wireReceiptMode:
             let selfUser = fetchSelfUser()
 
@@ -298,9 +296,6 @@ public final class UserRepository: UserRepositoryProtocol {
             /// Already handled with `user.properties-set` event (adding new labels and removing old ones)
             /// see `ConversationLabelsRepository`
             break
-
-        case nil:
-            logger.error("Unknown user property key: \(key)")
         }
     }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -543,6 +543,21 @@ public class MockUserRepositoryProtocol: UserRepositoryProtocol {
         try await mock()
     }
 
+    // MARK: - deleteUserProperty
+
+    public var deleteUserPropertyWithKey_Invocations: [String] = []
+    public var deleteUserPropertyWithKey_MockMethod: ((String) async -> Void)?
+
+    public func deleteUserProperty(withKey key: String) async {
+        deleteUserPropertyWithKey_Invocations.append(key)
+
+        guard let mock = deleteUserPropertyWithKey_MockMethod else {
+            fatalError("no mock for `deleteUserPropertyWithKey`")
+        }
+
+        await mock(key)
+    }
+
 }
 
 // swiftlint:enable variable_name

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -545,10 +545,10 @@ public class MockUserRepositoryProtocol: UserRepositoryProtocol {
 
     // MARK: - deleteUserProperty
 
-    public var deleteUserPropertyWithKey_Invocations: [String] = []
-    public var deleteUserPropertyWithKey_MockMethod: ((String) async -> Void)?
+    public var deleteUserPropertyWithKey_Invocations: [UserProperty.Key] = []
+    public var deleteUserPropertyWithKey_MockMethod: ((UserProperty.Key) async -> Void)?
 
-    public func deleteUserProperty(withKey key: String) async {
+    public func deleteUserProperty(withKey key: UserProperty.Key) async {
         deleteUserPropertyWithKey_Invocations.append(key)
 
         guard let mock = deleteUserPropertyWithKey_MockMethod else {

--- a/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserClientAddEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserClientAddEventProcessorTests.swift
@@ -46,7 +46,7 @@ final class UserClientAddEventProcessorTests: XCTestCase {
         sut = UserClientAddEventProcessor(
             repository: UserRepository(
                 context: context,
-                usersAPI: MockUsersAPI(), 
+                usersAPI: MockUsersAPI(),
                 selfUserAPI: MockSelfUserAPI()
             )
         )

--- a/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessorTests.swift
@@ -56,6 +56,6 @@ final class UserPropertiesDeleteEventProcessorTests: XCTestCase {
 
         // Then
 
-        XCTAssertEqual(userRepository.deleteUserPropertyWithKey_Invocations, [key.rawValue])
+        XCTAssertEqual(userRepository.deleteUserPropertyWithKey_Invocations, [key])
     }
 }

--- a/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessorTests.swift
@@ -52,7 +52,7 @@ final class UserPropertiesDeleteEventProcessorTests: XCTestCase {
 
         // When
 
-        try await sut.processEvent(event)
+        await sut.processEvent(event)
 
         // Then
 

--- a/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/UserEventProcessor/UserPropertiesDeleteEventProcessorTests.swift
@@ -1,0 +1,61 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAPI
+@testable import WireDomain
+import WireDomainSupport
+import XCTest
+
+final class UserPropertiesDeleteEventProcessorTests: XCTestCase {
+
+    var sut: UserPropertiesDeleteEventProcessor!
+    var userRepository: MockUserRepositoryProtocol!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        userRepository = MockUserRepositoryProtocol()
+        sut = UserPropertiesDeleteEventProcessor(
+            repository: userRepository
+        )
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        userRepository = nil
+        sut = nil
+    }
+
+    func testProcessEvent_It_Invokes_Delete_User_Property_Repo_Method() async throws {
+        // Given
+
+        let key = UserProperty.Key.wireReceiptMode
+        let event = UserPropertiesDeleteEvent(key: key.rawValue)
+
+        // Mock
+
+        userRepository.deleteUserPropertyWithKey_MockMethod = { _ in }
+
+        // When
+
+        try await sut.processEvent(event)
+
+        // Then
+
+        XCTAssertEqual(userRepository.deleteUserPropertyWithKey_Invocations, [key.rawValue])
+    }
+}

--- a/WireDomain/Tests/WireDomainTests/Repositories/UserRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/UserRepositoryTests.swift
@@ -263,8 +263,39 @@ class UserRepositoryTests: XCTestCase {
         XCTAssertEqual(selfUsersAPI.pushSupportedProtocols_Invocations, [expectedProtocols])
     }
 
+    func testDeleteUserProperty() async {
+        // Given
+
+        await context.perform { [self] in
+            let selfUser = modelHelper.createSelfUser(
+                id: Scaffolding.userID,
+                domain: nil,
+                in: context
+            )
+
+            selfUser.readReceiptsEnabled = true
+            selfUser.readReceiptsEnabledChangedRemotely = false
+        }
+
+        // When
+
+        await sut.deleteUserProperty(
+            withKey: Scaffolding.userPropertyKey.rawValue
+        )
+
+        // Then
+
+        await context.perform { [self] in
+            let selfUser = sut.fetchSelfUser()
+
+            XCTAssertEqual(selfUser.readReceiptsEnabled, false)
+            XCTAssertEqual(selfUser.readReceiptsEnabledChangedRemotely, true)
+        }
+    }
+
     private enum Scaffolding {
         static let userID = UUID()
+        static let userPropertyKey = UserProperty.Key.wireReceiptMode
         static let userClientID = UUID().uuidString
         static let lastPrekeyId = 65_535
         static let base64encodedString = "pQABAQoCoQBYIPEFMBhOtG0dl6gZrh3kgopEK4i62t9sqyqCBckq3IJgA6EAoQBYIC9gPmCdKyqwj9RiAaeSsUI7zPKDZS+CjoN+sfihk/5VBPY="

--- a/WireDomain/Tests/WireDomainTests/Repositories/UserRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/UserRepositoryTests.swift
@@ -280,7 +280,7 @@ class UserRepositoryTests: XCTestCase {
         // When
 
         await sut.deleteUserProperty(
-            withKey: Scaffolding.userPropertyKey.rawValue
+            withKey: Scaffolding.userPropertyKey
         )
 
         // Then

--- a/WireDomain/Tests/WireDomainTests/Repositories/UserRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/UserRepositoryTests.swift
@@ -263,7 +263,7 @@ class UserRepositoryTests: XCTestCase {
         XCTAssertEqual(selfUsersAPI.pushSupportedProtocols_Invocations, [expectedProtocols])
     }
 
-    func testDeleteUserProperty() async {
+    func testDeleteUserProperty_It_Updates_Read_Receipts_Flags() async {
         // Given
 
         await context.perform { [self] in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10198" title="WPB-10198" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10198</a>  [iOS] Process UserPropertiesDeleteEvent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is part of the quick sync refactoring plan and is related to processing the multiple events we receive from the backend or the push channel.

Specifically, this PR is about porting the existing implementation of the `UserPropertiesDelete` event.

### Testing

UTs cover the following use cases, ensuring that
- user property `wireReceiptMode` is correctly processed

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
