### PR TITLE
fix: new event decoding monitor - WPB-8700

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Responses/UpdateEventEnvelopeV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Responses/UpdateEventEnvelopeV0.swift
@@ -18,7 +18,9 @@
 
 import Foundation
 
-struct UpdateEventEnvelopeV0: Decodable, ToAPIModelConvertible {
+// TODO: [WPB-9612] make internal
+// This is public for testing purposes.
+public struct UpdateEventEnvelopeV0: Decodable, ToAPIModelConvertible {
 
     let id: UUID
     let payload: [UpdateEventDecodingProxy]?

--- a/wire-ios-sync-engine/Source/Synchronization/ZMOperationLoop+PushChannel.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMOperationLoop+PushChannel.swift
@@ -31,7 +31,7 @@ extension ZMOperationLoop: ZMPushChannelConsumer {
             // fix it. Once we're sure it works, we should remove this.
             do {
                 let decoder = JSONDecoder.defaultDecoder
-                _ = try decoder.decode(UpdateEventEnvelope.self, from: data)
+                _ = try decoder.decode(UpdateEventEnvelopeV0.self, from: data)
             } catch {
                 WireLogger.updateEvent.error("failed to decode 'UpdateEventEnvelope': \(error)")
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-8700" title="WPB-8700" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-8700</a>  [iOS] Rewrite quick sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The event decoding monitor (to catch decoding failures of new update events) is failing because the wrong event envelope is being decoded.

The solution is to decode the correct envelope, which requires making an internal payload public. We'll make it internal again after the monitor is removed.


### Testing

Receive events via the push channel and check data dog for decoding errors.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
