### PR TITLE
fix: Crash navigating to notification options - WPB-11062

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/ConversationNotificationOptionsViewController.swift
@@ -37,6 +37,8 @@ final class ConversationNotificationOptionsViewController: UIViewController {
         return UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewLayout)
     }()
 
+    private lazy var sizingFooter = SectionFooter()
+
     // MARK: - Initialization
 
     init(conversation: ZMConversation, userSession: ZMUserSession) {
@@ -133,16 +135,14 @@ extension ConversationNotificationOptionsViewController: UICollectionViewDelegat
         }
     }
 
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
-        let dequeuedView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter,
-                                                                           withReuseIdentifier: "SectionFooter",
-                                                                           for: IndexPath(item: 0, section: section))
-
-        guard let view = dequeuedView as? SectionFooter else { return .zero }
-
-        view.titleLabel.text = L10n.Localizable.GroupDetails.NotificationOptionsCell.description
-        view.size(fittingWidth: collectionView.bounds.width)
-        return view.bounds.size
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        referenceSizeForFooterInSection section: Int
+    ) -> CGSize {
+        sizingFooter.titleLabel.text = L10n.Localizable.GroupDetails.NotificationOptionsCell.description
+        sizingFooter.size(fittingWidth: collectionView.bounds.width)
+        return sizingFooter.bounds.size
     }
 
     // MARK: Saving Changes


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

When building using iOS 18 SDK on iOS 18 devices there is a crash when navigating to the notifications options screen. This is because we are dequeuing the footer from inside `ConversationNotificationOptionsViewController.collectionView(_:layout:referenceSizeForFooterInSection:)` which we should not be doing. 

The fix is to create a separate sizing footer view that we only use for generating the reference size.

### Testing

**This must be tested using an Xcode 16 (iOS 18SDK) build on a iOS 18 device.**

1. Navigate to any group conversation
2. Go to the details (by clicking the title)
3. Tap Notifications
4. There should be no crash and the footer is displayed correctly

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.