### PR TITLE
fix: Using camera to update profile picture - WPB-14659

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/Image/ImagePickerManager.swift
@@ -84,7 +84,7 @@ class ImagePickerManager: NSObject {
 
             Task { @MainActor in
                 self.getImage(
-                    fromSourceType: .photoLibrary,
+                    fromSourceType: .camera,
                     viewController: viewController,
                     popoverConfiguration: popoverConfiguration
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14659" title="WPB-14659" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14659</a>  [iOS] Cannot take photo on profile picture
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When implementing https://github.com/wireapp/wire-ios/pull/2100 a copy and paste error led to me getting rid of the ability to set the profile image using the camera. This PR fixes this.

### Testing

**Please test on both iPhone & iPad**

1. Tap profile icon to navigate to profile
2. Tap profile picture
3. Tap "Take Photo"
4. If asked for camera permission, tap "Allow"
5. Take a photo
6. Tap "Use Photo"
7. Close the profile page
8. Navigate to "Settings -> Account" tab
9. Tap "Profile Picture"
3. Tap "Take Photo"
5. Take a photo
6. Tap "Use Photo"

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.