### PR TITLE
fix: Reset password link - WPB-11566

### DIFF
--- a/wire-ios/Tests/TestPlans/SecurityTests.xctestplan
+++ b/wire-ios/Tests/TestPlans/SecurityTests.xctestplan
@@ -131,7 +131,8 @@
         "AppLockModuleViewTests\/test_ItSendsEvent_WhenApplicationWillEnterForeground()",
         "AppLockModuleViewTests\/test_ItSendsEvent_WhenLockViewRequestReauthentication()",
         "PasswordRuleSetTests\/testPasswordNotMatchingRuleSet()",
-        "PasswordRuleSetTests\/testThatItDetectsDisallowedCharacter()"
+        "PasswordRuleSetTests\/testThatItDetectsDisallowedCharacter()",
+        "URL_WireTests\/test_passwordReset_URLIsCorrect()"
       ],
       "target" : {
         "containerPath" : "container:Wire-iOS.xcodeproj",

--- a/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
+++ b/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
@@ -39,7 +39,6 @@ final class URL_WireTests: XCTestCase {
     }
 
     func testThatAccountURLsAreLoadedCorrectly() {
-        let accountsURL = URL(string: "https://account.wire.com")!
-        XCTAssertEqual(be.accountsURL, accountsURL)
+        XCTAssertEqual(WireURLs.shared.passwordReset, be.accountsURL.appendingPathComponent("forgot"))
     }
 }

--- a/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
+++ b/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
@@ -39,6 +39,11 @@ final class URL_WireTests: XCTestCase {
     }
 
     func testThatAccountURLsAreLoadedCorrectly() {
+        let accountsURL = URL(string: "https://account.wire.com")!
+        XCTAssertEqual(be.accountsURL, accountsURL)
+    }
+
+    func test_passwordReset_URLIsCorrect() {
         XCTAssertEqual(WireURLs.shared.passwordReset, be.accountsURL.appendingPathComponent("forgot"))
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11566" title="WPB-11566" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11566</a>  [iOS] Password reset link points to incorrect URL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The wrong `Reset password` link for C builds.

@netbe I've added the test, but we should make sure that it runs with C builds configurations.

### Testing

Reset password in C builds
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
