### PR TITLE
fix: Multiple conversation reloads on dynamic font size changes - WPB-12077

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -173,8 +173,6 @@ final class ZClientViewController: UIViewController {
 
         NotificationCenter.default.post(name: NSNotification.Name.ZMUserSessionDidBecomeAvailable, object: nil)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(contentSizeCategoryDidChange(_:)), name: UIContentSizeCategory.didChangeNotification, object: nil)
-
         NotificationCenter.default.addObserver(forName: .featureDidChangeNotification, object: nil, queue: .main) { [weak self] note in
             guard let change = note.object as? FeatureRepository.FeatureChange else { return }
 
@@ -453,16 +451,6 @@ final class ZClientViewController: UIViewController {
         }
     }
 
-    // MARK: - ColorSchemeControllerDidApplyChangesNotification
-
-    private func reloadCurrentConversation() {
-        guard let currentConversation else { return }
-
-        Task {
-            await mainCoordinator.showConversation(conversation: currentConversation, message: nil)
-        }
-    }
-
     // MARK: - Debug logging notifications
 
     @objc
@@ -509,11 +497,6 @@ final class ZClientViewController: UIViewController {
             // selectListItemWhenNoPreviousItemSelected()
             return false
         }
-    }
-
-    @objc
-    func contentSizeCategoryDidChange(_ notification: Notification?) {
-        reloadCurrentConversation()
     }
 
     private func setupAppearance() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12077" title="WPB-12077" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-12077</a>  [iOS] ConversationView Reloading Multiple Times on Dynamic Font Size Change
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


## Issue

When users change their device's font size settings, the `ConversationView` was being unnecessarily reloaded and pushed multiple times onto the navigation stack. This was caused by the `ContentSizeCategoryDidChange` notification triggering a full conversation reload through the mainCoordinator.

## Solution

- Removed the reloadCurrentConversation() function that was causing multiple view pushes. 
- The view now handles font size changes naturally through the iOS dynamic type system
- Eliminated unnecessary view reloading and navigation stack modifications

## Impact

- Improved app performance during font size changes
- Fixed navigation stack issues
- Better memory usage by preventing multiple view controller instances
- More stable user experience when changing accessibility settings

## BEFORE

![Before - with bug](https://github.com/user-attachments/assets/6f1823db-25b9-4cb4-a019-a675e59c8ffc)

## AFTER

![After - without bug](https://github.com/user-attachments/assets/d420879e-b1b5-41e5-b724-d16bcb0ec104)

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---
