### PR TITLE
fix: crash when registering with a registered email - WPB-14566

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -81,7 +81,10 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
                 error = NSError.invalidActivationCode(with: response) ??
                     NSError(userSessionErrorCode: .unknownError, userInfo: [:])
             default:
+                // We can end up here because more than one request can be sent for a single action/phase.
+                // This is an issue in some other part of SyncEngine but as a quick fix we will log and abort here.
                 let phaseString = registrationStatus.phase.map { "\($0)" } ?? "<nil>"
+                WireLogger.authentication.error("Recieved unsuccessful response for invalid phase (\(phaseString))", attributes: .safePublic)
                 return assertionFailure("Error occurs for invalid phase: \(phaseString)")
             }
             registrationStatus.handleError(error)

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -82,7 +82,7 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
                     NSError(userSessionErrorCode: .unknownError, userInfo: [:])
             default:
                 let phaseString = registrationStatus.phase.map { "\($0)" } ?? "<nil>"
-                fatal("Error occurs for invalid phase: \(phaseString)")
+                return assertionFailure("Error occurs for invalid phase: \(phaseString)")
             }
             registrationStatus.handleError(error)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14566" title="WPB-14566" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14566</a>  Crash - Create Personal account - during email validation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

A bug leads to a crash when a user tries to create a new account with an already registered address.
The actual reason is that the send-activation-code request is fired more than once and any subsequent unsuccessful response after the first response is considered as a fatal error in the registration flow state.

This PR only replaces the fatal error by `assertionFailure`.

### Testing

From the first screen of the app try to create a new account with an already registered email address.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
