### PR TITLE
fix: Crowdin Action not creating a PR - WPB-11296

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -48,7 +48,6 @@ jobs:
           HEAD_BRANCH="chore/update-localization"
           TITLE="chore: Update localization - no ticket"
           BODY="This PR pulls in the latest localization translations from Crowdin."
-          REVIEWER="wireapp/iOS"
 
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Trim unused localizations from string catalogs
+      - name: Trim unused localizations from string catalogs and create PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -48,7 +48,7 @@ jobs:
           HEAD_BRANCH="chore/update-localization"
           TITLE="chore: Update localization - no ticket"
           BODY="This PR pulls in the latest localization translations from Crowdin."
-          REVIEWER="wireapp/ios"
+          REVIEWER="wireapp/iOS"
 
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
@@ -75,7 +75,7 @@ jobs:
           # abort if the pr already exists
           apt update && apt install -y gh
           PR_EXISTS=$(gh pr list --base "$BASE_BRANCH" --head "$HEAD_BRANCH" --state open --json number --jq '.[0].number')
-          if [ -z "$PR_EXISTS" ]; then
+          if [ -n "$PR_EXISTS" ]; then
           echo "A PR already exists, aborting."
           exit 0
           fi
@@ -85,4 +85,3 @@ jobs:
           --head "$HEAD_BRANCH" \
           --title "$TITLE" \
           --body "$BODY" \
-          --reviewer "$REVIEWER"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11296" title="WPB-11296" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11296</a>  [iOS] Fix `Crowdin Action`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently our `Crowdin Action` fails to create a PR for two reasons:

1. We are exiting early when no existing localization PR exists (the opposite of the logic we want)
2. `gh` cli tool is failing to create a PR when passed a reviewer of `wireapp/iOS` or `wireapp/ios`. It fails with `could not request reviewer: 'wireapp/iOS' not found`. According to [docs](https://cli.github.com/manual/gh_pr_create) it should work but I can't get it to work 😢 - probably I'm doing something wrong but didn't want to invest too much time here. Therefore I've removed setting a reviewer.

I ran the updated GitHub action [here](https://github.com/wireapp/wire-ios/actions/runs/11051535358/job/30701633600) and it worked creating this [PR](https://github.com/wireapp/wire-ios/pull/1972).

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
