### PR TITLE
fix: Liking a message doesn't get tracked on Countly - WPB-11311

### DIFF
--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -34,6 +34,8 @@ import WireCoreCrypto
 
 @testable import WireDataModel
 
+// It's because of this error that we need to create this mock manually:
+// Cannot declare conformance to 'NSObjectProtocol' in Swift; 'MockZMConversationMessage' should inherit 'NSObject' instead
 public class MockZMConversationMessage: NSObject, ZMConversationMessage {
 
     // MARK: - nonce

--- a/wire-ios-data-model/Support/Sources/ModelHelper.swift
+++ b/wire-ios-data-model/Support/Sources/ModelHelper.swift
@@ -25,6 +25,25 @@ public struct ModelHelper {
 
     public init() {}
 
+    // MARK: - Messages
+
+    @discardableResult
+    public func addTextMessages(
+        to conversation: ZMConversation,
+        messagePrefix: String = "message",
+        sender: ZMUser?,
+        count: Int,
+        in context: NSManagedObjectContext
+    ) throws -> [ZMMessage] {
+        let messageSender = sender ?? ZMUser.selfUser(in: context)
+        return try (0..<count).map { index in
+            let message = try conversation.appendText(content: "\(messagePrefix) \(index)") as! ZMMessage
+            message.sender = messageSender
+            return message
+        }
+
+    }
+
     // MARK: - Users
 
     @discardableResult

--- a/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
@@ -50,4 +50,6 @@ public protocol MessageAppendableConversation {
 
 extension ZMConversation: MessageAppendableConversation {
 
+    
+
 }

--- a/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
@@ -50,6 +50,4 @@ public protocol MessageAppendableConversation {
 
 extension ZMConversation: MessageAppendableConversation {
 
-    
-
 }

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -29,7 +29,6 @@ public protocol ToggleMessageReactionUseCaseProtocol {
 }
 
 public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
-
     private let analyticsSession: AnalyticsSessionProtocol?
 
     public init(analyticsSession: AnalyticsSessionProtocol?) {
@@ -41,23 +40,22 @@ public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol
         for message: ZMConversationMessage,
         in conversation: Conversation
     ) {
-        if message.selfUserReactions().contains(reaction) {
+        let currentReactions = message.selfUserReactions()
+        if currentReactions.contains(reaction) {
             ZMMessage.removeReaction(reaction, from: message)
         } else {
             ZMMessage.addReaction(reaction, to: message)
-
-            analyticsSession?.trackEvent(
-                ConversationContributionAnalyticsEvent(
-                    contributionType: .likeMessage,
-                    conversationType: .init(conversation.conversationType),
-                    conversationSize: UInt(
-                        conversation.localParticipants.count
+            if reaction == "❤️" {
+                analyticsSession?.trackEvent(
+                    ConversationContributionAnalyticsEvent(
+                        contributionType: .likeMessage,
+                        conversationType: .init(conversation.conversationType),
+                        conversationSize: UInt(conversation.localParticipants.count)
                     )
                 )
-            )
+            }
         }
     }
-
 }
 
 extension ZMConversationMessage {

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+import WireAnalytics
+
+public protocol ToggleMessageReactionUseCaseProtocol {
+
+    func invoke<Conversation: MessageAppendableConversation>(
+        _ reaction: String,
+        for message: ZMConversationMessage,
+        in conversation: Conversation
+    )
+}
+
+public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
+
+    private let analyticsSession: AnalyticsSessionProtocol?
+
+    public init(analyticsSession: AnalyticsSessionProtocol?) {
+        self.analyticsSession = analyticsSession
+    }
+
+    public func invoke<Conversation: MessageAppendableConversation>(
+        _ reaction: String,
+        for message: ZMConversationMessage,
+        in conversation: Conversation
+    ) {
+        if message.selfUserReactions().contains(reaction) {
+            ZMMessage.removeReaction(reaction, from: message)
+        } else {
+            ZMMessage.addReaction(reaction, to: message)
+
+            analyticsSession?.trackEvent(
+                ConversationContributionAnalyticsEvent(
+                    contributionType: .likeMessage,
+                    conversationType: .init(conversation.conversationType),
+                    conversationSize: UInt(
+                        conversation.localParticipants.count
+                    )
+                )
+            )
+        }
+    }
+
+}
+
+extension ZMConversationMessage {
+
+    func selfUserReactions() -> Set<String> {
+        let result = usersReaction
+            .filter { _, users in users.contains(where: \.isSelfUser) }
+            .map(\.key)
+
+        return Set(result)
+    }
+}

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -28,15 +28,15 @@ public protocol ToggleMessageReactionUseCaseProtocol {
     )
 }
 
-struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
+public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
 
     private let analyticsSession: AnalyticsSessionProtocol?
 
-    init(analyticsSession: AnalyticsSessionProtocol?) {
+    public init(analyticsSession: AnalyticsSessionProtocol?) {
         self.analyticsSession = analyticsSession
     }
 
-    func invoke<Conversation: MessageAppendableConversation>(
+    public func invoke<Conversation: MessageAppendableConversation>(
         _ reaction: String,
         for message: ZMConversationMessage,
         in conversation: Conversation

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -28,15 +28,15 @@ public protocol ToggleMessageReactionUseCaseProtocol {
     )
 }
 
-public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
+struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
 
     private let analyticsSession: AnalyticsSessionProtocol?
 
-    public init(analyticsSession: AnalyticsSessionProtocol?) {
+    init(analyticsSession: AnalyticsSessionProtocol?) {
         self.analyticsSession = analyticsSession
     }
 
-    public func invoke<Conversation: MessageAppendableConversation>(
+    func invoke<Conversation: MessageAppendableConversation>(
         _ reaction: String,
         for message: ZMConversationMessage,
         in conversation: Conversation

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireDataModel
 import WireAnalytics
+import WireDataModel
 
 public protocol ToggleMessageReactionUseCaseProtocol {
 

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -57,14 +57,3 @@ public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol
         }
     }
 }
-
-extension ZMConversationMessage {
-
-    func selfUserReactions() -> Set<String> {
-        let result = usersReaction
-            .filter { _, users in users.contains(where: \.isSelfUser) }
-            .map(\.key)
-
-        return Set(result)
-    }
-}

--- a/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToggleMessageReactionUseCase.swift
@@ -29,6 +29,7 @@ public protocol ToggleMessageReactionUseCaseProtocol {
 }
 
 public struct ToggleMessageReactionUseCase: ToggleMessageReactionUseCaseProtocol {
+
     private let analyticsSession: AnalyticsSessionProtocol?
 
     public init(analyticsSession: AnalyticsSessionProtocol?) {

--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -276,6 +276,8 @@ public protocol UserSession: AnyObject {
 
     func makeAppendFileMessageUseCase() -> any AppendFileMessageUseCaseProtocol
 
+   func makeToggleMessageReactionUseCase() -> any ToggleMessageReactionUseCaseProtocol
+
     func fetchSelfConversationMLSGroupID() async -> MLSGroupID?
 
     func e2eIdentityUpdateCertificateUpdateStatus() -> E2EIdentityCertificateUpdateStatusUseCaseProtocol?

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -375,6 +375,10 @@ extension ZMUserSession: UserSession {
         return AppendFileMessageUseCase(analyticsSession: analyticsSession)
     }
 
+    public func makeToggleMessageReactionUseCase() -> ToggleMessageReactionUseCaseProtocol {
+        return ToggleMessageReactionUseCase(analyticsSession: analyticsSession)
+    }
+
 }
 
 extension UInt64 {

--- a/wire-ios-sync-engine/Source/Utility/ZMConversationMessage+SelfUserReactions.swift
+++ b/wire-ios-sync-engine/Source/Utility/ZMConversationMessage+SelfUserReactions.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+extension ZMConversationMessage {
+
+    func selfUserReactions() -> Set<String> {
+        let result = usersReaction
+            .filter { _, users in users.contains(where: \.isSelfUser) }
+            .map(\.key)
+
+        return Set(result)
+    }
+}

--- a/wire-ios-sync-engine/Tests/Source/Use cases/FetchShareableConversationUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/FetchShareableConversationUseCaseTests.swift
@@ -76,7 +76,6 @@ class FetchShareableConversationUseCaseTests: XCTestCase {
         conversation.isArchived = false
         conversation.messageProtocol = .proteus
         conversation.conversationType = .group
-
         return conversation
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ToggleMessageReactionUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ToggleMessageReactionUseCaseTests.swift
@@ -24,8 +24,6 @@ import WireSyncEngineSupport
 import XCTest
 
 @testable import WireSyncEngine
-@testable import WireDataModel
-
 final class ToggleMessageReactionUseCaseTests: XCTestCase {
 
     // MARK: - Properties

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ToggleMessageReactionUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ToggleMessageReactionUseCaseTests.swift
@@ -80,7 +80,7 @@ final class ToggleMessageReactionUseCaseTests: XCTestCase {
         sut.invoke("❤️", for: firstMessage, in: convo)
 
         // THEN
-        let userReactions = firstMessage.usersReaction // Get the usersReaction dictionary
+        let userReactions = firstMessage.usersReaction
 
         XCTAssert(userReactions.keys.contains("❤️"), "Expected the first message to have a ❤️ reaction.")
         XCTAssertEqual(mockAnalyticsSessionProtocol.trackEvent_Invocations.count, 1)

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ToggleMessageReactionUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ToggleMessageReactionUseCaseTests.swift
@@ -1,0 +1,98 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAnalytics
+import WireAnalyticsSupport
+import WireDataModel
+import WireDataModelSupport
+import WireSyncEngineSupport
+import XCTest
+
+@testable import WireSyncEngine
+
+final class ToggleMessageReactionUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var mockAnalyticsSessionProtocol: MockAnalyticsSessionProtocol!
+    private var mockConversation: MockMessageAppendableConversation!
+    private var sut: ToggleMessageReactionUseCase!
+    private var message: MockZMConversationMessage!
+    
+    // MARK: - setUp
+
+    override func setUp() {
+        super.setUp()
+        mockAnalyticsSessionProtocol = .init()
+        mockConversation = .init()
+        sut = ToggleMessageReactionUseCase(analyticsSession: mockAnalyticsSessionProtocol)
+        message = MockZMConversationMessage()
+        message.senderUser = UserType
+
+        // create coredatastack with CoreDataStackHelper
+
+        // add create message in ModelHelper -> ZMMessage
+        // modelhelper gives you an user, a conversation
+    }
+
+    // MARK: - tearDown
+
+    override func tearDown() {
+        sut = nil
+        mockConversation = nil
+        mockAnalyticsSessionProtocol = nil
+        message = nil
+    }
+
+    func testInvoke_ToggleMessageReaction_TracksEventCorrectly() throws {
+        // GIVEN
+        mockConversation.conversationType = .group
+        mockConversation.localParticipants = []
+
+        // WHEN
+        sut.invoke("❤️", for: message, in: mockConversation)
+
+        // THEN
+        // Assert that add reaction from ZMMessage has been invoked
+        let senderUser = try XCTUnwrap(message.senderUser)
+        XCTAssert(message.usersReaction, ["❤️", senderUser])
+        XCTAssertEqual(mockAnalyticsSessionProtocol.trackEvent_Invocations.count, 1)
+        let trackEventInvocation = try XCTUnwrap(mockAnalyticsSessionProtocol.trackEvent_Invocations.first as? ConversationContributionAnalyticsEvent)
+        XCTAssertEqual(trackEventInvocation.contributionType, .reaction)
+        XCTAssertEqual(trackEventInvocation.conversationType, .group)
+
+    }
+
+
+    func testInvoke_ToggleMessageReaction_DoesNotTrackEvent() {
+        // GIVEN
+        mockConversation.conversationType = .group
+        mockConversation.localParticipants = []
+        mockConversation.
+
+
+
+        // WHEN
+        sut.invoke("😧", for: message, in: mockConversation)
+
+        // THEN
+        // Assert that add reaction from ZMMessage has been invoked
+        // Assert that trackEventInvocation has not invoked for the analytic event
+    }
+
+}

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		E6D1B1F22B988166001CA68B /* GetMLSFeatureUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D1B1F12B988166001CA68B /* GetMLSFeatureUseCaseTests.swift */; };
 		E6E5579A2BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */; };
 		E6F31B502C19B42E005DFA0C /* ZMUserSession+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F31B4F2C19B42E005DFA0C /* ZMUserSession+Notifications.swift */; };
+		E91180DF2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */; };
 		E948DB142C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */; };
 		E955D3DF2C36CFFF0090BEAB /* ConversationType+ZMConversationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E955D3DE2C36CFFF0090BEAB /* ConversationType+ZMConversationType.swift */; };
 		E955D3E32C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E955D3E22C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift */; };
@@ -1446,6 +1447,7 @@
 		E6D1B1F12B988166001CA68B /* GetMLSFeatureUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMLSFeatureUseCaseTests.swift; sourceTree = "<group>"; };
 		E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMReachability+ServerConnection.swift"; sourceTree = "<group>"; };
 		E6F31B4F2C19B42E005DFA0C /* ZMUserSession+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Notifications.swift"; sourceTree = "<group>"; };
+		E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleMessageReactionUseCase.swift; sourceTree = "<group>"; };
 		E934249D2C2D3BBA001A8EBD /* ProcessInfo+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Tests.swift"; sourceTree = "<group>"; };
 		E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendLocationMessageUseCaseTests.swift; sourceTree = "<group>"; };
 		E955D3DE2C36CFFF0090BEAB /* ConversationType+ZMConversationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationType+ZMConversationType.swift"; sourceTree = "<group>"; };
@@ -2981,6 +2983,7 @@
 				E97296242C4A784300C4F1DB /* MessageAppendableConversation.swift */,
 				E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */,
 				E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */,
+				E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */,
 			);
 			path = "Use cases";
 			sourceTree = "<group>";
@@ -3983,6 +3986,7 @@
 				16E6F26224B371190015B249 /* ZMUserSession+EncryptionAtRest.swift in Sources */,
 				BFE7FCBF2101E50700D1165F /* CompanyLoginVerificationToken.swift in Sources */,
 				5498162E1A432BC800A7CE2E /* ZMLastUpdateEventIDTranscoder.m in Sources */,
+				E91180DF2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift in Sources */,
 				F9B171F61C0EF21100E6EEC6 /* ClientUpdateStatus.swift in Sources */,
 				EEC7AB0C2A08F3DF005614BE /* OperationStateProvider.swift in Sources */,
 				549816351A432BC800A7CE2E /* ZMLoginTranscoder.m in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -580,6 +580,7 @@
 		E6E5579A2BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */; };
 		E6F31B502C19B42E005DFA0C /* ZMUserSession+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F31B4F2C19B42E005DFA0C /* ZMUserSession+Notifications.swift */; };
 		E91180DF2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */; };
+		E91180E12CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91180E02CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift */; };
 		E948DB142C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */; };
 		E955D3DF2C36CFFF0090BEAB /* ConversationType+ZMConversationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E955D3DE2C36CFFF0090BEAB /* ConversationType+ZMConversationType.swift */; };
 		E955D3E32C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E955D3E22C36E9240090BEAB /* AppendKnockMessageUseCaseTests.swift */; };
@@ -1448,6 +1449,7 @@
 		E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMReachability+ServerConnection.swift"; sourceTree = "<group>"; };
 		E6F31B4F2C19B42E005DFA0C /* ZMUserSession+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Notifications.swift"; sourceTree = "<group>"; };
 		E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleMessageReactionUseCase.swift; sourceTree = "<group>"; };
+		E91180E02CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+SelfUserReactions.swift"; sourceTree = "<group>"; };
 		E934249D2C2D3BBA001A8EBD /* ProcessInfo+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Tests.swift"; sourceTree = "<group>"; };
 		E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppendLocationMessageUseCaseTests.swift; sourceTree = "<group>"; };
 		E955D3DE2C36CFFF0090BEAB /* ConversationType+ZMConversationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConversationType+ZMConversationType.swift"; sourceTree = "<group>"; };
@@ -2828,6 +2830,7 @@
 				01D33D8029B8ED97009E94F3 /* SyncStatusLog.swift */,
 				EE0CAEAE2AAF2E8E00BD2DB7 /* URLSession+MinTLSVersion.swift */,
 				E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */,
+				E91180E02CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -4107,6 +4110,7 @@
 				63C4B3C62C35B56A00C09A93 /* ShareFileUseCase.swift in Sources */,
 				1660AA0D1ECDB0250056D403 /* SearchTask.swift in Sources */,
 				E9AD0A362C2AF9B300CA88DF /* AnalyticsSessionConfiguration.swift in Sources */,
+				E91180E12CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift in Sources */,
 				F9245BED1CBF95A8009D1E85 /* ZMHotFixDirectory+Swift.swift in Sources */,
 				E6C983EC2B98627200D55177 /* GetMLSFeatureUseCase.swift in Sources */,
 				54991D5A1DEDD07E007E282F /* ContactAddressBook.swift in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		E6D1B1F22B988166001CA68B /* GetMLSFeatureUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D1B1F12B988166001CA68B /* GetMLSFeatureUseCaseTests.swift */; };
 		E6E5579A2BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */; };
 		E6F31B502C19B42E005DFA0C /* ZMUserSession+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F31B4F2C19B42E005DFA0C /* ZMUserSession+Notifications.swift */; };
+		E910CF142CABF65E00B30E87 /* ToggleMessageReactionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E910CF132CABF65E00B30E87 /* ToggleMessageReactionUseCaseTests.swift */; };
 		E91180DF2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */; };
 		E91180E12CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91180E02CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift */; };
 		E948DB142C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */; };
@@ -1448,6 +1449,7 @@
 		E6D1B1F12B988166001CA68B /* GetMLSFeatureUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetMLSFeatureUseCaseTests.swift; sourceTree = "<group>"; };
 		E6E557992BBD4D9C0033E62B /* ZMReachability+ServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMReachability+ServerConnection.swift"; sourceTree = "<group>"; };
 		E6F31B4F2C19B42E005DFA0C /* ZMUserSession+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+Notifications.swift"; sourceTree = "<group>"; };
+		E910CF132CABF65E00B30E87 /* ToggleMessageReactionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleMessageReactionUseCaseTests.swift; sourceTree = "<group>"; };
 		E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleMessageReactionUseCase.swift; sourceTree = "<group>"; };
 		E91180E02CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversationMessage+SelfUserReactions.swift"; sourceTree = "<group>"; };
 		E934249D2C2D3BBA001A8EBD /* ProcessInfo+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Tests.swift"; sourceTree = "<group>"; };
@@ -1769,6 +1771,7 @@
 				E97296262C4AA72100C4F1DB /* AppendImageMessageUseCaseTests.swift */,
 				E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */,
 				E96970572C8F3546009F037C /* AppendFileMessageUseCaseTests.swift */,
+				E910CF132CABF65E00B30E87 /* ToggleMessageReactionUseCaseTests.swift */,
 			);
 			path = "Use cases";
 			sourceTree = "<group>";
@@ -3709,6 +3712,7 @@
 				162A81D6202B5BC600F6200C /* SessionManagerAVSTests.swift in Sources */,
 				169BA1F825ECF8F700374343 /* MockAppLock.swift in Sources */,
 				06F98D602437916B007E914A /* SignatureRequestStrategyTests.swift in Sources */,
+				E910CF142CABF65E00B30E87 /* ToggleMessageReactionUseCaseTests.swift in Sources */,
 				06D16AB02B9F3C9F00D5A28A /* E2EIdentityCertificateUpdateStatusUseCaseTests.swift in Sources */,
 				5474C80C1921309400185A3A /* MessagingTestTests.m in Sources */,
 				16D74BF62B5A961800160298 /* ChangeUsernameUseCaseTests.swift in Sources */,

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -343,6 +343,10 @@ final class UserSessionMock: UserSession {
         AppendFileMessageUseCase(analyticsSession: nil)
     }
 
+    func makeToggleMessageReactionUseCase() -> any ToggleMessageReactionUseCaseProtocol {
+        ToggleMessageReactionUseCase(analyticsSession: nil)
+    }
+
     var e2eiFeature: Feature.E2EI = Feature.E2EI(status: .enabled)
 
     var mlsFeature: Feature.MLS = Feature.MLS(

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversationMessage+Reactions.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversationMessage+Reactions.swift
@@ -92,17 +92,4 @@ extension ZMConversationMessage {
         readReceipts.sortedAscendingPrependingNil(by: \.userType.name)
     }
 
-    func react(_ reaction: Emoji.ID) {
-        if selfUserReactions().contains(reaction) {
-            ZMMessage.removeReaction(
-                reaction,
-                from: self
-            )
-        } else {
-            ZMMessage.addReaction(
-                reaction,
-                to: self
-            )
-        }
-    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -161,7 +161,8 @@ extension ConversationContentViewController {
             client.resetSession()
         case .react(let reaction):
             userSession.perform {
-                message.react(reaction)
+                let useCase = self.userSession.makeToggleMessageReactionUseCase()
+                useCase.invoke(reaction, for: message, in: self.conversation)
             }
         case .visitLink:
             if let textMessageData = message.textMessageData,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11311" title="WPB-11311" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11311</a>  [iOS] Liking a message doesn't get tracked on Countly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


## Overview

This PR introduces a new use case, `ToggleMessageReactionUseCase`, to encapsulate the logic for toggling message reactions in our application. This change aims to improve code organization, testability, and maintainability by separating the reaction toggle logic from other parts of the codebase.

## Changes

- Introduced `ToggleMessageReactionUseCaseProtocol` to define the contract for toggling message reactions.
- Implemented `ToggleMessageReactionUseCase` struct that conforms to the above protocol.
- The use case handles both adding and removing reactions based on the current state.
- Integrated analytics tracking for "like" reactions (heart emoji).

## Implementation Details

- The use case takes a generic `Conversation` parameter that conforms to `MessageAppendableConversation`, allowing for flexibility in the types of conversations it can handle.
- It uses the `selfUserReactions()` method on `ZMConversationMessage` to determine whether to add or remove a reaction.
- Analytics events are tracked only when adding a heart emoji reaction.

## TODO

- [ ] Add tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---