### PR TITLE
fix: do not disable `Go deep link` button in the developer tools - WPB-14547

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeepLinks/DeepLinksView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeepLinks/DeepLinksView.swift
@@ -36,8 +36,8 @@ struct DeepLinksView: View {
                     Button("Go") {
                         viewModel.openLink(urlString: urlString)
                     }
+                    .disabled(urlString.isEmpty)
                 }
-                .disabled(urlString.isEmpty)
             }
             .listStyle(InsetGroupedListStyle())
             .frame(height: 150)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14547" title="WPB-14547" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14547</a>  [iOS] Add QRCode reader for deep links to the Developer tools
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Bug was introduces [here](https://github.com/wireapp/wire-ios/pull/2187).
We should disable only the `Go` button if deep link input field is empty in the developer tools.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
