### PR TITLE
fix: Placeholder copy of the SearchBar based on the filter that it's applied - WPB-11889

### DIFF
--- a/wire-ios/Wire-iOS UnitTests/ConversationListViewControllerSearchTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/ConversationListViewControllerSearchTests.swift
@@ -1,0 +1,143 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireMainNavigationUI
+
+@testable import Wire
+
+final class ConversationListViewControllerSearchTests: XCTestCase {
+
+    func test_makeSearchController_withNoFilter() {
+        // Given
+        let filter: ConversationFilter? = nil
+
+        // When
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: filter,
+            mainSplitViewState: .collapsed,
+            isEmptyPlaceholderVisible: false
+        )
+
+        // Then
+        XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.placeholder)
+        XCTAssertTrue(searchController.hidesNavigationBarDuringPresentation)
+        XCTAssertFalse(searchController.obscuresBackgroundDuringPresentation)
+        XCTAssertFalse(searchController.searchBar.isTranslucent)
+    }
+
+    func test_makeSearchController_withFavoritesFilter() {
+        // Given
+        let filter: ConversationFilter = .favorites
+
+        // When
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: filter,
+            mainSplitViewState: .collapsed,
+            isEmptyPlaceholderVisible: false
+        )
+
+        // Then
+        XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.favoritesPlaceholder)
+    }
+
+    func test_makeSearchController_withGroupsFilter() {
+        // Given
+        let filter: ConversationFilter = .groups
+
+        // When
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: filter,
+            mainSplitViewState: .collapsed,
+            isEmptyPlaceholderVisible: false
+        )
+
+        // Then
+        XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.groupsPlaceholder)
+    }
+
+    func test_makeSearchController_withOneOnOneFilter() {
+        // Given
+        let filter: ConversationFilter = .oneOnOne
+
+        // When
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: filter,
+            mainSplitViewState: .collapsed,
+            isEmptyPlaceholderVisible: false
+        )
+
+        // Then
+        XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.oneOnOnePlaceholder)
+    }
+
+    func test_makeSearchController_expandedState() {
+        // Given
+        let filter: ConversationFilter? = nil
+
+        // When
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: filter,
+            mainSplitViewState: .expanded,
+            isEmptyPlaceholderVisible: false
+        )
+
+        // Then
+        XCTAssertFalse(searchController.hidesNavigationBarDuringPresentation)
+    }
+
+    func test_makeSearchController_withEmptyPlaceholder() {
+        // Given
+        let filter: ConversationFilter? = nil
+
+        // When
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: filter,
+            mainSplitViewState: .collapsed,
+            isEmptyPlaceholderVisible: true
+        )
+
+        // Then
+        XCTAssertFalse(searchController.obscuresBackgroundDuringPresentation)
+        XCTAssertFalse(searchController.searchBar.isTranslucent)
+    }
+
+    func test_makeSearchController_commonConfiguration() {
+        // Given
+        let configurations: [(ConversationFilter?, MainSplitViewState, Bool)] = [
+            (nil, .collapsed, false),
+            (.favorites, .expanded, true),
+            (.groups, .collapsed, false),
+            (.oneOnOne, .expanded, true)
+        ]
+
+        for (filter, splitViewState, isEmptyPlaceholderVisible) in configurations {
+            // When
+            let searchController = ConversationListViewController.makeSearchController(
+                filter: filter,
+                mainSplitViewState: splitViewState,
+                isEmptyPlaceholderVisible: isEmptyPlaceholderVisible
+            )
+
+            // Then
+            XCTAssertFalse(searchController.obscuresBackgroundDuringPresentation, "Failed for filter: \(String(describing: filter))")
+            XCTAssertFalse(searchController.searchBar.isTranslucent, "Failed for filter: \(String(describing: filter))")
+            XCTAssertNil(searchController.searchResultsController, "Failed for filter: \(String(describing: filter))")
+        }
+    }
+}

--- a/wire-ios/Wire-iOS UnitTests/ConversationListViewControllerSearchTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/ConversationListViewControllerSearchTests.swift
@@ -23,17 +23,17 @@ import XCTest
 final class ConversationListViewControllerSearchTests: XCTestCase {
 
     func test_makeSearchController_withNoFilter() {
-        // Given
+        // GIVEN
         let filter: ConversationFilter? = nil
 
-        // When
+        // WHEN
         let searchController = ConversationListViewController.makeSearchController(
             filter: filter,
             mainSplitViewState: .collapsed,
             isEmptyPlaceholderVisible: false
         )
 
-        // Then
+        // THEN
         XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.placeholder)
         XCTAssertTrue(searchController.hidesNavigationBarDuringPresentation)
         XCTAssertFalse(searchController.obscuresBackgroundDuringPresentation)
@@ -41,77 +41,77 @@ final class ConversationListViewControllerSearchTests: XCTestCase {
     }
 
     func test_makeSearchController_withFavoritesFilter() {
-        // Given
+        // GIVEN
         let filter: ConversationFilter = .favorites
 
-        // When
+        // WHEN
         let searchController = ConversationListViewController.makeSearchController(
             filter: filter,
             mainSplitViewState: .collapsed,
             isEmptyPlaceholderVisible: false
         )
 
-        // Then
+        // THEN
         XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.favoritesPlaceholder)
     }
 
     func test_makeSearchController_withGroupsFilter() {
-        // Given
+        // GIVEN
         let filter: ConversationFilter = .groups
 
-        // When
+        // WHEN
         let searchController = ConversationListViewController.makeSearchController(
             filter: filter,
             mainSplitViewState: .collapsed,
             isEmptyPlaceholderVisible: false
         )
 
-        // Then
+        // THEN
         XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.groupsPlaceholder)
     }
 
     func test_makeSearchController_withOneOnOneFilter() {
-        // Given
+        // GIVEN
         let filter: ConversationFilter = .oneOnOne
 
-        // When
+        // WHEN
         let searchController = ConversationListViewController.makeSearchController(
             filter: filter,
             mainSplitViewState: .collapsed,
             isEmptyPlaceholderVisible: false
         )
 
-        // Then
+        // THEN
         XCTAssertEqual(searchController.searchBar.placeholder, L10n.Localizable.ConversationList.SearchBar.oneOnOnePlaceholder)
     }
 
     func test_makeSearchController_expandedState() {
-        // Given
+        // GIVEN
         let filter: ConversationFilter? = nil
 
-        // When
+        // WHEN
         let searchController = ConversationListViewController.makeSearchController(
             filter: filter,
             mainSplitViewState: .expanded,
             isEmptyPlaceholderVisible: false
         )
 
-        // Then
+        // THEN
         XCTAssertFalse(searchController.hidesNavigationBarDuringPresentation)
     }
 
     func test_makeSearchController_withEmptyPlaceholder() {
-        // Given
+        // GIVEN
         let filter: ConversationFilter? = nil
 
-        // When
+        // WHEN
         let searchController = ConversationListViewController.makeSearchController(
             filter: filter,
             mainSplitViewState: .collapsed,
             isEmptyPlaceholderVisible: true
         )
 
-        // Then
+        // THEN
         XCTAssertFalse(searchController.obscuresBackgroundDuringPresentation)
         XCTAssertFalse(searchController.searchBar.isTranslucent)
     }

--- a/wire-ios/Wire-iOS UnitTests/ConversationListViewControllerSearchTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/ConversationListViewControllerSearchTests.swift
@@ -17,7 +17,6 @@
 //
 
 import XCTest
-import WireMainNavigationUI
 
 @testable import Wire
 
@@ -117,27 +116,4 @@ final class ConversationListViewControllerSearchTests: XCTestCase {
         XCTAssertFalse(searchController.searchBar.isTranslucent)
     }
 
-    func test_makeSearchController_commonConfiguration() {
-        // Given
-        let configurations: [(ConversationFilter?, MainSplitViewState, Bool)] = [
-            (nil, .collapsed, false),
-            (.favorites, .expanded, true),
-            (.groups, .collapsed, false),
-            (.oneOnOne, .expanded, true)
-        ]
-
-        for (filter, splitViewState, isEmptyPlaceholderVisible) in configurations {
-            // When
-            let searchController = ConversationListViewController.makeSearchController(
-                filter: filter,
-                mainSplitViewState: splitViewState,
-                isEmptyPlaceholderVisible: isEmptyPlaceholderVisible
-            )
-
-            // Then
-            XCTAssertFalse(searchController.obscuresBackgroundDuringPresentation, "Failed for filter: \(String(describing: filter))")
-            XCTAssertFalse(searchController.searchBar.isTranslucent, "Failed for filter: \(String(describing: filter))")
-            XCTAssertNil(searchController.searchResultsController, "Failed for filter: \(String(describing: filter))")
-        }
-    }
 }

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -1448,6 +1448,7 @@
 		E9E20AEA2AC42ED3005D7E00 /* CreateSecureGuestLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E20AE92AC42ED3005D7E00 /* CreateSecureGuestLinkViewController.swift */; };
 		E9E49A5D2CBED6FD0026801A /* SectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E49A5C2CBED6FD0026801A /* SectionFooterView.swift */; };
 		E9E49A5F2CBED7FB0026801A /* SectionTableFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E49A5E2CBED7FB0026801A /* SectionTableFooter.swift */; };
+		E9E4BFC62CD11F4200A04713 /* ConversationListViewControllerSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4BFC52CD11F4200A04713 /* ConversationListViewControllerSearchTests.swift */; };
 		E9F0BC292BFD4D13008DD6E9 /* SnapshotTesting+UITableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F0BC282BFD4D13008DD6E9 /* SnapshotTesting+UITableViewCell.swift */; };
 		E9F2D63E2B55D2D200133C59 /* ConversationCannotDecryptSystemMessageCellDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F2D63D2B55D2D200133C59 /* ConversationCannotDecryptSystemMessageCellDescription.swift */; };
 		E9F2D6402B55D9CD00133C59 /* ConversationStartedSystemMessageCellDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F2D63F2B55D9CD00133C59 /* ConversationStartedSystemMessageCellDescription.swift */; };
@@ -3477,6 +3478,7 @@
 		E9E20AE92AC42ED3005D7E00 /* CreateSecureGuestLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSecureGuestLinkViewController.swift; sourceTree = "<group>"; };
 		E9E49A5C2CBED6FD0026801A /* SectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionFooterView.swift; sourceTree = "<group>"; };
 		E9E49A5E2CBED7FB0026801A /* SectionTableFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTableFooter.swift; sourceTree = "<group>"; };
+		E9E4BFC52CD11F4200A04713 /* ConversationListViewControllerSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListViewControllerSearchTests.swift; sourceTree = "<group>"; };
 		E9F0BC282BFD4D13008DD6E9 /* SnapshotTesting+UITableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnapshotTesting+UITableViewCell.swift"; sourceTree = "<group>"; };
 		E9F2D63D2B55D2D200133C59 /* ConversationCannotDecryptSystemMessageCellDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationCannotDecryptSystemMessageCellDescription.swift; sourceTree = "<group>"; };
 		E9F2D63F2B55D9CD00133C59 /* ConversationStartedSystemMessageCellDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStartedSystemMessageCellDescription.swift; sourceTree = "<group>"; };
@@ -7706,6 +7708,7 @@
 				2584AE462B98A2CD008E1DEA /* DeviceInfoViewModelTests.swift */,
 				E6A09CD62C2ECA960069C15A /* SystemSettingsTests.swift */,
 				E9DD582C2C539B3C00645A2F /* ChangeEmailViewModelTests.swift */,
+				E9E4BFC52CD11F4200A04713 /* ConversationListViewControllerSearchTests.swift */,
 			);
 			path = "Wire-iOS UnitTests";
 			sourceTree = "<group>";
@@ -10800,6 +10803,7 @@
 				E6579E582AFFA024004E7FD8 /* MockZiphyClient.swift in Sources */,
 				E682939A2B9B600C00322645 /* ConversationMissedCallSystemMessageViewModelTests.swift in Sources */,
 				E6579E752AFFA36D004E7FD8 /* AppLockModule.MockPresenter.swift in Sources */,
+				E9E4BFC62CD11F4200A04713 /* ConversationListViewControllerSearchTests.swift in Sources */,
 				E6579E6D2AFFA029004E7FD8 /* MockConversation.m in Sources */,
 				E6579E5B2AFFA024004E7FD8 /* Account+Mock.swift in Sources */,
 				E6579E432AFF9D33004E7FD8 /* AuthenticationEmailVerificationRequiredErrorHandlerTests.swift in Sources */,

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -2830,6 +2830,16 @@ internal enum L10n {
           internal static let title = L10n.tr("Localizable", "conversation_list.right_accessory.join_button.title", fallback: "Join")
         }
       }
+      internal enum SearchBar {
+        /// Search favourites
+        internal static let favoritesPlaceholder = L10n.tr("Localizable", "conversation_list.search_bar.favoritesPlaceholder", fallback: "Search favourites")
+        /// Search groups
+        internal static let groupsPlaceholder = L10n.tr("Localizable", "conversation_list.search_bar.groupsPlaceholder", fallback: "Search groups")
+        /// Search 1:1 conversations
+        internal static let oneOnOnePlaceholder = L10n.tr("Localizable", "conversation_list.search_bar.oneOnOnePlaceholder", fallback: "Search 1:1 conversations")
+        /// Search conversations
+        internal static let placeholder = L10n.tr("Localizable", "conversation_list.search_bar.placeholder", fallback: "Search conversations")
+      }
       internal enum Voiceover {
         internal enum BottomBar {
           internal enum CameraButton {

--- a/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings
@@ -123,6 +123,14 @@
 "conversation_list.empty.all_archived.message" = "Everything archived";
 "conversation_list.empty.no_contacts.message" = "Start a conversation or\ncreate a group.";
 
+// Conversation List - Search Bar
+
+"conversation_list.search_bar.placeholder" = "Search conversations";
+"conversation_list.search_bar.favoritesPlaceholder" = "Search favourites";
+"conversation_list.search_bar.groupsPlaceholder" = "Search groups";
+"conversation_list.search_bar.oneOnOnePlaceholder" = "Search 1:1 conversations";
+
+
 // Conversation List - Filter Conversations
 "conversation_list.filter.all_conversations.title" = "All Conversations";
 "conversation_list.filter.favorites.title" = "Favorites";

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -81,6 +81,19 @@ final class ConversationListViewController: UIViewController {
         }
     }
 
+    private var searchPlaceholderText: String {
+        switch listContentController.listViewModel.selectedFilter {
+        case .none:
+            return L10n.Localizable.ConversationList.SearchBar.placeholder
+        case .favorites:
+            return L10n.Localizable.ConversationList.SearchBar.favoritesPlaceholder
+        case .groups:
+            return L10n.Localizable.ConversationList.SearchBar.groupsPlaceholder
+        case .oneOnOne:
+            return L10n.Localizable.ConversationList.SearchBar.oneOnOnePlaceholder
+        }
+    }
+
     /// for NetworkStatusViewDelegate
     var shouldAnimateNetworkStatusView = false
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -81,19 +81,6 @@ final class ConversationListViewController: UIViewController {
         }
     }
 
-    private var searchPlaceholderText: String {
-        switch listContentController.listViewModel.selectedFilter {
-        case .none:
-            return L10n.Localizable.ConversationList.SearchBar.placeholder
-        case .favorites:
-            return L10n.Localizable.ConversationList.SearchBar.favoritesPlaceholder
-        case .groups:
-            return L10n.Localizable.ConversationList.SearchBar.groupsPlaceholder
-        case .oneOnOne:
-            return L10n.Localizable.ConversationList.SearchBar.oneOnOnePlaceholder
-        }
-    }
-
     /// for NetworkStatusViewDelegate
     var shouldAnimateNetworkStatusView = false
 
@@ -404,16 +391,40 @@ final class ConversationListViewController: UIViewController {
         : ColorTheme.Backgrounds.surface
     }
 
-    private func setupSearchController() {
-
-        let searchController = UISearchController(searchResultsController: .none)
+    static func makeSearchController(
+            filter: ConversationFilter?,
+            mainSplitViewState: MainSplitViewState,
+            isEmptyPlaceholderVisible: Bool
+    ) -> UISearchController {
+        let searchController = UISearchController(searchResultsController: nil)
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.isTranslucent = false
-        searchController.searchResultsUpdater = self
-
-        searchController.searchBar.placeholder = searchPlaceholderText
-
         searchController.hidesNavigationBarDuringPresentation = mainSplitViewState == .collapsed
+        searchController.searchBar.placeholder = searchPlaceholderText(for: filter)
+        return searchController
+    }
+
+    private static func searchPlaceholderText(for filter: ConversationFilter?) -> String {
+        switch filter {
+        case .none:
+            return L10n.Localizable.ConversationList.SearchBar.placeholder
+        case .favorites:
+            return L10n.Localizable.ConversationList.SearchBar.favoritesPlaceholder
+        case .groups:
+            return L10n.Localizable.ConversationList.SearchBar.groupsPlaceholder
+        case .oneOnOne:
+            return L10n.Localizable.ConversationList.SearchBar.oneOnOnePlaceholder
+        }
+    }
+
+    private func setupSearchController() {
+        let searchController = ConversationListViewController.makeSearchController(
+            filter: listContentController.listViewModel.selectedFilter,
+            mainSplitViewState: mainSplitViewState,
+            isEmptyPlaceholderVisible: isEmptyPlaceholderVisible
+        )
+
+        searchController.searchResultsUpdater = self
 
         if !isEmptyPlaceholderVisible {
             navigationItem.searchController = searchController

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -412,7 +412,7 @@ final class ConversationListViewController: UIViewController {
         searchController.searchResultsUpdater = self
 
         searchController.searchBar.placeholder = searchPlaceholderText
-        
+
         searchController.hidesNavigationBarDuringPresentation = mainSplitViewState == .collapsed
 
         if !isEmptyPlaceholderVisible {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -411,6 +411,8 @@ final class ConversationListViewController: UIViewController {
         searchController.searchBar.isTranslucent = false
         searchController.searchResultsUpdater = self
 
+        searchController.searchBar.placeholder = searchPlaceholderText
+        
         searchController.hidesNavigationBarDuringPresentation = mainSplitViewState == .collapsed
 
         if !isEmptyPlaceholderVisible {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11889" title="WPB-11889" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11889</a>  [iOS] Search field placeholder text doesn’t change text based on filter in Conversation List
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->



With this PR we update the placeholder of the search bar based on the filter that it's been applied in the conversation list. 

## Design

<img width="873" alt="Screenshot 2024-10-28 at 15 53 45" src="https://github.com/user-attachments/assets/46d34db6-c9fe-45e8-a36f-6201826a9a1a">

<img width="873" alt="Screenshot 2024-10-28 at 15 53 41" src="https://github.com/user-attachments/assets/228e7716-e3f9-4192-9e9b-76c2d35547d0">

<img width="873" alt="Screenshot 2024-10-28 at 15 53 33" src="https://github.com/user-attachments/assets/25e692f8-9e6a-43f6-9a27-9f1d331f2760">



---


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---
