### PR TITLE
fix: Add construct the Password Reset url - WPB-11566

### DIFF
--- a/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
+++ b/wire-ios/Wire-iOS Tests/Bundle/URL+WireTests.swift
@@ -44,6 +44,6 @@ final class URL_WireTests: XCTestCase {
     }
 
     func test_passwordReset_URLIsCorrect() {
-        XCTAssertEqual(WireURLs.shared.passwordReset, be.accountsURL.appendingPathComponent("forgot"))
+        XCTAssertEqual(URL.wr_passwordReset, be.accountsURL.appendingPathComponent("forgot"))
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -340,7 +340,7 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
 
     @objc
     func forgotPasswordTapped(sender: UIButton) {
-        actioner?.executeAction(.openURL(WireURLs.shared.passwordReset))
+        actioner?.executeAction(.openURL(URL.wr_passwordReset))
     }
 
     override func createConstraints() {

--- a/wire-ios/Wire-iOS/Sources/Helpers/Bundle/Bundle+WireURLs.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/Bundle/Bundle+WireURLs.swift
@@ -57,9 +57,6 @@ struct WireURLs: Codable {
     /// Link to the license information page.
     let licenseInformation: URL
 
-    /// Link to the password reset page.
-    let passwordReset: URL
-
     /// Link to the support page where the user can submit a support request for various issues.
     let askSupportArticle: URL
 
@@ -117,7 +114,6 @@ struct WireURLs: Codable {
         case privacyPolicy
         case legal
         case licenseInformation
-        case passwordReset
         case askSupportArticle
         case reportAbuse
         case wireEnterpriseInfo

--- a/wire-ios/Wire-iOS/Sources/Helpers/URL+Wire.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/URL+Wire.swift
@@ -74,6 +74,10 @@ extension URL {
         BackendEnvironment.selfUserProfileLink
     }
 
+    static var wr_passwordReset: URL {
+        BackendEnvironment.accountsLink(path: "forgot")
+    }
+
 }
 
 // MARK: - BackendEnvironment Standard URLs

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -348,7 +348,7 @@ extension SettingsCellDescriptorFactory {
     func resetPasswordElement() -> SettingsCellDescriptorType {
         let resetPasswordTitle = L10n.Localizable.Self.Settings.PasswordResetMenu.title
         return SettingsExternalScreenCellDescriptor(title: resetPasswordTitle, isDestructive: false, presentationStyle: .modal, presentationAction: {
-            return BrowserViewController(url: WireURLs.shared.passwordReset)
+            return BrowserViewController(url: URL.wr_passwordReset)
         }, previewGenerator: .none)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11566" title="WPB-11566" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11566</a>  [iOS] Password reset link points to incorrect URL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We need to construct the `passwordrReset` URL because it depends on the `accountsURL` that we got when we switched to another server using deeplink.


### Testing

Reset password

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
