### PR TITLE
fix: Crash unwrapping `MainCoordinator.splitViewController` - WPB-14510

### DIFF
--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -1422,20 +1422,20 @@ class MockSelfProfileViewControllerBuilderProtocol: SelfProfileViewControllerBui
 
     // MARK: - build
 
-    var build_Invocations: [Void] = []
-    var build_MockMethod: (() -> UIViewController)?
-    var build_MockValue: UIViewController?
+    var buildMainCoordinator_Invocations: [AnyMainCoordinator] = []
+    var buildMainCoordinator_MockMethod: ((AnyMainCoordinator) -> UIViewController)?
+    var buildMainCoordinator_MockValue: UIViewController?
 
     @MainActor
-    func build() -> UIViewController {
-        build_Invocations.append(())
+    func build(mainCoordinator: AnyMainCoordinator) -> UIViewController {
+        buildMainCoordinator_Invocations.append(mainCoordinator)
 
-        if let mock = build_MockMethod {
-            return mock()
-        } else if let mock = build_MockValue {
+        if let mock = buildMainCoordinator_MockMethod {
+            return mock(mainCoordinator)
+        } else if let mock = buildMainCoordinator_MockValue {
             return mock
         } else {
-            fatalError("no mock for `build`")
+            fatalError("no mock for `buildMainCoordinator`")
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -341,7 +341,9 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
     @objc
     private func presentProfile() {
         Task {
-            let selfProfileUI = UINavigationController(rootViewController: selfProfileViewControllerBuilder.build())
+            let selfProfileUI = UINavigationController(
+                rootViewController: selfProfileViewControllerBuilder.build(mainCoordinator: mainCoordinator)
+            )
             selfProfileUI.modalPresentationStyle = .formSheet
             await mainCoordinator.presentViewController(selfProfileUI)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerDelegate.swift
@@ -42,7 +42,9 @@ final class SidebarViewControllerDelegate: WireSidebarUI.SidebarViewControllerDe
     @MainActor
     public func sidebarViewControllerDidSelectAccountImage(_ viewController: SidebarViewController) {
         Task {
-            let selfProfileUI = UINavigationController(rootViewController: selfProfileUIBuilder.build())
+            let selfProfileUI = UINavigationController(
+                rootViewController: selfProfileUIBuilder.build(mainCoordinator: mainCoordinator)
+            )
             selfProfileUI.modalPresentationStyle = .formSheet
             await mainCoordinator.presentViewController(selfProfileUI)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -285,8 +285,6 @@ final class ZClientViewController: UIViewController {
         mainSplitViewController.borderColor = ColorTheme.Strokes.outline
         mainSplitViewController.conversationListUI = conversationListViewController
 
-        selfProfileViewControllerBuilder.mainCoordinator = .init(mainCoordinator: mainCoordinator)
-
         settingsViewControllerBuilder.settingsPropertyFactoryDelegate = defaultSettingsPropertyFactoryDelegate
         mainTabBarController.archiveUI = archiveUI
         mainTabBarController.settingsUI = settingsViewControllerBuilder

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewControllerBuilder.swift
@@ -26,7 +26,6 @@ final class SelfProfileViewControllerBuilder: SelfProfileViewControllerBuilderPr
     var selfUser: SettingsSelfUser
     var userRightInterfaceType: UserRightInterface.Type
     var userSession: UserSession
-    var mainCoordinator: AnyMainCoordinator!
     var accountSelector: AccountSelector?
     var trackingManager: TrackingManager?
 
@@ -42,7 +41,7 @@ final class SelfProfileViewControllerBuilder: SelfProfileViewControllerBuilderPr
         self.accountSelector = accountSelector
     }
 
-    func build() -> UIViewController {
+    func build(mainCoordinator: AnyMainCoordinator) -> UIViewController {
         SelfProfileViewController(
             selfUser: selfUser,
             userRightInterfaceType: userRightInterfaceType,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewControllerBuilderProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewControllerBuilderProtocol.swift
@@ -21,5 +21,5 @@ import UIKit
 // sourcery: AutoMockable
 protocol SelfProfileViewControllerBuilderProtocol {
     @MainActor
-    func build() -> UIViewController
+    func build(mainCoordinator: AnyMainCoordinator) -> UIViewController
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -380,7 +380,9 @@ extension ProfileViewController: ProfileFooterViewDelegate, IncomingRequestFoote
 
     private func openSelfProfile() {
         Task {
-            let selfProfileUI = UINavigationController(rootViewController: selfProfileUIBuilder.build())
+            let selfProfileUI = UINavigationController(
+                rootViewController: selfProfileUIBuilder.build(mainCoordinator: mainCoordinator)
+            )
             selfProfileUI.modalPresentationStyle = .formSheet
             await mainCoordinator.presentViewController(selfProfileUI)
         }


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR attempts to fix a crash when accessing `MainMainCoordinator.splitViewController`. I haven't managed to reproduce the crash but I have instead fixed a strong references cycle which I think is the underlying reason for the crash.

#### Details

`MainCoordinator.splitViewController` is an explicitly unwrapped weak property. `ZClientViewController` maintains a strong reference to both the `ZClientViewController` and `MainCoordinator`. When `ZClientViewController` is deallocated, `MainCoordinator` should also be deallocated. However when the `Lock With Passcode` option is enabled, and a user returns to the app and the password / faceID login app Lock Screen is shown, `ZClientViewController` is deallocated but it's `MainCoordinator` is **not** deallocated. This leaves `MainCoordinator.splitViewController` in a dangerous state. The following screenshot shows that after returning to the app twice we now have 3 `MainCoordinator` instances - there should be only one.

<img width="649" alt="Screenshot 2024-11-26 at 14 15 38" src="https://github.com/user-attachments/assets/160cc1e1-d82d-475d-943d-90890f1c7203">

This PR tackles the crash by fixing the underlying strong reference cycle. The reference cycle is:

```
MainCoordinator -> ConversationViewControllerBuilder -> SelfProfileViewControllerBuilder -> AnyMainCoordinator -> MainCoordinator
```

My fix removes the reference from `SelfProfileViewControllerBuilder` to `AnyMainCoordinator` and instead requires users of `SelfProfileViewControllerBuilder` to pass in a main coordinator reference when building.


### Testing

1. Enable  `Settings -> Options -> Lock With Passcode`
2. Put the app in the background
3. Wait more than 60 seconds
4. Return to the app
5. There should be no crash
6. Repeat from different screens

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
