### PR TITLE
crashfix: move typing users related objects back to WireSyncEngine - no ticket

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/ConversationLocalStore.swift
@@ -598,10 +598,12 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
                     context.object(with: $0) as? ZMUser
                 }
 
-                context.typingUsers?.update(
-                    typingUsers: Set(users),
-                    in: conversation
-                )
+                // TODO: [WPB-14889] Implement a new mechanism to send events from WireDomain to the UI
+                
+//                context.typingUsers?.update(
+//                    typingUsers: Set(users),
+//                    in: conversation
+//                )
 
                 self.notifyTypingUsers(
                     Set(users),
@@ -1004,10 +1006,11 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         _ typingUsers: Set<ZMUser>,
         in conversation: ZMConversation
     ) {
+        let typingNotificationName = Notification.Name(rawValue: "ZMTypingNotification")
         let typingNotificationUsersKey = "typingUsers"
 
         NotificationInContext(
-            name: .typingNotification,
+            name: typingNotificationName,
             context: context.notificationContext,
             object: self,
             userInfo: [typingNotificationUsersKey: typingUsers]

--- a/WireDomain/Tests/WireDomainTests/LocalStores/ConversationLocalStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/LocalStores/ConversationLocalStoreTests.swift
@@ -455,8 +455,10 @@ final class ConversationLocalStoreTests: XCTestCase {
             users: Set([userObjectID]),
             conversationID: conversationObjectID
         )
+        
+        let typingNotificationName = Notification.Name(rawValue: "ZMTypingNotification")
 
-        subscription = NotificationCenter.default.publisher(for: .typingNotification)
+        subscription = NotificationCenter.default.publisher(for: typingNotificationName)
             .compactMap { $0.userInfo?["typingUsers"] as? Set<ZMUser> }
             .sink { typingUsers in
                 // Then

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -516,8 +516,6 @@
 		BFF8AE8520E4E12A00988700 /* ZMMessage+ShouldDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF8AE8420E4E12A00988700 /* ZMMessage+ShouldDisplay.swift */; };
 		BFFBFD931D59E3F00079773E /* ConversationMessage+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */; };
 		BFFBFD951D59E49D0079773E /* ZMClientMessageTests+Deletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */; };
-		C9D574D32CEF630500012A0E /* TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D574D22CEF630500012A0E /* TypingUsers.swift */; };
-		C9D574D52CEF63AC00012A0E /* NSManagedObjectContext+TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D574D42CEF63AC00012A0E /* NSManagedObjectContext+TypingUsers.swift */; };
 		CB1BF6FC2C8AF6A5001EC670 /* ExpirationReason+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1BF6FB2C8AF6A5001EC670 /* ExpirationReason+Description.swift */; };
 		CB7979182C747652006FBA58 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7979172C747652006FBA58 /* WireTransportSupport.framework */; };
 		CB79791B2C7476AC006FBA58 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB79791A2C7476AC006FBA58 /* TestSetup.swift */; };
@@ -1429,8 +1427,6 @@
 		BFF8AE8420E4E12A00988700 /* ZMMessage+ShouldDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+ShouldDisplay.swift"; sourceTree = "<group>"; };
 		BFFBFD921D59E3F00079773E /* ConversationMessage+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ConversationMessage+Deletion.swift"; sourceTree = "<group>"; };
 		BFFBFD941D59E49D0079773E /* ZMClientMessageTests+Deletion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Deletion.swift"; sourceTree = "<group>"; };
-		C9D574D22CEF630500012A0E /* TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingUsers.swift; sourceTree = "<group>"; };
-		C9D574D42CEF63AC00012A0E /* NSManagedObjectContext+TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+TypingUsers.swift"; sourceTree = "<group>"; };
 		CB1BF6FB2C8AF6A5001EC670 /* ExpirationReason+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExpirationReason+Description.swift"; sourceTree = "<group>"; };
 		CB7979172C747652006FBA58 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB79791A2C7476AC006FBA58 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
@@ -2470,15 +2466,6 @@
 			name = Accounts;
 			sourceTree = "<group>";
 		};
-		C9D574D12CEF62DB00012A0E /* TypingUsers */ = {
-			isa = PBXGroup;
-			children = (
-				C9D574D22CEF630500012A0E /* TypingUsers.swift */,
-				C9D574D42CEF63AC00012A0E /* NSManagedObjectContext+TypingUsers.swift */,
-			);
-			path = TypingUsers;
-			sourceTree = "<group>";
-		};
 		CE4EDC071D6D9A04002A20AA /* Reaction */ = {
 			isa = PBXGroup;
 			children = (
@@ -2877,7 +2864,6 @@
 		F9A705D91CAEE01D00C2F5FE /* Conversation */ = {
 			isa = PBXGroup;
 			children = (
-				C9D574D12CEF62DB00012A0E /* TypingUsers */,
 				63C2EABB2A93B14D008A0AB7 /* Actions */,
 				A943BBE725B5A59D003D66BA /* ConversationLike.swift */,
 				F1103BD82135471A00EB9ED6 /* Calling */,
@@ -4442,7 +4428,6 @@
 				EE9AD9162696F01700DD5F51 /* FeatureRepository.swift in Sources */,
 				63B1337329A798C800009D84 /* ProteusProvider.swift in Sources */,
 				0630E4B6257F888600C75BFB /* NSManagedObjectContext+AppLock.swift in Sources */,
-				C9D574D52CEF63AC00012A0E /* NSManagedObjectContext+TypingUsers.swift in Sources */,
 				63495E1B23FED9A9002A7C59 /* ZMUser+Protobuf.swift in Sources */,
 				EEF4010723A9213B007B1A97 /* UserType+Team.swift in Sources */,
 				EE4CCA95256C558400848212 /* Feature.AppLock.swift in Sources */,
@@ -4503,7 +4488,6 @@
 				E6E504412BC542C5004948E7 /* PublicEARKeyDescription.swift in Sources */,
 				F9C877091E000C9D00792613 /* AssetCollection.swift in Sources */,
 				169315EF25AC4C8100709F15 /* MigrateSenderClient.swift in Sources */,
-				C9D574D32CEF630500012A0E /* TypingUsers.swift in Sources */,
 				BF10B58B1E6432ED00E7036E /* Message.swift in Sources */,
 				59F4B6F22B87563E00AC84B1 /* IsUserE2EICertifiedUseCaseProtocol.swift in Sources */,
 				E6E504342BC542C5004948E7 /* BaseEARKeyDescription.swift in Sources */,

--- a/wire-ios-sync-engine/Source/Data Model/NSManagedObjectContext+TypingUsers.swift
+++ b/wire-ios-sync-engine/Source/Data Model/NSManagedObjectContext+TypingUsers.swift
@@ -23,7 +23,7 @@ extension NSManagedObjectContext {
 
     private static let TypingUsersKey = "ZMTypingUsers"
 
-    public var typingUsers: TypingUsers? {
+    var typingUsers: TypingUsers? {
         guard zm_isUserInterfaceContext else { return nil }
 
         if let users = userInfo[NSManagedObjectContext.TypingUsersKey] as? TypingUsers {

--- a/wire-ios-sync-engine/Source/Data Model/TypingUsers.swift
+++ b/wire-ios-sync-engine/Source/Data Model/TypingUsers.swift
@@ -16,12 +16,10 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-public extension Notification.Name {
-    static let typingNotification = Notification.Name("ZMTypingNotification")
-}
+import Foundation
 
 @objc
-public class TypingUsers: NSObject {
+class TypingUsers: NSObject {
 
     // MARK: - Properties
 
@@ -30,7 +28,7 @@ public class TypingUsers: NSObject {
     // MARK: - Internal Methods
 
     @objc(updateTypingUsers:inConversation:)
-    public func update(typingUsers: Set<ZMUser>, in conversation: ZMConversation) {
+    func update(typingUsers: Set<ZMUser>, in conversation: ZMConversation) {
         let conversationId = conversation.objectID
         require(!conversationId.isTemporaryID)
 
@@ -45,7 +43,7 @@ public class TypingUsers: NSObject {
         conversationIdToUserIds[conversationId] = userIds
     }
 
-    public func typingUsers(in conversation: ZMConversation) -> Set<ZMUser> {
+    func typingUsers(in conversation: ZMConversation) -> Set<ZMUser> {
         let conversationId = conversation.objectID
 
         guard

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -424,6 +424,8 @@
 		BF8367311C52651900364B37 /* store125.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BF8367301C52651900364B37 /* store125.wiredatabase */; };
 		BFCE9A5B1C4E4C4D00951B3D /* store124.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = BFCE9A581C4E4C4D00951B3D /* store124.wiredatabase */; };
 		BFE7FCBF2101E50700D1165F /* CompanyLoginVerificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7FCBE2101E50700D1165F /* CompanyLoginVerificationToken.swift */; };
+		C95078AF2D09950500D7D1DC /* TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95078AD2D09950500D7D1DC /* TypingUsers.swift */; };
+		C95078B02D09950500D7D1DC /* NSManagedObjectContext+TypingUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95078AE2D09950500D7D1DC /* NSManagedObjectContext+TypingUsers.swift */; };
 		CB4895532C4FB77C00CA2C25 /* WireTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4895522C4FB77C00CA2C25 /* WireTesting.framework */; };
 		CBD3AED02C4A742B007643A0 /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD3AECF2C4A742B007643A0 /* TestSetup.swift */; };
 		D522571E2062552800562561 /* AssetDeletionRequestStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D522571D2062552800562561 /* AssetDeletionRequestStrategy.swift */; };
@@ -1127,6 +1129,8 @@
 		BFCE9A581C4E4C4D00951B3D /* store124.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = store124.wiredatabase; sourceTree = "<group>"; };
 		BFE7FCBE2101E50700D1165F /* CompanyLoginVerificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanyLoginVerificationToken.swift; sourceTree = "<group>"; };
 		C3BF3961360B7EB12679AF27 /* ZMOperationLoopTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZMOperationLoopTests.swift; sourceTree = "<group>"; };
+		C95078AD2D09950500D7D1DC /* TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingUsers.swift; sourceTree = "<group>"; };
+		C95078AE2D09950500D7D1DC /* NSManagedObjectContext+TypingUsers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+TypingUsers.swift"; sourceTree = "<group>"; };
 		CB4895522C4FB77C00CA2C25 /* WireTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB79AC7B2C6DFAA2003CF5F4 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBD3AECF2C4A742B007643A0 /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
@@ -1684,7 +1688,9 @@
 				EE1108FA23D2087F005DC663 /* Typing.swift */,
 				EE1108F823D1F945005DC663 /* TypingUsersTimeout.swift */,
 				EE1DEBBC23D5E0390087EE1F /* TypingUsersTimeout+Key.swift */,
+				C95078AD2D09950500D7D1DC /* TypingUsers.swift */,
 				16F5F16B1E4092C00062F0AE /* NSManagedObjectContext+CTCallCenter.swift */,
+				C95078AE2D09950500D7D1DC /* NSManagedObjectContext+TypingUsers.swift */,
 				0640C26C26EA0B5C0057AF80 /* NSManagedObjectContext+Packaging.swift */,
 				16085B321F71811A000B9F22 /* UserChangeInfo+UserSession.swift */,
 				8754B8491F73C25400EC02AD /* ConversationListChangeInfo+UserSession.swift */,
@@ -3491,6 +3497,8 @@
 				549710081F6FF5C100026EDD /* NotificationInContext+UserSession.swift in Sources */,
 				16D0A11D234C8CD700A83F87 /* LabelUpstreamRequestStrategy.swift in Sources */,
 				63FE4B9E25C1D2EC002878E5 /* VideoGridPresentationMode.swift in Sources */,
+				C95078AF2D09950500D7D1DC /* TypingUsers.swift in Sources */,
+				C95078B02D09950500D7D1DC /* NSManagedObjectContext+TypingUsers.swift in Sources */,
 				8798607B1C3D48A400218A3E /* DeleteAccountRequestStrategy.swift in Sources */,
 				E9A96E7E2B88E0EA00914FDD /* ResolveOneOnOneConversationsUseCase.swift in Sources */,
 				E967757F2BD8237D00EFEED5 /* SetAllowGuestAndServicesUseCase.swift in Sources */,


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->
no ticket
<!--jira-description-action-hidden-marker-end-->

### Issue

A crash related to typing users was **most likely** introduced in one of the quick sync related PR (ticket WPB-10178 PR #2194) where some objects were moved from WireSyncEngine to WireDataModel so they could be accessed by WireDomain.

This PR moves these files back to WireSyncEngine, just like it was before.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
