### PR TITLE
fix: Make `TwoLineTitleView` accessible by using `UILargeContentViewer` - WPB-12074

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -111,8 +111,6 @@ final class ConversationImagesViewController: UIViewController {
 
         self.imageMessages = self.collection.assetCollection.assets(for: imagesMatch)
         self.collection.assetCollectionDelegate.add(self)
-
-        self.createNavigationTitle()
     }
 
     deinit {
@@ -127,7 +125,7 @@ final class ConversationImagesViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationItem.rightBarButtonItem?.accessibilityLabel = L10n.Accessibility.PictureView.CloseButton.description
-
+        createNavigationTitle()
         if let navigationBar = navigationController?.navigationBar {
             navigationBar.isTranslucent = true
             navigationBar.barTintColor = SemanticColors.View.backgroundDefault
@@ -368,13 +366,17 @@ final class ConversationImagesViewController: UIViewController {
     }
 
     private func createNavigationTitle() {
-        guard let sender = currentMessage.senderUser, let serverTimestamp = currentMessage.serverTimestamp else {
+        guard let sender = currentMessage.senderUser,
+              let serverTimestamp = currentMessage.serverTimestamp else {
             return
         }
-        navigationItem.titleView = TwoLineTitleView(first: (sender.name ?? "").localized.attributedString,
-                                                    second: serverTimestamp.formattedDate.attributedString)
-        navigationItem.titleView?.accessibilityTraits = .header
-        navigationItem.titleView?.accessibilityLabel = "\(sender.name ?? ""), \(serverTimestamp.formattedDate)"
+
+        let titleView = TwoLineTitleView(
+            first: (sender.name ?? "").localized.attributedString,
+            second: serverTimestamp.formattedDate.attributedString)
+
+        titleView.addInteraction(UILargeContentViewerInteraction())
+        navigationItem.titleView = titleView
     }
 
     private func updateButtonsForMessage() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/ConversationImagesViewController.swift
@@ -372,7 +372,7 @@ final class ConversationImagesViewController: UIViewController {
         }
 
         let titleView = TwoLineTitleView(
-            first: (sender.name ?? "").localized.attributedString,
+            first: (sender.name ?? "").attributedString,
             second: serverTimestamp.formattedDate.attributedString)
 
         titleView.addInteraction(UILargeContentViewerInteraction())

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
@@ -22,7 +22,9 @@ import WireDesign
 final class TwoLineTitleView: UIView {
 
     // MARK: - Views
-
+    // Fixed font sizes are used since this is a navigation bar titleView.
+    // Instead of scaling with Dynamic Type, it uses UILargeContentViewer
+    // for accessibility, consistent with iOS navigation bar behavior.
     let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 17, weight: .semibold)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
@@ -22,6 +22,7 @@ import WireDesign
 final class TwoLineTitleView: UIView {
 
     // MARK: - Views
+
     // Fixed font sizes are used since this is a navigation bar titleView.
     // Instead of scaling with Dynamic Type, it uses UILargeContentViewer
     // for accessibility, consistent with iOS navigation bar behavior.

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/TwoLineTitleView.swift
@@ -21,32 +21,59 @@ import WireDesign
 
 final class TwoLineTitleView: UIView {
 
-    let titleLabel: DynamicFontLabel = {
-        let label = DynamicFontLabel(fontSpec: .headerSemiboldFont,
-                                     color: SemanticColors.Label.textDefault)
+    // MARK: - Views
+
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        label.textColor = SemanticColors.Label.textDefault
         return label
     }()
 
-    let subtitleLabel: DynamicFontLabel = {
-        let label = DynamicFontLabel(fontSpec: .mediumRegularFont,
-                                     color: SemanticColors.Label.textDefault)
+    let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.textColor = SemanticColors.Label.textDefault
         return label
     }()
+
+    // MARK: - Properties
+
+    private var originalTitle: NSAttributedString
+    private var originalSubtitle: NSAttributedString?
+
+    // MARK: - Life cycle
 
     init(first: NSAttributedString, second: NSAttributedString?) {
-        super.init(frame: CGRect.zero)
-        isAccessibilityElement = true
+        self.originalTitle = first
+        self.originalSubtitle = second
 
+        super.init(frame: CGRect.zero)
+
+        setupView()
+        setupAccessibility()
+        setupLargeContentViewer()
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupView() {
         titleLabel.textAlignment = .center
         subtitleLabel.textAlignment = .center
 
-        titleLabel.attributedText = first
-        subtitleLabel.attributedText = second
+        titleLabel.attributedText = originalTitle
+        subtitleLabel.attributedText = originalSubtitle
 
         addSubview(titleLabel)
         addSubview(subtitleLabel)
 
         [self, titleLabel, subtitleLabel].forEach { $0.translatesAutoresizingMaskIntoConstraints = false }
+
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
@@ -58,8 +85,29 @@ final class TwoLineTitleView: UIView {
         ])
     }
 
-    @available(*, unavailable)
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    // MARK: - Accessibility
+
+    private func setupAccessibility() {
+        isAccessibilityElement = true
+        accessibilityTraits = .header
+
+        let accessibilityText = [
+            originalTitle.string,
+            originalSubtitle?.string
+        ].compactMap { $0 }.joined(separator: ", ")
+
+        accessibilityLabel = accessibilityText
     }
+
+    private func setupLargeContentViewer() {
+        showsLargeContentViewer = true
+        scalesLargeContentImage = true
+
+        if let subtitle = originalSubtitle?.string {
+            largeContentTitle = originalTitle.string + "\n" + subtitle
+        } else {
+            largeContentTitle = originalTitle.string
+        }
+    }
+
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -123,16 +123,19 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
 
     private func setupNavigatiomItem() {
         navigationController?.navigationBar.backgroundColor = SemanticColors.View.backgroundDefault
-        navigationItem.titleView = TwoLineTitleView(
+
+        let titleView = TwoLineTitleView(
             first: L10n.Localizable.Participants.title.capitalized.attributedString,
             second: verificationStatus)
+
+        titleView.addInteraction(UILargeContentViewerInteraction())
+        navigationItem.titleView = titleView
         navigationItem.rightBarButtonItem = UIBarButtonItem.closeButton(action: UIAction { [weak self] _ in
             self?.presentingViewController?.dismiss(animated: true)
         }, accessibilityLabel: L10n.Accessibility.ConversationDetails.CloseButton.description)
 
         navigationItem.backBarButtonItem?.accessibilityLabel = L10n.Accessibility.Profile.BackButton.description
     }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12074" title="WPB-12074" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-12074</a>  [iOS] TwoLineTitleView should support accessibility via Large Content Viewer
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


## Changes

With this PR we make `TwoLineTitleView` accessible by using `UILargeContentViewer`. In addition to that we replaced DynamicFontLabel instances with UILabel, to make sure we have a fixed font size for both title and subtitle.

More specifically:


- Set fixed font sizes in TwoLineTitleView (17pt semibold title, 12pt regular subtitle)
- Add UILargeContentViewerInteraction to TwoLineTitleView instances
- Remove redundant accessibility setup from view controllers
- Centralize accessibility and large content viewer setup in TwoLineTitleView

## Testing
1. Open any screen with a TwoLineTitleView (Group Details)
2. Enable Large Text in iOS Settings
3. Long press on the navigation title
4. Verify the large content viewer appears showing both title and subtitle

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---