### PR TITLE
fix: Unarchive from "Archive" tab - WPB-11640

### DIFF
--- a/wire-ios/Wire-iOS Tests/UserInterface/ConversationList/ArchivedList/ArchivedListViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserInterface/ConversationList/ArchivedList/ArchivedListViewModelTests.swift
@@ -29,8 +29,6 @@ final class ArchivedListViewModelTests: XCTestCase {
 
     @MainActor
     override func setUp() async throws {
-        try await super.setUp()
-
         let modelHelper = ModelHelper()
         stack = try await CoreDataStackHelper().createStack()
         userSession = UserSessionMock()
@@ -52,8 +50,6 @@ final class ArchivedListViewModelTests: XCTestCase {
         stack = nil
         userSession = nil
         sut = nil
-
-        try await super.tearDown()
     }
 
     func testUnarchiveConversation() throws {

--- a/wire-ios/Wire-iOS Tests/UserInterface/ConversationList/ArchivedList/ArchivedListViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserInterface/ConversationList/ArchivedList/ArchivedListViewModelTests.swift
@@ -1,0 +1,75 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModelSupport
+import WireTestingPackage
+import XCTest
+
+@testable import Wire
+
+final class ArchivedListViewModelTests: XCTestCase {
+    private var stack: CoreDataStack!
+    private var userSession: UserSessionMock!
+    private var sut: ArchivedListViewModel!
+
+    @MainActor
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let modelHelper = ModelHelper()
+        stack = try await CoreDataStackHelper().createStack()
+        userSession = UserSessionMock()
+        userSession.mockConversationList = ConversationList(
+            allConversations: ["A", "B", "C"].map { name in
+                let conversation = modelHelper.createGroupConversation(in: stack.viewContext)
+                conversation.userDefinedName = name
+                conversation.isArchived = true
+                return conversation
+            },
+            filteringPredicate: .init(value: true),
+            managedObjectContext: .init(concurrencyType: .mainQueueConcurrencyType),
+            description: "mock conversations"
+        )
+        sut = ArchivedListViewModel(userSession: userSession)
+    }
+
+    override func tearDown() async throws {
+        stack = nil
+        userSession = nil
+        sut = nil
+
+        try await super.tearDown()
+    }
+
+    func testUnarchiveConversation() throws {
+        // given
+        let selectedRow = 1
+        let objectID = sut[selectedRow].objectID
+
+        // when
+        sut.unarchiveConversation(at: 1)
+
+        // then
+        let fetchRequest = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+        let conversations = try stack.viewContext.fetch(fetchRequest)
+        let unarchived = conversations.filter { !$0.isArchived }
+
+        XCTAssertEqual(unarchived.count, 1)
+        XCTAssertEqual(unarchived.first?.objectID, objectID)
+    }
+}

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -1178,6 +1178,7 @@
 		BFFD439E1DE47FFA00505C8C /* UIView+RightToLeft.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */; };
 		BFFE943C1E7839D10025AD75 /* ConversationRenamedCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE943B1E7839D10025AD75 /* ConversationRenamedCellTests.swift */; };
 		BFFE943E1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFE943D1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift */; };
+		CB366A902CC7DE410083701F /* ArchivedListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB366A8F2CC7DE410083701F /* ArchivedListViewModelTests.swift */; };
 		CB4870F22C7F4FE5001E9151 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4870F12C7F4FE5001E9151 /* WireTransportSupport.framework */; };
 		CB4E15122C81CC81005DDEC8 /* Down in Frameworks */ = {isa = PBXBuildFile; productRef = CB4E15112C81CC81005DDEC8 /* Down */; };
 		CE2402811E0A992200665A91 /* AnalyticsConsoleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */; };
@@ -3273,6 +3274,7 @@
 		BFFD439D1DE47FFA00505C8C /* UIView+RightToLeft.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+RightToLeft.swift"; sourceTree = "<group>"; };
 		BFFE943B1E7839D10025AD75 /* ConversationRenamedCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConversationRenamedCellTests.swift; sourceTree = "<group>"; };
 		BFFE943D1E7839EB0025AD75 /* CoreDataSnapshotTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataSnapshotTestCase.swift; sourceTree = "<group>"; };
+		CB366A8F2CC7DE410083701F /* ArchivedListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedListViewModelTests.swift; sourceTree = "<group>"; };
 		CB4870F12C7F4FE5001E9151 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE06C93E1DF5C3D900497685 /* AVAsset+VideoConvert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVAsset+VideoConvert.swift"; sourceTree = "<group>"; };
 		CE2402801E0A992200665A91 /* AnalyticsConsoleProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsConsoleProvider.swift; sourceTree = "<group>"; };
@@ -4608,6 +4610,7 @@
 			isa = PBXGroup;
 			children = (
 				5902F8DF2BF7B14F00F1D392 /* ArchivedListViewControllerSnapshotTests.swift */,
+				CB366A8F2CC7DE410083701F /* ArchivedListViewModelTests.swift */,
 			);
 			path = ArchivedList;
 			sourceTree = "<group>";
@@ -10430,6 +10433,7 @@
 				25CCE9D42BA1EA09002AB21F /* OtherUserDeviceDetailsViewTests.swift in Sources */,
 				2521832C2B4C1B8B000C4325 /* SaveFileManagerTests.swift in Sources */,
 				EF6E3C7C208A02FE003F6752 /* GiphySearchViewControllerSnapshotTests.swift in Sources */,
+				CB366A902CC7DE410083701F /* ArchivedListViewModelTests.swift in Sources */,
 				EFC0C7F121778FB000380C4B /* SettingsTextCellSnapshotTests.swift in Sources */,
 				EFE806301FE006A7006A0EE7 /* DateFormatterTests.swift in Sources */,
 				7CCB8F7F229D67BD005BBC10 /* URL+WireTests.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
@@ -144,8 +144,8 @@ extension ArchivedListViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let conversation = viewModel[indexPath.row]
-        delegate?.archivedListViewController(self, didSelectConversation: conversation)
         viewModel.unarchiveConversation(at: indexPath.row)
+        delegate?.archivedListViewController(self, didSelectConversation: conversation)
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
@@ -145,6 +145,7 @@ extension ArchivedListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let conversation = viewModel[indexPath.row]
         delegate?.archivedListViewController(self, didSelectConversation: conversation)
+        viewModel.unarchiveConversation(at: indexPath.row)
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
@@ -143,7 +143,7 @@ final class ArchivedListViewController: UIViewController {
 extension ArchivedListViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let conversation = viewModel[indexPath.row] else { return }
+        let conversation = viewModel[indexPath.row]
         delegate?.archivedListViewController(self, didSelectConversation: conversation)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewModel.swift
@@ -48,7 +48,7 @@ final class ArchivedListViewModel: NSObject {
         return archivedConversations.count
     }
 
-    subscript(key: Int) -> ZMConversation? {
+    subscript(key: Int) -> ZMConversation {
         return archivedConversations[key]
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewModel.swift
@@ -51,6 +51,13 @@ final class ArchivedListViewModel: NSObject {
     subscript(key: Int) -> ZMConversation {
         return archivedConversations[key]
     }
+
+    func unarchiveConversation(at row: Int) {
+        let conversation = self[row]
+        userSession.enqueue {
+            conversation.isArchived = false
+        }
+    }
 }
 
 extension ArchivedListViewModel: ZMConversationListObserver {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -491,23 +491,6 @@ final class ConversationListViewController: UIViewController {
     }
 }
 
-// MARK: - ConversationListViewController + ArchivedListViewControllerDelegate
-
-extension ConversationListViewController: ArchivedListViewControllerDelegate {
-
-    func archivedListViewController(
-        _ viewController: ArchivedListViewController,
-        didSelectConversation conversation: ZMConversation
-    ) {
-        _ = selectOnListContentController(
-            conversation,
-            scrollTo: nil,
-            focusOnView: true,
-            animated: true
-        )
-    }
-}
-
 // MARK: - Helpers
 
 private extension NSAttributedString {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11640" title="WPB-11640" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11640</a>  [iOS] : un-Archive Bug - Nav Overhaul 3.114.0 (12669)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds the current behavior of the production app to navigation overhaul branch so that clicking on a conversation in the `Archive` tab both opens that conversation (current implementation) and unarchives it.

### Testing

1. Open the app.
2. Navigate to the `Conversations` tab.
3. Long press a conversation and select `Archive`.
4. Confirm the conversation is removed from the `Conversations` tab.
5. Select the `Archive` tab.
6. Confirm the conversation exists in the `Archive` tab.
7. Select the conversation.
8. Confirm the conversation opens.
9. Tap back.
10. Confirm the conversation exists in the `Conversations` tab.
11. Confirm the conversation is removed from the `Archive` tab.

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [X] Adds/updates automated tests.
