### PR TITLE
fix: slow sync instead of resync in case of no last event id - WPB-14794

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/SyncStatus.swift
@@ -129,8 +129,8 @@ public class SyncStatus: NSObject, SyncStatusProtocol, SyncProgress {
     public func resyncResources() {
         // Refetch user settings.
         ZMUser.selfUser(in: managedObjectContext).needsPropertiesUpdate = true
-        // Set the status.
-        currentSyncPhase = SyncPhase.fetchingLastUpdateEventID.nextPhase
+        // If we don't have a last event id, we need to get that first, otherwise the quick sync will fetch all events in the notification queue.
+        currentSyncPhase = hasPersistedLastEventID ? SyncPhase.fetchingLastUpdateEventID.nextPhase : .fetchingLastUpdateEventID
         RequestAvailableNotification.notifyNewRequestsAvailable(nil)
         log("resyncResources")
         syncStateDelegate?.didStartSlowSync()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14794" title="WPB-14794" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14794</a>  [iOS] Recover from interrupted DB migrations resulting from federation being turned on
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In case a user logs in fresh, restores an old backup, then a database migration will trigger a resync of resources. This will override the slow sync that happens after a login, which means that we skip the step of fetching the last event id. As a result, after the resync finishes, a quick sync will start, and because there is no last event id, it will fetch **ALL OF THE EVENTS FROM THE BACKEND** which may take a very long time to finish.

The solution is when triggering a resync, to check if we need to start with fetching the last id or if we can already skip that step.

Note, it's important not to fetch the last event id if we have one locally because doing some may mean we skip fetching some events from the backend.

### Testing

1. Install 3.114.1, login fresh restore a backup
2. Assert that sync happens but in the normal expected time

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
