### PR TITLE
fix: url and only open the browser on legal hold learn more - WPB-11607

### DIFF
--- a/wire-ios/Configuration/url.json
+++ b/wire-ios/Configuration/url.json
@@ -12,7 +12,7 @@
     "askSupportArticle": "https://support.wire.com/hc/requests/new",
     "reportAbuse": "https://support.wire.com/hc/requests/new",
     "wireEnterpriseInfo": "https://wire.com/pricing",
-    "legalHoldInfo": "https://support.wire.com/hc/articles/360002018278-What-is-legal-hold-",
+    "legalHoldInfo": "https://support.wire.com/hc/en-us/articles/360002018278-What-is-legal-hold",
     "guestLinksInfo": "https://support.wire.com/hc/articles/360000574069-Share-a-link-with-a-person-without-a-Wire-account-to-join-a-guest-room-conversation-in-my-team",
     "unreachableBackendInfo": "https://support.wire.com/hc/articles/9357718008093-Backend",
     "federationInfo": "https://support.wire.com/hc/categories/4719917054365-Federation",

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationLegalHoldCell.swift
@@ -97,26 +97,3 @@ final class ConversationLegalHoldCellDescription: ConversationMessageCellDescrip
     }
 
 }
-
-extension ConversationLegalHoldSystemMessageCell {
-
-    override func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-
-        if url == ConversationLegalHoldSystemMessageCell.legalHoldURL,
-            let conversation,
-            let clientViewController = ZClientViewController.shared {
-
-            LegalHoldDetailsViewController.present(
-                in: clientViewController,
-                conversation: conversation,
-                userSession: clientViewController.userSession,
-                mainCoordinator: MainCoordinator(zClientViewController: clientViewController)
-            )
-
-            return true
-        }
-
-        return false
-    }
-
-}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11607" title="WPB-11607" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11607</a>  [iOS] Fix action after tapping legal hold cell
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently when tapping "LEARN MORE" of the message "This conversation is under legal hold" we perform two actions:
- a modal for legal hold info is presented (LegalHoldDetailsViewController)
- we jump out of the app into the browser (also to the wrong link)

This PR fixes the issue by setting the correct link and disabling the presentation of the `LegalHoldDetailsViewController`.

### Testing

- Be on a conversation with a user where legal hold is enabled.
- Tap the "LEARN MORE" link of the system message.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
