### PR TITLE
fix: building on Xcode 15 - WPB-10140

### DIFF
--- a/WireFoundation/.swiftpm/WireFoundation-Package.xctestplan
+++ b/WireFoundation/.swiftpm/WireFoundation-Package.xctestplan
@@ -9,7 +9,9 @@
     }
   ],
   "defaultOptions" : {
-
+    "language" : "en",
+    "region" : "DE",
+    "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {

--- a/WireUI/Sources/WireMainNavigation/MainSplitViewController.swift
+++ b/WireUI/Sources/WireMainNavigation/MainSplitViewController.swift
@@ -21,7 +21,15 @@ import SwiftUI
 public final class MainSplitViewController<Sidebar, TabContainer>: UISplitViewController, MainSplitViewControllerProtocol where
 Sidebar: MainSidebarProtocol, TabContainer: MainTabBarControllerProtocol {
 
+    public typealias ConversationList = TabContainer.ConversationList
+    public typealias Archive = TabContainer.Archive
     public typealias Settings = TabContainer.Settings
+
+    public typealias Conversation = TabContainer.Conversation
+    public typealias SettingsContent = TabContainer.SettingsContent
+
+    public typealias Connect = TabContainer.Connect
+
     public typealias NoConversationPlaceholderBuilder = () -> UIViewController
 
     /// If the width of the view is lower than this value, the `preferredDisplayMode` property

--- a/WireUI/Tests/WireMainNavigationTests/Main/MainCoordinatorTests.swift
+++ b/WireUI/Tests/WireMainNavigationTests/Main/MainCoordinatorTests.swift
@@ -72,7 +72,7 @@ final class MainCoordinatorTests: XCTestCase {
     func testShowingGroupConversations() {
         // When
         let conversationFilter: MockConversationListViewController.ConversationFilter = .groups
-        sut.showConversationList(conversationFilter: conversationFilter, conversationID: nil, messageID: nil)
+        sut.showConversationList(conversationFilter: conversationFilter)
 
         // Then
         XCTAssertNotNil(splitViewController.conversationList)

--- a/WireUI/Tests/WireMainNavigationTests/Main/Mocks/MockViewControllerBuilder.swift
+++ b/WireUI/Tests/WireMainNavigationTests/Main/Mocks/MockViewControllerBuilder.swift
@@ -21,11 +21,13 @@ import WireMainNavigation
 
 struct MockViewControllerBuilder: MainCoordinatorInjectingViewControllerBuilder, MainSettingsContentBuilderProtocol {
 
+    typealias SettingsContentViewController = MockSettingsContentViewController
+
     @MainActor
     func build(mainCoordinator: some MainCoordinatorProtocol) -> UIViewController { .init() }
 
     @MainActor
     func build(
         content: MockSettingsContentViewController.SettingsContent
-    ) async -> MockSettingsContentViewController { .init() }
+    ) -> MockSettingsContentViewController { .init() }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10140" title="WPB-10140" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10140</a>  [iOS][iPad] Sidebar - Conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Some code related to generic constraints prevented the Swift 5.10 compiler to successfully build.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
