### PR TITLE
fix: create an activity indicator when instantiating AuthenticationCoordinator - WPB-10673

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -50,7 +50,7 @@ final class AuthenticationCoordinator: NSObject, AuthenticationEventResponderCha
     let log = ZMSLog(tag: "Authentication")
 
     /// The navigation controller that presents the authentication interface.
-    weak var presenter: UINavigationController? {
+    private(set) weak var presenter: UINavigationController? {
         didSet { activityIndicator = presenter.map { .init(view: $0.view) } }
     }
 
@@ -128,6 +128,7 @@ final class AuthenticationCoordinator: NSObject, AuthenticationEventResponderCha
         statusProvider: AuthenticationStatusProvider
     ) {
         self.presenter = presenter
+        self.activityIndicator = BlockingActivityIndicator.init(view: presenter.view)
         self.sessionManager = sessionManager
         self.statusProvider = statusProvider
         self.featureProvider = featureProvider


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10673" title="WPB-10673" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10673</a>  [iOS] Loading indicators are missing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The loading indicator throughout the authentication flow was missing.


### Testing

Delete the app.
Reinstall the app.
Log into an app with lots of content to load on login.
After the "It's the first time you're using Wire on this device" screen, you should see a loading indicator while the app loads your conversations.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
