### PR TITLE
fix: Creating group bug - WPB-11624

### DIFF
--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -494,20 +494,20 @@ class MockCreateGroupConversationViewControllerBuilderProtocol: CreateGroupConve
 
     // MARK: - build
 
-    var buildMainCoordinator_Invocations: [AnyMainCoordinator] = []
-    var buildMainCoordinator_MockMethod: ((AnyMainCoordinator) -> UINavigationController)?
-    var buildMainCoordinator_MockValue: UINavigationController?
+    var build_Invocations: [Void] = []
+    var build_MockMethod: (() -> UIViewController)?
+    var build_MockValue: UIViewController?
 
     @MainActor
-    func build(mainCoordinator: AnyMainCoordinator) -> UINavigationController {
-        buildMainCoordinator_Invocations.append(mainCoordinator)
+    func build() -> UIViewController {
+        build_Invocations.append(())
 
-        if let mock = buildMainCoordinator_MockMethod {
-            return mock(mainCoordinator)
-        } else if let mock = buildMainCoordinator_MockValue {
+        if let mock = build_MockMethod {
+            return mock()
+        } else if let mock = build_MockValue {
             return mock
         } else {
-            fatalError("no mock for `buildMainCoordinator`")
+            fatalError("no mock for `build`")
         }
     }
 

--- a/wire-ios/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
@@ -94,6 +94,7 @@ final class StartUIViewControllerSnapshotTests: CoreDataSnapshotTestCase {
             addressBookHelperType: MockAddressBookHelper.self,
             userSession: userSession,
             mainCoordinator: mockMainCoordinator,
+            createGroupConversationUIBuilder: MockCreateGroupConversationViewControllerBuilderProtocol(),
             selfProfileUIBuilder: MockSelfProfileViewControllerBuilderProtocol()
         )
         sut.view.backgroundColor = SemanticColors.View.backgroundDefault

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/CreateGroupConversationViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/CreateGroupConversationViewControllerBuilder.swift
@@ -22,8 +22,6 @@ import WireSyncEngine
 
 final class CreateGroupConversationViewControllerBuilder: CreateGroupConversationViewControllerBuilderProtocol {
 
-    typealias Dependencies = MainCoordinatorDependencies
-
     let userSession: UserSession
     var delegate: ConversationCreationControllerDelegate?
 
@@ -31,14 +29,12 @@ final class CreateGroupConversationViewControllerBuilder: CreateGroupConversatio
         self.userSession = userSession
     }
 
-    func build<MainCoordinator: MainCoordinatorProtocol>(
-        mainCoordinator _: MainCoordinator
-    ) -> UINavigationController where MainCoordinator.Dependencies == Dependencies {
-        let rootViewController = ConversationCreationController(
+    func build() -> UIViewController {
+        let viewController = ConversationCreationController(
             preSelectedParticipants: nil,
             userSession: userSession
         )
-        rootViewController.delegate = delegate
-        return .init(rootViewController: rootViewController)
+        viewController.delegate = delegate
+        return viewController
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/CreateGroupConversationViewControllerBuilderProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/CreateGroupConversationViewControllerBuilderProtocol.swift
@@ -21,5 +21,5 @@ import UIKit
 // sourcery: AutoMockable
 protocol CreateGroupConversationViewControllerBuilderProtocol {
     @MainActor
-    func build(mainCoordinator: AnyMainCoordinator) -> UINavigationController
+    func build() -> UIViewController
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -317,7 +317,7 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
     @objc
     private func presentCreateConversationUI() {
         Task {
-            let createConversationUI = createGroupConversationViewControllerBuilder.build(mainCoordinator: mainCoordinator)
+            let createConversationUI = UINavigationController(rootViewController: createGroupConversationUIBuilder.build())
             createConversationUI.modalPresentationStyle = .formSheet
             await mainCoordinator.presentViewController(createConversationUI)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -34,7 +34,7 @@ final class ConversationListViewController: UIViewController {
     let mainCoordinator: AnyMainCoordinator
     let connectViewControllerBuilder: any ConnectViewControllerBuilderProtocol
     let selfProfileViewControllerBuilder: any SelfProfileViewControllerBuilderProtocol
-    let createGroupConversationViewControllerBuilder: any CreateGroupConversationViewControllerBuilderProtocol
+    let createGroupConversationUIBuilder: any CreateGroupConversationViewControllerBuilderProtocol
     let conversationListCoordinator: any ConversationListCoordinatorProtocol
     weak var zClientViewController: ZClientViewController?
 
@@ -157,7 +157,7 @@ final class ConversationListViewController: UIViewController {
         self.zClientViewController = zClientViewController
         self.connectViewControllerBuilder = connectViewControllerBuilder
         self.selfProfileViewControllerBuilder = selfProfileViewControllerBuilder
-        self.createGroupConversationViewControllerBuilder = createGroupConversationViewControllerBuilder
+        self.createGroupConversationUIBuilder = createGroupConversationViewControllerBuilder
         let conversationListCoordinator = ConversationListCoordinator(mainCoordinator: mainCoordinator)
         self.conversationListCoordinator = conversationListCoordinator
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -254,6 +254,7 @@ final class ZClientViewController: UIViewController {
         mainSplitViewController.delegate = mainCoordinator
         archiveUI.delegate = mainCoordinator
         connectBuilder.delegate = self
+        connectBuilder.conversationCreationControllerDelegate = mainCoordinator
 
         addChild(mainSplitViewController)
         mainSplitViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -88,6 +88,7 @@ final class ZClientViewController: UIViewController {
 
     private lazy var connectBuilder = StartUIViewControllerBuilder(
         userSession: userSession,
+        createGroupConversationUIBuilder: createGroupConversationBuilder,
         selfProfileUIBuilder: selfProfileViewControllerBuilder
     )
 
@@ -254,7 +255,7 @@ final class ZClientViewController: UIViewController {
         mainSplitViewController.delegate = mainCoordinator
         archiveUI.delegate = mainCoordinator
         connectBuilder.delegate = self
-        connectBuilder.conversationCreationControllerDelegate = mainCoordinator
+        createGroupConversationBuilder.delegate = mainCoordinator
 
         addChild(mainSplitViewController)
         mainSplitViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+NavigationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+NavigationController.swift
@@ -27,24 +27,20 @@ extension StartUIViewController {
             action: UIAction { [weak self] _ in
                 _ = self?.searchController.searchBar.resignFirstResponder()
                 self?.navigationController?.dismiss(animated: true)
-            })
-
+            }
+        )
         cancelButton.accessibilityLabel = L10n.Accessibility.ContactsList.CancelButton.description
         cancelButton.accessibilityIdentifier = "cancel"
-
         navigationItem.leftBarButtonItem = cancelButton
 
         let createGroupButton = UIBarButtonItem.createNavigationRightBarButtonItem(
             title: L10n.Localizable.Peoplepicker.Button.createConversation,
             action: UIAction { [weak self] _ in
                 guard let self else { return }
-                let conversationCreationController = ConversationCreationController(
-                    preSelectedParticipants: nil,
-                    userSession: userSession
-                )
-                conversationCreationController.delegate = conversationCreationControllerDelegate
+                let conversationCreationController = createGroupConversationUIBuilder.build()
                 navigationController?.pushViewController(conversationCreationController, animated: true)
-            })
+            }
+        )
 
         // We explicitly set the font here because the font provided inside createNavigationRightBarButtonItem
         // might not reflect the required design specifications in this particular context.
@@ -52,10 +48,8 @@ extension StartUIViewController {
         // The only change between the two is the weight. In this case it's semibold.
         let font = UIFont.systemFont(ofSize: 17, weight: .semibold)
         createGroupButton.setTitleTextAttributes([.font: font], for: .normal)
-
         createGroupButton.accessibilityLabel = L10n.Localizable.Peoplepicker.Button.createConversation
         createGroupButton.accessibilityIdentifier = "create_group"
-
         navigationItem.rightBarButtonItem = createGroupButton
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+NavigationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+NavigationController.swift
@@ -42,6 +42,7 @@ extension StartUIViewController {
                     preSelectedParticipants: nil,
                     userSession: userSession
                 )
+                conversationCreationController.delegate = conversationCreationControllerDelegate
                 navigationController?.pushViewController(conversationCreationController, animated: true)
             })
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -33,6 +33,8 @@ final class StartUIViewController: UIViewController {
 
     weak var delegate: StartUIDelegate?
 
+    weak var conversationCreationControllerDelegate: ConversationCreationControllerDelegate?
+
     let searchController = UISearchController(searchResultsController: nil)
 
     let groupSelector = SearchGroupSelector()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -33,8 +33,6 @@ final class StartUIViewController: UIViewController {
 
     weak var delegate: StartUIDelegate?
 
-    weak var conversationCreationControllerDelegate: ConversationCreationControllerDelegate?
-
     let searchController = UISearchController(searchResultsController: nil)
 
     let groupSelector = SearchGroupSelector()
@@ -46,6 +44,7 @@ final class StartUIViewController: UIViewController {
     let userSession: UserSession
 
     let mainCoordinator: AnyMainCoordinator
+    let createGroupConversationUIBuilder: CreateGroupConversationViewControllerBuilderProtocol
 
     let isFederationEnabled: Bool
 
@@ -86,6 +85,7 @@ final class StartUIViewController: UIViewController {
         isFederationEnabled: Bool = BackendInfo.isFederationEnabled,
         userSession: UserSession,
         mainCoordinator: AnyMainCoordinator,
+        createGroupConversationUIBuilder: CreateGroupConversationViewControllerBuilderProtocol,
         selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol
     ) {
         self.isFederationEnabled = isFederationEnabled
@@ -99,6 +99,7 @@ final class StartUIViewController: UIViewController {
         )
         self.userSession = userSession
         self.mainCoordinator = mainCoordinator
+        self.createGroupConversationUIBuilder = createGroupConversationUIBuilder
         profilePresenter = .init(
             mainCoordinator: mainCoordinator,
             selfProfileUIBuilder: selfProfileUIBuilder

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewControllerBuilder.swift
@@ -25,6 +25,7 @@ final class StartUIViewControllerBuilder: ConnectViewControllerBuilderProtocol {
     let userSession: UserSession
     let selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol
     var delegate: StartUIDelegate?
+    weak var conversationCreationControllerDelegate: ConversationCreationControllerDelegate?
 
     init(
         userSession: UserSession,
@@ -41,6 +42,7 @@ final class StartUIViewControllerBuilder: ConnectViewControllerBuilderProtocol {
             selfProfileUIBuilder: selfProfileUIBuilder
         )
         rootViewController.delegate = delegate
+        rootViewController.conversationCreationControllerDelegate = conversationCreationControllerDelegate
         return .init(rootViewController: rootViewController)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewControllerBuilder.swift
@@ -23,15 +23,17 @@ import WireSyncEngine
 final class StartUIViewControllerBuilder: ConnectViewControllerBuilderProtocol {
 
     let userSession: UserSession
+    let createGroupConversationUIBuilder: CreateGroupConversationViewControllerBuilderProtocol
     let selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol
     var delegate: StartUIDelegate?
-    weak var conversationCreationControllerDelegate: ConversationCreationControllerDelegate?
 
     init(
         userSession: UserSession,
+        createGroupConversationUIBuilder: CreateGroupConversationViewControllerBuilderProtocol,
         selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol
     ) {
         self.userSession = userSession
+        self.createGroupConversationUIBuilder = createGroupConversationUIBuilder
         self.selfProfileUIBuilder = selfProfileUIBuilder
     }
 
@@ -39,10 +41,10 @@ final class StartUIViewControllerBuilder: ConnectViewControllerBuilderProtocol {
         let rootViewController = StartUIViewController(
             userSession: userSession,
             mainCoordinator: mainCoordinator,
+            createGroupConversationUIBuilder: createGroupConversationUIBuilder,
             selfProfileUIBuilder: selfProfileUIBuilder
         )
         rootViewController.delegate = delegate
-        rootViewController.conversationCreationControllerDelegate = conversationCreationControllerDelegate
-        return .init(rootViewController: rootViewController)
+        return UINavigationController(rootViewController: rootViewController)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11624" title="WPB-11624" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11624</a>  [iOS] : Creating a group Bug - Nav Overhaul 3.114.0 (12669)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently while creating a group on iPhone on the navigation epic branch, once the group is created (via tapping `Skip` or `Done`), the modal UI is not dismissed. Tapping `Skip` or `Done` again will lead to more groups being created with the same name.

This PR fixes this so that one the group is created, the UI is dismissed and the group (conversation) is loaded. This is similar to the current behavior in the production app.

The fix is just setting the `ConversationCreationControllerDelegate`. As the `MainCoordinator` has already conformed to the protocol, I just needed to pass it through a few layers as a `ConversationCreationControllerDelegate`. I couldn't make direct use of `StartUIViewController.mainCoordinator.base` due to typing even those these are the same underlying objects.

@caldrian I'm not really sure if my approach here is the way you want to go. Feel free to let me know if there is another approach you would prefer.


https://github.com/user-attachments/assets/d40ed913-92b6-45ff-a1eb-e78f328d0fbd

### Testing

1. From the `Conversations` tab, tap the `plus` icon.
2. Tap `Create Group`
3. Enter a group name and tap `Next`
4. Tap `Skip`
5. Ensure the UI dismisses,  the group is created and the conversation is loaded.
6. From the `Conversations` tab, tap the `plus` icon.
7. Tap `Create Group`
8. Enter a group name and tap `Next`
9. Select some contacts and tap `Done`
11. Ensure the UI dismisses,  the group is created and the conversation is loaded.

### Checklist

- [X] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [X] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
