### PR TITLE
fix: user is not asked to enable analytics after login - WPB-11332

### DIFF
--- a/wire-ios/Wire-iOS Tests/ExtensionSettingsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ExtensionSettingsTests.swift
@@ -38,7 +38,7 @@ final class ExtensionSettingsTests: XCTestCase {
     }
 
     func testThatItHandlesAnalyticsPreferenceChange() {
-        XCTAssertEqual(settings.disableAnalyticsSharing, true)
+        XCTAssertNil(settings.disableAnalyticsSharing)
 
         settings.disableAnalyticsSharing = false
         XCTAssertEqual(settings.disableAnalyticsSharing, false)

--- a/wire-ios/Wire-iOS Tests/ExtensionSettingsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ExtensionSettingsTests.swift
@@ -37,18 +37,14 @@ final class ExtensionSettingsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testThatItDisablesAnalyticsReportByDefault() {
-        XCTAssertTrue(settings.disableAnalyticsSharing)
-    }
-
     func testThatItHandlesAnalyticsPreferenceChange() {
-        XCTAssertTrue(settings.disableAnalyticsSharing)
+        XCTAssertEqual(settings.disableAnalyticsSharing, true)
 
         settings.disableAnalyticsSharing = false
-        XCTAssertFalse(settings.disableAnalyticsSharing)
+        XCTAssertEqual(settings.disableAnalyticsSharing, false)
 
         settings.disableAnalyticsSharing = true
-        XCTAssertTrue(settings.disableAnalyticsSharing)
+        XCTAssertEqual(settings.disableAnalyticsSharing, true)
     }
 
     func testThatItEnablesLinkPreviewsByDefault() {

--- a/wire-ios/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/wire-ios/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -47,12 +47,23 @@ final class ZMMockAVSMediaManager: AVSMediaManagerInterface {
 }
 
 final class ZMMockTracking: TrackingInterface {
-    func disableAnalyticsSharing(isDisabled: Bool, resultHandler: @escaping (Result<Void, any Error>) -> Void) {
-        // no - op
+
+    var isAnalyticsDisabled: Bool = true
+    var disableCrashAndAnalyticsSharing: Bool = false
+
+    func requestAnalyticsConsent() async throws -> Bool {
+        // no op
+        return false
     }
 
-    var disableAnalyticsSharing: Bool = true
-    var disableCrashAndAnalyticsSharing: Bool = false
+    func disableAnalytics() throws {
+        // no op
+    }
+
+    func enableAnalytics() async throws {
+        // no op
+    }
+
 }
 
 final class SettingsPropertyTests: XCTestCase {

--- a/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager+UIAlertController.swift
+++ b/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager+UIAlertController.swift
@@ -30,6 +30,19 @@ extension TrackingManager {
     }
 
     @MainActor
+    func requestFirstTimeAnalyticsConsentIfNeeded() async throws {
+        // Only ask if user has not given a preference yet.
+        guard !doesUserConsentPreferenceExist else {
+            return
+        }
+
+        WireLogger.analytics.debug("requesting first time analytics content")
+        let didConsent = try await requestAnalyticsConsent()
+        WireLogger.analytics.debug("user did consent: \(didConsent)")
+        await updateAnalyticsSharing(disabled: !didConsent)
+    }
+
+    @MainActor
     func requestAnalyticsConsent() async throws -> Bool {
         guard let viewController = UIApplication.shared.topmostViewController(onlyFullScreen: false) else {
             throw AnalyticsError.unableToPresentAlert

--- a/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager+UIAlertController.swift
+++ b/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager+UIAlertController.swift
@@ -30,19 +30,6 @@ extension TrackingManager {
     }
 
     @MainActor
-    func requestFirstTimeAnalyticsConsentIfNeeded() async throws {
-        // Only ask if user has not given a preference yet.
-        guard !doesUserConsentPreferenceExist else {
-            return
-        }
-
-        WireLogger.analytics.debug("requesting first time analytics content")
-        let didConsent = try await requestAnalyticsConsent()
-        WireLogger.analytics.debug("user did consent: \(didConsent)")
-        await updateAnalyticsSharing(disabled: !didConsent)
-    }
-
-    @MainActor
     func requestAnalyticsConsent() async throws -> Bool {
         guard let viewController = UIApplication.shared.topmostViewController(onlyFullScreen: false) else {
             throw AnalyticsError.unableToPresentAlert

--- a/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager.swift
@@ -29,14 +29,14 @@ final class TrackingManager: NSObject, TrackingInterface {
     init(sessionManager: SessionManager) {
         self.sessionManager = sessionManager
         super.init()
-        AVSFlowManager.getInstance()?.setEnableMetrics(!disableAnalyticsSharing)
+        AVSFlowManager.getInstance()?.setEnableMetrics(!isAnalyticsDisabled)
         observerToken = NotificationCenter.default.addObserver(
             forName: FlowManager.AVSFlowManagerCreatedNotification,
             object: nil,
             queue: OperationQueue.main,
             using: { [weak self] _ in
                 guard let self else { return }
-                AVSFlowManager.getInstance()?.setEnableMetrics(!self.disableAnalyticsSharing)
+                AVSFlowManager.getInstance()?.setEnableMetrics(!self.isAnalyticsDisabled)
             }
         )
     }
@@ -45,55 +45,38 @@ final class TrackingManager: NSObject, TrackingInterface {
         ExtensionSettings.shared.disableAnalyticsSharing != nil
     }
 
-    var disableAnalyticsSharing: Bool {
+    var isAnalyticsDisabled: Bool {
         ExtensionSettings.shared.disableAnalyticsSharing ?? true
     }
 
-    func disableAnalyticsSharing(
-        isDisabled: Bool,
-        resultHandler: @escaping (Result<Void, any Error>) -> Void
-    ) {
-        Task { @MainActor in
-            if isDisabled {
-                await self.updateAnalyticsSharing(disabled: true)
-                resultHandler(.success(()))
-            } else {
-                // User wants to enable.
-                do {
-                    let isConsentGiven = try await self.requestAnalyticsConsent()
-
-                    if isConsentGiven {
-                        await self.updateAnalyticsSharing(disabled: false)
-                        resultHandler(.success(()))
-                    } else {
-                        // User rejected, keep analytics disabled.
-                        await self.updateAnalyticsSharing(disabled: true)
-                        resultHandler(.failure(TrackingManagerError.userConsentDenied))
-                    }
-                } catch {
-                    WireLogger.analytics.error("failed to enable analytics: \(error)")
-                    resultHandler(.failure(error))
-                }
-            }
-        }
-    }
-
-    func updateAnalyticsSharing(disabled: Bool) async {
-        do {
-            if disabled {
-                let disableUseCase = try sessionManager.makeDisableAnalyticsUseCase()
-                try disableUseCase.invoke()
-            } else {
-                let enableUseCase = try await sessionManager.makeEnableAnalyticsUseCase()
-                try await enableUseCase.invoke()
-            }
-        } catch {
-            WireLogger.analytics.error("Failed to toggle analytics sharing: \(error)")
+    @MainActor
+    func firstTimeRequestToEnableAnalytics() async throws {
+        // Only ask if user has not given a preference yet.
+        guard !doesUserConsentPreferenceExist else {
             return
         }
 
-        ExtensionSettings.shared.disableAnalyticsSharing = disabled
-        AVSFlowManager.getInstance()?.setEnableMetrics(!disabled)
+        WireLogger.analytics.debug("requesting first time analytics content")
+        let didConsent = try await requestAnalyticsConsent()
+        WireLogger.analytics.debug("user did consent: \(didConsent)")
+
+        if didConsent {
+            try await enableAnalytics()
+        } else {
+            try disableAnalytics()
+        }
+    }
+
+    func enableAnalytics() async throws {
+        try await sessionManager.makeEnableAnalyticsUseCase().invoke()
+        ExtensionSettings.shared.disableAnalyticsSharing = false
+        AVSFlowManager.getInstance()?.setEnableMetrics(true)
+    }
+
+    func disableAnalytics() throws {
+        try sessionManager.makeDisableAnalyticsUseCase().invoke()
+        ExtensionSettings.shared.disableAnalyticsSharing = true
+        AVSFlowManager.getInstance()?.setEnableMetrics(false)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/AnalytitcsServiceConfigurationBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/AnalytitcsServiceConfigurationBuilder.swift
@@ -33,7 +33,7 @@ struct AnalyticsServiceConfigurationBuilder {
         return AnalyticsServiceConfiguration(
             secretKey: secretKey,
             serverHost: countlyURL,
-            didUserGiveTrackingConsent: !ExtensionSettings.shared.disableAnalyticsSharing
+            didUserGiveTrackingConsent: !(ExtensionSettings.shared.disableAnalyticsSharing ?? true)
         )
     }
 

--- a/wire-ios/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -240,7 +240,7 @@ final class SettingsPropertyFactory {
                 guard let tracking else {
                     return
                 }
-                
+
                 guard case .number(let shouldDisable) = value else {
                     throw SettingsPropertyError.WrongValue("Incorrect type \(value) for key \(propertyName)")
                 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -239,7 +239,11 @@ final class ZClientViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         Task {
-            try await trackingManager?.firstTimeRequestToEnableAnalytics()
+            do {
+                try await trackingManager?.firstTimeRequestToEnableAnalytics()
+            } catch {
+                WireLogger.analytics.error("failed to first time enable analytics: \(error)")
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -238,6 +238,10 @@ final class ZClientViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        firstTimeRequestToEnableAnalytics()
+    }
+
+    private func firstTimeRequestToEnableAnalytics() {
         Task {
             do {
                 try await trackingManager?.firstTimeRequestToEnableAnalytics()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -236,6 +236,13 @@ final class ZClientViewController: UIViewController {
         setUpConferenceCallingUnavailableObserver()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        Task {
+            try await trackingManager?.requestFirstTimeAnalyticsConsentIfNeeded()
+        }
+    }
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return wr_supportedInterfaceOrientations
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -239,7 +239,7 @@ final class ZClientViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         Task {
-            try await trackingManager?.requestFirstTimeAnalyticsConsentIfNeeded()
+            try await trackingManager?.firstTimeRequestToEnableAnalytics()
         }
     }
 

--- a/wire-ios/WireCommonComponents/ExtensionSettings.swift
+++ b/wire-ios/WireCommonComponents/ExtensionSettings.swift
@@ -26,9 +26,9 @@ private enum ExtensionSettingsKey: String, CaseIterable {
 
     private var defaultValue: Any? {
         switch self {
-        // Always disable analytics by default.
         case .disableAnalyticsSharing:
-            return true
+            // No default value because the user needs to decide.
+            return nil
         case .disableLinkPreviews:
             return false
         }
@@ -63,8 +63,8 @@ public final class ExtensionSettings: NSObject {
         }
     }
 
-    public var disableAnalyticsSharing: Bool {
-        get { defaults.object(forKey: ExtensionSettingsKey.disableAnalyticsSharing.rawValue) as? Bool ?? true }
+    public var disableAnalyticsSharing: Bool? {
+        get { defaults.object(forKey: ExtensionSettingsKey.disableAnalyticsSharing.rawValue) as? Bool }
         set { defaults.set(newValue, forKey: ExtensionSettingsKey.disableAnalyticsSharing.rawValue) }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11332" title="WPB-11332" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11332</a>  [iOS] Analytics user consent is not requested after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

After logging in, the user should be asked if they wish to enable analytics. This functionality was removed recently (a regression). In this PR, we reintroduce the request, which is now based on the presence of the user preference:

- Previously the preference `disableAnalyticsSharing` was given a default value of `true`. Now we don't set a default, and instead consider a `nil` value as both `true` (analytics is disabled) and that the user hasn't yet made a choice.
- After login, if the user hasn't yet made a choice, then they will be prompted to enable analytics.

### Testing

After a clean install (with an analytics capable build) and login, you should be prompted. Further logins should not trigger a prompt.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
