### PR TITLE
fix: remove PR_S3_SUBFOLDER for development builds - WPB-12081

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -16,9 +16,6 @@ on:
       distribute_externals:
         type: boolean
         default: false
-      pr_s3_path:
-        required: false
-        type: string
 
     secrets:
       KEYCHAIN_PASSWORD:
@@ -121,7 +118,6 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.WIRE_IOS_CI_WEBHOOK }}
       SKIP_SECURITY_TESTS: ${{ inputs.skip_security_tests }}
       SEND_TO_EXTERNALS: ${{ inputs.distribute_externals }}
-      PR_S3_SUBFOLDER: ${{ inputs.pr_s3_path }}
       
     steps:
       - name: Add Masks


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Builds created after merging PRs to develop are not uploaded to the right location.

They are uploaded under `/development/device/release/PR/` instead of `/development/device/release/`.

This is due because [we read](https://github.com/wireapp/wire-ios/blob/089c1f162efa39690b1a6a5c41fba607e261fa6b/fastlane/Fastfile#L617C1-L618C6) the PR_S3_SUBFOLDER which is empty instead of nil.

This PR removes the ENV variable for the normal build workflow. It stays for the critical workflows run on PRs [here](https://github.com/wireapp/wire-ios/blob/089c1f162efa39690b1a6a5c41fba607e261fa6b/.github/workflows/_reusable_app_release_without_changelog.yml#L119). 
