### PR TITLE
fix: crash call switchAnalyticsUser after logged in, add log error message - WPB-11309

### DIFF
--- a/wire-ios-data-model/Source/Model/User/AnalyticsIdentifierProvider.swift
+++ b/wire-ios-data-model/Source/Model/User/AnalyticsIdentifierProvider.swift
@@ -49,7 +49,11 @@ public struct AnalyticsIdentifierProvider {
 
     private func broadcast(identifier: UUID, context: NSManagedObjectContext) {
         let message = DataTransfer(trackingIdentifier: identifier)
-        _ = try? ZMConversation.sendMessageToSelfClients(message, in: context)
+        do {
+            try ZMConversation.sendMessageToSelfClients(message, in: context)
+        } catch let error {
+            WireLogger.messaging.error("Error broadcasting analytics ID: \(identifier.safeForLoggingDescription) \(error)")
+        }
     }
 
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -881,7 +881,6 @@ public final class SessionManager: NSObject, SessionManagerType {
         withSession(for: account, notifyAboutMigration: true) { session in
             self.activeUserSession = session
             WireLogger.sessionManager.debug("Activated ZMUserSession for account - \(account.userIdentifier.safeForLoggingDescription)")
-            self.switchAnalyticsUser(to: session)
 
             self.delegate?.sessionManagerDidChangeActiveUserSession(userSession: session)
             self.configureUserNotifications()
@@ -893,6 +892,7 @@ public final class SessionManager: NSObject, SessionManagerType {
             if session.isLoggedIn {
                 self.delegate?.sessionManagerDidReportLockChange(forSession: session)
                 self.performPostUnlockActionsIfPossible(for: session)
+                self.switchAnalyticsUser(to: session)
 
                 Task {
                     await self.requestCertificateEnrollmentIfNeeded()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11309" title="WPB-11309" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11309</a>  [iOS] Crash when analytics is enabled and you log in with a second account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…-11309

<!--do not remove the jira markers to link tickets automatically -->


### Issue

A crash is occurring when analytics is enabled and we're trying to log in with a second account, specifically a fatal error is thrown since the selfUser ID cannot  be found locally because we're not logged in yet.

```
+ (ZMConversation *)selfConversationInContext:(NSManagedObjectContext *)managedObjectContext
{
    NSUUID *selfUserID = [ZMConversation selfConversationIdentifierInContext:managedObjectContext];
    RequireString(selfUserID != nil, "selfUserID should exist");
    return [ZMConversation fetchWith:selfUserID in:managedObjectContext];
}
```

Calling `self.switchAnalyticsUser(to: session)` method after we're logged in fixes the crash.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
