### PR TITLE
fix: Group & 1:1 conversation filters not showing all conversations - WPB-11636

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
@@ -66,20 +66,17 @@ public final class ConversationPredicateFactory: NSObject {
     public func predicateForOneToOneConversations() -> NSPredicate {
         // We consider a conversation to be one-to-one if it's of type .oneToOne, is a team 1:1 or an outgoing connection request.
         let oneToOneConversationPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicateForOneToOneConversation(), predicateForUnconnectedConversations()])
-        let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
 
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), oneToOneConversationPredicate, notInFolderPredicate])
+        return NSCompoundPredicate(andPredicateWithSubpredicates: [predicateForConversationsExcludingArchived(), oneToOneConversationPredicate])
     }
 
     @objc(predicateForGroupConversations)
     public func predicateForGroupConversations() -> NSPredicate {
         let groupConversationPredicate = NSPredicate(format: "\(ZMConversationConversationTypeKey) == \(ZMConversationType.group.rawValue)")
-        let notInFolderPredicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicateForConversationsInFolders())
 
         return .all(of: [
             predicateForConversationsExcludingArchived(),
-            groupConversationPredicate,
-            notInFolderPredicate
+            groupConversationPredicate
         ])
     }
 
@@ -150,10 +147,6 @@ public final class ConversationPredicateFactory: NSObject {
         // whether this group has a one on one user to filter it out.
         let hasNoOneOnOneUser = NSPredicate(format: "\(#keyPath(ZMConversation.oneOnOneUser)) == NULL")
         return isGroup.and(hasNoOneOnOneUser)
-    }
-
-    private func predicateForConversationsInFolders() -> NSPredicate {
-        return NSPredicate(format: "ANY %K.%K == \(Label.Kind.folder.rawValue)", ZMConversationLabelsKey, #keyPath(Label.type))
     }
 
     private func predicateForOneToOneConversation() -> NSPredicate {

--- a/wire-ios-data-model/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/ConversationList/ZMConversationListDirectoryTests.m
@@ -307,8 +307,10 @@
 {
     // when
     ZMConversationList *list = self.uiMOC.conversationListDirectory.groupConversations;
-    NSSet *expected = [NSSet setWithArray:@[self.groupConversation, self.favoritedConversation]];
-    
+    NSSet *expected = [NSSet setWithArray:@[self.groupConversation,
+                                            self.favoritedConversation,
+                                            self.groupConversationInFolder]];
+
     // then
     XCTAssertEqualObjects([NSSet setWithArray:list.items], expected);
 }
@@ -317,7 +319,11 @@
 {
     // when
     ZMConversationList *list = self.uiMOC.conversationListDirectory.oneToOneConversations;
-    NSSet *expected = [NSSet setWithArray:@[self.oneToOneConversation, self.oneToOneConversationInTeam, self.outgoingPendingConnectionConversation, self.serviceConversation]];
+    NSSet *expected = [NSSet setWithArray:@[self.oneToOneConversation,
+                                            self.oneToOneConversationInTeam,
+                                            self.outgoingPendingConnectionConversation,
+                                            self.serviceConversation,
+                                            self.oneToOneConversationInFolder]];
 
     // then
     XCTAssertEqualObjects([NSSet setWithArray:list.items], expected);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11636" title="WPB-11636" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11636</a>  [iOS] - Group filter bug - Filtering on groups do not show all my groups Nav Overhaul 3.114.0 (12669)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a user filters conversations by `Groups` or `1:1 Conversations` the result doesn't include items that belong to a folder. This behavior is undesired.

To fix this I adjusted the predicates returned from `ConversationPredicateFactory`. I was slightly worried this change may have undesired behavioral side affects, but looking through the code, I haven't found any.

If you can think of anything else to check let me know.


### Testing

#### Prerequisites

Add a group conversation & 1:1 conversation to a folder using the macos app.

#### Steps

1. Open the app and go to the `Conversations` tab
2. Confirm that the conversations added in the prerequisite steps above are listed.
3. Filter the `Conversations` tab by  `Groups`
4. Confirm that all non-archived group conversation are visible including that from the prerequisites above.
5. Filter the `Conversations` tab by  `1:1 Conversations`
4. Confirm that all non-archived 1:1 Conversations are visible including that from the prerequisites above.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.