### PR TITLE
fix: update displayed user status when updating user status - WPB-11509

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserStatus/UserStatusViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserStatus/UserStatusViewController.swift
@@ -60,6 +60,7 @@ final class UserStatusViewController: UIViewController {
         let availabilityChangedHandler = { [weak self] (availability: Availability) in
             guard let self else { return }
 
+            userStatus.availability = availability
             delegate?.userStatusViewController(self, didSelect: availability)
             feedbackGenerator.impactOccurred()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11509" title="WPB-11509" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11509</a>  [iOS] Status update is not reflecting immediately in the account screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When updating the user's availability, the user's new availability status was not immediately updated in the account view.
It was fixed in #1922, so we backported the fix.

### Testing

- Log in 
- Go to user account
- Change the status
- Status is updated in the profile screen

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
