### PR TITLE
fix: analytics requested repeatedly after declined - WPB-11332

### DIFF
--- a/wire-ios-sync-engine/Source/Use cases/DisableAnalyticsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/DisableAnalyticsUseCase.swift
@@ -35,7 +35,12 @@ struct DisableAnalyticsUseCase: DisableAnalyticsUseCaseProtocol {
     let provider: (any AnalyticsEventTrackerProvider)?
 
     func invoke() throws {
-        try service.disableTracking()
+        do {
+            try service.disableTracking()
+        } catch AnalyticsServiceError.serviceIsNotConfigured {
+            // Already disabled, don't consider it an error
+        }
+
         provider?.setAnalyticsEventTracker(nil)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11332" title="WPB-11332" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11332</a>  [iOS] Analytics user consent is not requested after login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Given fresh install and login, user is presented with request to enable analytics, user declines, terminates and relaunches the app.... then analytics is requested again.

The reason is that declining analytics will attempt to disable analytics, which will "fail" because it is already disabled. However this error means we return early in the flow and don't set the user preference to disable analytics. The next time the app is started, it sees that there is no user preference and will request to enable analytics.

The fix is to not consider `serviceNotConfigured` as an error when disabling analytics.

### Testing

1. Fresh install, login, decline analytics request
2. Terminate and relaunch app, assert analytics is not requested again.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
