### PR TITLE
feat: Introduce ConversationFolderSelectionUseCase - WPB-12010

### DIFF
--- a/wire-ios-sync-engine/Source/Use cases/ConversationFolderSelectionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ConversationFolderSelectionUseCase.swift
@@ -20,7 +20,7 @@ import WireDataModel
 
 // MARK: - ConversationFolderSelectionUseCaseProtocol
 
-protocol ConversationFolderSelectionUseCaseProtocol {
+public protocol ConversationFolderSelectionUseCaseProtocol {
 
     func invoke<Conversation: ToFolderMovableConversation>(
         folder: LabelType,

--- a/wire-ios-sync-engine/Source/Use cases/ConversationFolderSelectionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ConversationFolderSelectionUseCase.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+
+// MARK: - ConversationFolderSelectionUseCaseProtocol
+
+protocol ConversationFolderSelectionUseCaseProtocol {
+
+    func invoke<Conversation: MessageAppendableConversation>(
+        folder: LabelType,
+        conversation: Conversation
+    )
+
+}
+
+// MARK: - ConversationFolderSelectionUseCase
+
+final class ConversationFolderSelectionUseCase: ConversationFolderSelectionUseCaseProtocol {
+
+    public func invoke<Conversation: MessageAppendableConversation>(
+        folder: LabelType,
+        conversation: Conversation
+    ) {
+        conversation.moveToFolder(folder)
+    }
+}

--- a/wire-ios-sync-engine/Source/Use cases/ConversationFolderSelectionUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ConversationFolderSelectionUseCase.swift
@@ -22,7 +22,7 @@ import WireDataModel
 
 protocol ConversationFolderSelectionUseCaseProtocol {
 
-    func invoke<Conversation: MessageAppendableConversation>(
+    func invoke<Conversation: ToFolderMovableConversation>(
         folder: LabelType,
         conversation: Conversation
     )
@@ -33,7 +33,7 @@ protocol ConversationFolderSelectionUseCaseProtocol {
 
 final class ConversationFolderSelectionUseCase: ConversationFolderSelectionUseCaseProtocol {
 
-    public func invoke<Conversation: MessageAppendableConversation>(
+    public func invoke<Conversation: ToFolderMovableConversation>(
         folder: LabelType,
         conversation: Conversation
     ) {

--- a/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
@@ -49,6 +49,4 @@ public protocol MessageAppendableConversation {
     func moveToFolder(_ folder: LabelType)
 }
 
-extension ZMConversation: MessageAppendableConversation {
-
-}
+extension ZMConversation: MessageAppendableConversation { }

--- a/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
@@ -45,8 +45,6 @@ public protocol MessageAppendableConversation {
         with fileMetadata: ZMFileMetadata,
         nonce: UUID
     ) throws -> ZMConversationMessage
-
-    func moveToFolder(_ folder: LabelType)
 }
 
 extension ZMConversation: MessageAppendableConversation { }

--- a/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/MessageAppendableConversation.swift
@@ -46,6 +46,7 @@ public protocol MessageAppendableConversation {
         nonce: UUID
     ) throws -> ZMConversationMessage
 
+    func moveToFolder(_ folder: LabelType)
 }
 
 extension ZMConversation: MessageAppendableConversation {

--- a/wire-ios-sync-engine/Source/Use cases/ToFolderMovableConversation.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ToFolderMovableConversation.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+// sourcery: AutoMockable
+/// A protocol defining behavior for moving conversations between folders
+public protocol ToFolderMovableConversation {
+
+   /// Moves the conversation to a specified folder
+   /// - Parameter folder: The destination folder to move the conversation to
+   func moveToFolder(_ folder: LabelType)
+}
+
+extension ZMConversation: ToFolderMovableConversation { }

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1037,6 +1037,30 @@ public class MockSupportedProtocolsServiceInterface: SupportedProtocolsServiceIn
 
 }
 
+public class MockToFolderMovableConversation: ToFolderMovableConversation {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - moveToFolder
+
+    public var moveToFolder_Invocations: [LabelType] = []
+    public var moveToFolder_MockMethod: ((LabelType) -> Void)?
+
+    public func moveToFolder(_ folder: LabelType) {
+        moveToFolder_Invocations.append(folder)
+
+        guard let mock = moveToFolder_MockMethod else {
+            fatalError("no mock for `moveToFolder`")
+        }
+
+        mock(folder)
+    }
+
+}
+
 public class MockUserProfile: UserProfile {
 
     // MARK: - Life cycle

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -229,25 +229,38 @@ public class MockMessageAppendableConversation: MessageAppendableConversation {
 
     // MARK: - appendFile
 
-       public var appendFile_Invocations: [(fileMetadata: ZMFileMetadata, nonce: UUID)] = []
-       public var appendFile_MockError: Error?
-       public var appendFile_MockMethod: ((ZMFileMetadata, UUID) throws -> ZMConversationMessage)?
-       public var appendFile_MockValue: ZMConversationMessage?
+    public var appendFile_Invocations: [(fileMetadata: ZMFileMetadata, nonce: UUID)] = []
+    public var appendFile_MockError: Error?
+    public var appendFile_MockMethod: ((ZMFileMetadata, UUID) throws -> ZMConversationMessage)?
+    public var appendFile_MockValue: ZMConversationMessage?
 
-       @discardableResult
-       public func appendFile(with fileMetadata: ZMFileMetadata, nonce: UUID) throws -> ZMConversationMessage {
-           appendFile_Invocations.append((fileMetadata: fileMetadata, nonce: nonce))
+    @discardableResult
+    public func appendFile(with fileMetadata: ZMFileMetadata, nonce: UUID) throws -> ZMConversationMessage {
+        appendFile_Invocations.append((fileMetadata: fileMetadata, nonce: nonce))
 
-           if let error = appendFile_MockError {
-               throw error
-           }
+        if let error = appendFile_MockError {
+            throw error
+        }
 
-           if let mock = appendFile_MockMethod {
-               return try mock(fileMetadata, nonce)
-           } else if let mock = appendFile_MockValue {
-               return mock
-           } else {
-               fatalError("no mock for `appendFile`")
-           }
-       }
+        if let mock = appendFile_MockMethod {
+            return try mock(fileMetadata, nonce)
+        } else if let mock = appendFile_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `appendFile`")
+        }
+    }
+
+    // MARK: - moveToFolder
+
+    public var moveToFolder_Invocations: [LabelType] = []
+    public var moveToFolder_MockMethod: ((LabelType) -> Void)?
+
+    public func moveToFolder(_ folder: LabelType) {
+        moveToFolder_Invocations.append(folder)
+
+        if let mock = moveToFolder_MockMethod {
+            mock(folder)
+        }
+    }
 }

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -250,17 +250,4 @@ public class MockMessageAppendableConversation: MessageAppendableConversation {
             fatalError("no mock for `appendFile`")
         }
     }
-
-    // MARK: - moveToFolder
-
-    public var moveToFolder_Invocations: [LabelType] = []
-    public var moveToFolder_MockMethod: ((LabelType) -> Void)?
-
-    public func moveToFolder(_ folder: LabelType) {
-        moveToFolder_Invocations.append(folder)
-
-        if let mock = moveToFolder_MockMethod {
-            mock(folder)
-        }
-    }
 }

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockLabelType.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockLabelType.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+class MockLabelType: NSObject, LabelType {
+    
+    var remoteIdentifier: UUID?
+    var kind: Label.Kind
+    var name: String?
+
+    init(
+        remoteIdentifier: UUID? = nil,
+        kind: Label.Kind,
+        name: String? = nil
+    ) {
+        self.remoteIdentifier = remoteIdentifier
+        self.kind = kind
+        self.name = name
+        super.init()
+    }
+}

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockLabelType.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockLabelType.swift
@@ -17,7 +17,7 @@
 //
 
 class MockLabelType: NSObject, LabelType {
-    
+
     var remoteIdentifier: UUID?
     var kind: Label.Kind
     var name: String?

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ConversationFolderSelectionUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ConversationFolderSelectionUseCaseTests.swift
@@ -1,0 +1,60 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireSyncEngineSupport
+
+@testable import WireSyncEngine
+
+final class ConversationFolderSelectionUseCaseTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var mockConversation: MockMessageAppendableConversation!
+    private var sut: ConversationFolderSelectionUseCase!
+
+    // MARK: - setUp
+
+    override func setUp() {
+        mockConversation = .init()
+        sut = ConversationFolderSelectionUseCase()
+    }
+
+    // MARK: - tearDown
+
+    override func tearDown() {
+        mockConversation = nil
+        sut = nil
+    }
+
+    // MARK: - Tests
+
+    func testInvoke_ShouldMoveConversationToSpecifiedFolder() {
+        // GIVEN
+        let expectedFolder = MockLabelType(kind: .folder, name: "Test Folder")
+
+        // WHEN
+        sut.invoke(folder: expectedFolder, conversation: mockConversation)
+
+        // THEN
+        XCTAssertEqual(mockConversation.moveToFolder_Invocations.count, 1)
+        XCTAssertEqual(mockConversation.moveToFolder_Invocations.first?.kind, expectedFolder.kind)
+        XCTAssertEqual(mockConversation.moveToFolder_Invocations.first?.name, expectedFolder.name)
+    }
+
+}

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ConversationFolderSelectionUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ConversationFolderSelectionUseCaseTests.swift
@@ -25,7 +25,7 @@ final class ConversationFolderSelectionUseCaseTests: XCTestCase {
 
     // MARK: - Properties
 
-    private var mockConversation: MockMessageAppendableConversation!
+    private var mockConversation: MockToFolderMovableConversation!
     private var sut: ConversationFolderSelectionUseCase!
 
     // MARK: - setUp
@@ -47,6 +47,7 @@ final class ConversationFolderSelectionUseCaseTests: XCTestCase {
     func testInvoke_ShouldMoveConversationToSpecifiedFolder() {
         // GIVEN
         let expectedFolder = MockLabelType(kind: .folder, name: "Test Folder")
+        mockConversation.moveToFolder_MockMethod = { _ in }
 
         // WHEN
         sut.invoke(folder: expectedFolder, conversation: mockConversation)

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ConversationFolderSelectionUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ConversationFolderSelectionUseCaseTests.swift
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import XCTest
 import WireSyncEngineSupport
+import XCTest
 
 @testable import WireSyncEngine
 

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 		E9D6FC212CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */; };
 		E9D6FC232CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC222CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift */; };
 		E9D6FC262CD4EC5C007924B8 /* MockLabelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */; };
+		E9D6FC282CD4F201007924B8 /* ToFolderMovableConversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC272CD4F201007924B8 /* ToFolderMovableConversation.swift */; };
 		E9E4D4712C2AD61500364352 /* TeamRole+AnalyticsValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */; };
 		E9EAEAA72BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */; };
 		E9F403152C5B96CD00F81366 /* EnableAnalyticsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */; };
@@ -1191,6 +1192,7 @@
 		E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFolderSelectionUseCase.swift; sourceTree = "<group>"; };
 		E9D6FC222CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFolderSelectionUseCaseTests.swift; sourceTree = "<group>"; };
 		E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLabelType.swift; sourceTree = "<group>"; };
+		E9D6FC272CD4F201007924B8 /* ToFolderMovableConversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToFolderMovableConversation.swift; sourceTree = "<group>"; };
 		E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TeamRole+AnalyticsValue.swift"; sourceTree = "<group>"; };
 		E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConversationGuestLinkUseCase.swift; sourceTree = "<group>"; };
 		E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableAnalyticsUseCase.swift; sourceTree = "<group>"; };
@@ -2589,6 +2591,7 @@
 		EEE46E5528C5EF3B005F48D7 /* Use cases */ = {
 			isa = PBXGroup;
 			children = (
+				E9D6FC272CD4F201007924B8 /* ToFolderMovableConversation.swift */,
 				16D74BF32B59670B00160298 /* ChangeUsernameUseCase.swift */,
 				EE8584DA2B6938390045EAD4 /* CreateTeamOneOnOneConversationUseCase.swift */,
 				EEE46E5628C5EF56005F48D7 /* FetchUserClientsUseCase.swift */,
@@ -3567,6 +3570,7 @@
 				E9E4D4712C2AD61500364352 /* TeamRole+AnalyticsValue.swift in Sources */,
 				5E8BB8A22147F89000EEA64B /* CallCenterSupport.swift in Sources */,
 				63C4B3C62C35B56A00C09A93 /* ShareFileUseCase.swift in Sources */,
+				E9D6FC282CD4F201007924B8 /* ToFolderMovableConversation.swift in Sources */,
 				1660AA0D1ECDB0250056D403 /* SearchTask.swift in Sources */,
 				E9AD0A362C2AF9B300CA88DF /* AnalyticsServiceConfiguration.swift in Sources */,
 				E91180E12CA6FD3E00DD63E2 /* ZMConversationMessage+SelfUserReactions.swift in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		E9C0B1E82C58E34000D242D6 /* DisableAnalyticsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */; };
 		E9C60E922C259F3C004E5F13 /* WireAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E9C60E912C259F3C004E5F13 /* WireAnalytics */; };
 		E9D6FC212CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */; };
+		E9D6FC262CD4EC5C007924B8 /* MockLabelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */; };
 		E9E4D4712C2AD61500364352 /* TeamRole+AnalyticsValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */; };
 		E9EAEAA72BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */; };
 		E9F403152C5B96CD00F81366 /* EnableAnalyticsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */; };
@@ -1187,6 +1188,7 @@
 		E9AD0A352C2AF9B300CA88DF /* AnalyticsServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceConfiguration.swift; sourceTree = "<group>"; };
 		E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAnalyticsUseCase.swift; sourceTree = "<group>"; };
 		E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFolderSelectionUseCase.swift; sourceTree = "<group>"; };
+		E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLabelType.swift; sourceTree = "<group>"; };
 		E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TeamRole+AnalyticsValue.swift"; sourceTree = "<group>"; };
 		E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConversationGuestLinkUseCase.swift; sourceTree = "<group>"; };
 		E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableAnalyticsUseCase.swift; sourceTree = "<group>"; };
@@ -1596,6 +1598,7 @@
 		169BA1F625ECF8C300374343 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */,
 				169BA1F725ECF8F700374343 /* MockAppLock.swift */,
 				169BA23C25EF6E2A00374343 /* MockRegistrationStatusDelegate.swift */,
 				169BA24B25EF753100374343 /* MockReachability.swift */,
@@ -3188,6 +3191,7 @@
 				EFC8281E1FB34F9600E27E21 /* EmailVerificationStrategyTests.swift in Sources */,
 				87D4625D1C3D526D00433469 /* DeleteAccountRequestStrategyTests.swift in Sources */,
 				A97E4F56267CF681006FC545 /* ZMUserSessionTestsBase.swift in Sources */,
+				E9D6FC262CD4EC5C007924B8 /* MockLabelType.swift in Sources */,
 				166264932166517A00300F45 /* CallEventStatusTests.swift in Sources */,
 				160C31411E6DDFC30012E4BC /* VoiceChannelV3Tests.swift in Sources */,
 				F9ABE8561EFD56BF00D83214 /* TeamDownloadRequestStrategyTests.swift in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		E9C0B1E82C58E34000D242D6 /* DisableAnalyticsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */; };
 		E9C60E922C259F3C004E5F13 /* WireAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E9C60E912C259F3C004E5F13 /* WireAnalytics */; };
 		E9D6FC212CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */; };
+		E9D6FC232CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC222CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift */; };
 		E9D6FC262CD4EC5C007924B8 /* MockLabelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */; };
 		E9E4D4712C2AD61500364352 /* TeamRole+AnalyticsValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */; };
 		E9EAEAA72BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */; };
@@ -1188,6 +1189,7 @@
 		E9AD0A352C2AF9B300CA88DF /* AnalyticsServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceConfiguration.swift; sourceTree = "<group>"; };
 		E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAnalyticsUseCase.swift; sourceTree = "<group>"; };
 		E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFolderSelectionUseCase.swift; sourceTree = "<group>"; };
+		E9D6FC222CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFolderSelectionUseCaseTests.swift; sourceTree = "<group>"; };
 		E9D6FC252CD4EC5C007924B8 /* MockLabelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLabelType.swift; sourceTree = "<group>"; };
 		E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TeamRole+AnalyticsValue.swift"; sourceTree = "<group>"; };
 		E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConversationGuestLinkUseCase.swift; sourceTree = "<group>"; };
@@ -1469,6 +1471,7 @@
 				E948DB132C4AB09D00146025 /* AppendLocationMessageUseCaseTests.swift */,
 				E96970572C8F3546009F037C /* AppendFileMessageUseCaseTests.swift */,
 				E910CF132CABF65E00B30E87 /* ToggleMessageReactionUseCaseTests.swift */,
+				E9D6FC222CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift */,
 			);
 			path = "Use cases";
 			sourceTree = "<group>";
@@ -3142,6 +3145,7 @@
 				F9410F631DE44C2E007451FF /* TypingStrategyTests.swift in Sources */,
 				EE5BF6351F8F907C00B49D06 /* ZMLocalNotificationTests.swift in Sources */,
 				169BA25225EF778E00374343 /* TestUserProfileUpdateObserver.swift in Sources */,
+				E9D6FC232CD4E92D007924B8 /* ConversationFolderSelectionUseCaseTests.swift in Sources */,
 				BF50CFA71F39ACE8007833A4 /* MockUserInfoParser.swift in Sources */,
 				5E0EB1F92100A46F00B5DC2B /* MockCompanyLoginRequesterDelegate.swift in Sources */,
 				169BA24C25EF753100374343 /* MockReachability.swift in Sources */,

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 		E9AD0A362C2AF9B300CA88DF /* AnalyticsServiceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AD0A352C2AF9B300CA88DF /* AnalyticsServiceConfiguration.swift */; };
 		E9C0B1E82C58E34000D242D6 /* DisableAnalyticsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */; };
 		E9C60E922C259F3C004E5F13 /* WireAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E9C60E912C259F3C004E5F13 /* WireAnalytics */; };
+		E9D6FC212CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */; };
 		E9E4D4712C2AD61500364352 /* TeamRole+AnalyticsValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */; };
 		E9EAEAA72BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */; };
 		E9F403152C5B96CD00F81366 /* EnableAnalyticsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */; };
@@ -1185,6 +1186,7 @@
 		E9ACAED02CBE43C2000E13B5 /* ZMUserSession+WireCallStateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+WireCallStateObserver.swift"; sourceTree = "<group>"; };
 		E9AD0A352C2AF9B300CA88DF /* AnalyticsServiceConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceConfiguration.swift; sourceTree = "<group>"; };
 		E9C0B1E72C58E34000D242D6 /* DisableAnalyticsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisableAnalyticsUseCase.swift; sourceTree = "<group>"; };
+		E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFolderSelectionUseCase.swift; sourceTree = "<group>"; };
 		E9E4D4702C2AD61500364352 /* TeamRole+AnalyticsValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TeamRole+AnalyticsValue.swift"; sourceTree = "<group>"; };
 		E9EAEAA62BC7C50B0042F5C9 /* CreateConversationGuestLinkUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateConversationGuestLinkUseCase.swift; sourceTree = "<group>"; };
 		E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableAnalyticsUseCase.swift; sourceTree = "<group>"; };
@@ -2609,6 +2611,7 @@
 				E9F403142C5B96CD00F81366 /* EnableAnalyticsUseCase.swift */,
 				E91180DE2CA6E86400DD63E2 /* ToggleMessageReactionUseCase.swift */,
 				0148133F2CC0522500F36DAA /* SubmitCallQualitySurveyUseCase.swift */,
+				E9D6FC202CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift */,
 			);
 			path = "Use cases";
 			sourceTree = "<group>";
@@ -3316,6 +3319,7 @@
 				59E6A9162B4EE5D500DBCC6B /* RecurringActionServiceInterface.swift in Sources */,
 				09C77C531BA6C77000E2163F /* UserClientRequestStrategy.swift in Sources */,
 				F1B5D53D2181FDA300986911 /* NetworkQuality.swift in Sources */,
+				E9D6FC212CD4E496007924B8 /* ConversationFolderSelectionUseCase.swift in Sources */,
 				634976E9268A185A00824A05 /* AVSVideoStreams.swift in Sources */,
 				5EC2C593213827BF00C6CE35 /* WireCallCenterV3+Events.swift in Sources */,
 				EE1DEBBE23D5E12F0087EE1F /* TypingUsersTimeout+Key.swift in Sources */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12010" title="WPB-12010" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12010</a>  [iOS] Folder Managements View Models 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


---

In preparation for re-writing the Move to Folder feature in SwiftUI with this PR we introduce one of the use cases we're going to use: `ConversationFolderSelectionUseCase` More specifically:

1. New `ToFolderMovableConversation` Protocol
  - Dedicated protocol for folder movement capabilities
  - Single responsibility: `moveToFolder(_ folder: LabelType)`

2. Use Case Pattern Implementation
  - `ConversationFolderSelectionUseCase` for handling folder selection

3. Testing
  - `MockLabelType` for simulating folders
  - ConversationFolderSelectionUseCaseTests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---