### PR TITLE
feat: open password reset link in browser - WPB-11685

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -72,6 +72,13 @@ on:
         required: true
       COUNTLY_INTERNAL_KEY:
         required: true  
+      # this key can be removed after 3.112.X is not maintained anymore
+      OLD_COUNTLY_PRODUCTION_KEY:
+        required: true
+      # this key can be removed after 3.112.X is not maintained anymore
+      OLD_COUNTLY_INTERNAL_KEY:
+          required: true  
+
       SUBMODULE_PAT:
         required: true
 
@@ -121,8 +128,8 @@ jobs:
       C3_APP_CENTER_APP_NAME_PRODUCTION: ${{ secrets.C3_APP_CENTER_APP_NAME_PRODUCTION }}
       BETA_TESTFLIGHT_LINK: ${{ secrets.BETA_TESTFLIGHT_LINK }}
       PLAYGROUND_TESTFLIGHT_LINK: ${{ secrets.PLAYGROUND_TESTFLIGHT_LINK }}
-      COUNTLY_PRODUCTION_KEY: ${{ secrets.COUNTLY_PRODUCTION_KEY }}
-      COUNTLY_INTERNAL_KEY: ${{ secrets.COUNTLY_INTERNAL_KEY }}
+      COUNTLY_PRODUCTION_KEY: ${{ secrets.OLD_COUNTLY_PRODUCTION_KEY }}
+      COUNTLY_INTERNAL_KEY: ${{ secrets.OLD_COUNTLY_INTERNAL_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.WIRE_IOS_CI_WEBHOOK }}
       SKIP_SECURITY_TESTS: ${{ inputs.skip_security_tests }}
       SEND_TO_EXTERNALS: ${{ inputs.distribute_externals }}

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -501,18 +501,9 @@ extension AuthenticationCoordinator {
 
     // MARK: - Modals
 
-    /// Opens the browser and reopens the current alert upon dismissal if needed.
+    /// Opens the URL in the selected browser
     private func openURL(_ url: URL) {
-        let browser = BrowserViewController(url: url)
-        browser.onDismiss = {
-            if let alertModel = self.pendingAlert {
-                self.presenter?.isLoadingViewVisible = false
-                self.presentAlert(for: alertModel)
-                self.pendingAlert = nil
-            }
-        }
-
-        self.presenter?.present(browser, animated: true, completion: nil)
+        url.open()
     }
 
     /// Presents an error alert.

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -348,7 +348,8 @@ extension SettingsCellDescriptorFactory {
     func resetPasswordElement() -> SettingsCellDescriptorType {
         let resetPasswordTitle = L10n.Localizable.Self.Settings.PasswordResetMenu.title
         return SettingsExternalScreenCellDescriptor(title: resetPasswordTitle, isDestructive: false, presentationStyle: .modal, presentationAction: {
-            return BrowserViewController(url: URL.wr_passwordReset)
+            URL.wr_passwordReset.open()
+            return nil
         }, previewGenerator: .none)
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11685" title="WPB-11685" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11685</a>  [iOS] Wire app ignores default browser setting for static links - C builds
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The password reset & forgot password links should be opened in the selected browser instead of a Safari web view.

### Testing

Go to account -> settings -> account -> reset password.
Tap the button. The password reset page should open in your selected browser.

Logout
Log in -> Forgot password?
Tap the link. The password reset page should open in your selected browser.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
