### PR TITLE
fix: crash datadog enabled - WPB-11306

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/DatadogWrapper.swift
@@ -37,7 +37,8 @@ public final class DatadogWrapper {
 
         guard
             let appID = bundle.infoForKey("DatadogAppId"),
-            let clientToken = bundle.infoForKey("DatadogClientToken")
+            let clientToken = bundle.infoForKey("DatadogClientToken"),
+            !appID.isEmpty, !clientToken.isEmpty
         else {
             print("missing Datadog appID and clientToken - logging disabled")
             return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11306" title="WPB-11306" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11306</a>  Crash on Datadog enabled when it should not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

As to be merge with https://github.com/wireapp/wire-ios-build-assets/pull/119


### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
