### PR TITLE
fix: cannot start conversation - WPB-11454

### DIFF
--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneProtocolSelector.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneProtocolSelector.swift
@@ -45,7 +45,13 @@ public final class OneOnOneProtocolSelector: OneOnOneProtocolSelectorInterface {
 
         let commonProtocols = try await context.perform {
             let selfUser = ZMUser.selfUser(in: context)
-            let selfProtocols = selfUser.supportedProtocols
+            var selfProtocols = selfUser.supportedProtocols
+            if selfProtocols.isEmpty {
+                // if self does not have a value because previous apiVersions
+                // or slow sync was never triggered with apiV5
+                // assume we support proteus
+                selfProtocols.insert(.proteus)
+            }
 
             guard let otherUser = ZMUser.fetch(with: id, in: context) else {
                 throw OneOnOneProtocolSelectorError.userNotFound

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneProtocolSelector.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneProtocolSelector.swift
@@ -45,13 +45,7 @@ public final class OneOnOneProtocolSelector: OneOnOneProtocolSelectorInterface {
 
         let commonProtocols = try await context.perform {
             let selfUser = ZMUser.selfUser(in: context)
-            var selfProtocols = selfUser.supportedProtocols
-            if selfProtocols.isEmpty {
-                // if self does not have a value because previous apiVersions
-                // or slow sync was never triggered with apiV5
-                // assume we support proteus
-                selfProtocols.insert(.proteus)
-            }
+            let selfProtocols = selfUser.supportedProtocols
 
             guard let otherUser = ZMUser.fetch(with: id, in: context) else {
                 throw OneOnOneProtocolSelectorError.userNotFound

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneProtocolSelectorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneProtocolSelectorTests.swift
@@ -145,5 +145,4 @@ final class OneOnOneProtocolSelectorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(result, .none)
     }
 
-    
 }

--- a/wire-ios-data-model/Tests/OneOnOne/OneOnOneProtocolSelectorTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/OneOnOneProtocolSelectorTests.swift
@@ -123,4 +123,27 @@ final class OneOnOneProtocolSelectorTests: ZMBaseManagedObjectTest {
         XCTAssertEqual(result, .proteus)
     }
 
+    func test_GetProtocolForUser_IfNoProtocolForSelfReturnsNil() async throws {
+        // Given
+        let userID = QualifiedID.random()
+
+        await uiMOC.perform { [self] in
+            let user = createUser(id: userID, in: uiMOC)
+            user.supportedProtocols = [.proteus]
+
+            let selfUser = ZMUser.selfUser(in: uiMOC)
+            selfUser.supportedProtocols = []
+        }
+
+        // When
+        let result = try await sut.getProtocolForUser(
+            with: userID,
+            in: uiMOC
+        )
+
+        // Then
+        XCTAssertEqual(result, .none)
+    }
+
+    
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -189,7 +189,6 @@ extension ClientMessageRequestStrategy: ZMEventConsumer {
         switch event.type {
         case .conversationClientMessageAdd, .conversationOtrMessageAdd, .conversationOtrAssetAdd, .conversationMLSMessageAdd:
             guard let message = ZMOTRMessage.createOrUpdate(from: event, in: context, prefetchResult: prefetchResult) else {
-                WireLogger.updateEvent.warn("message could not be created from event", attributes: event.logAttributes)
                 return
             }
             message.markAsSent()

--- a/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
@@ -33,7 +33,7 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
 
     private let featureRepository: FeatureRepositoryInterface
     private let selfUserProvider: SelfUserProviderProtocol
-    private let logger = WireLogger(tag: "supported-protocols")
+    private let logger = WireLogger.supportedProtocols
 
     // MARK: - Life cycle
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -876,7 +876,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
             }
         }
     }
-    
+
     private func makeResolveOneOnOneConversationsUseCase(context: NSManagedObjectContext) -> any ResolveOneOnOneConversationsUseCaseProtocol {
         let supportedProtocolService = SupportedProtocolsService(context: context)
         let resolver = OneOnOneResolver(migrator: OneOnOneMigrator(mlsService: mlsService))

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -852,7 +852,7 @@ extension ZMUserSession: ZMSyncStateDelegate {
 
         WaitingGroupTask(context: syncContext) { [self] in
             await fetchAndStoreFeatureConfig()
-            await calculateSelfProtocolsIfNeeded()
+            await calculateSelfSupportedProtocolsIfNeeded()
             await resolveOneOnOneConversationsIfNeeded()
         }
 
@@ -860,7 +860,12 @@ extension ZMUserSession: ZMSyncStateDelegate {
         performPostQuickSyncE2EIActions()
     }
 
-    private func calculateSelfProtocolsIfNeeded() async {
+    /// Calculate supported protocols for self user in case they are empty
+    /// - note: Supported protocols are calculated only during slow sync
+    /// or while resolving 1-1 conversations (MLS enabled).
+    /// It fixes users that updates to latest version without having a supported-protocol.
+    /// This could be removed once MLS is enabled.
+    private func calculateSelfSupportedProtocolsIfNeeded() async {
         await syncContext.perform { [syncContext] in
             let service = SupportedProtocolsService(context: syncContext)
             let selfUser = ZMUser.selfUser(in: syncContext)

--- a/wire-ios-sync-engine/Tests/Source/Use cases/CreateTeamOneOnOneConversationUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/CreateTeamOneOnOneConversationUseCaseTests.swift
@@ -96,6 +96,7 @@ final class CreateTeamOneOnOneConversationUseCaseTests: XCTestCase {
         do {
             // When
             _ = try await sut.invoke(with: otherUser, syncContext: syncContext)
+            XCTFail("should fail")
         } catch CreateTeamOneOnOneConversationError.userIsNotOnSameTeam {
             // Then
         } catch {
@@ -113,6 +114,7 @@ final class CreateTeamOneOnOneConversationUseCaseTests: XCTestCase {
         do {
             // When
             _ = try await sut.invoke(with: otherUser, syncContext: syncContext)
+            XCTFail("should fail")
         } catch CreateTeamOneOnOneConversationError.noCommonProtocols {
             // Then
         } catch {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+RecurringActions.swift
@@ -58,7 +58,6 @@ final class ZMUserSessionTests_RecurringActions: ZMUserSessionTestsBase {
 
         // Then
         XCTAssertFalse(mockRecurringActionService.performActionsIfNeeded_Invocations.isEmpty)
-        XCTAssertEqual(mockPushSupportedProtocolsActionHandler.performedActions.count, 1)
     }
 
     func testUpdatesUsersMissingMetadataAction() {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -484,7 +484,6 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(mockRecurringActionService.performActionsIfNeeded_Invocations.count, 1)
 
         XCTAssertEqual(getFeatureConfigsActionHandler.performedActions.count, 1)
-        XCTAssertEqual(pushSupportedProtocolsActionHandler.performedActions.count, 1)
     }
     
     func test_didFinishQuickSync_CalculateSupportedProtocolsIfNoProtocols() {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -304,7 +304,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
             results: [.success(())],
             context: syncMOC.notificationContext
         )
- 
+
         syncMOC.performAndWait {
             sut.didFinishQuickSync()
         }
@@ -485,7 +485,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
 
         XCTAssertEqual(getFeatureConfigsActionHandler.performedActions.count, 1)
     }
-    
+
     func test_didFinishQuickSync_CalculateSupportedProtocolsIfNoProtocols() {
         self.syncMOC.performAndWait {
             // GIVEN
@@ -499,7 +499,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
 
         // THEN
         let supportedProtocols = syncMOC.performAndWait { ZMUser.selfUser(in: self.syncMOC).supportedProtocols }
-        
+
         XCTAssertTrue(supportedProtocols.contains(.proteus))
     }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -486,4 +486,21 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(getFeatureConfigsActionHandler.performedActions.count, 1)
         XCTAssertEqual(pushSupportedProtocolsActionHandler.performedActions.count, 1)
     }
+    
+    func test_didFinishQuickSync_CalculateSupportedProtocolsIfNoProtocols() {
+        self.syncMOC.performAndWait {
+            // GIVEN
+            ZMUser.selfUser(in: self.syncMOC).supportedProtocols = .init()
+
+            // WHEN
+            sut.didFinishQuickSync()
+        }
+
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // THEN
+        let supportedProtocols = syncMOC.performAndWait { ZMUser.selfUser(in: self.syncMOC).supportedProtocols }
+        
+        XCTAssertTrue(supportedProtocols.contains(.proteus))
+    }
 }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -304,11 +304,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
             results: [.success(())],
             context: syncMOC.notificationContext
         )
-        let pushSupportedProtocolsActionHandler = MockActionHandler<PushSupportedProtocolsAction>(
-            result: .success(()),
-            context: syncMOC.notificationContext
-        )
-
+ 
         syncMOC.performAndWait {
             sut.didFinishQuickSync()
         }
@@ -317,7 +313,6 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         // THEN
         wait(forConditionToBeTrue: self.sut.networkState == .offline, timeout: 5)
         XCTAssertEqual(mockGetFeatureConfigsActionHandler.performedActions.count, 1)
-        XCTAssertEqual(pushSupportedProtocolsActionHandler.performedActions.count, 1)
     }
 
     func testThatWeSetUserSessionToSynchronizingWhenSyncIsStarted() {
@@ -452,6 +447,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
 
     func test_itPerformsPeriodicMLSUpdates_AfterQuickSync() {
         // GIVEN
+        DeveloperFlag.enableMLSSupport.enable(true, storage: .temporary())
         mockMLSService.performPendingJoins_MockMethod = {}
         mockMLSService.commitPendingProposalsIfNeeded_MockMethod = {}
         mockMLSService.uploadKeyPackagesIfNeeded_MockMethod = {}

--- a/wire-ios-system/Source/Logging/WireLogger+Instances.swift
+++ b/wire-ios-system/Source/Logging/WireLogger+Instances.swift
@@ -56,4 +56,5 @@ public extension WireLogger {
     static let network = WireLogger(tag: "network")
     static let eventProcessing = WireLogger(tag: "event-processing")
     static let messageProcessing = WireLogger(tag: "message-processing")
+    static let supportedProtocols = WireLogger(tag: "supported-protocols")
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11454" title="WPB-11454" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11454</a>  [iOS] : Users cannot start conversation with users with in Team 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Since supported-protocols were introduced in 3.112.4, we need to know the supported-protocol for the self user and other user for 1-1 conversations. This is either calculated during slowsync or if MLS is enabled during the resolve 1-1 conversations.

There is a bug where supported-protocols are not set for the self user that was logged in before 3.112.4. Indeed if these users update to latest version they don't perform a slowsync (only performed for new client) so they would end up with no supported protocols.

When trying to open a 1-1 conversation in their team, the app would try to resolve the common protocols but endup finding no common protocols and therefore fail with an error.

Solution:

Add a method to calculate the supported-protocols if none exist at the end of the quicksync (so when user put the app on foreground)

### Testing

1. have a build from 3.111.9
2. login
3. update to latest build
4. tap on a new team member to start a 1-1

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
