### PR TITLE
fix: crash ipad - WPB-14999

### DIFF
--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/CancellationSheet.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/CancellationSheet.swift
@@ -27,7 +27,7 @@ func cancellationSheetFactory(
     let alert = UIAlertController(
         title: String.localized(key: "individualToTeam.cancellation.title", bundle: .module),
         message: String.localized(key: "individualToTeam.cancellation.body", bundle: .module),
-        preferredStyle: .actionSheet
+        preferredStyle: UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
     )
     alert.addAction(UIAlertAction(
         title: String.localized(key: "individualToTeam.cancellation.leave", bundle: .module),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14999" title="WPB-14999" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14999</a>  Personal to Team: Bottom sheet on iPad crash
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

On iPad, cancelling the workflow of Individual to team crashes with error:

```
your application has presented a UIAlertController (<UIAlertController: 0x11301c400>) of style UIAlertControllerStyleActionSheet from WireIndividualToTeamMigrationUI.IndividualToTeamMigrationViewController (<WireIndividualToTeamMigrationUI.IndividualToTeamMigrationViewController: 0x11105a600>). The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'
```

Solution:

Change type of alert style.

### Testing

![IMG_0030](https://github.com/user-attachments/assets/bf5481a9-975f-428e-b355-55ddd1726e44)
---
