### PR TITLE
fix: Missing close button - WPB-14444

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -445,7 +445,10 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
             guard let self, let mainCoordinator else { return }
 
             Task { @MainActor [folderPickerViewControllerBuilder] in
-                let viewController = folderPickerViewControllerBuilder.build(mainCoordinator: mainCoordinator)
+                let viewController = folderPickerViewControllerBuilder.build(
+                    mainCoordinator: mainCoordinator,
+                    showCloseButton: true
+                )
                 if let sheet = viewController.sheetPresentationController {
                     sheet.detents = [.medium(), .large()]
                     sheet.prefersGrabberVisible = true

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewControllerBuilder.swift
@@ -30,7 +30,7 @@ struct FolderPickerViewControllerBuilder {
     }
 
     @MainActor
-    func build(mainCoordinator: AnyMainCoordinator) -> UIViewController {
+    func build(mainCoordinator: AnyMainCoordinator, showCloseButton: Bool) -> UIViewController {
         let folders: [FolderPickerOption] = conversationDirectory.allFolders.compactMap {
             guard let id = $0.remoteIdentifier, let title = $0.name else { return nil }
 
@@ -54,7 +54,7 @@ struct FolderPickerViewControllerBuilder {
 
         let navigationStack = NavigationStack {
             FolderPicker(
-                showCloseButton: false,
+                showCloseButton: showCloseButton,
                 options: folders,
                 helpLink: WireURLs.shared.howToAddConversationToCustomFolder,
                 selected: selected

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerDelegate.swift
@@ -51,7 +51,10 @@ final class SidebarViewControllerDelegate: WireSidebarUI.SidebarViewControllerDe
     @MainActor
     func sidebarViewController(_ viewController: SidebarViewController, didTapFoldersMenuItem frame: CGRect) {
         Task {
-            let folderPicker = folderPickerViewControllerBuilder.build(mainCoordinator: mainCoordinator)
+            let folderPicker = folderPickerViewControllerBuilder.build(
+                mainCoordinator: mainCoordinator,
+                showCloseButton: false
+            )
             folderPicker.modalPresentationStyle = .popover
 
             if let popover = folderPicker.popoverPresentationController,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14444" title="WPB-14444" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14444</a>  [iOS][iPad] Close button is missing in the folder overlay
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a missing close button on the folder picker on iPhone **only**. According to designs it should not be visible on iPad.

| iPhone | iPad |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 - TESTS - 2024-11-22 at 09 17 03](https://github.com/user-attachments/assets/0e411e50-f8eb-4c04-920b-1a0ed3fd102b) | ![Simulator Screenshot - iPad (10th generation) - 2024-11-22 at 09 17 32](https://github.com/user-attachments/assets/51b09d1f-6ae6-4e5b-9dcd-c225811386d4) |


### Testing

#### iPhone

1. Tap filter button
2. Tap `Folders`
3. Confirm close button exists on folder picker

#### iPad

1. Navigate to sidebar
2. Tap `Folders`
3. Confirm there is no close button on folder picker

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
