### PR TITLE
fix: migrate from #file to #filePath - WPB-14392

### DIFF
--- a/WireAPI/Tests/WireAPITests/Helpers/APIServiceSnapshotHelper.swift
+++ b/WireAPI/Tests/WireAPITests/Helpers/APIServiceSnapshotHelper.swift
@@ -53,7 +53,7 @@ struct APIServiceSnapshotHelper<API> {
     func verifyRequestForAllAPIVersions(
         apiService: (() throws -> MockAPIServiceProtocol)? = nil,
         when block: (API) async throws -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) async throws {
@@ -85,7 +85,7 @@ struct APIServiceSnapshotHelper<API> {
         for apiVersions: any Sequence<APIVersion>,
         apiService: (() throws -> MockAPIServiceProtocol)? = nil,
         when block: (API) async throws -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) async throws {
@@ -121,7 +121,7 @@ struct APIServiceSnapshotHelper<API> {
         apiVersion: APIVersion,
         apiService: MockAPIServiceProtocol,
         when block: (API) async throws -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) async throws {

--- a/WireAPI/Tests/WireAPITests/Helpers/APISnapshotHelper.swift
+++ b/WireAPI/Tests/WireAPITests/Helpers/APISnapshotHelper.swift
@@ -50,7 +50,7 @@ struct APISnapshotHelper<API> {
     func verifyRequestForAllAPIVersions(
         httpClient: (() throws -> HTTPClientMock)? = nil,
         when block: (API) async throws -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) async throws {
@@ -82,7 +82,7 @@ struct APISnapshotHelper<API> {
         for apiVersions: any Sequence<APIVersion>,
         httpClient: (() throws -> HTTPClientMock)? = nil,
         when block: (API) async throws -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) async throws {
@@ -118,7 +118,7 @@ struct APISnapshotHelper<API> {
         apiVersion: APIVersion,
         httpClient: HTTPClientMock,
         when block: (API) async throws -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) async throws {

--- a/WireAPI/Tests/WireAPITests/Helpers/HTTPRequestSnapshotHelper.swift
+++ b/WireAPI/Tests/WireAPITests/Helpers/HTTPRequestSnapshotHelper.swift
@@ -36,7 +36,7 @@ struct HTTPRequestSnapshotHelper {
     func verifyRequest(
         request: HTTPRequest,
         resourceName: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) {
@@ -68,7 +68,7 @@ struct HTTPRequestSnapshotHelper {
         request: URLRequest,
         resourceName: String? = nil,
         record: Bool = false,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         function: String = #function,
         line: UInt = #line
     ) {

--- a/WireDomain/Tests/WireDomainTests/Repositories/ConnectionsRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/ConnectionsRepositoryTests.swift
@@ -103,7 +103,7 @@ final class ConnectionsRepositoryTests: XCTestCase {
 
     func internalTestPullConnections_GivenConnectionDoesNotExist(
         federationEnabled: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         // Mock

--- a/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
+++ b/WireFoundation/Sources/WireTesting/Utilities/SnapshotHelper.swift
@@ -113,7 +113,7 @@ public struct SnapshotHelper {
 
     public func verify<View: SwiftUI.View>(
         testName: String = #function,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         matching createView: () -> View
     ) {
@@ -137,7 +137,7 @@ public struct SnapshotHelper {
         matching value: View,
         named name: String? = nil,
         testName: String = #function,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let snapshotDirectory = snapshotDirectory(file: file)
@@ -175,7 +175,7 @@ public struct SnapshotHelper {
         size: CGSize? = nil,
         named name: String? = nil,
         record recording: Bool = false,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -212,7 +212,7 @@ public struct SnapshotHelper {
     public func verify(
         matching value: UIView,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -256,7 +256,7 @@ public struct SnapshotHelper {
 
     public func verifyInAllDeviceSizes(
         matching value: UIViewController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -291,7 +291,7 @@ public struct SnapshotHelper {
     public func verifyInAllIPhoneSizes(
         matching value: UIViewController,
         orientation: ViewImageConfig.Orientation = .portrait,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -326,7 +326,7 @@ public struct SnapshotHelper {
     public func verify(
         matching value: UIImage,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -357,7 +357,7 @@ public struct SnapshotHelper {
     public func verifyForDynamicType(
         matching value: UIView,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -393,7 +393,7 @@ public struct SnapshotHelper {
         }
     }
 
-    private func snapshotDirectory(file: StaticString = #file) -> String {
+    private func snapshotDirectory(file: StaticString = #filePath) -> String {
         var snapshotReferenceDirectory = snapshotReferenceDirectory
         if snapshotReferenceDirectory.isEmpty {
             snapshotReferenceDirectory = ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"]!

--- a/WireFoundation/Tests/WireFoundationTests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
+++ b/WireFoundation/Tests/WireFoundationTests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
@@ -18,6 +18,6 @@
 
 import Foundation
 
-public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #file)
+public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .path

--- a/WireUI/Tests/WireAccountImageUITests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
+++ b/WireUI/Tests/WireAccountImageUITests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
@@ -18,6 +18,6 @@
 
 import Foundation
 
-public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #file)
+public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .path

--- a/WireUI/Tests/WireDesignTests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
+++ b/WireUI/Tests/WireDesignTests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
@@ -18,6 +18,6 @@
 
 import Foundation
 
-public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #file)
+public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .path

--- a/WireUI/Tests/WireMainNavigationUITests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
+++ b/WireUI/Tests/WireMainNavigationUITests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
@@ -18,6 +18,6 @@
 
 import Foundation
 
-public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #file)
+public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .path

--- a/WireUI/Tests/WireReusableUIComponentsTests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
+++ b/WireUI/Tests/WireReusableUIComponentsTests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
@@ -18,6 +18,6 @@
 
 import Foundation
 
-public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #file)
+public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .path

--- a/WireUI/Tests/WireSidebarUITests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
+++ b/WireUI/Tests/WireSidebarUITests/Resources/ReferenceImages/SnapshotTestReferenceImageDirectory.swift
@@ -18,6 +18,6 @@
 
 import Foundation
 
-public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #file)
+public let SnapshotTestReferenceImageDirectory = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .path

--- a/wire-ios-cryptobox/WireCryptoboxTests/ChaCha20StreamEncryptionTests.swift
+++ b/wire-ios-cryptobox/WireCryptoboxTests/ChaCha20StreamEncryptionTests.swift
@@ -182,7 +182,7 @@ class ChaCha20StreamEncryptionTests: XCTestCase {
     private func decryptFromURL(
         _ url: URL,
         passphrase: Sut.Passphrase,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> Data {
         let outputURL = createTemporaryURL()

--- a/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
+++ b/wire-ios-data-model/Tests/MLS/CommitSenderTests.swift
@@ -153,7 +153,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         withRecovery recovery: CommitError.RecoveryStrategy,
         for error: SendCommitBundleAction.Failure,
         shouldClearPendingCommit: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         // Given
@@ -232,7 +232,7 @@ class CommitSenderTests: ZMBaseManagedObjectTest {
         withRecovery recovery: ExternalCommitError.RecoveryStrategy,
         for error: SendCommitBundleAction.Failure,
         shouldClearPendingGroup: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         // Given

--- a/wire-ios-data-model/Tests/Source/Helper/DatabaseMigrationHelper.swift
+++ b/wire-ios-data-model/Tests/Source/Helper/DatabaseMigrationHelper.swift
@@ -97,7 +97,7 @@ struct DatabaseMigrationHelper {
         storeDirectory: URL,
         preMigrationAction: MigrationAction,
         postMigrationAction: MigrationAction,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         // GIVEN
@@ -154,7 +154,7 @@ struct DatabaseMigrationHelper {
         accountIdentifier: UUID,
         versionName: String,
         database: Database = .messaging,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
 
@@ -176,7 +176,7 @@ struct DatabaseMigrationHelper {
         storeFile: URL,
         versionName: String,
         database: Database = .messaging,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         try FileManager.default.createDirectory(
@@ -194,7 +194,7 @@ struct DatabaseMigrationHelper {
     func databaseFixtureURL(
         version: String,
         database: Database = .messaging,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> URL? {
 
@@ -273,7 +273,7 @@ extension XCTestCase {
     func createStorageStackAndWaitForCompletion(
         userID: UUID,
         applicationContainer: URL,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> CoreDataStack {
 

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/CoreDataStackTests+Backup.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/CoreDataStackTests+Backup.swift
@@ -50,7 +50,7 @@ final class CoreDataStackTests_Backup: DatabaseBaseTest {
     func createBackup(
         accountIdentifier: UUID,
         databaseKey: VolatileData? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> Result<URL, Error> {
         var result: Result<URL, Error>?
@@ -73,7 +73,7 @@ final class CoreDataStackTests_Backup: DatabaseBaseTest {
         accountIdentifier: UUID,
         backup: URL,
         migrator: CoreDataMessagingMigratorProtocol,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> Result<URL, Error>? {
 
@@ -94,7 +94,7 @@ final class CoreDataStackTests_Backup: DatabaseBaseTest {
 
     func createBackupAndDeleteOriginalAccount(
         accountIdentifier: UUID,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> URL {
 

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/DatabaseBaseTest.swift
@@ -57,7 +57,7 @@ class DatabaseBaseTest: ZMTBaseTest {
     /// Create storage stack
     func createStorageStackAndWaitForCompletion(
         userID: UUID = UUID(),
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> CoreDataStack {
 

--- a/wire-ios-data-model/Tests/Source/ManagedObjectContext/NSPersistentStoreMetadataTests.swift
+++ b/wire-ios-data-model/Tests/Source/ManagedObjectContext/NSPersistentStoreMetadataTests.swift
@@ -162,7 +162,7 @@ extension NSPersistentStoreMetadataTests {
 
     func checkThatItCanSave<T: Equatable & SwiftPersistableInMetadata>(
         data: T,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationExternalParticipantsStateTests.swift
@@ -173,7 +173,7 @@ class ZMConversationExternalParticipantsStateTests: ZMConversationTestsBase {
         selfUser selfUserType: RelativeUserState,
         otherUsers: [RelativeUserState],
         expectedResult: ZMConversation.ExternalParticipantsState,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let conversation = createConversationWithSelfUser()

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+AccessMode.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+AccessMode.swift
@@ -290,7 +290,7 @@ class ZMConversationAccessModeTests: ZMConversationTestsBase {
         allowServices: Bool,
         expectedAccessModes: Set<String>,
         expectedAccessRoles: Set<ConversationAccessRoleV2>,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // WHEN

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Legalhold.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Legalhold.swift
@@ -776,7 +776,7 @@ class ZMConversationTests_Legalhold: ZMConversationTestsBase {
         expectSystemMessage: Bool,
         expectLegalHoldVerification: Bool,
         messageContent: @escaping () -> MessageCapable,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         syncMOC.performGroupedBlock {

--- a/wire-ios-data-model/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/FeatureConfiguration/AppLock/AppLockControllerTests.swift
@@ -411,7 +411,7 @@ extension AppLockControllerTests {
     typealias Input = (passcodePreference: AppLockPasscodePreference, canEvaluate: Bool, biometricsChanged: Bool)
     typealias Output = AppLockAuthenticationResult
 
-    private func assert(input: Input, output: Output, file: StaticString = #file, line: UInt = #line) {
+    private func assert(input: Input, output: Output, file: StaticString = #filePath, line: UInt = #line) {
         mockAuthenticationContext.canEvaluatePolicyError_MockValue = input.canEvaluate
 
         let sut = createSut()

--- a/wire-ios-data-model/Tests/Source/Model/Messages/BaseClientMessageTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/BaseClientMessageTests.swift
@@ -200,7 +200,7 @@ class BaseZMClientMessageTests: BaseZMMessageTests {
         DeveloperFlag.storage = UserDefaults.standard
     }
 
-    func assertRecipients(_ recipients: [Proteus_UserEntry], file: StaticString = #file, line: UInt = #line) {
+    func assertRecipients(_ recipients: [Proteus_UserEntry], file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertEqual(recipients.count, expectedRecipients.count, file: file, line: line)
 
         for recipientEntry in recipients {

--- a/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTests+SystemMessages.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Messages/ZMMessageTests+SystemMessages.swift
@@ -59,7 +59,7 @@ class ZMMessageTests_SystemMessages: BaseZMMessageTests {
     private func assertDecryptionErrorIsReportedAsRecoverable(
         _ decryptionError: CBoxResult,
         recoverable: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -300,7 +300,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
     func assertThatTheListIsReorderedWhenAConversationChangesTheLastModifiedTime(
         team: Team? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given
@@ -362,7 +362,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
     func assertThatTheListIsOrderedWhenAConversationIsInserted(
         team: Team? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given
@@ -614,7 +614,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
     func assertThatItNotifiesObserversWhenTheEstimatedUnreadCountChanges(
         team: Team? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given
@@ -935,7 +935,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
     func assertThatCanGetTheCurrentStateFromTheChangeInfo(
         team: Team? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationObserverTests.swift
@@ -26,7 +26,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
         modifier: (ZMConversation, ConversationObserver) -> Void,
         expectedChangedField: String?,
         expectedChangedKeys: Set<String>,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
 
@@ -71,7 +71,7 @@ final class ConversationObserverTests: NotificationDispatcherTestBase {
         modifier: (ZMConversation, ConversationObserver) -> Void,
         expectedChangedFields: Set<String>,
         expectedChangedKeys: Set<String>,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
 

--- a/wire-ios-data-model/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/NotificationDispatcherTests.swift
@@ -24,7 +24,7 @@ extension ObjectChangeInfo {
     func checkForExpectedChangeFields(
         userInfoKeys: Set<String>,
         expectedChangedFields: Set<String>,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         guard userInfoKeys.isSuperset(of: expectedChangedFields) else {

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ObjectObserverToken/ParticipantRoleObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ObjectObserverToken/ParticipantRoleObserverTests.swift
@@ -57,7 +57,7 @@ final class ParticipantRoleObserverTests: NotificationDispatcherTestBase {
         modifier: (ParticipantRole) -> Void,
         expectedChangedFields: Set<String>,
         customAffectedKeys: AffectedKeys? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given

--- a/wire-ios-data-model/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/TextSearchQueryTests.swift
@@ -621,7 +621,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         uiMOC.saveOrRollback()
     }
 
-    func verifyAllMessagesAreIndexed(in conversation: ZMConversation, file: StaticString = #file, line: UInt = #line) {
+    func verifyAllMessagesAreIndexed(in conversation: ZMConversation, file: StaticString = #filePath, line: UInt = #line) {
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             ZMClientMessage.predicateForNotIndexedMessages(),
             ZMClientMessage.predicateForMessages(inConversationWith: conversation.remoteIdentifier!)
@@ -644,7 +644,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         whenSearchingFor query: String,
         shouldFind: Bool = true,
         in conversation: ZMConversation? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         messageModifier: ((ZMMessage) -> Void)? = nil
     ) {
@@ -683,7 +683,7 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
     fileprivate func search(
         for text: String,
         in conversation: ZMConversation,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> [TextQueryResult] {
         let delegate = MockTextSearchQueryDelegate()

--- a/wire-ios-data-model/Tests/Source/Model/TextSearchQueryTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/TextSearchQueryTests.swift
@@ -621,7 +621,11 @@ class TextSearchQueryTests: BaseZMClientMessageTests {
         uiMOC.saveOrRollback()
     }
 
-    func verifyAllMessagesAreIndexed(in conversation: ZMConversation, file: StaticString = #filePath, line: UInt = #line) {
+    func verifyAllMessagesAreIndexed(
+        in conversation: ZMConversation,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
             ZMClientMessage.predicateForNotIndexedMessages(),
             ZMClientMessage.predicateForMessages(inConversationWith: conversation.remoteIdentifier!)

--- a/wire-ios-data-model/Tests/Source/Model/Utils/RichAssetFileTypeTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Utils/RichAssetFileTypeTests.swift
@@ -63,7 +63,7 @@ class RichAssetFileTypeTests: XCTestCase {
     private func assertFileType(
         _ mimeType: String,
         _ expectedType: RichAssetFileType?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertEqual(RichAssetFileType(mimeType: mimeType), expectedType, file: file, line: line)

--- a/wire-ios-link-preview/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -205,7 +205,11 @@ class MetaStreamContainerTests: XCTestCase {
         XCTAssertEqual(sut.reachedEndOfHead, shouldUpdate, line: line)
     }
 
-    func assertThatItAppendsBytes(file: StaticString = #filePath, line: UInt = #line, encoding: String.Encoding = .utf8) {
+    func assertThatItAppendsBytes(
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        encoding: String.Encoding = .utf8
+    ) {
         // given
         let first = "First".data(using: encoding)!
         let second = "Second".data(using: encoding)!

--- a/wire-ios-link-preview/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -165,7 +165,7 @@ class MetaStreamContainerTests: XCTestCase {
         _ html: String,
         expectedHead: String,
         encoding: String.Encoding = .utf8,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // when
@@ -205,7 +205,7 @@ class MetaStreamContainerTests: XCTestCase {
         XCTAssertEqual(sut.reachedEndOfHead, shouldUpdate, line: line)
     }
 
-    func assertThatItAppendsBytes(file: StaticString = #file, line: UInt = #line, encoding: String.Encoding = .utf8) {
+    func assertThatItAppendsBytes(file: StaticString = #filePath, line: UInt = #line, encoding: String.Encoding = .utf8) {
         // given
         let first = "First".data(using: encoding)!
         let second = "Second".data(using: encoding)!

--- a/wire-ios-link-preview/WireLinkPreviewTests/NSDataDetectorAttachmentTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/NSDataDetectorAttachmentTests.swift
@@ -115,7 +115,7 @@ class NSDataDetectorAttachmentTests: XCTestCase {
     private func checkAttachments(
         in text: String,
         expectation: (url: String, type: LinkAttachmentType)?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let attachments = detector.detectLinkAttachments(in: text, excluding: [])

--- a/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/MockTransportSessionTests.swift
@@ -54,7 +54,7 @@ extension MockTransportSessionTests {
     func assertExpectedPayload(
         _ expectedPayload: [String: Any],
         in response: ZMTransportResponse,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let keys = [String](expectedPayload.keys)

--- a/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
@@ -27,7 +27,7 @@ final class MockTransportSessionTeamEventsTests: MockTransportSessionTests {
         hasType type: ZMUpdateEventType,
         team: MockTeam,
         data: [String: String] = [:],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         check(event: event, hasType: type, teamIdentifier: team.identifier, data: data, file: file, line: line)
@@ -38,7 +38,7 @@ final class MockTransportSessionTeamEventsTests: MockTransportSessionTests {
         hasType type: ZMUpdateEventType,
         teamIdentifier: String,
         data: [String: String?] = [:],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         guard let event else { XCTFail("Should have event", file: file, line: line); return }

--- a/wire-ios-mocktransport/Tests/Source/Teams/MockTransportSessionTeamTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Teams/MockTransportSessionTeamTests.swift
@@ -28,7 +28,7 @@ class MockTransportSessionTeamTests: MockTransportSessionTests {
         response: ZMTransportResponse?,
         contains teams: [MockTeam],
         hasMore: Bool = false,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
 

--- a/wire-ios-request-strategy/Sources/Helpers/MessageExpirationTimerTests.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/MessageExpirationTimerTests.swift
@@ -233,7 +233,7 @@ private extension MessageExpirationTimerTests {
     }
 
     /// Checks that the message is expired. Asserts if not.
-    func checkExpiration(of message: ZMMessage, file: StaticString = #file, line: UInt = #line) {
+    func checkExpiration(of message: ZMMessage, file: StaticString = #filePath, line: UInt = #line) {
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
         XCTAssertFalse(message.hasChanges, file: file, line: line)
         XCTAssertNil(message.expirationDate, file: file, line: line)

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageInfoExtractorTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageInfoExtractorTests.swift
@@ -279,7 +279,7 @@ final class MessageInfoExtractorTests: XCTestCase {
     private func internalTest_NativePush(
         expectedNativePush: Bool,
         message: GenericMessage,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         var conversation: ZMConversation!

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewUpdateRequestStrategyTests.swift
@@ -136,7 +136,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
 
     func insertMessage(
         with state: ZMLinkPreviewState,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> ZMClientMessage {
         let message = try! groupConversation.appendText(content: "Test message") as! ZMClientMessage
@@ -148,7 +148,7 @@ class LinkPreviewUpdateRequestStrategyTests: MessagingTestBase {
 
     func verifyThatItDoesNotScheduleMessageUpdate(
         for state: ZMLinkPreviewState,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         syncMOC.performGroupedAndWait {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Base Strategies/AbstractRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Base Strategies/AbstractRequestStrategyTests.swift
@@ -246,7 +246,7 @@ class AbstractRequestStrategyTests: MessagingTestBase {
         operationState: OperationState,
         synchronizationState: SynchronizationState,
         sut: RequestStrategy & TestableAbstractRequestStrategy,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
 
@@ -264,7 +264,7 @@ class AbstractRequestStrategyTests: MessagingTestBase {
         operationState: OperationState,
         synchronizationState: SynchronizationState,
         sut: RequestStrategy & TestableAbstractRequestStrategy,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessorTests.swift
@@ -174,7 +174,7 @@ final class ConversationEventProcessorTests: MessagingTestBase {
     func internalTest_UpdateConversationMemberLeave(
         messageProtocol: MessageProtocol,
         shouldWipeMLSGroup: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         // Given

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationParticipantsServiceTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationParticipantsServiceTests.swift
@@ -396,7 +396,7 @@ private extension ConversationParticipantsServiceTests {
     func assertSystemMessageWasInserted(
         forUsers users: Set<ZMUser>,
         in conversation: ZMConversation,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         await uiMOC.perform {
@@ -411,7 +411,7 @@ private extension ConversationParticipantsServiceTests {
 
     func assertReachableUsersWereAddedOnRetry(
         expectedUsers: Set<ZMUser>,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
 

--- a/wire-ios-request-strategy/Tests/Helpers/ActionHandlerTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/ActionHandlerTestBase.swift
@@ -118,7 +118,7 @@ class ActionHandlerTestBase<Action: EntityAction, Handler: ActionHandler<Action>
         payload: ZMTransportData? = nil,
         label: String? = nil,
         apiVersion: APIVersion = .v1,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         validation: @escaping ValidationBlock
     ) {
@@ -171,7 +171,7 @@ extension ActionHandlerTestBase {
         payload: ZMTransportData? = nil,
         label: String? = nil,
         apiVersion: APIVersion = .v1,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         validation: @escaping ValidationBlock
     ) {
@@ -196,7 +196,7 @@ extension ActionHandlerTestBase {
         status: Int,
         payload: ZMTransportData? = nil,
         apiVersion: APIVersion = .v1,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> Action.Result? {
         var result: Action.Result?

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -273,7 +273,7 @@ extension MessagingTestBase {
     /// Extract the outgoing message wrapper (non-encrypted) protobuf
     func outgoingMessageWrapper(
         from request: ZMTransportRequest,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> Proteus_NewOtrMessage? {
         guard let data = request.binaryData else {
@@ -288,7 +288,7 @@ extension MessagingTestBase {
         from request: ZMTransportRequest,
         for client: UserClient,
         line: UInt = #line,
-        file: StaticString = #file
+        file: StaticString = #filePath
     ) -> GenericMessage? {
 
         guard let data = request.binaryData, let protobuf = try? Proteus_NewOtrMessage(serializedData: data) else {

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/Helpers/MLSEventProcessorTests.swift
@@ -234,7 +234,7 @@ final class MLSEventProcessorTests: MessagingTestBase {
     func internalTest_wipeMLSGroupWithProtocol(
         _ messageProtocol: MessageProtocol,
         shouldWipe: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         // Given

--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -180,7 +180,7 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
 
     private func log(
         _ message: String,
-        file: String = #filePath,
+        file: String = #fileID,
         line: Int = #line
     ) {
         let messageWithLineNumber = String(

--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -180,7 +180,7 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
 
     private func log(
         _ message: String,
-        file: String = #file,
+        file: String = #filePath,
         line: Int = #line
     ) {
         let messageWithLineNumber = String(

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -140,7 +140,7 @@ final class WireCallCenterV3Tests: MessagingTest {
         expectedCallerId: AVSIdentifier,
         expectedConversationId: AVSIdentifier,
         line: UInt = #line,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         actionBlock: () throws -> Void
     ) rethrows {
         // expect

--- a/wire-ios-sync-engine/Tests/Source/Integration/CallingV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Integration/CallingV3Tests.swift
@@ -40,7 +40,7 @@ final class CallStateTestObserver: WireCallCenterCallStateObserver {
         changes.append(callState)
     }
 
-    func checkLastNotificationHasCallState(_ callState: CallState, line: UInt = #line, file: StaticString = #file) {
+    func checkLastNotificationHasCallState(_ callState: CallState, line: UInt = #line, file: StaticString = #filePath) {
         guard let lastCallState = changes.last else {
             return XCTFail("Did not receive a notification", file: file, line: line)
         }

--- a/wire-ios-sync-engine/Tests/Source/Registration/AddressBookTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Registration/AddressBookTests.swift
@@ -503,7 +503,7 @@ private func checkEqual(
     lhs: [String: [String]]?,
     rhs: [String: [String]]?,
     line: UInt = #line,
-    file: StaticString = #file
+    file: StaticString = #filePath
 ) {
     guard let lhs, let rhs else {
         XCTFail("Value is nil", file: file, line: line)

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EmailVerificationStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EmailVerificationStrategyTests.swift
@@ -191,7 +191,7 @@ extension RegistrationCredentialVerificationStrategyTests: RegistrationStatusStr
         code: UserSessionErrorCode,
         errorLabel: String,
         httpStatus: NSInteger,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given
@@ -206,7 +206,7 @@ extension RegistrationCredentialVerificationStrategyTests: RegistrationStatusStr
         code: UserSessionErrorCode,
         errorLabel: String,
         httpStatus: NSInteger,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // given

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/RegistrationStatusTestHelper.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/RegistrationStatusTestHelper.swift
@@ -48,7 +48,7 @@ extension RegistrationStatusStrategyTestHelper {
         code: UserSessionErrorCode,
         errorLabel: String,
         httpStatus: NSInteger,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         registrationStatus.phase = phase

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -494,7 +494,11 @@ final class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
 
     // MARK: - Helper
 
-    private func processEvent(fromPayload eventPayload: [String: Any], file: StaticString = #filePath, line: UInt = #line) {
+    private func processEvent(
+        fromPayload eventPayload: [String: Any],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         guard let event = ZMUpdateEvent(fromEventStreamPayload: eventPayload as ZMTransportData, uuid: nil) else {
             return XCTFail("Unable to create update event from payload", file: file, line: line)
         }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -391,7 +391,7 @@ final class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
         in conversation: ZMConversation,
         isLeaveMessageFor user: ZMUser,
         at timestamp: Date,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         guard let lastMessage = conversation.lastMessage as? ZMSystemMessage else { XCTFail(
@@ -494,7 +494,7 @@ final class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
 
     // MARK: - Helper
 
-    private func processEvent(fromPayload eventPayload: [String: Any], file: StaticString = #file, line: UInt = #line) {
+    private func processEvent(fromPayload eventPayload: [String: Any], file: StaticString = #filePath, line: UInt = #line) {
         guard let event = ZMUpdateEvent(fromEventStreamPayload: eventPayload as ZMTransportData, uuid: nil) else {
             return XCTFail("Unable to create update event from payload", file: file, line: line)
         }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchRequestTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchRequestTests.swift
@@ -72,7 +72,7 @@ class SearchRequestTests: MessagingTest {
         from query: String,
         handle expectedHandle: String,
         domain expectedDomain: String?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
         // when

--- a/wire-ios-sync-engine/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
@@ -341,7 +341,7 @@ extension TopConversationsDirectoryTests {
         in managedObjectContext: NSManagedObjectContext,
         fillWithNew new: Int = 0,
         old: Int = 0,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) -> ZMConversation {
         let conversation = ZMConversation.insertNewObject(in: managedObjectContext)
@@ -361,14 +361,14 @@ extension TopConversationsDirectoryTests {
         return conversation
     }
 
-    func fill(_ conversation: ZMConversation, with messageCount: Int, file: StaticString = #file, line: UInt = #line) {
+    func fill(_ conversation: ZMConversation, with messageCount: Int, file: StaticString = #filePath, line: UInt = #line) {
         fill(conversation, with: (messageCount, 0), file: file, line: line)
     }
 
     func fill(
         _ conversation: ZMConversation,
         with messageCount: (new: Int, old: Int),
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         guard messageCount.new > 0 || messageCount.old > 0 else { return }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/TopConversationsDirectoryTests.swift
@@ -361,7 +361,12 @@ extension TopConversationsDirectoryTests {
         return conversation
     }
 
-    func fill(_ conversation: ZMConversation, with messageCount: Int, file: StaticString = #filePath, line: UInt = #line) {
+    func fill(
+        _ conversation: ZMConversation,
+        with messageCount: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
         fill(conversation, with: (messageCount, 0), file: file, line: line)
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/UserProfileImageUpdateStatusTests.swift
@@ -83,7 +83,7 @@ class MockChangeDelegate: WireSyncEngine.UserProfileImageUploadStateChangeDelega
         states.append(currentState)
     }
 
-    func check(lastStates: [ProfileUpdateState], file: StaticString = #file, line: UInt = #line) {
+    func check(lastStates: [ProfileUpdateState], file: StaticString = #filePath, line: UInt = #line) {
         XCTAssert(
             states.count >= lastStates.count,
             "Not enough transitions happened. States: \(states)",
@@ -131,7 +131,7 @@ protocol StateTransition: Equatable {
 }
 
 extension StateTransition {
-    func checkThatTransition(to newState: Self, isValid: Bool, file: StaticString = #file, line: UInt = #line) {
+    func checkThatTransition(to newState: Self, isValid: Bool, file: StaticString = #filePath, line: UInt = #line) {
         let result = canTransition(to: newState)
         if isValid {
             XCTAssertTrue(result, "Should transition: [\(self)] -> [\(newState)]", file: file, line: line)
@@ -143,7 +143,7 @@ extension StateTransition {
     static func canTransition(
         from oldState: Self,
         onlyTo newStates: [Self],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         for state in allStates {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -92,7 +92,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         super.tearDown()
     }
 
-    private func setEncryptionAtRest(enabled: Bool, file: StaticString = #file, line: UInt = #line) {
+    private func setEncryptionAtRest(enabled: Bool, file: StaticString = #filePath, line: UInt = #line) {
         try? sut.setEncryptionAtRest(enabled: true, skipMigration: true)
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+PushNotifications.swift
@@ -325,7 +325,7 @@ extension ZMUserSessionTests_PushNotifications {
     func assertHasReadConfirmationForMessage(
         nonce: UUID,
         conversation: ZMConversation,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let containsReadConfirmation = conversation.lastMessages().contains { message in

--- a/wire-ios-system/Source/ZMSAsserts.swift
+++ b/wire-ios-system/Source/ZMSAsserts.swift
@@ -21,7 +21,7 @@ import Foundation
 /// Reports an error and terminates the application
 public func fatal(
     _ message: String,
-    file: StaticString = #filePath,
+    file: StaticString = #fileID,
     line: UInt = #line
 ) -> Never {
 
@@ -46,7 +46,7 @@ public func fatal(
 }
 
 /// If the condition is not true, reports an error and terminates the application
-public func require(_ condition: Bool, _ message: String = "", file: StaticString = #filePath, line: UInt = #line) {
+public func require(_ condition: Bool, _ message: String = "", file: StaticString = #fileID, line: UInt = #line) {
     if !condition {
         fatal(message, file: file, line: line)
     }
@@ -83,7 +83,7 @@ public enum AppBuild: UInt8 {
 public func requireInternal(
     _ condition: Bool,
     _ message: @autoclosure () -> String,
-    file: StaticString = #filePath,
+    file: StaticString = #fileID,
     line: UInt = #line
 ) {
     guard !condition else { return }

--- a/wire-ios-system/Source/ZMSAsserts.swift
+++ b/wire-ios-system/Source/ZMSAsserts.swift
@@ -21,7 +21,7 @@ import Foundation
 /// Reports an error and terminates the application
 public func fatal(
     _ message: String,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) -> Never {
 
@@ -46,7 +46,7 @@ public func fatal(
 }
 
 /// If the condition is not true, reports an error and terminates the application
-public func require(_ condition: Bool, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+public func require(_ condition: Bool, _ message: String = "", file: StaticString = #filePath, line: UInt = #line) {
     if !condition {
         fatal(message, file: file, line: line)
     }
@@ -83,7 +83,7 @@ public enum AppBuild: UInt8 {
 public func requireInternal(
     _ condition: Bool,
     _ message: @autoclosure () -> String,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     guard !condition else { return }

--- a/wire-ios-system/Source/ZMSLog.swift
+++ b/wire-ios-system/Source/ZMSLog.swift
@@ -91,26 +91,26 @@ public extension ZMSLog {
         _ message: @autoclosure () -> SanitizedString,
         level: ZMLogLevel = .info,
         osLogOn: Bool = true,
-        file: String = #filePath,
+        file: String = #fileID,
         line: UInt = #line
     ) {
         let entry = ZMSLogEntry(text: message().value, timestamp: Date())
         ZMSLog.logEntry(entry, level: level, isSafe: true, tag: tag, osLogOn: osLogOn, file: file, line: line)
     }
 
-    func error(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
+    func error(_ message: @autoclosure () -> String, file: String = #fileID, line: UInt = #line) {
         ZMSLog.logWithLevel(.error, message: message(), tag: tag, file: file, line: line)
     }
 
-    func warn(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
+    func warn(_ message: @autoclosure () -> String, file: String = #fileID, line: UInt = #line) {
         ZMSLog.logWithLevel(.warn, message: message(), tag: tag, file: file, line: line)
     }
 
-    func info(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
+    func info(_ message: @autoclosure () -> String, file: String = #fileID, line: UInt = #line) {
         ZMSLog.logWithLevel(.info, message: message(), tag: tag, file: file, line: line)
     }
 
-    func debug(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
+    func debug(_ message: @autoclosure () -> String, file: String = #fileID, line: UInt = #line) {
         ZMSLog.logWithLevel(.debug, message: message(), tag: tag, file: file, line: line)
     }
 }
@@ -228,7 +228,7 @@ extension ZMSLog {
         _ level: ZMLogLevel,
         message: @autoclosure () -> String,
         tag: String?,
-        file: String = #filePath,
+        file: String = #fileID,
         line: UInt = #line
     ) {
         let entry = ZMSLogEntry(text: message(), timestamp: Date())
@@ -241,7 +241,7 @@ extension ZMSLog {
         isSafe: Bool,
         tag: String?,
         osLogOn: Bool = true,
-        file: String = #filePath,
+        file: String = #fileID,
         line: UInt = #line
     ) {
         logQueue.async {

--- a/wire-ios-system/Source/ZMSLog.swift
+++ b/wire-ios-system/Source/ZMSLog.swift
@@ -91,26 +91,26 @@ public extension ZMSLog {
         _ message: @autoclosure () -> SanitizedString,
         level: ZMLogLevel = .info,
         osLogOn: Bool = true,
-        file: String = #file,
+        file: String = #filePath,
         line: UInt = #line
     ) {
         let entry = ZMSLogEntry(text: message().value, timestamp: Date())
         ZMSLog.logEntry(entry, level: level, isSafe: true, tag: tag, osLogOn: osLogOn, file: file, line: line)
     }
 
-    func error(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
+    func error(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
         ZMSLog.logWithLevel(.error, message: message(), tag: tag, file: file, line: line)
     }
 
-    func warn(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
+    func warn(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
         ZMSLog.logWithLevel(.warn, message: message(), tag: tag, file: file, line: line)
     }
 
-    func info(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
+    func info(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
         ZMSLog.logWithLevel(.info, message: message(), tag: tag, file: file, line: line)
     }
 
-    func debug(_ message: @autoclosure () -> String, file: String = #file, line: UInt = #line) {
+    func debug(_ message: @autoclosure () -> String, file: String = #filePath, line: UInt = #line) {
         ZMSLog.logWithLevel(.debug, message: message(), tag: tag, file: file, line: line)
     }
 }
@@ -228,7 +228,7 @@ extension ZMSLog {
         _ level: ZMLogLevel,
         message: @autoclosure () -> String,
         tag: String?,
-        file: String = #file,
+        file: String = #filePath,
         line: UInt = #line
     ) {
         let entry = ZMSLogEntry(text: message(), timestamp: Date())
@@ -241,7 +241,7 @@ extension ZMSLog {
         isSafe: Bool,
         tag: String?,
         osLogOn: Bool = true,
-        file: String = #file,
+        file: String = #filePath,
         line: UInt = #line
     ) {
         logQueue.async {

--- a/wire-ios-system/Tests/ZMLogTests.swift
+++ b/wire-ios-system/Tests/ZMLogTests.swift
@@ -682,7 +682,7 @@ extension ZMLogTests {
         XCTAssertTrue(lines[4].hasSuffix("[4] [tag] DEBUG"))
     }
 
-    func getLinesFromCurrentLog(file: StaticString = #file, line: UInt = #line) -> [String] {
+    func getLinesFromCurrentLog(file: StaticString = #filePath, line: UInt = #line) -> [String] {
 
         guard
             let currentLog = ZMSLog.currentLogURL,

--- a/wire-ios-testing/Source/Public/XCTestCase+Helpers.swift
+++ b/wire-ios-testing/Source/Public/XCTestCase+Helpers.swift
@@ -53,7 +53,7 @@ public extension XCTestCase {
     func assertItThrows(
         error expectedError: some EquatableError,
         block: AsyncThrowingBlock,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         do {
@@ -76,7 +76,7 @@ public extension XCTestCase {
     func assertItThrows(
         error expectedError: some EquatableError,
         block: ThrowingBlock,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertThrowsError(try block(), file: file, line: line) { error in
@@ -92,7 +92,7 @@ public extension XCTestCase {
     func assertError<T: EquatableError>(
         _ error: Error,
         equals expectedError: T,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         guard let error = error as? T else {
@@ -114,7 +114,7 @@ public extension XCTestCase {
     func assertMethodCompletesWithError<Success, Error: EquatableError>(
         _ expectedError: Error,
         method: (@escaping (Result<Success, Error>) -> Void) -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         assertMethodCompletesWithValidation(method: method) { result in
@@ -133,7 +133,7 @@ public extension XCTestCase {
 
     func assertMethodCompletesWithSuccess<Success, Error: EquatableError>(
         method: (@escaping (Result<Success, Error>) -> Void) -> Void,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         assertMethodCompletesWithValidation(method: method, validation: { result in

--- a/wire-ios-testing/Source/Public/ZMTSwiftHelpers.swift
+++ b/wire-ios-testing/Source/Public/ZMTSwiftHelpers.swift
@@ -22,7 +22,7 @@ import XCTest
 public func AssertOptionalNil(
     _ condition: @autoclosure () -> (some Any)?,
     _ message: String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     if let value = condition() {
@@ -34,7 +34,7 @@ public func AssertOptionalEqual<T: Equatable>(
     _ expression1: @autoclosure () -> T?,
     expression2: @autoclosure () -> T,
     _ message: String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     if let v = expression1() {
@@ -47,7 +47,7 @@ public func AssertOptionalEqual<T: Equatable>(
 public func AssertOptionalNotNil<T>(
     _ expression: @autoclosure () -> T?,
     _ message: String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line,
     block: (T) -> Void = { _ in }
 ) {
@@ -63,7 +63,7 @@ public func AssertDictionaryHasOptionalValue<T: NSObject>(
     key: @autoclosure () -> String,
     expected: @autoclosure () -> T,
     _ message: String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     if let v = dictionary()[key()] {
@@ -77,7 +77,7 @@ public func AssertDictionaryHasOptionalNilValue(
     _ dictionary: @autoclosure () -> [String: (some NSObject)?],
     key: @autoclosure () -> String,
     _ message: String = "",
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     if let v = dictionary()[key()] {

--- a/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.swift
+++ b/wire-ios-transport/Tests/Source/TransportSession/ZMTransportSessionTests.swift
@@ -111,7 +111,7 @@ final class ZMTransportSessionTests_Initialization: ZMTBaseTest {
         super.tearDown()
     }
 
-    func check(identifier: String?, contains items: [String], file: StaticString = #file, line: UInt = #line) {
+    func check(identifier: String?, contains items: [String], file: StaticString = #filePath, line: UInt = #line) {
         guard let identifier else { XCTFail("identifier should not be nil", file: file, line: line); return }
         for item in items {
             XCTAssert(identifier.contains(item), "[\(identifier)] should contain [\(item)]", file: file, line: line)

--- a/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
@@ -37,7 +37,7 @@ struct PinnedKeysData: Decodable {
 
 extension SecTrust {
 
-    static func trustWithChain(certificateData: [Data], file: StaticString = #file, line: UInt = #line) -> SecTrust? {
+    static func trustWithChain(certificateData: [Data], file: StaticString = #filePath, line: UInt = #line) -> SecTrust? {
         let policy = SecPolicyCreateBasicX509()
         let certificates: [SecCertificate] = certificateData.compactMap {
             guard let cert = SecCertificateCreateWithData(nil, $0 as CFData) else { XCTFail(

--- a/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
@@ -37,7 +37,11 @@ struct PinnedKeysData: Decodable {
 
 extension SecTrust {
 
-    static func trustWithChain(certificateData: [Data], file: StaticString = #filePath, line: UInt = #line) -> SecTrust? {
+    static func trustWithChain(
+        certificateData: [Data],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> SecTrust? {
         let policy = SecPolicyCreateBasicX509()
         let certificates: [SecCertificate] = certificateData.compactMap {
             guard let cert = SecCertificateCreateWithData(nil, $0 as CFData) else { XCTFail(

--- a/wire-ios-ziphy/ZiphyTests/ZiphyTests.swift
+++ b/wire-ios-ziphy/ZiphyTests/ZiphyTests.swift
@@ -29,7 +29,7 @@ final class ZiphTests: XCTestCase {
     }
 
     /// Example checker method which can be reused in different tests
-    fileprivate func checkerExample(file: StaticString = #file, line: UInt = #line) {
+    fileprivate func checkerExample(file: StaticString = #filePath, line: UInt = #line) {
         XCTAssert(true, file: file, line: line)
     }
 

--- a/wire-ios/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
+++ b/wire-ios/Wire-iOS Tests/AccessoryTextField/AccessoryTextFieldValidationTests.swift
@@ -73,7 +73,7 @@ final class AccessoryTextFieldValidationTests: XCTestCase {
     private func checkSucceed(
         textFieldType: ValidatedTextField.Kind,
         text: String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // WHEN
@@ -110,7 +110,7 @@ final class AccessoryTextFieldValidationTests: XCTestCase {
         textFieldType: ValidatedTextField.Kind,
         text: String?,
         expectedError: TextFieldValidator.ValidationError?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // WHEN

--- a/wire-ios/Wire-iOS Tests/ArticleViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ArticleViewTests.swift
@@ -321,7 +321,7 @@ final class ArticleViewTests: XCTestCase {
 
     func createTestForArticleViewWithImage(
         named: String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/AudioRecordViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/AudioRecordViewControllerTests.swift
@@ -64,7 +64,7 @@ final class AudioRecordViewControllerTests: XCTestCase {
     }
 
     func verify(
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
+++ b/wire-ios/Wire-iOS Tests/Authentication/AuthenticationInterfaceBuilderTests.swift
@@ -195,7 +195,7 @@ final class AuthenticationInterfaceBuilderTests: XCTestCase, CoreDataFixtureTest
 
     private func runSnapshotTest(
         for step: AuthenticationFlowStep,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line,
         customSize: CGSize? = nil

--- a/wire-ios/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallGridViewControllerSnapshotTests.swift
@@ -338,7 +338,7 @@ extension CallGridViewControllerSnapshotTests {
     private func assertHint(
         input: HintTestCase.Input,
         output: HintTestCase.Output,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         mockHintView.didCallHideAndStopTimer = false
@@ -462,7 +462,7 @@ extension CallGridViewControllerSnapshotTests {
 
             func assert(
                 mockHintView: MockCallGridHintNotificationLabel,
-                file: StaticString = #file,
+                file: StaticString = #filePath,
                 line: UInt = #line
             ) {
                 switch self {

--- a/wire-ios/Wire-iOS Tests/Calling/CallInfoConfigurationTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/CallInfoConfigurationTests.swift
@@ -55,7 +55,7 @@ final class CallInfoConfigurationTests: ZMSnapshotTestCase {
     func assertEquals(
         _ lhsConfig: CallInfoViewControllerInput,
         _ rhsConfig: CallInfoViewControllerInput,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertTrue(

--- a/wire-ios/Wire-iOS Tests/Calling/GridViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/GridViewTests.swift
@@ -99,7 +99,7 @@ final class GridViewTests: XCTestCase {
     private func testGrid(
         withAmount amount: Int,
         maxItemsPerPage: Int = 8,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/CameraKeyboardViewControllerTests.swift
@@ -241,7 +241,7 @@ final class CameraKeyboardViewControllerTests: XCTestCase {
 
     private func initialStateLayoutSizeCompact(
         with permissions: PhotoPermissionsController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -294,7 +294,7 @@ final class CameraKeyboardViewControllerTests: XCTestCase {
 
     private func initialStateLayoutSizeRegularPortrait(
         with permissions: PhotoPermissionsController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -348,7 +348,7 @@ final class CameraKeyboardViewControllerTests: XCTestCase {
 
     func initialStateLayoutSizeRegularLandscape(
         with permissions: PhotoPermissionsController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -402,7 +402,7 @@ final class CameraKeyboardViewControllerTests: XCTestCase {
 
     private func cameraScrolledHorizontallySomePercent(
         with permissions: PhotoPermissionsController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -457,7 +457,7 @@ final class CameraKeyboardViewControllerTests: XCTestCase {
 
     private func cameraScrolledHorizontallyAwayPercent(
         with permissions: PhotoPermissionsController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/ChangeEmailViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ChangeEmailViewControllerSnapshotTests.swift
@@ -79,7 +79,7 @@ final class ChangeEmailViewControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: viewController,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ChangeHandleViewControllerTests.swift
@@ -81,7 +81,7 @@ final class ChangeHandleViewControllerTests: XCTestCase {
         newHandle: String?,
         availability: HandleChangeState.HandleAvailability,
         federationEnabled: Bool = false,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/ContactsCellSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ContactsCellSnapshotTests.swift
@@ -57,7 +57,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -67,7 +67,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -82,7 +82,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -92,7 +92,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -109,7 +109,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -119,7 +119,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -137,7 +137,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -147,7 +147,7 @@ final class ContactsCellSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/ConversationCreationControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCreationControllerSnapshotTests.swift
@@ -60,7 +60,7 @@ final class ConversationCreationControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -70,7 +70,7 @@ final class ConversationCreationControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationInputBarViewController/ConversationInputBarViewController+DropInteractionTests.swift
@@ -51,7 +51,7 @@ final class ConversationInputBarViewControllerDropInteractionTests: XCTestCase {
         let dropProposal = sut.dropProposal(mediaShareRestrictionManager: shareRestrictionManager)
 
         // THEN
-        XCTAssertEqual(dropProposal.operation, UIDropOperation.copy, file: #file, line: #line)
+        XCTAssertEqual(dropProposal.operation, UIDropOperation.copy, file: #filePath, line: #line)
     }
 
     func testThatItPreventsDroppingFiles_FlagDisabled() {
@@ -64,7 +64,7 @@ final class ConversationInputBarViewControllerDropInteractionTests: XCTestCase {
         let dropProposal = sut.dropProposal(mediaShareRestrictionManager: shareRestrictionManager)
 
         // THEN
-        XCTAssertEqual(dropProposal.operation, UIDropOperation.forbidden, file: #file, line: #line)
+        XCTAssertEqual(dropProposal.operation, UIDropOperation.forbidden, file: #filePath, line: #line)
     }
 
     private func makeConversationInputBarViewController(conversation: MockInputBarConversationType)

--- a/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerSnapshotTests.swift
@@ -283,7 +283,7 @@ final class ConversationListViewControllerSnapshotTests: XCTestCase {
         // THEN
         snapshotHelper.verify(matching: renderedImage())
     }
-    
+
     // MARK: - Helper Methods
 
     private func createConversations(conversationsData: [(name: String, isFavorite: Bool)]) -> [ZMConversation] {

--- a/wire-ios/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/ConversationListCell/ConversationListCellTests.swift
@@ -135,7 +135,7 @@ final class ConversationListCellTests: XCTestCase {
     private func verify(
         _ conversation: MockConversation,
         icon: ConversationStatusIcon? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
@@ -37,7 +37,7 @@ private extension ConversationMessageContext {
 func XCTAssertArrayEqual(
     _ descriptions: [Any],
     _ expectedDescriptions: [Any],
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     let classes = descriptions.map { String(describing: $0) }
@@ -68,7 +68,7 @@ class ConversationMessageSnapshotTestCase: ZMSnapshotTestCase {
         allColorSchemes: Bool = false,
         allWidths: Bool = true,
         snapshotBackgroundColor: UIColor? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -127,7 +127,7 @@ class ConversationMessageSnapshotTestCase: ZMSnapshotTestCase {
         named name: String? = nil,
         allColorSchemes: Bool = false,
         allWidths: Bool = true,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/ConversationReplyCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationReplyCellTests.swift
@@ -510,7 +510,7 @@ final class ConversationReplyCellTests: CoreDataSnapshotTestCase {
     private func verifyAccessibilityIdentifiers(
         _ cell: ConversationReplyCell,
         _ message: ZMConversationMessage?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let contentView = cell.contentView

--- a/wire-ios/Wire-iOS Tests/CustomAppLock/AppLockChangeWarningViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/CustomAppLock/AppLockChangeWarningViewControllerTests.swift
@@ -55,7 +55,7 @@ class AppLockChangeWarningViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -65,7 +65,7 @@ class AppLockChangeWarningViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -86,7 +86,7 @@ class AppLockChangeWarningViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -96,7 +96,7 @@ class AppLockChangeWarningViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/CustomAppLock/WipeDatabaseViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/CustomAppLock/WipeDatabaseViewControllerTests.swift
@@ -62,7 +62,7 @@ final class WipeDatabaseViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/GroupConversationCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/GroupConversationCellTests.swift
@@ -63,7 +63,7 @@ final class GroupConversationCellTests: XCTestCase {
 
     private func verify(
         conversation: GroupConversationCellConversation,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/GroupParticipantsDetailViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/GroupParticipantsDetailViewControllerTests.swift
@@ -86,7 +86,7 @@ final class GroupParticipantsDetailViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -96,7 +96,7 @@ final class GroupParticipantsDetailViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/IconLabelButtonTests.swift
+++ b/wire-ios/Wire-iOS Tests/IconLabelButtonTests.swift
@@ -48,7 +48,7 @@ final class IconLabelButtonTests: XCTestCase {
         }
     }
 
-    func verify(appearance: IconLabelButtonTestCase.Appearance, file: StaticString = #file, line: UInt = #line) {
+    func verify(appearance: IconLabelButtonTestCase.Appearance, file: StaticString = #filePath, line: UInt = #line) {
         button.appearance = appearance.callActionAppearance
         button.isEnabled = appearance.isEnabled
         button.isSelected = appearance.isSelected

--- a/wire-ios/Wire-iOS Tests/LegalHoldDetailsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/LegalHoldDetailsViewControllerSnapshotTests.swift
@@ -88,7 +88,7 @@ final class LegalHoldDetailsViewControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: sut(),
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -98,7 +98,7 @@ final class LegalHoldDetailsViewControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: sut(),
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -129,7 +129,7 @@ final class LegalHoldDetailsViewControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -139,7 +139,7 @@ final class LegalHoldDetailsViewControllerSnapshotTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/MessageDetails/MessageDetailsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessageDetails/MessageDetailsViewControllerTests.swift
@@ -457,7 +457,7 @@ final class MessageDetailsViewControllerTests: XCTestCase {
     private func verify(
         _ detailsViewController: MessageDetailsViewController,
         configuration: ((MessageDetailsViewController) -> Void)? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/MessageReplyPreviewViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/MessageReplyPreviewViewTests.swift
@@ -74,7 +74,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -84,7 +84,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -99,7 +99,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -109,7 +109,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -123,7 +123,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -133,7 +133,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -151,7 +151,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -161,7 +161,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -176,7 +176,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -186,7 +186,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -201,7 +201,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -211,7 +211,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -242,7 +242,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: previewView.prepareForSnapshot(),
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -252,7 +252,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: previewView.prepareForSnapshot(),
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -270,7 +270,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: previewView.prepareForSnapshot(),
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -280,7 +280,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: previewView.prepareForSnapshot(),
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -299,7 +299,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: previewView.prepareForSnapshot(),
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -309,7 +309,7 @@ final class MessageReplyPreviewViewTests: XCTestCase {
             .verify(
                 matching: previewView.prepareForSnapshot(),
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerSnapshotTests.swift
@@ -96,7 +96,7 @@ final class NetworkStatusViewControllerSnapshotTests: XCTestCase {
     private func verify(
         for newState: NetworkState,
         testName: String = #function,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // GIVEN

--- a/wire-ios/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/NetworkStatusView/NetworkStatusViewControllerTests.swift
@@ -115,7 +115,7 @@ final class NetworkStatusViewControllerTests: XCTestCase {
     private func checkResult(
         listState: NetworkStatusViewState,
         rootState: NetworkStatusViewState,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertEqual(
@@ -149,7 +149,7 @@ final class NetworkStatusViewControllerTests: XCTestCase {
         orientation: UIInterfaceOrientation,
         listState: NetworkStatusViewState,
         rootState: NetworkStatusViewState,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         // GIVEN & WHEN

--- a/wire-ios/Wire-iOS Tests/PasswordRules/PasswordRuleSetTests.swift
+++ b/wire-ios/Wire-iOS Tests/PasswordRules/PasswordRuleSetTests.swift
@@ -81,7 +81,7 @@ class PasswordRuleSetTests: XCTestCase {
     func checkPassword(
         _ password: String,
         expectedResult: PasswordValidationResult,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertEqual(defaultRuleSet.validatePassword(password), expectedResult, file: file, line: line)

--- a/wire-ios/Wire-iOS Tests/ProfileActionsFactoryTests.swift
+++ b/wire-ios/Wire-iOS Tests/ProfileActionsFactoryTests.swift
@@ -861,7 +861,7 @@ final class ProfileActionsFactoryTests: XCTestCase {
         conversation: MockConversation?,
         expectedActions: [ProfileAction],
         context: ProfileViewControllerContext = .oneToOneConversation,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let factory = ProfileActionsFactory(

--- a/wire-ios/Wire-iOS Tests/ProfileDetailsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ProfileDetailsViewControllerTests.swift
@@ -1184,7 +1184,7 @@ final class ProfileDetailsViewControllerTests: XCTestCase {
         viewer: UserType,
         conversation: MockConversation?,
         context: ProfileViewControllerContext,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -1219,7 +1219,7 @@ final class ProfileDetailsViewControllerTests: XCTestCase {
         viewer: UserType,
         conversation: MockConversation,
         expectedContents: [ProfileDetailsContentController.Content],
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let controller = ProfileDetailsContentController(

--- a/wire-ios/Wire-iOS Tests/ProfileViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ProfileViewTests.swift
@@ -106,7 +106,7 @@ final class ProfileViewTests: XCTestCase {
     func verifyProfile(
         options: ProfileHeaderViewController.Options,
         availability: Availability = .available,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/SecurityLevel/SecurityLevelViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/SecurityLevel/SecurityLevelViewTests.swift
@@ -59,7 +59,7 @@ final class SecurityLevelViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -69,7 +69,7 @@ final class SecurityLevelViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -83,7 +83,7 @@ final class SecurityLevelViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -93,7 +93,7 @@ final class SecurityLevelViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -107,7 +107,7 @@ final class SecurityLevelViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -117,7 +117,7 @@ final class SecurityLevelViewTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
+++ b/wire-ios/Wire-iOS Tests/Settings/SettingsPropertyTests.swift
@@ -87,7 +87,7 @@ final class SettingsPropertyTests: XCTestCase {
     func saveAndCheck<T>(
         _ property: SettingsProperty,
         value: T,
-        file: String = #file,
+        file: String = #filePath,
         line: UInt = #line
     ) throws where T: Equatable {
         var property = property

--- a/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -102,7 +102,7 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
     private func testForAccountGroup(
         federated: Bool,
         disabledEditing: Bool = false,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) throws {
@@ -208,7 +208,7 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
 
     private func verify(
         group: Any,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) throws {

--- a/wire-ios/Wire-iOS Tests/ShareViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ShareViewControllerTests.swift
@@ -108,7 +108,7 @@ final class ShareViewControllerTests: XCTestCase {
     }
 
     private func verifyLocation(
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -127,7 +127,7 @@ final class ShareViewControllerTests: XCTestCase {
     }
 
     private func verifyImage(
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -172,7 +172,7 @@ final class ShareViewControllerTests: XCTestCase {
     /// create a SUT with a group conversation and a one-to-one conversation and verify snapshot
     private func makeTestForShareViewController(
         message: MockShareableMessage,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/SwiftSnapshotTesting/XCTestCase+SnapshotTesting.swift
+++ b/wire-ios/Wire-iOS Tests/SwiftSnapshotTesting/XCTestCase+SnapshotTesting.swift
@@ -37,7 +37,7 @@ extension XCTestCase {
         snapshotBackgroundColor: UIColor,
         configuration: ((UIView) -> Swift.Void)? = nil,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -67,7 +67,7 @@ extension XCTestCase {
         matching value: UIView,
         width: CGFloat,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -91,7 +91,7 @@ extension XCTestCase {
         snapshotBackgroundColor: UIColor? = nil,
         configuration: ((UIView) -> Swift.Void)? = nil,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -112,7 +112,7 @@ extension XCTestCase {
 
 extension XCTestCase {
 
-    func snapshotDirectory(file: StaticString = #file) -> String {
+    func snapshotDirectory(file: StaticString = #filePath) -> String {
         let fileName = "\(file)"
         return ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"]! + "/" + URL(fileURLWithPath: fileName)
             .deletingPathExtension().lastPathComponent
@@ -121,7 +121,7 @@ extension XCTestCase {
     /// verify for a UIAlertController
     func verify(
         matching value: UIAlertController,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) throws {
@@ -159,7 +159,7 @@ extension XCTestCase {
     func verify(
         matching value: UIView,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -255,7 +255,7 @@ extension XCTestCase {
         createSut: () -> UIView,
         snapshotBackgroundColor: UIColor? = nil,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -275,7 +275,7 @@ extension XCTestCase {
         createSut: () -> UIViewController,
         snapshotBackgroundColor: UIColor? = nil,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -296,7 +296,7 @@ extension XCTestCase {
         widths: Set<CGFloat>,
         snapshotBackgroundColor: UIColor,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -319,7 +319,7 @@ extension XCTestCase {
         widths: Set<CGFloat>,
         snapshotBackgroundColor: UIColor,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -342,7 +342,7 @@ extension XCTestCase {
         width: CGFloat,
         snapshotBackgroundColor: UIColor,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -374,7 +374,7 @@ extension XCTestCase {
         width: CGFloat,
         snapshotBackgroundColor: UIColor,
         named name: String? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {

--- a/wire-ios/Wire-iOS Tests/UserCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserCellTests.swift
@@ -59,7 +59,7 @@ final class UserCellTests: XCTestCase {
         mockUser: UserType,
         conversation: GroupDetailsConversationType,
         isE2EICertified: Bool,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         testName: String = #function,
         line: UInt = #line
     ) {
@@ -245,7 +245,7 @@ final class UserCellTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -255,7 +255,7 @@ final class UserCellTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -285,7 +285,7 @@ final class UserCellTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -295,7 +295,7 @@ final class UserCellTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserSearchResultsViewControllerTests.swift
@@ -66,7 +66,7 @@ final class UserSearchResultsViewControllerTests: XCTestCase {
         sut.view.backgroundColor = SemanticColors.View.backgroundDefault
     }
 
-    func mockSearchResultUsers(file: StaticString = #file, line: UInt = #line) -> [UserType] {
+    func mockSearchResultUsers(file: StaticString = #filePath, line: UInt = #line) -> [UserType] {
         var allUsers: [UserType] = []
 
         for name in MockUserType.usernames {
@@ -103,7 +103,7 @@ final class UserSearchResultsViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "LightTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -113,7 +113,7 @@ final class UserSearchResultsViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )
@@ -128,7 +128,7 @@ final class UserSearchResultsViewControllerTests: XCTestCase {
             .verify(
                 matching: sut,
                 named: "DarkTheme",
-                file: #file,
+                file: #filePath,
                 testName: #function,
                 line: #line
             )

--- a/wire-ios/Wire-iOS Tests/UserStatusViewSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserStatusViewSnapshotTests.swift
@@ -194,7 +194,7 @@ final class UserStatusViewSnapshotTests: ZMSnapshotTestCase {
         userInterfaceStyle: UIUserInterfaceStyle = .dark,
         isE2EICertified: Bool = false,
         isProteusVerified: Bool = false,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line,
         testName: String = #function
     ) {

--- a/wire-ios/Wire-iOS Tests/WirelessExpirationTimeFormatterTests.swift
+++ b/wire-ios/Wire-iOS Tests/WirelessExpirationTimeFormatterTests.swift
@@ -110,7 +110,7 @@ class WirelessExpirationTimeFormatterTests: XCTestCase {
     private func assert(
         remainingTime: TimeInterval,
         expected: String?,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         let result = WirelessExpirationTimeFormatter.shared.string(for: remainingTime)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+EmptyState.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+EmptyState.swift
@@ -22,7 +22,7 @@ import WireSyncEngine
 extension ConversationListViewController {
 
     var isEmptyPlaceholderVisible: Bool {
-        return listContentController.listViewModel.isEmptyList
+        listContentController.listViewModel.isEmptyList
     }
 
     var emptyPlaceholderForSelectedFilter: EmptyPlaceholder {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyConversationSearchResultsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyConversationSearchResultsView.swift
@@ -24,40 +24,59 @@ final class EmptyConversationSearchResultsView: UIView {
 
     var newConversationAction: () -> Void
     var connectWithPeopleAction: (() -> Void)?
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     private var hostingViewController: UIHostingController<EmptyView>!
 
-    init(iPadTargeted: Bool,
-         newConversationAction: @escaping () -> Void,
-         connectWithPeopleAction: (() -> Void)?) {
+    init(
+        iPadTargeted: Bool,
+        newConversationAction: @escaping () -> Void,
+        connectWithPeopleAction: (() -> Void)?
+    ) {
         self.newConversationAction = newConversationAction
         self.connectWithPeopleAction = connectWithPeopleAction
 
         super.init(frame: .zero)
 
-        self.hostingViewController = UIHostingController(rootView: EmptyView(iPadTargeted: iPadTargeted, newConversationAction: { [weak self] in
-            self?.newConversationAction()
-        }, connectWithPeopleAction: { [weak self] in
-            self?.connectWithPeopleAction?()
-        }))
+        self.hostingViewController = UIHostingController(rootView: EmptyView(
+            iPadTargeted: iPadTargeted,
+            newConversationAction: { [weak self] in
+                self?.newConversationAction()
+            },
+            connectWithPeopleAction: { [weak self] in
+                self?.connectWithPeopleAction?()
+            }
+        ))
 
-        self.addSubview(hostingViewController.view)
+        addSubview(hostingViewController.view)
         hostingViewController.sizingOptions = .intrinsicContentSize
         hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         let stackView = hostingViewController!.view!
         stackView.backgroundColor = .clear
         NSLayoutConstraint.activate([
 
-            stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            stackView.leadingAnchor.constraint(greaterThanOrEqualToSystemSpacingAfter: self.safeAreaLayoutGuide.leadingAnchor, multiplier: 1),
-            stackView.topAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: self.safeAreaLayoutGuide.topAnchor, multiplier: 1),
-            self.safeAreaLayoutGuide.trailingAnchor.constraint(greaterThanOrEqualToSystemSpacingAfter: stackView.trailingAnchor, multiplier: 1),
-            self.safeAreaLayoutGuide.bottomAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: stackView.bottomAnchor, multiplier: 1),
+            stackView.leadingAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingAfter: safeAreaLayoutGuide.leadingAnchor,
+                multiplier: 1
+            ),
+            stackView.topAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingBelow: safeAreaLayoutGuide.topAnchor,
+                multiplier: 1
+            ),
+            safeAreaLayoutGuide.trailingAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingAfter: stackView.trailingAnchor,
+                multiplier: 1
+            ),
+            safeAreaLayoutGuide.bottomAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingBelow: stackView.bottomAnchor,
+                multiplier: 1
+            ),
 
             stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 272)
         ])
@@ -72,8 +91,10 @@ private struct EmptyView: View {
 
     var body: some View {
         if iPadTargeted {
-            TabletEmptyView(newConversationAction: newConversationAction,
-                            connectWithPeopleAction: connectWithPeopleAction)
+            TabletEmptyView(
+                newConversationAction: newConversationAction,
+                connectWithPeopleAction: connectWithPeopleAction
+            )
         } else {
             PhoneEmptyView(newConversationAction: newConversationAction)
         }
@@ -128,17 +149,22 @@ private struct TabletEmptyView: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(nil)
 
-            CapsuleButton(title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.Button.ipad,
-                          accessibilityIdentifier: "new-conversation.button", action: newConversationAction)
+            CapsuleButton(
+                title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.Button.ipad,
+                accessibilityIdentifier: "new-conversation.button",
+                action: newConversationAction
+            )
 
             Text(L10n.Localizable.General.or)
                 .font(.textStyle(.body1))
                 .foregroundStyle(Color.secondaryText)
                 .multilineTextAlignment(.center)
 
-            CapsuleButton(title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.connectButton,
-                          accessibilityIdentifier: "connect.button",
-                          action: connectWithPeopleAction)
+            CapsuleButton(
+                title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.connectButton,
+                accessibilityIdentifier: "connect.button",
+                action: connectWithPeopleAction
+            )
 
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyPlaceholderContainerView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyPlaceholderContainerView.swift
@@ -28,30 +28,38 @@ final class EmptyPlaceholderContainerView: UIView {
 
     // MARK: - Init
 
-    init(content: ConversationListViewController.EmptyPlaceholder,
-         connectWithPeopleAction: @escaping () -> Void,
-         newConversationAction: @escaping () -> Void) {
+    init(
+        content: ConversationListViewController.EmptyPlaceholder,
+        connectWithPeopleAction: @escaping () -> Void,
+        newConversationAction: @escaping () -> Void
+    ) {
         self.connectWithPeopleAction = connectWithPeopleAction
         self.newConversationAction = newConversationAction
 
         super.init(frame: .zero)
 
-        self.searchResultsView = EmptyConversationSearchResultsView(iPadTargeted: isIPadRegular(), newConversationAction: { [weak self] in
-            self?.newConversationAction()
-        }, connectWithPeopleAction: { [weak self] in
-            self?.connectWithPeopleAction()
-        })
+        self.searchResultsView = EmptyConversationSearchResultsView(
+            iPadTargeted: isIPadRegular(),
+            newConversationAction: { [weak self] in
+                self?.newConversationAction()
+            },
+            connectWithPeopleAction: { [weak self] in
+                self?.connectWithPeopleAction()
+            }
+        )
 
         let action = UIAction { [weak self] _ in
             self?.connectWithPeopleAction()
         }
         self.placeholderView = EmptyPlaceholderView(content: content, connectWithPeopleAction: action)
 
-        backgroundColor = isIPadRegular() ? ColorTheme.Backgrounds.backgroundVariant : ColorTheme.Backgrounds.surfaceVariant
+        backgroundColor = isIPadRegular() ? ColorTheme.Backgrounds.backgroundVariant : ColorTheme.Backgrounds
+            .surfaceVariant
 
         setupConstraints()
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -221,7 +221,7 @@ final class ConversationListViewModel: NSObject {
     private var sections: [Section] = []
 
     var isEmptyList: Bool {
-        let totalItems = sections.map { $0.items.count }.reduce(0, +)
+        let totalItems = sections.map(\.items.count).reduce(0, +)
         return totalItems == 0
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14392" title="WPB-14392" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-14392</a>  Migrate #file to #filePath
  </td></table>

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->

### Issue

In Swift 6 the `#file` special literal expression has a new behavior which breaks our snapshot tests in Swift packages.
See the SnapshotTestReferenceImageDirectory contents. 
https://forums.swift.org/t/file-vs-fileid-in-swift-6/74614/1

Also some code is formatted.

### Testing

No testing needed apart from CI.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
