### PR TITLE
fix: accent color picker presentation - WPB-10141

### DIFF
--- a/wire-ios/Wire-iOS Tests/AccentColorPickerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/AccentColorPickerSnapshotTests.swift
@@ -36,7 +36,6 @@ final class AccentColorPickerSnapshotTests: XCTestCase {
     // MARK: - setUp
 
     override func setUp() {
-        super.setUp()
         snapshotHelper = SnapshotHelper()
         selfUser = MockUserType.createDefaultSelfUser()
         selfUser.accentColorValue = AccentColor.default.rawValue
@@ -52,8 +51,6 @@ final class AccentColorPickerSnapshotTests: XCTestCase {
         selfUser = nil
         userSession = nil
         sut = nil
-
-        super.tearDown()
     }
 
     // MARK: - Snapshot Test

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
@@ -16,12 +16,15 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Inject
 import SwiftUI
 import WireCommonComponents
 import WireDesign
 import WireFoundation
 import WireSyncEngine
+
+#if canImport(Inject)
+import Inject
+#endif
 
 struct AccentColorPicker: View {
 
@@ -29,36 +32,34 @@ struct AccentColorPicker: View {
     var selectedColor: AccentColor
     private let colorViewSize: CGFloat = 28
 
+#if canImport(Inject)
     @ObserveInjection var inject
+#endif
 
     let onColorSelect: ((AccentColor) -> Void)?
 
     var body: some View {
-        // The NavigationView is needed here to properly set the font size for the navigation bar title.
-        // Currently, there's no other way to set the font size of the navigation bar title to the desired value.
-        // Without the NavigationView, the title would be too small.
-        NavigationView {
-            List(AccentColor.allCases, id: \.self) { color in
-                cell(for: color)
-                    .listRowBackground(Color(SemanticColors.View.backgroundUserCell))
-                    .onTapGesture {
-                        self.selectedColor = color
-                        onColorSelect?(color)
-                    }
-            }
-            .listStyle(.plain)
-            .modifier(ListBackgroundStyleModifier())
-            .background(Color(SemanticColors.View.backgroundDefault))
-        }
-        .enableInjection()
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                VStack {
-                    Text(L10n.Localizable.Self.Settings.AccountPictureGroup.color.capitalized)
-                        .font(.textStyle(.h3))
+#if canImport(Inject)
+        accentColorList
+            .enableInjection()
+#else
+        accentColorList
+#endif
+    }
+
+    @ViewBuilder
+    private var accentColorList: some View {
+        List(AccentColor.allCases, id: \.self) { color in
+            cell(for: color)
+                .listRowBackground(Color(SemanticColors.View.backgroundUserCell))
+                .onTapGesture {
+                    self.selectedColor = color
+                    onColorSelect?(color)
                 }
-            }
         }
+        .listStyle(.plain)
+        .modifier(ListBackgroundStyleModifier())
+        .background(Color(SemanticColors.View.backgroundDefault))
     }
 
     @ViewBuilder

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
@@ -16,15 +16,12 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import Inject
 import SwiftUI
 import WireCommonComponents
 import WireDesign
 import WireFoundation
 import WireSyncEngine
-
-#if canImport(Inject)
-import Inject
-#endif
 
 struct AccentColorPicker: View {
 
@@ -32,19 +29,13 @@ struct AccentColorPicker: View {
     var selectedColor: AccentColor
     private let colorViewSize: CGFloat = 28
 
-#if canImport(Inject)
     @ObserveInjection var inject
-#endif
 
     let onColorSelect: ((AccentColor) -> Void)?
 
     var body: some View {
-#if canImport(Inject)
         accentColorList
             .enableInjection()
-#else
-        accentColorList
-#endif
     }
 
     @ViewBuilder

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPickerController.swift
@@ -17,10 +17,8 @@
 //
 
 import SwiftUI
-import WireDataModel
 import WireFoundation
 import WireSyncEngine
-import WireUtilities
 
 final class AccentColorPickerController: UIHostingController<AccentColorPicker> {
 
@@ -43,7 +41,7 @@ final class AccentColorPickerController: UIHostingController<AccentColorPicker> 
                 }
             }
         )
-
         super.init(rootView: colorPickerView)
+        navigationItem.title = L10n.Localizable.Self.Settings.AccountPictureGroup.color.capitalized
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10141" title="WPB-10141" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10141</a>  [iOS][iPad] Sidebar - Settings&Support
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently the accent color picker view contains a `NavigationView` which is similar to a `UINavigationController`. 
This view is pushed onto a navigation controller and results in weird behavior on iPad with split view controller.

### Testing

Open the account settings and change the profile color.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
