### PR TITLE
fix: Update Navigation Bar title for SelectParticipantsViewController to match design specs - WPB-11821

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -4439,12 +4439,12 @@ internal enum L10n {
         /// Skip
         internal static let skip = L10n.tr("Localizable", "peoplepicker.group.skip", fallback: "Skip")
         internal enum Title {
-          /// Add Participants (%d)
+          /// Select Participants (%d)
           internal static func plural(_ p1: Int) -> String {
-            return L10n.tr("Localizable", "peoplepicker.group.title.plural", p1, fallback: "Add Participants (%d)")
+            return L10n.tr("Localizable", "peoplepicker.group.title.plural", p1, fallback: "Select Participants (%d)")
           }
-          /// Add Participants
-          internal static let singular = L10n.tr("Localizable", "peoplepicker.group.title.singular", fallback: "Add Participants")
+          /// Select Participants
+          internal static let singular = L10n.tr("Localizable", "peoplepicker.group.title.singular", fallback: "Select Participants")
         }
       }
       internal enum Header {

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -59,8 +59,8 @@
 "peoplepicker.header.directory" = "Connect";
 "peoplepicker.header.federation" = "Connect with other domain";
 
-"peoplepicker.group.title.singular" = "Add Participants";
-"peoplepicker.group.title.plural" = "Add Participants (%d)";
+"peoplepicker.group.title.singular" = "Select Participants";
+"peoplepicker.group.title.plural" = "Select Participants (%d)";
 "peoplepicker.group.skip" = "Skip";
 "peoplepicker.group.done" = "Done";
 "peoplepicker.group.create" = "Create";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11821" title="WPB-11821" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11821</a>  [iOS]  The screen name to add participants for a group is incorrect in the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


## Description

With this PR we update the navigation bar title for SelectParticipantsViewController to match [design specs](https://www.figma.com/design/sOAbcd6UVtlZ5ejK4BoEvX/iOS?node-id=563-7404&t=w7ZaDDPuCHp4svJQ-4)

## Design 

<img width="581" alt="Screenshot 2024-10-24 at 11 57 36" src="https://github.com/user-attachments/assets/245835ed-199d-4e53-bd8e-497241a3598e">
<img width="581" alt="Screenshot 2024-10-24 at 11 57 32" src="https://github.com/user-attachments/assets/00e52f50-4ee1-4713-ab4b-a656b3a5feac">

---

Note: With this PR we don't tackle the change regarding the Selected section in `SelectParticipantsViewController`. This is out of the scope for Navigation Overhaul and it's going to happen later probably Millestone 2. 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---