### PR TITLE
fix: Crash when viewing conversation details with no admins - WPB-14572

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/ParticipantsSectionController.swift
@@ -186,6 +186,7 @@ final class ParticipantsSectionController: GroupDetailsSectionController {
     private var viewModel: ParticipantsSectionViewModel
     private let conversation: GroupDetailsConversationType
     private var token: NSObjectProtocol?
+    private lazy var sizingFooter = SectionFooter()
 
     init(
         participants: [UserType],
@@ -299,17 +300,12 @@ final class ParticipantsSectionController: GroupDetailsSectionController {
         referenceSizeForFooterInSection section: Int
     ) -> CGSize {
 
-        guard
-            viewModel.footerVisible,
-            let footer = collectionView.dequeueFooter(for: IndexPath(item: 0, section: section)) as? SectionFooter
-        else {
-            return .zero
-        }
+        guard viewModel.footerVisible else { return .zero }
 
-        footer.titleLabel.text = viewModel.footerTitle
-        footer.size(fittingWidth: collectionView.bounds.width)
+        sizingFooter.titleLabel.text = viewModel.footerTitle
+        sizingFooter.size(fittingWidth: collectionView.bounds.width)
 
-        return footer.bounds.size
+        return sizingFooter.bounds.size
     }
 
     override func collectionView(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14572" title="WPB-14572" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14572</a>  [iOS] Crash accessing Details of group user has left
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes a crash that occurs when viewing the details of a conversation with no admins. (Yes, that is a messy state to be in and we will raise this topic elsewhere)

The crash is a UIKit precondition due to us dequeuing a section footer in order to read its size. We should not do this. We should only dequeue when asked to by UIKit.

The fix is to not dequeue a footer and instead keep one around for sizing.

### Testing

1. Tap Create Group
2. Name group and tap Next
3. Add a participant and tap Done
4. Navigate back to conversation list
5. Long press new group
6. Tap Leave Group...
7. Tap Leave
8. Navigate to Archive
9. Tap on the group
10. Navigate to conversation details by tapping group title
11. Verify there is no crash

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
