### PR TITLE
feat: Introduce FolderCreationViewModel - WPB-12189

### DIFF
--- a/WireUI/Sources/WireMoveToFolderUI/FolderCreationViewModel.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/FolderCreationViewModel.swift
@@ -57,7 +57,7 @@ public enum FolderCreationError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .emptyName:
-            return "Folder name cannot be empty"
+            "Folder name cannot be empty"
         }
     }
 }

--- a/WireUI/Sources/WireMoveToFolderUI/FolderCreationViewModel.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/FolderCreationViewModel.swift
@@ -1,0 +1,63 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public final class FolderCreationViewModel: ObservableObject {
+
+    // MARK: - Properties
+
+    @Published private(set) var canCreate: Bool = false
+    @Published var name: String = "" {
+        didSet {
+            canCreate = !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private let useCase: any FolderCreationUseCaseType
+
+    // MARK: - Lifecycle
+
+    public init(useCase: any FolderCreationUseCaseType) {
+        self.useCase = useCase
+    }
+
+    // MARK: - Public Inreface
+
+    public func createFolder() async throws -> Folder {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            throw FolderCreationError.emptyName
+        }
+
+        return try await useCase.invoke(name: trimmedName)
+    }
+}
+
+// MARK: - FolderCreationError
+
+public enum FolderCreationError: LocalizedError {
+    case emptyName
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "Folder name cannot be empty"
+        }
+    }
+}

--- a/WireUI/Sources/WireMoveToFolderUI/Protocols/FolderCreationUseCaseType.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/Protocols/FolderCreationUseCaseType.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+/// Protocol for handling creating a folder
+public protocol FolderCreationUseCaseType: Sendable {
+    /// Creates a folder
+    /// - Parameters:
+    ///   - name: The name of the folder to create
+    func invoke(name: String) async throws -> Folder
+}

--- a/WireUI/Sources/WireMoveToFolderUISupport/Sourcery/AutoMockable.manual.swift
+++ b/WireUI/Sources/WireMoveToFolderUISupport/Sourcery/AutoMockable.manual.swift
@@ -56,3 +56,30 @@ public class MockMoveConversationToFolderUseCaseType: @unchecked Sendable, MoveC
         try await mock(folder, conversation)
     }
 }
+
+public class MockFolderCreationUseCaseType: @unchecked Sendable, FolderCreationUseCaseType {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+    // MARK: - invoke
+
+    public var invokeName_Invocations: [String] = []
+    public var invokeName_MockError: (any Error)?
+    public var invokeName_MockMethod: ((String) async throws -> Folder)?
+
+    public func invoke(name: String) async throws -> Folder {
+        invokeName_Invocations.append(name)
+
+        if let error = invokeName_MockError {
+            throw error
+        }
+
+        guard let mock = invokeName_MockMethod else {
+            fatalError("no mock for `invokeName`")
+        }
+
+        return try await mock(name)
+    }
+}

--- a/WireUI/Tests/WireMoveToFolderUITests/FolderCreationViewModelTests.swift
+++ b/WireUI/Tests/WireMoveToFolderUITests/FolderCreationViewModelTests.swift
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import XCTest
 import WireMoveToFolderUISupport
+import XCTest
 
 @testable import WireMoveToFolderUI
 
@@ -40,57 +40,57 @@ final class FolderCreationViewModelTests: XCTestCase {
         sut = nil
         mockUseCase = nil
     }
-    
+
     // MARK: - Creation State
-    
+
     func test_init_canCreateIsFalse() {
         // GIVEN & WHEN
         createSUT()
-        
+
         // THEN
         XCTAssertFalse(sut.canCreate)
     }
-    
+
     func test_setEmptyName_canCreateIsFalse() {
         // GIVEN
         createSUT()
-        
+
         // WHEN
         sut.name = ""
-        
+
         // THEN
         XCTAssertFalse(sut.canCreate)
     }
-    
+
     func test_setWhitespaceName_canCreateIsFalse() {
         // GIVEN
         createSUT()
-        
+
         // WHEN
         sut.name = "   "
-        
+
         // THEN
         XCTAssertFalse(sut.canCreate)
     }
-    
+
     func test_setValidName_canCreateIsTrue() {
         // GIVEN
         createSUT()
-        
+
         // WHEN
         sut.name = "Work"
-        
+
         // THEN
         XCTAssertTrue(sut.canCreate)
     }
-    
+
     // MARK: - Folder Creation
-    
+
     func test_createFolder_withEmptyName_throwsError() async {
         // GIVEN
         createSUT()
         sut.name = ""
-        
+
         // WHEN & THEN
         do {
             _ = try await sut.createFolder()
@@ -99,12 +99,12 @@ final class FolderCreationViewModelTests: XCTestCase {
             XCTAssertEqual(error as? FolderCreationError, .emptyName)
         }
     }
-    
+
     func test_createFolder_withWhitespaceName_throwsError() async {
         // GIVEN
         createSUT()
         sut.name = "   "
-        
+
         // WHEN & THEN
         do {
             _ = try await sut.createFolder()
@@ -113,13 +113,13 @@ final class FolderCreationViewModelTests: XCTestCase {
             XCTAssertEqual(error as? FolderCreationError, .emptyName)
         }
     }
-    
+
     func test_createFolder_withValidName_callsUseCase() async throws {
         // GIVEN
         createSUT()
         sut.name = "Work"
         let expectedFolder = Folder(identifier: UUID(), name: "Work")
-        mockUseCase.invokeName_MockMethod = { (name: String) in expectedFolder }
+        mockUseCase.invokeName_MockMethod = { (_: String) in expectedFolder }
 
         // WHEN
         let folder = try await sut.createFolder()
@@ -137,7 +137,7 @@ final class FolderCreationViewModelTests: XCTestCase {
         struct TestError: Error {}
         let expectedError = TestError()
         mockUseCase.invokeName_MockError = expectedError
-        
+
         // WHEN & THEN
         do {
             _ = try await sut.createFolder()
@@ -147,9 +147,9 @@ final class FolderCreationViewModelTests: XCTestCase {
             XCTAssertEqual(mockUseCase.invokeName_Invocations.first, "Work")
         }
     }
-    
+
     // MARK: - Helpers
-    
+
     private func createSUT() {
         sut = FolderCreationViewModel(useCase: mockUseCase)
     }

--- a/WireUI/Tests/WireMoveToFolderUITests/FolderCreationViewModelTests.swift
+++ b/WireUI/Tests/WireMoveToFolderUITests/FolderCreationViewModelTests.swift
@@ -1,0 +1,156 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+import WireMoveToFolderUISupport
+
+@testable import WireMoveToFolderUI
+
+final class FolderCreationViewModelTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var sut: FolderCreationViewModel!
+    private var mockUseCase: MockFolderCreationUseCaseType!
+
+    // MARK: - setUp
+
+    override func setUp() {
+        mockUseCase = MockFolderCreationUseCaseType()
+    }
+
+    // MARK: - tearDown
+
+    override func tearDown() {
+        sut = nil
+        mockUseCase = nil
+    }
+    
+    // MARK: - Creation State
+    
+    func test_init_canCreateIsFalse() {
+        // GIVEN & WHEN
+        createSUT()
+        
+        // THEN
+        XCTAssertFalse(sut.canCreate)
+    }
+    
+    func test_setEmptyName_canCreateIsFalse() {
+        // GIVEN
+        createSUT()
+        
+        // WHEN
+        sut.name = ""
+        
+        // THEN
+        XCTAssertFalse(sut.canCreate)
+    }
+    
+    func test_setWhitespaceName_canCreateIsFalse() {
+        // GIVEN
+        createSUT()
+        
+        // WHEN
+        sut.name = "   "
+        
+        // THEN
+        XCTAssertFalse(sut.canCreate)
+    }
+    
+    func test_setValidName_canCreateIsTrue() {
+        // GIVEN
+        createSUT()
+        
+        // WHEN
+        sut.name = "Work"
+        
+        // THEN
+        XCTAssertTrue(sut.canCreate)
+    }
+    
+    // MARK: - Folder Creation
+    
+    func test_createFolder_withEmptyName_throwsError() async {
+        // GIVEN
+        createSUT()
+        sut.name = ""
+        
+        // WHEN & THEN
+        do {
+            _ = try await sut.createFolder()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? FolderCreationError, .emptyName)
+        }
+    }
+    
+    func test_createFolder_withWhitespaceName_throwsError() async {
+        // GIVEN
+        createSUT()
+        sut.name = "   "
+        
+        // WHEN & THEN
+        do {
+            _ = try await sut.createFolder()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? FolderCreationError, .emptyName)
+        }
+    }
+    
+    func test_createFolder_withValidName_callsUseCase() async throws {
+        // GIVEN
+        createSUT()
+        sut.name = "Work"
+        let expectedFolder = Folder(identifier: UUID(), name: "Work")
+        mockUseCase.invokeName_MockMethod = { (name: String) in expectedFolder }
+
+        // WHEN
+        let folder = try await sut.createFolder()
+
+        // THEN
+        XCTAssertEqual(mockUseCase.invokeName_Invocations.count, 1)
+        XCTAssertEqual(mockUseCase.invokeName_Invocations.first, "Work")
+        XCTAssertEqual(folder, expectedFolder)
+    }
+
+    func test_createFolder_whenUseCaseThrows_propagatesError() async {
+        // GIVEN
+        createSUT()
+        sut.name = "Work"
+        struct TestError: Error {}
+        let expectedError = TestError()
+        mockUseCase.invokeName_MockError = expectedError
+        
+        // WHEN & THEN
+        do {
+            _ = try await sut.createFolder()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(mockUseCase.invokeName_Invocations.count, 1)
+            XCTAssertEqual(mockUseCase.invokeName_Invocations.first, "Work")
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func createSUT() {
+        sut = FolderCreationViewModel(useCase: mockUseCase)
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12189" title="WPB-12189" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-12189</a>  [iOS] Introduce `FolderCreationViewModel`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


This PR adds the view model and testing infrastructure for folder creation functionality, 
preparing for the upcoming UI implementation.

## Changes

### Domain
- Add `FolderCreationUseCaseType` protocol
- Support async/await for folder creation operations

### View Model
- Add `FolderCreationViewModel` with:
 - Name validation logic
 - Real-time creation state tracking (`canCreate` property)
 - Async folder creation support
 - Error handling for invalid inputs

### Testing
- Add `MockFolderCreationUseCaseType` with proper Sendable conformance
- Add comprehensive test suite covering:
 - Name validation states
 - Creation state management
 - Error propagation
 - Use case interaction verification

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---