### PR TITLE
chore: Remove empty `resetInstance()` implementation - WPB-14434

### DIFF
--- a/WireAnalytics/Sources/WireAnalytics/Countly/Countly+CountlyProtocol.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Countly/Countly+CountlyProtocol.swift
@@ -19,8 +19,6 @@
 import Countly
 
 extension Countly: CountlyProtocol {
-    func resetInstance() {}
-
     func start(
         appKey: String,
         host: URL

--- a/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Analytics/TrackingManager/TrackingManager.swift
@@ -53,7 +53,7 @@ final class TrackingManager: NSObject, TrackingInterface {
     func firstTimeRequestToEnableAnalytics() async throws {
         // Ask if user has not given a preference yet
         // and tracking can be enabled
-        guard !doesUserConsentPreferenceExist && sessionManager.canEnableTracking else {
+        guard !doesUserConsentPreferenceExist, sessionManager.canEnableTracking else {
             return
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14434" title="WPB-14434" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14434</a>  [iOS] Remove empty `resetInstance()` implementation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In Countly+CountlyProtocol.swift there is an empty implementation of Countly.resetInstance(). 

```swift
extension Countly: CountlyProtocol {
    func resetInstance() {}
}
```

This func name shadows the same method in the obj-c implementation of Countly. My assumption is that this implementation was added by accident. It is not required for protocol conformance.

This means there are two versions of Countly.resetInstance() - one with behavior and one without. I believe which one is chosen is undefined.

This PR removes the empty conformance

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---
