### PR TITLE
feat: avs logs to datadog - WPB-10860

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-binary "wire-avs.json" "9.8.19"
+binary "wire-avs.json" "9.9.5"
 github "wireapp/ZipArchive" "v2.4.2"
 github "wireapp/core-crypto" "v1.0.2"
 github "wireapp/countly-sdk-ios" "23.02.3"

--- a/wire-avs.json
+++ b/wire-avs.json
@@ -1,3 +1,3 @@
 {
-  "9.8.19": "https://github.com/wireapp/wire-avs/releases/download/9.8.19/avs.xcframework.zip",
+  "9.9.5": "https://github.com/wireapp/wire-avs/releases/download/9.9.5/avs.xcframework.zip",
 }

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -214,7 +214,7 @@ extension WireCallCenterV3 {
             let jsonObject = try JSONSerialization.jsonObject(with: metricsData, options: .mutableContainers)
             guard let attributes = jsonObject as? [String: NSObject] else { return }
             analytics?.tagEvent("calling.avs_metrics_ended_call", attributes: attributes)
-            WireLogger.avs.info("Calling metrics: \(String(data: metricsData, encoding: .utf8) ?? ""))")
+            WireLogger.avs.info("Calling metrics: \(String(decoding: metricsData, as: UTF8.self) )")
         } catch {
             WireLogger.calling.error("Unable to parse call metrics JSON: \(error)")
         }
@@ -294,8 +294,8 @@ extension WireCallCenterV3 {
                 let members = change.members.map(AVSCallMember.init)
                 self.callParticipantsChanged(conversationId: AVSIdentifier.from(string: change.convid), participants: members)
             } catch {
-                let change = String(data: data, encoding: .utf8)
-                Self.logger.info("Cannot decode participant change JSON: \(String(describing: change))", attributes: .safePublic)
+                let change = String(decoding: data, as: UTF8.self)
+                Self.logger.info("Cannot decode participant change JSON: \(change)", attributes: .safePublic)
             }
         }
     }

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -217,6 +217,7 @@ extension WireCallCenterV3 {
             let jsonObject = try JSONSerialization.jsonObject(with: metricsData, options: .mutableContainers)
             guard let attributes = jsonObject as? [String: NSObject] else { return }
             analytics?.tagEvent("calling.avs_metrics_ended_call", attributes: attributes)
+            WireLogger.avs.info("Calling metrics: \(String(data: metricsData, encoding: .utf8) ?? ""))")
         } catch {
             zmLog.error("Unable to parse call metrics JSON: \(error)")
         }

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -245,7 +245,7 @@ extension WireCallCenterV3 {
                 selfUser.avsIdentifier == senderUserId,
                 selfUser.selfClient()?.remoteIdentifier == senderClientId
             else {
-                zmLog.warn("Received request to send calling message from non self user and/or client")
+                Self.logger.warn("Received request to send calling message from non self user and/or client")
                 return
             }
 

--- a/wire-ios-sync-engine/Source/SessionManager/AVSLogObserver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/AVSLogObserver.swift
@@ -18,8 +18,6 @@
 
 import avs
 
-private let zmLog = ZMSLog(tag: "AVS")
-
 final class AVSLogObserver: AVSLogger {
     private var token: Any!
 
@@ -30,6 +28,6 @@ final class AVSLogObserver: AVSLogger {
     // MARK: - AVSLoggger
 
     func log(message: String) {
-        zmLog.safePublic(SanitizedString(stringLiteral: message), level: .public)
+        WireLogger.avs.info(SanitizedString(stringLiteral: message).safeForLoggingDescription, attributes: .safePublic)
     }
 }

--- a/wire-ios-sync-engine/Source/SessionManager/AVSLogObserver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/AVSLogObserver.swift
@@ -25,7 +25,7 @@ final class AVSLogObserver: AVSLogger {
         token = SessionManager.addLogger(self)
     }
 
-    // MARK: - AVSLoggger
+    // MARK: - AVSLogger
 
     func log(message: String) {
         WireLogger.avs.info(SanitizedString(stringLiteral: message).safeForLoggingDescription, attributes: .safePublic)

--- a/wire-ios-system/Source/Logging/WireLogger+Instances.swift
+++ b/wire-ios-system/Source/Logging/WireLogger+Instances.swift
@@ -56,4 +56,5 @@ public extension WireLogger {
     static let network = WireLogger(tag: "network")
     static let eventProcessing = WireLogger(tag: "event-processing")
     static let messageProcessing = WireLogger(tag: "message-processing")
+    static let avs = WireLogger(tag: "avs")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10860" title="WPB-10860" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10860</a>  [iOS] Upload AVS metrics to Datadog
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

* Forwards some metrics to datadog from AVS
* Replace ZMSLog for AVS by WireLogger.avs


### Testing

* [x] Check datadog

Metrics in datadog:

![Screenshot 2024-09-27 at 14 05 31](https://github.com/user-attachments/assets/bf68de3b-be33-427a-8680-fec195c3c0fd)

Logs via WireLogger:

![Screenshot 2024-09-27 at 14 07 58](https://github.com/user-attachments/assets/f04b575b-7710-4c19-8f02-c0393b399609)

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
