### PR TITLE
fix: reference to the xcresult analyzation action - WPB-11406

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -213,7 +213,7 @@ jobs:
         run: ls -R
       
       - name: Analyze .xcresult file
-        uses: kronenthaler/analyze-xcoderesults-action@0.1.9
+        uses: wireapp/analyze-xcoderesults-action@v1
         with:
           results: ${{ matrix.xcresult_file }}
           warningAnnotations: true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11406" title="WPB-11406" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-11406</a>  Refactor CI tests workflow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In the CI refactoring the wrong xcresult analyze action was set.
It causes failures in the CI.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
