### PR TITLE
chore: Add additional logs to notifications - WPB-11672

### DIFF
--- a/wire-ios-notification-engine/Sources/NotificationSession.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSession.swift
@@ -576,7 +576,10 @@ extension NotificationSession {
         var note: ZMLocalNotification?
 
         guard let conversationID = event.conversationUUID else {
-            WireLogger.notifications.warn("failed to generate notification from event: missing conversation id")
+            WireLogger.notifications.warn(
+                "failed to generate notification from event: missing conversation id",
+                attributes: event.logAttributes
+            )
             return nil
         }
 

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -126,6 +126,7 @@ private class EventNotificationBuilder: NotificationBuilder {
         userInfo.senderID = event.senderUUID
         userInfo.conversationID = conversation?.remoteIdentifier
         userInfo.messageNonce = event.messageNonce
+        userInfo.eventID = event.uuid
         userInfo.eventTime = event.timestamp
         userInfo.conversationName = conversation?.displayName
         userInfo.teamName = selfUser.team?.name

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -129,11 +129,11 @@ public class ZMLocalNotification: NSObject {
 
     public var logAttributes: LogAttributes {
         [
-            LogAttributesKey.eventId.rawValue: userInfo?.eventID?.safeForLoggingDescription,
-            LogAttributesKey.nonce.rawValue: userInfo?.messageNonce?.safeForLoggingDescription,
-            LogAttributesKey.conversationId.rawValue: userInfo?.conversationID?.safeForLoggingDescription,
-            LogAttributesKey.senderUserId.rawValue: userInfo?.senderID?.safeForLoggingDescription,
-            LogAttributesKey.selfUserId.rawValue: userInfo?.selfUserID?.safeForLoggingDescription
+            LogAttributesKey.eventId: userInfo?.eventID?.safeForLoggingDescription,
+            LogAttributesKey.nonce: userInfo?.messageNonce?.safeForLoggingDescription,
+            LogAttributesKey.conversationId: userInfo?.conversationID?.safeForLoggingDescription,
+            LogAttributesKey.senderUserId: userInfo?.senderID?.safeForLoggingDescription,
+            LogAttributesKey.selfUserId: userInfo?.selfUserID?.safeForLoggingDescription
         ]
     }
 }

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification.swift
@@ -17,6 +17,7 @@
 //
 
 import UserNotifications
+import WireDataModel
 
 /// Defines the various types of local notifications, some of which
 /// have associated subtypes.
@@ -124,6 +125,16 @@ public class ZMLocalNotification: NSObject {
         hash.combine(title)
         hash.combine(body)
         return hash.finalize()
+    }
+
+    public var logAttributes: LogAttributes {
+        [
+            LogAttributesKey.eventId.rawValue: userInfo?.eventID?.safeForLoggingDescription,
+            LogAttributesKey.nonce.rawValue: userInfo?.messageNonce?.safeForLoggingDescription,
+            LogAttributesKey.conversationId.rawValue: userInfo?.conversationID?.safeForLoggingDescription,
+            LogAttributesKey.senderUserId.rawValue: userInfo?.senderID?.safeForLoggingDescription,
+            LogAttributesKey.selfUserId.rawValue: userInfo?.selfUserID?.safeForLoggingDescription
+        ]
     }
 }
 

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Helpers/NotificationUserInfo.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Helpers/NotificationUserInfo.swift
@@ -227,7 +227,7 @@ extension NotificationUserInfo {
         self.conversationID = conversation.remoteIdentifier
         self.senderID = event.senderUUID
         self.messageNonce = event.messageNonce
-        self.eventTime = event.uuid
+        self.eventID = event.uuid
         self.eventTime = event.timestamp
     }
 

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Helpers/NotificationUserInfo.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Helpers/NotificationUserInfo.swift
@@ -27,6 +27,7 @@ private enum NotificationUserInfoKey: String {
     case requestID = "requestIDString"
     case conversationID = "conversationIDString"
     case messageNonce = "messageNonceString"
+    case eventID = "eventIDString"
     case senderID = "senderIDString"
     case eventTime = "eventTime"
     case selfUserID = "selfUserIDString"
@@ -104,6 +105,11 @@ public class NotificationUserInfo: NSObject, NSCoding {
         set { self[.messageNonce] = newValue?.uuidString }
     }
 
+    public var eventID: UUID? {
+        get { return uuid(for: .eventID) }
+        set { self[.eventID] = newValue?.uuidString }
+    }
+
     public var senderID: UUID? {
         get { return uuid(for: .senderID) }
         set { self[.senderID] = newValue?.uuidString }
@@ -147,6 +153,7 @@ extension NotificationUserInfo {
                 lhs.conversationName == rhs.conversationName &&
                 lhs.teamName == rhs.teamName &&
                 lhs.messageNonce == rhs.messageNonce &&
+                lhs.eventID == rhs.eventID &&
                 lhs.senderID == rhs.senderID &&
                 lhs.eventTime == rhs.eventTime &&
                 lhs.selfUserID == rhs.selfUserID
@@ -220,6 +227,7 @@ extension NotificationUserInfo {
         self.conversationID = conversation.remoteIdentifier
         self.senderID = event.senderUUID
         self.messageNonce = event.messageNonce
+        self.eventTime = event.uuid
         self.eventTime = event.timestamp
     }
 

--- a/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
@@ -120,7 +120,7 @@ final class LegacyNotificationService: UNNotificationServiceExtension, Notificat
 
         removeNotification(withSameMessageId: notification.messageNonce)
 
-        WireLogger.notifications.info("session did generate a notification")
+        WireLogger.notifications.info("session did generate a notification", attributes: notification.logAttributes)
 
         defer { tearDown() }
 
@@ -138,7 +138,7 @@ final class LegacyNotificationService: UNNotificationServiceExtension, Notificat
             content.badge = badgeCount
         }
 
-        WireLogger.notifications.info("showing notification to user")
+        WireLogger.notifications.info("showing notification to user", attributes: notification.logAttributes)
         contentHandler(content)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11672" title="WPB-11672" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11672</a>  [iOS] Add additional logging around notifications
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR:

- add `eventID` to `NotificationUserInfo`
- adds `attributes` to a few log statements to help debug https://wearezeta.atlassian.net/browse/WPB-11226

### Testing

Run tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
