### PR TITLE
chore: Delete helper methods from `UIView+Constraints.swift` - WPB-14398

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/Container/ConversationListViewControllerSnapshotTests.swift
@@ -283,7 +283,7 @@ final class ConversationListViewControllerSnapshotTests: XCTestCase {
         // THEN
         snapshotHelper.verify(matching: renderedImage())
     }
-    
+
     // MARK: - Helper Methods
 
     private func createConversations(conversationsData: [(name: String, isFavorite: Bool)]) -> [ZMConversation] {

--- a/wire-ios/Wire-iOS/Sources/Helpers/UIView+Borders.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/UIView+Borders.swift
@@ -19,6 +19,13 @@
 import UIKit
 import WireDesign
 
+enum Anchor {
+    case top
+    case bottom
+    case leading
+    case trailing
+}
+
 extension UIView {
 
     func addBorder(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/TextSearchInputView.swift
@@ -101,31 +101,34 @@ final class TextSearchInputView: UIView {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
 
-        NSLayoutConstraint.activate(
-            searchInput.fitInConstraints(view: self, inset: 8) + [
-                iconView.leadingAnchor.constraint(equalTo: searchInput.leadingAnchor, constant: 16),
-                iconView.centerYAnchor.constraint(equalTo: searchInput.centerYAnchor),
+        NSLayoutConstraint.activate([
+            searchInput.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            searchInput.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            searchInput.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            searchInput.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
 
-                iconView.topAnchor.constraint(equalTo: topAnchor),
-                iconView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            iconView.leadingAnchor.constraint(equalTo: searchInput.leadingAnchor, constant: 16),
+            iconView.centerYAnchor.constraint(equalTo: searchInput.centerYAnchor),
 
-                heightAnchor.constraint(lessThanOrEqualToConstant: 100),
+            iconView.topAnchor.constraint(equalTo: topAnchor),
+            iconView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-                placeholderLabel.leadingAnchor.constraint(equalTo: searchInput.leadingAnchor, constant: 48),
-                placeholderLabel.topAnchor.constraint(equalTo: searchInput.topAnchor),
-                placeholderLabel.bottomAnchor.constraint(equalTo: searchInput.bottomAnchor),
-                placeholderLabel.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor),
+            heightAnchor.constraint(lessThanOrEqualToConstant: 100),
 
-                clearButton.centerYAnchor.constraint(equalTo: centerYAnchor),
-                clearButton.trailingAnchor.constraint(equalTo: searchInput.trailingAnchor, constant: -16),
-                clearButton.widthAnchor.constraint(equalToConstant: StyleKitIcon.Size.tiny.rawValue),
-                clearButton.heightAnchor.constraint(equalToConstant: StyleKitIcon.Size.tiny.rawValue),
+            placeholderLabel.leadingAnchor.constraint(equalTo: searchInput.leadingAnchor, constant: 48),
+            placeholderLabel.topAnchor.constraint(equalTo: searchInput.topAnchor),
+            placeholderLabel.bottomAnchor.constraint(equalTo: searchInput.bottomAnchor),
+            placeholderLabel.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor),
 
-                spinner.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor, constant: -6),
-                spinner.centerYAnchor.constraint(equalTo: clearButton.centerYAnchor),
-                spinner.widthAnchor.constraint(equalToConstant: StyleKitIcon.Size.tiny.rawValue)
-            ]
-        )
+            clearButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            clearButton.trailingAnchor.constraint(equalTo: searchInput.trailingAnchor, constant: -16),
+            clearButton.widthAnchor.constraint(equalToConstant: StyleKitIcon.Size.tiny.rawValue),
+            clearButton.heightAnchor.constraint(equalToConstant: StyleKitIcon.Size.tiny.rawValue),
+
+            spinner.trailingAnchor.constraint(equalTo: clearButton.leadingAnchor, constant: -6),
+            spinner.centerYAnchor.constraint(equalTo: clearButton.centerYAnchor),
+            spinner.widthAnchor.constraint(equalToConstant: StyleKitIcon.Size.tiny.rawValue)
+        ])
     }
 
     @available(*, unavailable)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+EmptyState.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+EmptyState.swift
@@ -22,7 +22,7 @@ import WireSyncEngine
 extension ConversationListViewController {
 
     var isEmptyPlaceholderVisible: Bool {
-        return listContentController.listViewModel.isEmptyList
+        listContentController.listViewModel.isEmptyList
     }
 
     var emptyPlaceholderForSelectedFilter: EmptyPlaceholder {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyConversationSearchResultsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyConversationSearchResultsView.swift
@@ -24,40 +24,59 @@ final class EmptyConversationSearchResultsView: UIView {
 
     var newConversationAction: () -> Void
     var connectWithPeopleAction: (() -> Void)?
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     private var hostingViewController: UIHostingController<EmptyView>!
 
-    init(iPadTargeted: Bool,
-         newConversationAction: @escaping () -> Void,
-         connectWithPeopleAction: (() -> Void)?) {
+    init(
+        iPadTargeted: Bool,
+        newConversationAction: @escaping () -> Void,
+        connectWithPeopleAction: (() -> Void)?
+    ) {
         self.newConversationAction = newConversationAction
         self.connectWithPeopleAction = connectWithPeopleAction
 
         super.init(frame: .zero)
 
-        self.hostingViewController = UIHostingController(rootView: EmptyView(iPadTargeted: iPadTargeted, newConversationAction: { [weak self] in
-            self?.newConversationAction()
-        }, connectWithPeopleAction: { [weak self] in
-            self?.connectWithPeopleAction?()
-        }))
+        self.hostingViewController = UIHostingController(rootView: EmptyView(
+            iPadTargeted: iPadTargeted,
+            newConversationAction: { [weak self] in
+                self?.newConversationAction()
+            },
+            connectWithPeopleAction: { [weak self] in
+                self?.connectWithPeopleAction?()
+            }
+        ))
 
-        self.addSubview(hostingViewController.view)
+        addSubview(hostingViewController.view)
         hostingViewController.sizingOptions = .intrinsicContentSize
         hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         let stackView = hostingViewController!.view!
         stackView.backgroundColor = .clear
         NSLayoutConstraint.activate([
 
-            stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
 
-            stackView.leadingAnchor.constraint(greaterThanOrEqualToSystemSpacingAfter: self.safeAreaLayoutGuide.leadingAnchor, multiplier: 1),
-            stackView.topAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: self.safeAreaLayoutGuide.topAnchor, multiplier: 1),
-            self.safeAreaLayoutGuide.trailingAnchor.constraint(greaterThanOrEqualToSystemSpacingAfter: stackView.trailingAnchor, multiplier: 1),
-            self.safeAreaLayoutGuide.bottomAnchor.constraint(greaterThanOrEqualToSystemSpacingBelow: stackView.bottomAnchor, multiplier: 1),
+            stackView.leadingAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingAfter: safeAreaLayoutGuide.leadingAnchor,
+                multiplier: 1
+            ),
+            stackView.topAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingBelow: safeAreaLayoutGuide.topAnchor,
+                multiplier: 1
+            ),
+            safeAreaLayoutGuide.trailingAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingAfter: stackView.trailingAnchor,
+                multiplier: 1
+            ),
+            safeAreaLayoutGuide.bottomAnchor.constraint(
+                greaterThanOrEqualToSystemSpacingBelow: stackView.bottomAnchor,
+                multiplier: 1
+            ),
 
             stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 272)
         ])
@@ -72,8 +91,10 @@ private struct EmptyView: View {
 
     var body: some View {
         if iPadTargeted {
-            TabletEmptyView(newConversationAction: newConversationAction,
-                            connectWithPeopleAction: connectWithPeopleAction)
+            TabletEmptyView(
+                newConversationAction: newConversationAction,
+                connectWithPeopleAction: connectWithPeopleAction
+            )
         } else {
             PhoneEmptyView(newConversationAction: newConversationAction)
         }
@@ -128,17 +149,22 @@ private struct TabletEmptyView: View {
                 .multilineTextAlignment(.center)
                 .lineLimit(nil)
 
-            CapsuleButton(title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.Button.ipad,
-                          accessibilityIdentifier: "new-conversation.button", action: newConversationAction)
+            CapsuleButton(
+                title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.Button.ipad,
+                accessibilityIdentifier: "new-conversation.button",
+                action: newConversationAction
+            )
 
             Text(L10n.Localizable.General.or)
                 .font(.textStyle(.body1))
                 .foregroundStyle(Color.secondaryText)
                 .multilineTextAlignment(.center)
 
-            CapsuleButton(title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.connectButton,
-                          accessibilityIdentifier: "connect.button",
-                          action: connectWithPeopleAction)
+            CapsuleButton(
+                title: L10n.Localizable.ConversationList.EmptyPlaceholder.Search.connectButton,
+                accessibilityIdentifier: "connect.button",
+                action: connectWithPeopleAction
+            )
 
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyPlaceholderContainerView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/Empty placeholders/EmptyPlaceholderContainerView.swift
@@ -28,30 +28,38 @@ final class EmptyPlaceholderContainerView: UIView {
 
     // MARK: - Init
 
-    init(content: ConversationListViewController.EmptyPlaceholder,
-         connectWithPeopleAction: @escaping () -> Void,
-         newConversationAction: @escaping () -> Void) {
+    init(
+        content: ConversationListViewController.EmptyPlaceholder,
+        connectWithPeopleAction: @escaping () -> Void,
+        newConversationAction: @escaping () -> Void
+    ) {
         self.connectWithPeopleAction = connectWithPeopleAction
         self.newConversationAction = newConversationAction
 
         super.init(frame: .zero)
 
-        self.searchResultsView = EmptyConversationSearchResultsView(iPadTargeted: isIPadRegular(), newConversationAction: { [weak self] in
-            self?.newConversationAction()
-        }, connectWithPeopleAction: { [weak self] in
-            self?.connectWithPeopleAction()
-        })
+        self.searchResultsView = EmptyConversationSearchResultsView(
+            iPadTargeted: isIPadRegular(),
+            newConversationAction: { [weak self] in
+                self?.newConversationAction()
+            },
+            connectWithPeopleAction: { [weak self] in
+                self?.connectWithPeopleAction()
+            }
+        )
 
         let action = UIAction { [weak self] _ in
             self?.connectWithPeopleAction()
         }
         self.placeholderView = EmptyPlaceholderView(content: content, connectWithPeopleAction: action)
 
-        backgroundColor = isIPadRegular() ? ColorTheme.Backgrounds.backgroundVariant : ColorTheme.Backgrounds.surfaceVariant
+        backgroundColor = isIPadRegular() ? ColorTheme.Backgrounds.backgroundVariant : ColorTheme.Backgrounds
+            .surfaceVariant
 
         setupConstraints()
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -221,7 +221,7 @@ final class ConversationListViewModel: NSObject {
     private var sections: [Section] = []
 
     var isEmptyList: Bool {
-        let totalItems = sections.map { $0.items.count }.reduce(0, +)
+        let totalItems = sections.map(\.items.count).reduce(0, +)
         return totalItems == 0
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -17,14 +17,6 @@
 //
 
 import UIKit
-import WireSystem
-
-enum Anchor {
-    case top
-    case bottom
-    case leading
-    case trailing
-}
 
 extension UIView {
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -29,16 +29,7 @@ enum Anchor {
 extension UIView {
 
     /// fit self in a container view
-    /// - Parameters:
-    ///   - view: the container view to fit in
-    ///   - inset: inset of self
-    func fitIn(view: UIView, inset: CGFloat) {
-        fitIn(view: view, insets: UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset))
-    }
-
-    /// fit self in a container view
-    /// notice bottom and right inset no need to set to negative of top/left, e.g. if you want to add inset to self with
-    /// 2 pt:
+    /// notice bottom and right inset no need to set to negative of top/left, e.g. if you want to add inset to self with 2 pt:
     ///
     /// self.fitIn(view: container, insets: UIEdgeInsets(top: 2, left: 2, bottom: 2, right: 2))
     ///

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -41,15 +41,9 @@ extension UIView {
         NSLayoutConstraint.activate(fitInConstraints(view: view, insets: insets))
     }
 
-    func fitInConstraints(view: UIView, inset: CGFloat) -> [NSLayoutConstraint] {
-        fitInConstraints(view: view, insets: UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset))
-    }
-
-    func fitInConstraints(
-        view: UIView,
-        insets: UIEdgeInsets = .zero
-    ) -> [NSLayoutConstraint] {
-        [
+    func fitInConstraints(view: UIView,
+                          insets: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
+        return [
             leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: insets.leading),
             trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -insets.trailing),
             topAnchor.constraint(equalTo: view.topAnchor, constant: insets.top),

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIView+Constraints.swift
@@ -28,26 +28,17 @@ enum Anchor {
 
 extension UIView {
 
-    /// fit self in a container view
-    /// notice bottom and right inset no need to set to negative of top/left, e.g. if you want to add inset to self with 2 pt:
-    ///
-    /// self.fitIn(view: container, insets: UIEdgeInsets(top: 2, left: 2, bottom: 2, right: 2))
-    ///
+    /// Fits `self` within a specified container view with optional insets.
     /// - Parameters:
-    ///   - view: the container view to fit in
-    ///   - insets: a UIEdgeInsets for inset of self.
+    ///   - view: The container view in which to fit `self`.
+    ///   - insets: Insets to apply on each side of `self` relative to the container.
     func fitIn(view: UIView, insets: UIEdgeInsets = .zero) {
         translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate(fitInConstraints(view: view, insets: insets))
-    }
-
-    func fitInConstraints(view: UIView,
-                          insets: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
-        return [
-            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: insets.leading),
-            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -insets.trailing),
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: insets.left),
+            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -insets.right),
             topAnchor.constraint(equalTo: view.topAnchor, constant: insets.top),
             bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -insets.bottom)
-        ]
+        ])
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountViews/BaseAccountView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountViews/BaseAccountView.swift
@@ -153,22 +153,24 @@ class BaseAccountView: UIView {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
 
-        NSLayoutConstraint.activate(
-            selectionView.fitInConstraints(view: imageViewContainer, inset: -1) +
-                [
-                    imageViewContainer.topAnchor.constraint(equalTo: topAnchor, constant: containerInset),
-                    imageViewContainer.centerXAnchor.constraint(equalTo: centerXAnchor),
-                    widthAnchor.constraint(greaterThanOrEqualTo: imageViewContainer.widthAnchor),
+        NSLayoutConstraint.activate([
+            selectionView.leadingAnchor.constraint(equalTo: imageViewContainer.leadingAnchor, constant: -1),
+            selectionView.trailingAnchor.constraint(equalTo: imageViewContainer.trailingAnchor, constant: 1),
+            selectionView.topAnchor.constraint(equalTo: imageViewContainer.topAnchor, constant: -1),
+            selectionView.bottomAnchor.constraint(equalTo: imageViewContainer.bottomAnchor, constant: 1),
 
-                    imageViewContainer.widthAnchor.constraint(equalToConstant: iconWidth),
-                    imageViewContainer.heightAnchor.constraint(equalTo: imageViewContainer.widthAnchor),
+            imageViewContainer.topAnchor.constraint(equalTo: topAnchor, constant: containerInset),
+            imageViewContainer.centerXAnchor.constraint(equalTo: centerXAnchor),
+            widthAnchor.constraint(greaterThanOrEqualTo: imageViewContainer.widthAnchor),
 
-                    imageViewContainer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -containerInset),
-                    imageViewContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: containerInset),
-                    imageViewContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -containerInset),
-                    widthAnchor.constraint(lessThanOrEqualToConstant: 128)
-                ]
-        )
+            imageViewContainer.widthAnchor.constraint(equalToConstant: iconWidth),
+            imageViewContainer.heightAnchor.constraint(equalTo: imageViewContainer.widthAnchor),
+
+            imageViewContainer.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -containerInset),
+            imageViewContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: containerInset),
+            imageViewContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -containerInset),
+            widthAnchor.constraint(lessThanOrEqualToConstant: 128)
+        ])
     }
 
     // MARK: - Actions

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountViews/PersonalAccountView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountViews/PersonalAccountView.swift
@@ -65,7 +65,13 @@ final class PersonalAccountView: BaseAccountView {
 
         imageViewContainer.addSubview(userImageView)
         userImageView.translatesAutoresizingMaskIntoConstraints = false
-        userImageView.fitIn(view: imageViewContainer, inset: 2)
+
+        NSLayoutConstraint.activate([
+            userImageView.topAnchor.constraint(equalTo: imageViewContainer.topAnchor, constant: 2),
+            userImageView.bottomAnchor.constraint(equalTo: imageViewContainer.bottomAnchor, constant: -2),
+            userImageView.leadingAnchor.constraint(equalTo: imageViewContainer.leadingAnchor, constant: 2),
+            userImageView.trailingAnchor.constraint(equalTo: imageViewContainer.trailingAnchor, constant: -2)
+        ])
 
         update()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14398" title="WPB-14398" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14398</a>  [iOS] Delete helper methods from `UIView+Constraints.swift`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


With this PR we get rid of a lot of helper methods from `UIView+Constraints.swift`. We should avoid using those helper methods and instead set the constraints directly. More specifically:

- Removed `func fitIn(view: UIView, inset: CGFloat)` and set constraints directly
- Removed  `Replace fitInConstraints(view: UIView, inset:` and set constraints directly
- Merged  `fitInConstraints` logic into fitIn method to simplify things
- Moved Anchor enum to the file where it's being used

I'm planning to delete `func fitIn(view: UIView, insets: UIEdgeInsets = .zero)` on a separate PR because it's being used in 40 places and it will be harder to review. 

```swift
func fitIn(view: UIView, insets: UIEdgeInsets = .zero) {
        translatesAutoresizingMaskIntoConstraints = false
        NSLayoutConstraint.activate([
            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: insets.left),
            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -insets.right),
            topAnchor.constraint(equalTo: view.topAnchor, constant: insets.top),
            bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -insets.bottom)
        ])
    }
```

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---