### PR TITLE
fix: prevent credentials from being logged - WPB-14251

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -20,8 +20,6 @@ import avs
 import Combine
 import Foundation
 
-private let zmLog = ZMSLog(tag: "calling")
-
 /// WireCallCenter is used for making Wire calls and observing their state. There can only be one instance of the
 /// WireCallCenter.
 ///
@@ -942,7 +940,7 @@ extension WireCallCenterV3 {
         overMLSSelfConversation: Bool = false
     ) {
         Self.logger.info("sending call message for AVS")
-        zmLog.debug("\(self): send call message, transport = \(String(describing: transport))")
+        Self.logger.debug("\(self): send call message, transport = \(String(describing: transport))")
         transport?.send(
             data: data,
             conversationId: conversationId,
@@ -957,10 +955,10 @@ extension WireCallCenterV3 {
     /// Sends an SFT call message when requested by AVS through `wcall_sft_req_h`.
     func sendSFT(token: WireCallMessageToken, url: String, data: Data) {
         Self.logger.info("sending SFT message for AVS")
-        zmLog.debug("\(self): send SFT call message, transport = \(String(describing: transport))")
+        Self.logger.debug("\(self): send SFT call message, transport = \(String(describing: transport))")
 
         guard let endpoint = URL(string: url) else {
-            zmLog.error("SFT request failed. Invalid url: \(url)")
+            Self.logger.error("SFT request failed. Invalid url: \(url)")
             avsWrapper.handleSFTResponse(data: nil, context: token)
             return
         }
@@ -968,7 +966,7 @@ extension WireCallCenterV3 {
         transport?.sendSFT(data: data, url: endpoint) { [weak self] result in
             switch result {
             case let .failure(error):
-                zmLog.error("SFT request failed: \(error.localizedDescription)")
+                Self.logger.error("SFT request failed: \(error.localizedDescription)")
                 self?.avsWrapper.handleSFTResponse(data: nil, context: token)
 
             case let .success(data):
@@ -979,17 +977,17 @@ extension WireCallCenterV3 {
 
     /// Sends the config request when requested by AVS through `wcall_config_req_h`.
     func requestCallConfig() {
-        zmLog.debug("\(self): requestCallConfig(), transport = \(String(describing: transport))")
+        Self.logger.debug("\(self): requestCallConfig(), transport = \(String(describing: transport))")
         transport?.requestCallConfig(completionHandler: { [weak self] config, httpStatusCode in
             guard let self else { return }
-            zmLog.debug("\(self): self.avsWrapper.update with \(String(describing: config))")
+            Self.logger.debug("\(self): self.avsWrapper.update with \(String(describing: config))")
             avsWrapper.update(callConfig: config, httpStatusCode: httpStatusCode)
         })
     }
 
     /// Tags a call as missing when requested by AVS through `wcall_missed_h`.
     func missed(conversationId: AVSIdentifier, userId: AVSIdentifier, timestamp: Date, isVideoCall: Bool) {
-        zmLog.debug("missed call")
+        Self.logger.debug("missed call")
 
         if let context = uiMOC {
             WireCallCenterMissedCallNotification(

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -84,7 +84,10 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
                 // We can end up here because more than one request can be sent for a single action/phase.
                 // This is an issue in some other part of SyncEngine but as a quick fix we will log and abort here.
                 let phaseString = registrationStatus.phase.map { "\($0)" } ?? "<nil>"
-                WireLogger.authentication.error("Recieved unsuccessful response for invalid phase (\(phaseString))", attributes: .safePublic)
+                WireLogger.authentication.error(
+                    "Recieved unsuccessful response for invalid phase (\(phaseString))",
+                    attributes: .safePublic
+                )
                 return assertionFailure("Error occurs for invalid phase: \(phaseString)")
             }
             registrationStatus.handleError(error)

--- a/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
+++ b/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
@@ -73,7 +73,21 @@ final class CocoaLumberjackLogger: LoggerProtocol {
         //    return
         // }
 
-        guard isDebug || (level.rawValue <= DDLogLevel.info.rawValue) else { return }
+        // Filter logs by level:
+        // Only continue if we're running a DEBUG build or
+        // the level is greater than or equal to error and lower than or equal to info.
+        //
+        // DDLogLevelOff     00000 0
+        // DDLogLevelError   00001 1
+        // DDLogLevelWarning 00011 3
+        // DDLogLevelInfo    00111 7
+        // DDLogLevelDebug   01111 15
+        // DDLogLevelVerbose 11111 31
+        // DDLogLevelAll  1..11111 UInt.max
+        guard
+            isDebug ||
+            (level.rawValue >= DDLogLevel.error.rawValue && level.rawValue <= DDLogLevel.info.rawValue)
+        else { return }
 
         var entry =
             "[\(formattedLevel(level))] \(message.logDescription)\(attributesDescription(from: mergedAttributes))"

--- a/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
+++ b/wire-ios-system/Source/Logging/CocoaLumberjackLogger.swift
@@ -73,6 +73,8 @@ final class CocoaLumberjackLogger: LoggerProtocol {
         //    return
         // }
 
+        guard isDebug || (level.rawValue <= DDLogLevel.info.rawValue) else { return }
+
         var entry =
             "[\(formattedLevel(level))] \(message.logDescription)\(attributesDescription(from: mergedAttributes))"
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -180,7 +180,11 @@ final class AuthenticationEventResponderChain {
     /// - parameter eventType: The type of event that occured, and any required context.
 
     func handleEvent(ofType eventType: EventType) {
-        log.info("Event handling manager received event: \(eventType)")
+        if case .userInput = eventType {
+            log.info("Event handling manager received event: userInput")
+        } else {
+            log.info("Event handling manager received event: \(eventType)")
+        }
 
         switch eventType {
         case let .flowStart(error, numberOfAccounts):

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationLoginCredentialsInputHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/Input/AuthenticationLoginCredentialsInputHandler.swift
@@ -47,7 +47,12 @@ final class AuthenticationLoginCredentialsInputHandler: AuthenticationEventHandl
 
 }
 
-struct EmailPasswordInput {
+struct EmailPasswordInput: CustomStringConvertible {
+
     var email: String
     var password: String
+
+    var description: String {
+        String(describing: Self.self)
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/PasscodeSetupViewController.swift
@@ -97,7 +97,8 @@ final class PasscodeSetupViewController: UIViewController {
     private lazy var infoLabel: UILabel = {
         let label = DynamicFontLabel(
             fontSpec: .normalRegularFont,
-            color: ColorTheme.Backgrounds.onSurfaceVariant)
+            color: ColorTheme.Backgrounds.onSurfaceVariant
+        )
         label.textAlignment = .center
         label.configMultipleLineLabel()
         return label
@@ -222,8 +223,14 @@ final class PasscodeSetupViewController: UIViewController {
             contentView.widthAnchor.constraint(lessThanOrEqualToConstant: 375),
             contentView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
             contentView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor),
-            contentView.leadingAnchor.constraint(greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor, constant: contentPadding),
-            contentView.trailingAnchor.constraint(lessThanOrEqualTo: contentLayoutGuide.trailingAnchor, constant: -contentPadding),
+            contentView.leadingAnchor.constraint(
+                greaterThanOrEqualTo: contentLayoutGuide.leadingAnchor,
+                constant: contentPadding
+            ),
+            contentView.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentLayoutGuide.trailingAnchor,
+                constant: -contentPadding
+            ),
             contentView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
 
             // stack view


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14251" title="WPB-14251" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14251</a>  [sec] credentials logged to file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR 
- replaces ZMSLog statements by WireLogger, where debug logs are not logged in production
- prevents user input during of being logged

### Testing

- Use the app
- Go into Settings - Advanced - Debug Report and inspect the generated file logs.zip

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
