### PR TITLE
fix: `MessageLocalStoreTests` flaky test - WPB-14429

### DIFF
--- a/WireDomain/Tests/WireDomainTests/LocalStores/MessageLocalStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/LocalStores/MessageLocalStoreTests.swift
@@ -64,29 +64,24 @@ final class MessageLocalStoreTests: XCTestCase {
             modelHelper.createUser(id: Scaffolding.userID, in: context)
         }
 
-        await withTaskGroup(of: Void.self) { taskGroup in
-            for messageType in Scaffolding.allMessageTypes {
-                taskGroup.addTask { [self] in
+        for messageType in Scaffolding.allMessageTypes {
+            let conversation = await makeConversation(creator: user)
+            conversationLocalStore.fetchConversationIdDomain_MockValue = conversation
 
-                    let conversation = await makeConversation(creator: user)
-                    conversationLocalStore.fetchConversationIdDomain_MockValue = conversation
+            // When
 
-                    // When
+            await sut.addSystemMessageToConversation(
+                messageType: messageType,
+                conversationID: UUID(),
+                conversationDomain: Scaffolding.domain1
+            )
 
-                    await sut.addSystemMessageToConversation(
-                        messageType: messageType,
-                        conversationID: UUID(),
-                        conversationDomain: Scaffolding.domain1
-                    )
+            // Then
 
-                    // Then
-
-                    await internalTest_assertConversationLastMessages(
-                        messageType: messageType,
-                        conversation: conversation
-                    )
-                }
-            }
+            await internalTest_assertConversationLastMessages(
+                messageType: messageType,
+                conversation: conversation
+            )
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14429" title="WPB-14429" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14429</a>  [iOS] Fix flaky test in MessageLocalStoreTests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

`MessageLocalStoreTests.testAddMessageToConversation_It_Adds_Correct_Message_To_Conversation()` is flaky. 

This test creates a bunch of conversations, adds a system message to them, then asserts things are correct. This is repeated for an array of message types. A mock is used to return the relevant conversation to the `sut`.

Currently each of the above repetitions are done in parallel. As the mock is reused across each iteration, there is a race condition, writing and reading to the mock, meaning that the `sut` might be acting on the wrong conversation.

However this parallelism is unnecessary for this test.

The fix is to remove it.


### Testing

Run the tests.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
