### PR TITLE
fix: Profile color tappable area - WPB-14525

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/AccentColorPicker.swift
@@ -41,6 +41,7 @@ struct AccentColorPicker: View {
         List(AccentColor.allCases, id: \.self) { color in
             cell(for: color)
                 .listRowBackground(Color(SemanticColors.View.backgroundUserCell))
+                .contentShape(Rectangle())
                 .onTapGesture {
                     selectedColor = color
                     onColorSelect?(color)


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

When selecting a profile color the user must tap on a word or color circle. Tapping on empty space doesn’t work.

<img src="https://github.com/user-attachments/assets/41a4d281-02e3-4233-b44e-ad364323a704" width="300" />

This fix is to add a `contentShape` as outlined here: https://www.hackingwithswift.com/quick-start/swiftui/how-to-control-the-tappable-area-of-a-view-using-contentshape

https://github.com/user-attachments/assets/0846137c-d686-4c53-9856-ad52b9ffccbb

### Testing

1. Navigate to Settings -> Account -> Profile Color
2. Tap on some empty space in one of the unselected rows
3. The row is selected

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
