### PR TITLE
fix: rotation of calling screen - WPB-11448

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -275,11 +275,12 @@ final class ZClientViewController: UIViewController {
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return wr_supportedInterfaceOrientations
-    }
-
-    override var shouldAutorotate: Bool {
-        return presentedViewController?.shouldAutorotate ?? true
+          if let viewController = presentedViewController,
+             viewController is ModalPresentationViewController,
+             !viewController.isBeingDismissed {
+              return viewController.supportedInterfaceOrientations
+          }
+          return wr_supportedInterfaceOrientations
     }
 
     // MARK: keyboard shortcut


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11448" title="WPB-11448" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11448</a>  [iPhone] Fix rotation support
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

With navigation overall, we removed the RootViewController as the rootViewController of the window and use now ZClientViewController.

This PR moves the previous rotation code from RootViewController to ZClientViewController.

### Testing

* have a call
* rotate the device
