### PR TITLE
fix: VoiceOver Support for certain items on the ConversationList Navigation Bar - WPB-11606

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -553,6 +553,12 @@ internal enum L10n {
         internal static let hint = L10n.tr("Accessibility", "conversationDetails.showParticipantsButton.hint", fallback: "Double tap to open participant list")
       }
     }
+    internal enum ConversationList {
+      internal enum StartConversationButton {
+        /// Create group or search for people
+        internal static let description = L10n.tr("Accessibility", "conversationList.startConversationButton.description", fallback: "Create group or search for people")
+      }
+    }
     internal enum ConversationSearch {
       internal enum AudioMessage {
         /// Audio message

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Accessibility.strings
@@ -226,6 +226,7 @@
 "conversationsList.connectionRequest.description" = "Pending approval of connection request";
 "conversationsList.connectionRequest.hint" = "Double tap to open profile";
 
+"conversationList.startConversationButton.description" = "Create group or search for people";
 "conversationsList.filterButton.description" = "Filter conversations";
 
 "conversationsList.filter_menu_options.allConversations.description" = "Show all conversations";

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -235,9 +235,8 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
 
         let newConversationBarButton = IconButton()
         newConversationBarButton.setIcon(.plus, size: .tiny, for: .normal)
-        // TODO: [WPB-11606] fix accessibility
-        // newConversationBarButton.accessibilityIdentifier =
-        // newConversationBarButton.accessibilityLabel =
+        newConversationBarButton.accessibilityIdentifier = "create_group_or_search_button"
+        newConversationBarButton.accessibilityLabel = L10n.Accessibility.ConversationList.StartConversationButton.description
         newConversationBarButton.addAction(.init { [weak self] _ in
             Task {
                 await self?.mainCoordinator.showCreateGroupConversation()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -167,9 +167,8 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
         }
         let newConversationButton = UIButton(primaryAction: newConversationAction)
         let startConversationItem = UIBarButtonItem(customView: newConversationButton)
-        // TODO: [WPB-11606] fix accessibility
-        // startConversationItem.accessibilityIdentifier =
-        // startConversationItem.accessibilityLabel =
+        startConversationItem.accessibilityIdentifier = "create_group_or_search_button"
+        startConversationItem.accessibilityLabel = L10n.Accessibility.ConversationList.StartConversationButton.description
         navigationItem.rightBarButtonItems = [startConversationItem, spacer]
 
         let defaultFilterImage = UIImage(systemName: "line.3.horizontal.decrease.circle", withConfiguration: symbolConfiguration)!

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -42,14 +42,12 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
     ) {
 
         accountImageView?.accountImage = accountImage
+        accountImageView?.accessibilityIdentifier = "account_profile_image_view"
 
-        // TODO: [WPB-11606] fix accessibilityIdentifier if needed
         if let userName = viewModel.userSession.selfUser.name {
             accountImageView?.accessibilityValue = L10n.Localizable.ConversationList.Header.SelfTeam.accessibilityValue(userName)
-            accountImageView?.accessibilityIdentifier = .none
         } else {
             accountImageView?.accessibilityValue = .none
-            accountImageView?.accessibilityIdentifier = .none
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11606" title="WPB-11606" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11606</a>  Check accessibility labels for navigation overall
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


## Summary:
This PR focuses on enhancing accessibility support and cleaning up the accessibility identifiers for key UI elements within ConversationListViewController. Figma designs can be found [here](https://www.figma.com/design/sOAbcd6UVtlZ5ejK4BoEvX/iOS?node-id=30-5831&node-type=frame&t=sIH0inuTZAhDuwYu-0)

## Key Changes:
1. Accessibility Identifier for `Account Image View`:
	- Introduced a new accessibility identifier `account_profile_image_view` for the accountImageView to improve clarity and aid UI testing.
2. Improved Accessibility for `Start Conversation` Button:
	- Updated the `startConversationItem` to have a more descriptive accessibility identifier `create_group_or_search_button`.
	- Set the accessibilityLabel for `startConversationItem`.

## Testing:

- Ensured that the accessibility identifiers and labels are correctly applied and recognized.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
