### PR TITLE
fix: update displayed user status when updating user status - 11509

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserStatus/UserStatusViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserStatus/UserStatusViewController.swift
@@ -60,6 +60,7 @@ final class UserStatusViewController: UIViewController {
         let availabilityChangedHandler = { [weak self] (availability: Availability) in
             guard let self else { return }
 
+            userStatus.availability = availability
             delegate?.userStatusViewController(self, didSelect: availability)
             feedbackGenerator.impactOccurred()
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

When updating the user's availability, the user's new availability status was not immediately updated in the account view.
It was fixed in #1922, so we backported the fix.

This is tagged do not merge for now as no delivery is scheduled.

### Testing

- Log in 
- Go to user account
- Change the status
- Status is updated in the profile screen

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.