### PR TITLE
feat: Remove folder conversation filter when folder deleted - WPB-13905

### DIFF
--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/AnyMainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/AnyMainCoordinator.swift
@@ -24,6 +24,7 @@ public final class AnyMainCoordinator<Dependencies: MainCoordinatorDependenciesP
     public let base: any MainCoordinatorProtocol
 
     private let _showConversationList: @MainActor (_ conversationFilter: ConversationFilter?) async -> Void
+    private let _applyConversationFilter: @MainActor (_ conversationFilter: ConversationFilter?) -> Void
     private let _showArchive: @MainActor () async -> Void
     private let _showSettings: @MainActor () async -> Void
     private let _showConversation: @MainActor (
@@ -43,6 +44,9 @@ public final class AnyMainCoordinator<Dependencies: MainCoordinatorDependenciesP
         self.base = mainCoordinator
         self._showConversationList = { conversationFilter in
             await mainCoordinator.showConversationList(conversationFilter: conversationFilter)
+        }
+        self._applyConversationFilter = { conversationFilter in
+            mainCoordinator.applyConversationFilter(conversationFilter)
         }
         self._showArchive = {
             await mainCoordinator.showArchive()
@@ -73,6 +77,11 @@ public final class AnyMainCoordinator<Dependencies: MainCoordinatorDependenciesP
     @MainActor
     public func showConversationList(conversationFilter: ConversationFilter?) async {
         await _showConversationList(conversationFilter)
+    }
+
+    @MainActor
+    public func applyConversationFilter(_ conversationFilter: ConversationFilter?) {
+        _applyConversationFilter(conversationFilter)
     }
 
     @MainActor

--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
@@ -123,6 +123,10 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
             }
         }
 
+        applyConversationFilter(conversationFilter)
+    }
+
+    public func applyConversationFilter(_ conversationFilter: ConversationFilter?) {
         // apply the filter to the conversation list
         let conversationFilter = conversationFilter.map { ConversationFilter(mappingFrom: $0) }
         conversationListUI.conversationFilter = conversationFilter

--- a/WireUI/Sources/WireMainNavigationUI/Protocols/Coordinator/MainCoordinatorProtocol.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Protocols/Coordinator/MainCoordinatorProtocol.swift
@@ -30,6 +30,8 @@ public protocol MainCoordinatorProtocol: AnyObject {
     @MainActor
     func showConversationList(conversationFilter: ConversationFilter?) async
     @MainActor
+    func applyConversationFilter(_ filter: ConversationFilter?)
+    @MainActor
     func showArchive() async
     @MainActor
     func showSettings() async

--- a/WireUI/Tests/WireMainNavigationUITests/Coordinator/AnyMainCoordinatorTests.swift
+++ b/WireUI/Tests/WireMainNavigationUITests/Coordinator/AnyMainCoordinatorTests.swift
@@ -45,6 +45,15 @@ final class AnyMainCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockMainCoordinator.showConversationList_Invocations.first, .groups)
     }
 
+    func testApplyFilterIsInvoked() {
+        // When
+        sut.applyConversationFilter(.groups)
+
+        // Then
+        XCTAssertEqual(mockMainCoordinator.applyConversationFilter_Invocations.count, 1)
+        XCTAssertEqual(mockMainCoordinator.applyConversationFilter_Invocations.first, .groups)
+    }
+
     func testShowArchiveIsInvoked() async {
         // When
         await sut.showArchive()

--- a/WireUI/Tests/WireMainNavigationUITests/Mocks/MockMainCoordinator.swift
+++ b/WireUI/Tests/WireMainNavigationUITests/Mocks/MockMainCoordinator.swift
@@ -29,6 +29,11 @@ final class MockMainCoordinatorProtocol: MainCoordinatorProtocol {
         showConversationList_Invocations += [conversationFilter]
     }
 
+    var applyConversationFilter_Invocations: [ConversationFilter?] = []
+    func applyConversationFilter(_ filter: ConversationFilter?) {
+        applyConversationFilter_Invocations += [filter]
+    }
+
     var showArchive_Invocations: [Void] = []
     func showArchive() async {
         showArchive_Invocations.append(())

--- a/wire-ios-data-model/Source/ConversationList/ConversationDirectory.swift
+++ b/wire-ios-data-model/Source/ConversationList/ConversationDirectory.swift
@@ -50,8 +50,8 @@ public protocol ConversationDirectoryObserver: AnyObject {
 
 public protocol ConversationDirectoryType {
 
-    /// All folder created by the user
-    var allFolders: [LabelType] { get }
+    /// Folders excluding those marked for deletion
+    var nonDeletedFolders: [LabelType] { get }
 
     /// Create a new folder with a given name
     func createFolder(_ name: String) -> LabelType?

--- a/wire-ios-data-model/Source/ConversationList/ConversationDirectory.swift
+++ b/wire-ios-data-model/Source/ConversationList/ConversationDirectory.swift
@@ -44,7 +44,10 @@ public struct ConversationDirectoryChangeInfo {
 
 public protocol ConversationDirectoryObserver: AnyObject {
 
-    func conversationDirectoryDidChange(_ changeInfo: ConversationDirectoryChangeInfo)
+    func conversationDirectoryDidChange(
+        conversationDirectory: ConversationDirectoryType,
+        changeInfo: ConversationDirectoryChangeInfo
+    )
 
 }
 
@@ -136,19 +139,17 @@ private class ConversationListObserverProxy: NSObject, ZMConversationListObserve
     }
 
     func conversationListsDidReload() {
-        observer?.conversationDirectoryDidChange(ConversationDirectoryChangeInfo(
-            reloaded: true,
-            updatedLists: [],
-            updatedFolders: false
-        ))
+        observer?.conversationDirectoryDidChange(
+            conversationDirectory: directory,
+            changeInfo: ConversationDirectoryChangeInfo(reloaded: true, updatedLists: [], updatedFolders: false)
+        )
     }
 
     func conversationListsDidChangeFolders() {
-        observer?.conversationDirectoryDidChange(ConversationDirectoryChangeInfo(
-            reloaded: false,
-            updatedLists: [],
-            updatedFolders: true
-        ))
+        observer?.conversationDirectoryDidChange(
+            conversationDirectory: directory,
+            changeInfo: ConversationDirectoryChangeInfo(reloaded: false, updatedLists: [], updatedFolders: true)
+        )
     }
 
     func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
@@ -170,11 +171,14 @@ private class ConversationListObserverProxy: NSObject, ZMConversationListObserve
             []
         }
 
-        observer?.conversationDirectoryDidChange(ConversationDirectoryChangeInfo(
-            reloaded: false,
-            updatedLists: updatedLists,
-            updatedFolders: false
-        ))
+        observer?.conversationDirectoryDidChange(
+            conversationDirectory: directory,
+            changeInfo: ConversationDirectoryChangeInfo(
+                reloaded: false,
+                updatedLists: updatedLists,
+                updatedFolders: false
+            )
+        )
     }
 
 }

--- a/wire-ios-data-model/Source/ConversationList/ZMConversationListDirectory.h
+++ b/wire-ios-data-model/Source/ConversationList/ZMConversationListDirectory.h
@@ -42,6 +42,7 @@
 
 @property (nonatomic, readonly, nonnull) NSMutableDictionary<NSManagedObjectID *, ZMConversationList *> *listsByFolder;
 @property (nonatomic, readonly, nonnull) NSArray<id<LabelType>> *allFolders;
+@property (nonatomic, readonly, nonnull) NSArray<id<LabelType>> *nonDeletedFolders;
 
 
 /// Refetches all conversation lists and resets the snapshots

--- a/wire-ios-data-model/Source/ConversationList/ZMConversationListDirectory.m
+++ b/wire-ios-data-model/Source/ConversationList/ZMConversationListDirectory.m
@@ -203,6 +203,12 @@ static NSString * const PendingKey = @"Pending";
     return self.folderList.backingList;
 }
 
+- (NSArray<id<LabelType>> *)nonDeletedFolders
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"markedForDeletion == NO"];
+    return [self.folderList.backingList filteredArrayUsingPredicate:predicate];
+}
+
 @end
 
 

--- a/wire-ios/Tests/Mocks/MockConverationDirectory.swift
+++ b/wire-ios/Tests/Mocks/MockConverationDirectory.swift
@@ -21,7 +21,7 @@ import WireDataModel
 
 class MockConversationDirectory: ConversationDirectoryType {
 
-    var allFolders: [LabelType] = []
+    var nonDeletedFolders: [LabelType] = []
     var mockGroupConversations: [ZMConversation] = []
     var mockContactsConversations: [ZMConversation] = []
     var mockFavoritesConversations: [ZMConversation] = []

--- a/wire-ios/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
@@ -22,15 +22,7 @@ import XCTest
 @testable import Wire
 
 final class MockConversationListViewModelDelegate: NSObject, ConversationListViewModelDelegate {
-    func listViewModel(_ model: ConversationListViewModel?, didUpdateSection section: Int) {
-        // no-op
-    }
-
     func listViewModel(_ model: ConversationListViewModel?, didUpdateSectionForReload section: Int, animated: Bool) {
-        // no-op
-    }
-
-    func listViewModel(_ model: ConversationListViewModel?, didChangeFolderEnabled folderEnabled: Bool) {
         // no-op
     }
 
@@ -65,7 +57,6 @@ final class ConversationListViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        removeViewModelState()
         mockUserSession = UserSessionMock()
         sut = ConversationListViewModel(userSession: mockUserSession)
 
@@ -87,12 +78,6 @@ final class ConversationListViewModelTests: XCTestCase {
         coreDataFixture = nil
 
         super.tearDown()
-    }
-
-    func removeViewModelState() {
-        guard let persistentURL = ConversationListViewModel.persistentURL else { return }
-
-        try? FileManager.default.removeItem(at: persistentURL)
     }
 
     // 2 group conversations and 1 contact. First group conversation is mock conversation

--- a/wire-ios/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationList/ConversationListViewModel/ConversationListViewModelTests.swift
@@ -100,7 +100,10 @@ final class ConversationListViewModelTests: XCTestCase {
         mockUserSession.mockConversationDirectory.mockGroupConversations = [mockConversation, teamConversation]
         mockUserSession.mockConversationDirectory.mockContactsConversations = [oneToOneConversation]
 
-        sut.conversationDirectoryDidChange(info)
+        sut.conversationDirectoryDidChange(
+            conversationDirectory: mockUserSession.mockConversationDirectory,
+            changeInfo: info
+        )
     }
 
     func testForNumberOfItems() {

--- a/wire-ios/Wire-iOS Tests/UserInterface/MainController/ConversationFilterSelectorTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserInterface/MainController/ConversationFilterSelectorTests.swift
@@ -1,0 +1,105 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+import XCTest
+
+@testable import Wire
+
+final class ConversationFilterSelectorTests: XCTestCase {
+
+    private var sut: ConversationFilterSelector!
+    private var conversationDirectory: MockConversationDirectory!
+    private var conversationFilter: ConversationFilter?
+    private var conversationFilterDidChange: Bool!
+
+    @MainActor
+    override func setUpWithError() throws {
+        conversationDirectory = MockConversationDirectory()
+        sut = ConversationFilterSelector(
+            conversationFilter: { [unowned self] in conversationFilter },
+            updateConversationFilter: { [unowned self] newValue in
+                conversationFilter = newValue
+                conversationFilterDidChange = true
+            }
+        )
+        conversationFilterDidChange = false
+    }
+
+    @MainActor
+    override func tearDownWithError() throws {
+        conversationDirectory = nil
+        sut = nil
+        conversationFilterDidChange = nil
+    }
+
+    @MainActor
+    func testConversationDirectoryDidChange_whenFolderFilterSelected() throws {
+        // GIVEN
+        let folderA = MockLabel(remoteIdentifier: UUID())
+        let folderB = MockLabel(remoteIdentifier: UUID())
+
+        conversationFilter = .folder(id: folderA.remoteIdentifier!, name: "folderName")
+
+        // WHEN
+        conversationDirectory.nonDeletedFolders = [folderA, folderB]
+        sut.conversationDirectoryDidChange(conversationDirectory: conversationDirectory, changeInfo: .someValue)
+
+        // THEN
+        XCTAssertFalse(conversationFilterDidChange)
+        XCTAssertEqual(conversationFilter, .folder(id: folderA.remoteIdentifier!, name: "folderName"))
+
+        // WHEN
+        conversationDirectory.nonDeletedFolders = [folderB]
+        sut.conversationDirectoryDidChange(conversationDirectory: conversationDirectory, changeInfo: .someValue)
+
+        // THEN
+        XCTAssertTrue(conversationFilterDidChange)
+        XCTAssertNil(conversationFilter)
+    }
+
+    @MainActor
+    func testConversationDirectoryDidChange_whenNotFolderFilterSelected() throws {
+        let testCases: [ConversationFilter?] = [
+            .favorites,
+            .groups,
+            .oneOnOne,
+            .none
+        ]
+
+        for testCase in testCases {
+            // GIVEN
+            conversationFilter = testCase
+
+            // WHEN
+            sut.conversationDirectoryDidChange(conversationDirectory: conversationDirectory, changeInfo: .someValue)
+
+            // THEN
+            XCTAssertFalse(conversationFilterDidChange)
+        }
+    }
+
+}
+
+private extension ConversationDirectoryChangeInfo {
+    static let someValue = ConversationDirectoryChangeInfo(
+        reloaded: false,
+        updatedLists: [],
+        updatedFolders: false
+    )
+}

--- a/wire-ios/Wire-iOS Tests/UserInterface/MainCoordinator/MockMainCoordinator.swift
+++ b/wire-ios/Wire-iOS Tests/UserInterface/MainCoordinator/MockMainCoordinator.swift
@@ -33,6 +33,11 @@ final class MockMainCoordinator: MainCoordinatorProtocol {
     }
 
     @MainActor
+    func applyConversationFilter(_ filter: ConversationFilter?) {
+        fatalError("Mock method not implemented")
+    }
+
+    @MainActor
     func showArchive() {
         fatalError("Mock method not implemented")
     }

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -1164,6 +1164,7 @@
 		CB43DBC42CE639E800BF5AEB /* FolderPickerViewControllerBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB43DBC32CE639E800BF5AEB /* FolderPickerViewControllerBuilder.swift */; };
 		CB4870F22C7F4FE5001E9151 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4870F12C7F4FE5001E9151 /* WireTransportSupport.framework */; };
 		CB4E15122C81CC81005DDEC8 /* Down in Frameworks */ = {isa = PBXBuildFile; productRef = CB4E15112C81CC81005DDEC8 /* Down */; };
+		CB8E51E32CF89D9B00F7F01D /* ConversationFilterSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB8E51E22CF89D9B00F7F01D /* ConversationFilterSelector.swift */; };
 		D30880FB292CD8F200DDEAB0 /* CallingBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30880FA292CD8F200DDEAB0 /* CallingBottomSheetViewController.swift */; };
 		D30880FE292E521D00DDEAB0 /* CallingActionsInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30880FD292E521D00DDEAB0 /* CallingActionsInfoViewController.swift */; };
 		D3095761283CEB1C00CEC620 /* MediaShareRestrictionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D309575D283CDFED00CEC620 /* MediaShareRestrictionManager.swift */; };
@@ -3243,6 +3244,7 @@
 		CB366A8F2CC7DE410083701F /* ArchivedListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchivedListViewModelTests.swift; sourceTree = "<group>"; };
 		CB43DBC32CE639E800BF5AEB /* FolderPickerViewControllerBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderPickerViewControllerBuilder.swift; sourceTree = "<group>"; };
 		CB4870F12C7F4FE5001E9151 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB8E51E22CF89D9B00F7F01D /* ConversationFilterSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationFilterSelector.swift; sourceTree = "<group>"; };
 		CE06C93E1DF5C3D900497685 /* AVAsset+VideoConvert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVAsset+VideoConvert.swift"; sourceTree = "<group>"; };
 		CE8E4FA91DF066750009F437 /* FileMetaDataGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileMetaDataGenerator.swift; sourceTree = "<group>"; };
 		CE8E4FB21DF066EE0009F437 /* AudioProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioProcessing.swift; sourceTree = "<group>"; };
@@ -6750,6 +6752,7 @@
 			children = (
 				59AF77A02CC7FB39002438D1 /* AnyMainCoordinator.swift */,
 				596184AC2CC7B5F600787AF0 /* DefaultSettingsPropertyFactoryDelegate.swift */,
+				CB8E51E22CF89D9B00F7F01D /* ConversationFilterSelector.swift */,
 				5965E9722C9B1491001D8AE1 /* ConversationListViewController+MainConversationListProtocol.swift */,
 				59E67CB12CA8C356000F1C17 /* ConversationRootViewController+MainConversationProtocol.swift */,
 				597CAEB22CA40111002A1160 /* MainCoordinator+ArchivedListViewControllerDelegate.swift */,
@@ -10191,6 +10194,7 @@
 				5E65A7A721304B6B008BFCC0 /* UserEmailUpdateCodeSentEventHandler.swift in Sources */,
 				EF3371C22216D9D9005ED048 /* ZMUser+Self.swift in Sources */,
 				EFEE97C823229CF5007A4702 /* ConversationListCellDelegate.swift in Sources */,
+				CB8E51E32CF89D9B00F7F01D /* ConversationFilterSelector.swift in Sources */,
 				7CED30721FD97748009F0DAC /* IconStringsBuilder.swift in Sources */,
 				E9B0DED42B5E7151006DC9E4 /* AccentColorPicker.swift in Sources */,
 				EFABC92420208D80001F9866 /* UIViewController+removeUserConfirmationUI.swift in Sources */,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -181,7 +181,7 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
             withConfiguration: symbolConfiguration
         )!
 
-        var selectedFilterImage: UIImage = switch listContentController.listViewModel.selectedFilter {
+        let selectedFilterImage: UIImage = switch listContentController.listViewModel.selectedFilter {
         case .favorites, .groups, .oneOnOne, .folder:
             filledFilterImage
         case .none:

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ConversationListContentController.swift
@@ -74,8 +74,6 @@ final class ConversationListContentController: UICollectionViewController {
         flowLayout.sectionInset = .zero
         self.listViewModel = .init(userSession: userSession)
         super.init(collectionViewLayout: flowLayout)
-
-        registerSectionHeader()
     }
 
     @available(*, unavailable)
@@ -153,52 +151,6 @@ final class ConversationListContentController: UICollectionViewController {
         collectionView.accessibilityIdentifier = "conversation list"
         collectionView.backgroundColor = .clear
         clearsSelectionOnViewWillAppear = false
-    }
-
-    // MARK: - section header
-
-    override func collectionView(
-        _ collectionView: UICollectionView,
-        viewForSupplementaryElementOfKind kind: String,
-        at indexPath: IndexPath
-    ) -> UICollectionReusableView {
-
-        switch kind {
-        case UICollectionView.elementKindSectionHeader:
-            let section = indexPath.section
-
-            if let header = collectionView.dequeueReusableSupplementaryView(
-                ofKind: kind,
-                withReuseIdentifier: ConversationListHeaderView.reuseIdentifier,
-                for: indexPath
-            ) as? ConversationListHeaderView {
-                header.title = listViewModel.sectionHeaderTitle(sectionIndex: section)?.uppercased()
-
-                header.folderBadge = listViewModel.folderBadge(at: section)
-
-                header.collapsed = listViewModel.collapsed(at: section)
-
-                header.tapHandler = { [weak self] collapsed in
-                    self?.listViewModel.setCollapsed(sectionIndex: section, collapsed: collapsed)
-                }
-
-                return header
-            } else {
-                fatal("Unknown supplementary view for \(kind)")
-            }
-        default:
-            fatal("No supplementary view for \(kind)")
-        }
-    }
-
-    private func registerSectionHeader() {
-        collectionView?.register(
-            ConversationListHeaderView.self,
-            forSupplementaryViewOfKind:
-            UICollectionView.elementKindSectionHeader,
-            withReuseIdentifier: ConversationListHeaderView.reuseIdentifier
-        )
-
     }
 
     /// ensures that the list selection state matches that of the model.
@@ -386,18 +338,6 @@ extension ConversationListContentController: UICollectionViewDelegateFlowLayout 
     func collectionView(
         _ collectionView: UICollectionView,
         layout collectionViewLayout: UICollectionViewLayout,
-        referenceSizeForHeaderInSection section: Int
-    ) -> CGSize {
-        CGSize(
-            width: collectionView.bounds.size.width,
-            height: listViewModel.sectionHeaderVisible(section: section) ? CGFloat.ConversationListSectionHeader
-                .height : 0
-        )
-    }
-
-    func collectionView(
-        _ collectionView: UICollectionView,
-        layout collectionViewLayout: UICollectionViewLayout,
         sizeForItemAt indexPath: IndexPath
     ) -> CGSize {
         layoutCell.size(inCollectionViewSize: collectionView.bounds.size)
@@ -413,17 +353,6 @@ extension ConversationListContentController: UICollectionViewDelegateFlowLayout 
 }
 
 extension ConversationListContentController: ConversationListViewModelDelegate {
-
-    func listViewModel(_ model: ConversationListViewModel?, didUpdateSection section: Int) {
-        guard let header = collectionView.supplementaryView(
-            forElementKind: UICollectionView.elementKindSectionHeader,
-            at: IndexPath(item: 0, section: section)
-        ) as? ConversationListHeaderView else {
-            return
-        }
-
-        header.folderBadge = listViewModel.folderBadge(at: section)
-    }
 
     func listViewModel(_ model: ConversationListViewModel?, didSelectItem item: ConversationListItem?) {
         defer {
@@ -482,8 +411,6 @@ extension ConversationListContentController: ConversationListViewModelDelegate {
             }
         }
     }
-
-    func listViewModel(_ model: ConversationListViewModel?, didChangeFolderEnabled folderEnabled: Bool) {}
 
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -142,10 +142,9 @@ final class ConversationListViewModel: NSObject {
 
         var kind: Kind
         var items: [SectionItem]
-        var collapsed: Bool
 
         var elements: [SectionItem] {
-            collapsed ? [] : items
+            items
         }
 
         /// ref to AggregateArray, we return the first found item's index
@@ -166,33 +165,22 @@ final class ConversationListViewModel: NSObject {
 
         init(source: ConversationListViewModel.Section, elements: some Collection<SectionItem>) {
             self.kind = source.kind
-            self.collapsed = source.collapsed
             self.items = Array(elements)
         }
 
         init(
             kind: Kind,
-            conversationDirectory: ConversationDirectoryType,
-            collapsed: Bool
+            conversationDirectory: ConversationDirectoryType
         ) {
             self.items = ConversationListViewModel.newList(for: kind, conversationDirectory: conversationDirectory)
             self.kind = kind
-            self.collapsed = collapsed
         }
     }
 
     static let contactRequestsItem: ConversationListConnectRequestsItem = .init()
 
     /// current selected ZMConversaton or ConversationListConnectRequestsItem object
-    private(set) var selectedItem: ConversationListItem? {
-        didSet {
-            /// expand the section if selcted item is update
-            guard let indexPath = indexPath(for: selectedItem),
-                  collapsed(at: indexPath.section) else { return }
-
-            setCollapsed(sectionIndex: indexPath.section, collapsed: false, batchUpdate: false)
-        }
-    }
+    private(set) var selectedItem: ConversationListItem?
 
     weak var delegate: ConversationListViewModelDelegate?
 
@@ -273,8 +261,7 @@ final class ConversationListViewModel: NSObject {
     }
 
     func numberOfItems(inSection sectionIndex: Int) -> Int {
-        guard sections.indices.contains(sectionIndex),
-              !collapsed(at: sectionIndex) else { return 0 }
+        guard sections.indices.contains(sectionIndex) else { return 0 }
 
         return sections[sectionIndex].elements.count
     }
@@ -375,8 +362,7 @@ final class ConversationListViewModel: NSObject {
         let sections = kinds.map { kind in
             Section(
                 kind: kind,
-                conversationDirectory: conversationDirectory,
-                collapsed: false // FIXME: Removed collapsed property
+                conversationDirectory: conversationDirectory
             )
         }
         let filterUseCase = FilterConversationsUseCase(conversationContainers: sections)
@@ -454,60 +440,6 @@ final class ConversationListViewModel: NSObject {
 
         if let itemToSelect {
             delegate?.listViewModel(self, didSelectItem: itemToSelect)
-        }
-    }
-
-    // MARK: - folder badge
-
-    func folderBadge(at sectionIndex: Int) -> Int {
-        sections[sectionIndex].items.filter {
-            let status = ($0.item as? ZMConversation)?.status
-            return status?.messagesRequiringAttention.isEmpty == false &&
-                status?.showingAllMessages == true
-        }.count
-    }
-
-    func collapsed(at sectionIndex: Int) -> Bool {
-        false // FIXME: Remove
-    }
-
-    // FIXME: Remove
-    /// set a collpase state of a section
-    ///
-    /// - Parameters:
-    ///   - sectionIndex: section to update
-    ///   - collapsed: collapsed or expanded
-    ///   - batchUpdate: true for update with difference kit comparison, false for reload the section animated
-    func setCollapsed(
-        sectionIndex: Int,
-        collapsed: Bool,
-        batchUpdate: Bool = true
-    ) {
-        guard let conversationDirectory = userSession?.conversationDirectory else { return }
-        guard let kind = kind(of: sectionIndex) else { return }
-        guard self.collapsed(at: sectionIndex) != collapsed else { return }
-        guard let sectionNumber = sectionNumber(for: kind) else { return }
-
-        var newValue = sections
-        newValue[sectionNumber] = Section(
-            kind: kind,
-            conversationDirectory: conversationDirectory,
-            collapsed: collapsed
-        )
-
-        if batchUpdate {
-            let changeset = StagedChangeset(source: sections, target: newValue)
-
-            delegate?.reload(using: changeset, interrupt: { _ in
-                false
-            }, setData: { data in
-                if let data {
-                    self.sections = data
-                }
-            })
-        } else {
-            sections = newValue
-            delegate?.listViewModel(self, didUpdateSectionForReload: sectionIndex, animated: true)
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -252,18 +252,7 @@ final class ConversationListViewModel: NSObject {
 
     /// for folder enabled and collapse presistent
     private lazy var _state: State = {
-        guard isFolderStatePersistenceEnabled else { return .init() }
-
-        guard let persistentPath = ConversationListViewModel.persistentURL,
-              let jsonData = try? Data(contentsOf: persistentPath) else { return State()
-        }
-
-        do {
-            return try JSONDecoder().decode(ConversationListViewModel.State.self, from: jsonData)
-        } catch {
-            log.error("restore state error: \(error)")
-            return State()
-        }
+        return .init()
     }()
 
     private var state: State {
@@ -606,10 +595,6 @@ final class ConversationListViewModel: NSObject {
 
     // MARK: - state presistent
 
-    // TODO: [WPB-7307]: the follow-up PR will remove anything around folders
-    // https://github.com/wireapp/wire-ios/pull/1466
-    let isFolderStatePersistenceEnabled = false
-
     // TODO: [WPB-7307]: remove everything around the legacy folder view (grouped)
     private struct State: Codable, Equatable {
         var collapsed: Set<SectionIdentifier>
@@ -634,23 +619,7 @@ final class ConversationListViewModel: NSObject {
     }
 
     private func saveState(state: State) {
-
-        guard isFolderStatePersistenceEnabled,
-              let jsonString = state.jsonString,
-              let persistentDirectory = ConversationListViewModel.persistentDirectory,
-              let directoryURL = URL.directoryURL(persistentDirectory) else { return }
-
-        try! FileManager.default.createAndProtectDirectory(at: directoryURL)
-
-        do {
-            try jsonString.write(
-                to: directoryURL.appendingPathComponent(ConversationListViewModel.persistentFilename),
-                atomically: true,
-                encoding: .utf8
-            )
-        } catch {
-            log.error("error writing ConversationListViewModel to \(directoryURL): \(error)")
-        }
+        return
     }
 
     private static var persistentDirectory: String? {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -519,7 +519,10 @@ private let log = ZMSLog(tag: "ConversationListViewModel")
 // MARK: - ConversationDirectoryObserver
 
 extension ConversationListViewModel: ConversationDirectoryObserver {
-    func conversationDirectoryDidChange(_ changeInfo: ConversationDirectoryChangeInfo) {
+    func conversationDirectoryDidChange(
+        conversationDirectory: ConversationDirectoryType,
+        changeInfo: ConversationDirectoryChangeInfo
+    ) {
 
         if changeInfo.reloaded {
             // If the section was empty in certain cases collection view breaks down on the big amount of conversations,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -362,7 +362,7 @@ final class ConversationListViewModel: NSObject {
         case .oneOnOne:
             [.contacts, .contactRequests]
         case let .folder(id, _):
-            if let folder = conversationDirectory.allFolders.first(where: { $0.remoteIdentifier == id }) {
+            if let folder = conversationDirectory.nonDeletedFolders.first(where: { $0.remoteIdentifier == id }) {
                 [.folder(label: folder)]
             } else {
                 // FIXME: [WPB-13905] Log invalid state once WPB-13905 is implemented

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -194,28 +194,7 @@ final class ConversationListViewModel: NSObject {
         }
     }
 
-    weak var delegate: ConversationListViewModelDelegate? {
-        didSet {
-            delegateFolderEnableState(newState: state)
-        }
-    }
-
-    // TODO: [WPB-7307]: remove everything regarding folders
-    var folderEnabled: Bool {
-        get {
-            state.folderEnabled
-        }
-
-        set {
-            guard newValue != state.folderEnabled else { return }
-
-            state.folderEnabled = newValue
-
-            updateAllSections()
-            delegate?.listViewModelShouldBeReloaded()
-            delegateFolderEnableState(newState: state)
-        }
-    }
+    weak var delegate: ConversationListViewModelDelegate?
 
     // Local copies of the lists.
     private var sections: [Section] = []
@@ -250,29 +229,6 @@ final class ConversationListViewModel: NSObject {
         }
     }
 
-    /// for folder enabled and collapse presistent
-    private lazy var _state: State = {
-        return .init()
-    }()
-
-    private var state: State {
-        get {
-            _state
-        }
-
-        set {
-            /// simulate willSet
-
-            /// assign
-            if newValue != _state {
-                _state = newValue
-            }
-
-            /// simulate didSet
-            saveState(state: _state)
-        }
-    }
-
     private var conversationDirectoryToken: Any?
 
     let userSession: UserSession?
@@ -286,30 +242,12 @@ final class ConversationListViewModel: NSObject {
         updateAllSections()
     }
 
-    private func delegateFolderEnableState(newState: State) {
-        delegate?.listViewModel(self, didChangeFolderEnabled: folderEnabled)
-    }
-
     private func setupObservers() {
         conversationDirectoryToken = userSession?.conversationDirectory.addObserver(self)
     }
 
     func sectionHeaderTitle(sectionIndex: Int) -> String? {
         kind(of: sectionIndex)?.localizedName
-    }
-
-    /// return true if seaction header is visible.
-    /// For .contactRequests section it is always invisible
-    /// When folderEnabled == true, returns false
-    ///
-    /// - Parameter sectionIndex: section number of collection view
-    /// - Returns: if the section exists and visible, return true.
-    func sectionHeaderVisible(section: Int) -> Bool {
-        guard sections.indices.contains(section),
-              kind(of: section) != .contactRequests,
-              folderEnabled else { return false }
-
-        return !sections[section].items.isEmpty
     }
 
     private func kind(of sectionIndex: Int) -> Section.Kind? {
@@ -438,7 +376,7 @@ final class ConversationListViewModel: NSObject {
             Section(
                 kind: kind,
                 conversationDirectory: conversationDirectory,
-                collapsed: state.collapsed.contains(kind.identifier)
+                collapsed: false // FIXME: Removed collapsed property
             )
         }
         let filterUseCase = FilterConversationsUseCase(conversationContainers: sections)
@@ -464,7 +402,7 @@ final class ConversationListViewModel: NSObject {
 
             newValue[sectionNumber].items = newList
 
-            // Refresh the section header(since it may be hidden if the sectio is empty) when a section becomes
+            // Refresh the section header(since it may be hidden if the section is empty) when a section becomes
             // empty/from empty to non-empty
             if sections[sectionNumber].items.isEmpty || newList.isEmpty {
                 sections = newValue
@@ -486,15 +424,6 @@ final class ConversationListViewModel: NSObject {
                     self.sections = data
                 }
             })
-        }
-
-        if let kind,
-           let sectionNumber = sectionNumber(for: kind) {
-            delegate?.listViewModel(self, didUpdateSection: sectionNumber)
-        } else {
-            sections.indices.forEach {
-                delegate?.listViewModel(self, didUpdateSection: $0)
-            }
         }
     }
 
@@ -539,15 +468,10 @@ final class ConversationListViewModel: NSObject {
     }
 
     func collapsed(at sectionIndex: Int) -> Bool {
-        collapsed(at: sectionIndex, state: state)
+        false // FIXME: Remove
     }
 
-    private func collapsed(at sectionIndex: Int, state: State) -> Bool {
-        guard let kind = kind(of: sectionIndex) else { return false }
-
-        return state.collapsed.contains(kind.identifier)
-    }
-
+    // FIXME: Remove
     /// set a collpase state of a section
     ///
     /// - Parameters:
@@ -563,12 +487,6 @@ final class ConversationListViewModel: NSObject {
         guard let kind = kind(of: sectionIndex) else { return }
         guard self.collapsed(at: sectionIndex) != collapsed else { return }
         guard let sectionNumber = sectionNumber(for: kind) else { return }
-
-        if collapsed {
-            state.collapsed.insert(kind.identifier)
-        } else {
-            state.collapsed.remove(kind.identifier)
-        }
 
         var newValue = sections
         newValue[sectionNumber] = Section(
@@ -591,53 +509,6 @@ final class ConversationListViewModel: NSObject {
             sections = newValue
             delegate?.listViewModel(self, didUpdateSectionForReload: sectionIndex, animated: true)
         }
-    }
-
-    // MARK: - state presistent
-
-    // TODO: [WPB-7307]: remove everything around the legacy folder view (grouped)
-    private struct State: Codable, Equatable {
-        var collapsed: Set<SectionIdentifier>
-        var folderEnabled: Bool
-
-        init() {
-            self.collapsed = []
-            self.folderEnabled = false
-        }
-
-        var jsonString: String? {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .sortedKeys
-            guard let jsonData = try? encoder.encode(self) else { return nil }
-
-            return String(decoding: jsonData, as: UTF8.self)
-        }
-    }
-
-    var jsonString: String? {
-        state.jsonString
-    }
-
-    private func saveState(state: State) {
-        return
-    }
-
-    private static var persistentDirectory: String? {
-        guard let userID = ZMUser.selfUser()?.remoteIdentifier else { return nil }
-
-        return "UI_state/\(userID)"
-    }
-
-    private static var persistentFilename: String {
-        let className = String(describing: self)
-        return "\(className).json"
-    }
-
-    static var persistentURL: URL? {
-        guard let persistentDirectory else { return nil }
-
-        return URL.directoryURL(persistentDirectory)?
-            .appendingPathComponent(ConversationListViewModel.persistentFilename)
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModelDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModelDelegate.swift
@@ -34,10 +34,6 @@ protocol ConversationListViewModelDelegate: AnyObject {
 
     func listViewModel(_ model: ConversationListViewModel?, didUpdateSectionForReload section: Int, animated: Bool)
 
-    func listViewModel(_ model: ConversationListViewModel?, didChangeFolderEnabled folderEnabled: Bool)
-
-    func listViewModel(_ model: ConversationListViewModel?, didUpdateSection section: Int)
-
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)?,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Folders/FolderPickerViewControllerBuilder.swift
@@ -31,7 +31,7 @@ struct FolderPickerViewControllerBuilder {
 
     @MainActor
     func build(mainCoordinator: AnyMainCoordinator, showCloseButton: Bool) -> UIViewController {
-        let folders: [FolderPickerOption] = conversationDirectory.allFolders.compactMap {
+        let folders: [FolderPickerOption] = conversationDirectory.nonDeletedFolders.compactMap {
             guard let id = $0.remoteIdentifier, let title = $0.name else { return nil }
 
             return FolderPickerOption(id: id, title: title)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Folders/Mappers/WireFolderDirectoryMapper.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Folders/Mappers/WireFolderDirectoryMapper.swift
@@ -27,7 +27,7 @@ struct WireFolderDirectoryMapper: FolderDirectoryTypeProtocol {
     }
 
     var allFolders: [Folder] {
-        directory.allFolders.map { label -> Folder in
+        directory.nonDeletedFolders.map { label -> Folder in
             Folder(identifier: label.remoteIdentifier, name: label.name ?? "")
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ConversationFilterSelector.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ConversationFilterSelector.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireDataModel
+
+/// Updates `conversationFilter` based on system events rather than user selection.
+///
+/// For example, if the current filter is a folder filter, and the folder is deleted, this selector will remove
+/// the filter.
+
+@MainActor
+final class ConversationFilterSelector: @preconcurrency ConversationDirectoryObserver {
+
+    private let mainCoordinator: AnyMainCoordinator
+    private let conversationFilter: () -> ConversationFilter?
+    private var observation: Any?
+
+    /// Creates a new ConversationFilterSelector.
+    ///
+    /// - Parameters:
+    ///  - mainCoordinator: The main coordinator.
+    ///  - conversationFilter: A closure that returns the current conversation filter.
+
+    init(mainCoordinator: AnyMainCoordinator, conversationFilter: @escaping () -> ConversationFilter?) {
+        self.mainCoordinator = mainCoordinator
+        self.conversationFilter = conversationFilter
+    }
+
+    /// Start observing `conversationDirectory`.
+
+    func observe(conversationDirectory: any ConversationDirectoryType) {
+        observation = conversationDirectory.addObserver(self)
+    }
+
+    func conversationDirectoryDidChange(
+        conversationDirectory: ConversationDirectoryType,
+        changeInfo: ConversationDirectoryChangeInfo
+    ) {
+        if case let .folder(id, _) = conversationFilter(),
+           conversationDirectory.nonDeletedFolders.first(where: { $0.remoteIdentifier == id }) == nil {
+            mainCoordinator.applyConversationFilter(.none)
+        }
+    }
+}

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ConversationFilterSelector.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ConversationFilterSelector.swift
@@ -26,8 +26,8 @@ import WireDataModel
 @MainActor
 final class ConversationFilterSelector: @preconcurrency ConversationDirectoryObserver {
 
-    private let mainCoordinator: AnyMainCoordinator
     private let conversationFilter: () -> ConversationFilter?
+    private let updateConversationFilter: (ConversationFilter?) -> Void
     private var observation: Any?
 
     /// Creates a new ConversationFilterSelector.
@@ -36,9 +36,12 @@ final class ConversationFilterSelector: @preconcurrency ConversationDirectoryObs
     ///  - mainCoordinator: The main coordinator.
     ///  - conversationFilter: A closure that returns the current conversation filter.
 
-    init(mainCoordinator: AnyMainCoordinator, conversationFilter: @escaping () -> ConversationFilter?) {
-        self.mainCoordinator = mainCoordinator
+    init(
+        conversationFilter: @escaping () -> ConversationFilter?,
+        updateConversationFilter: @escaping (ConversationFilter?) -> Void
+    ) {
         self.conversationFilter = conversationFilter
+        self.updateConversationFilter = updateConversationFilter
     }
 
     /// Start observing `conversationDirectory`.
@@ -53,7 +56,7 @@ final class ConversationFilterSelector: @preconcurrency ConversationDirectoryObs
     ) {
         if case let .folder(id, _) = conversationFilter(),
            conversationDirectory.nonDeletedFolders.first(where: { $0.remoteIdentifier == id }) == nil {
-            mainCoordinator.applyConversationFilter(.none)
+            updateConversationFilter(nil)
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -46,6 +46,13 @@ final class ZClientViewController: UIViewController {
 
     private(set) var conversationRootViewController: UIViewController?
 
+    private lazy var conversationFilterSelector = ConversationFilterSelector(
+        mainCoordinator: AnyMainCoordinator(mainCoordinator: mainCoordinator),
+        conversationFilter: { [weak conversationListViewController] in
+            conversationListViewController?.conversationFilter
+        }
+    )
+
     var currentConversation: ZMConversation? {
         conversationListViewController.selectedConversation
     }
@@ -320,6 +327,8 @@ final class ZClientViewController: UIViewController {
             await updateCachedAccountImage()
             await updateCachedAccountInfo()
         }
+
+        conversationFilterSelector.observe(conversationDirectory: userSession.conversationDirectory)
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController.swift
@@ -47,9 +47,11 @@ final class ZClientViewController: UIViewController {
     private(set) var conversationRootViewController: UIViewController?
 
     private lazy var conversationFilterSelector = ConversationFilterSelector(
-        mainCoordinator: AnyMainCoordinator(mainCoordinator: mainCoordinator),
         conversationFilter: { [weak conversationListViewController] in
             conversationListViewController?.conversationFilter
+        },
+        updateConversationFilter: { [weak mainCoordinator] filter in
+            mainCoordinator?.applyConversationFilter(filter)
         }
     )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-13905" title="WPB-13905" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-13905</a>  [iOS] Remove `Folder` filter if folder deleted - edge case for improvement
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently when the folder filter is applied and the folder is deleted by removing its final conversation (locally or remotely), the folder filter remains leaving an empty conversation list.

This PR ensures the folder filter is removed when the folder is deleted. Specifically it:

- Introduces `ConversationFilterSelector` that updates the conversation filter based on system events rather than user selection - for now it only handles folder deletions but could handle the events if needed.
- Introduces a way of setting the current filter via the main coordinator without causing other navigation
- Replaces `ConversationDirectoryType.allFolders` with `ConversationDirectoryType.nonDeletedFolders` - the users of ConversationDirectoryType only care about folders that are not marked for deletion.
- Removes a bunch of dead code leftover from when folders we displayed as collapsable sections.

### Old


https://github.com/user-attachments/assets/104f80dc-4497-4c4e-97fb-4f4ab2177fab



### New


https://github.com/user-attachments/assets/3ce68d25-7e1f-4155-a7c0-9d3fc1ace940



### Testing

Please test on iPhone & iPad

#### Locally

1. Navigate to Conversations tab
2. Long press on a conversation
3. Tap "Move to..."
4. Tap `+` icon
5. Enter a folder name and tap "Create"
6. Tap the filter button
7. Select the folder from step `5` 
8. Verify the conversations list is filtered by the folder
9. Long press then conversation.
10. Tap "Remove from <folder name>"
11. Verify the conversations list filter is removed an all conversations are shown.

#### Remotely

1. On device 1 do steps 1-8 from above
2. On device 2 remove the conversation from the folder
3. On device 1 verify the conversations list filter is removed an all conversations are shown.


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.