### PR TITLE
fix: Remove passwordReset from url.json - WPB-11566

### DIFF
--- a/wire-ios/Configuration/url.json
+++ b/wire-ios/Configuration/url.json
@@ -9,7 +9,6 @@
     "privacyPolicy": "https://wire.com/privacy-policy",
     "legal": "https://wire.com/legal",
     "licenseInformation": "https://start.wire.com/en-us/en-us/terms-of-use-personal-0-0",
-    "passwordReset": "https://account.wire.com/forgot",
     "askSupportArticle": "https://support.wire.com/hc/requests/new",
     "reportAbuse": "https://support.wire.com/hc/requests/new",
     "wireEnterpriseInfo": "https://wire.com/pricing",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11566" title="WPB-11566" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11566</a>  [iOS] Password reset link points to incorrect URL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Remove passwordReset from url.json and update `wire-ios-build-assets` .

### Testing


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
