### PR TITLE
fix: Some flaky tests - WPB-15021

### DIFF
--- a/WireAPI/Tests/WireAPITests/Network/PushChannel/WebSocketTests.swift
+++ b/WireAPI/Tests/WireAPITests/Network/PushChannel/WebSocketTests.swift
@@ -80,13 +80,13 @@ final class WebSocketTests: XCTestCase {
         }
 
         // Wait for iteration to be in progress
-        await fulfillment(of: [didReceiveMessage], timeout: 0.5)
+        await fulfillment(of: [didReceiveMessage], timeout: 1)
 
         // When
         sut.close()
 
         // Then the stream finished successfully
-        await fulfillment(of: [didFinishIterating], timeout: 0.5)
+        await fulfillment(of: [didFinishIterating], timeout: 1)
 
         // Then the connection was cancelled
         let invocations = connection.cancelWithReason_Invocations
@@ -125,13 +125,13 @@ final class WebSocketTests: XCTestCase {
         }
 
         // Wait for iteration to be in progress
-        await fulfillment(of: [didReceiveMessage], timeout: 0.5)
+        await fulfillment(of: [didReceiveMessage], timeout: 1)
 
         // When
         connection.underlyingIsOpen = false
 
         // Then the stream finished successfully
-        await fulfillment(of: [didFinishIterating], timeout: 0.5)
+        await fulfillment(of: [didFinishIterating], timeout: 1)
     }
 
     func testWebSocketFinishesIfConnectionHasError() async throws {
@@ -166,13 +166,13 @@ final class WebSocketTests: XCTestCase {
         }
 
         // Wait for iteration to be in progress
-        await fulfillment(of: [didReceiveMessage], timeout: 0.5)
+        await fulfillment(of: [didReceiveMessage], timeout: 1)
 
         // When
         shouldSendError = true
 
         // Then the stream finished with an error
-        await fulfillment(of: [didFinishIteratingDueToError], timeout: 0.5)
+        await fulfillment(of: [didFinishIteratingDueToError], timeout: 1)
     }
 
     func testWebSocketIteratesSuccessfully() async throws {

--- a/wire-ios-cryptobox/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
+++ b/wire-ios-cryptobox/WireCryptoboxTests/EncryptionSessionsDirectoryTests.swift
@@ -607,7 +607,7 @@ extension EncryptionSessionsDirectoryTests {
         _ = try! statusAlice.encrypt(plainText, for: Person.Bob.identifier)
 
         // THEN
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token)
@@ -660,7 +660,7 @@ extension EncryptionSessionsDirectoryTests {
         )
 
         // THEN
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token)
@@ -689,7 +689,7 @@ extension EncryptionSessionsDirectoryTests {
         _ = try! statusBob.decrypt(message, from: Person.Alice.identifier)
 
         // THEN
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token)

--- a/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSActionExecutorTests.swift
@@ -293,7 +293,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         _ = try await sut.processWelcomeMessage(message)
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     // MARK: - Add members
@@ -392,7 +392,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         _ = try await sut.addMembers([], to: .random())
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     // MARK: - Remove clients
@@ -645,7 +645,7 @@ class MLSActionExecutorTests: ZMBaseManagedObjectTest {
         _ = try await sut.joinGroup(.random(), groupInfo: .random())
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     // MARK: - Decrypt Message

--- a/wire-ios-data-model/Tests/MLS/MLSGroupVerificationTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSGroupVerificationTests.swift
@@ -76,7 +76,7 @@ final class MLSGroupVerificationTests: XCTestCase {
         mlsGroupVerification.startObserving()
         streamContinuation.yield(mlsGroupID)
 
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         // then
         let groupIDs = mockUpdateVerificationStatus.invokeForGroupID_Invocations.map(\.groupID)
@@ -108,7 +108,7 @@ final class MLSGroupVerificationTests: XCTestCase {
         mlsGroupVerification = nil
         streamContinuation.yield(mlsGroupID)
 
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         // then
         XCTAssert(mockUpdateVerificationStatus.invokeForGroupID_Invocations.isEmpty)

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -348,7 +348,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         )
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
         _ = waitForAllGroupsToBeEmpty(withTimeout: 0.5)
     }
 
@@ -429,10 +429,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCrypto.createConversationConversationIdCreatorCredentialTypeConfig_MockMethod = { _, _, _ in }
 
         // When
-        try await sut.createGroup(for: groupID)
+        _ = try await sut.createGroup(for: groupID)
 
         // Then
-        await fulfillment(of: [fetchBackendPublicKeysExpectation], timeout: 0.5)
+        await fulfillment(of: [fetchBackendPublicKeysExpectation], timeout: 1)
         XCTAssertEqual(mockStaleMLSKeyDetector.keyingMaterialUpdatedFor_Invocations, [groupID])
     }
 
@@ -448,7 +448,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCrypto.createConversationConversationIdCreatorCredentialTypeConfig_MockMethod = { _, _, _ in }
 
         // When
-        try await sut.createGroup(for: groupID, removalKeys: removalKeys)
+        _ = try await sut.createGroup(for: groupID, removalKeys: removalKeys)
 
         // Then
         let invocation = mockCoreCrypto.createConversationConversationIdCreatorCredentialTypeConfig_Invocations.first
@@ -1282,7 +1282,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         try await sut.performPendingJoins()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         // it fetches public group state
         let groupStateInvocations = mockActionsProvider
@@ -1368,7 +1368,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         try await sut.performPendingJoins()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         // it fetches group info
         let groupInfoInvocations = mockActionsProvider
@@ -1414,7 +1414,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         try await sut.performPendingJoins()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         let groupInfoInvocations = mockActionsProvider
             .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations
@@ -1495,7 +1495,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // THEN
         // Verify expectation that the conversation was rejoined
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
         // Wait for groups that need the current context before its deallocated
         XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
     }
@@ -1525,7 +1525,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // THEN
         // Verify expectation that the conversation was NOT rejoined
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     func test_FetchAndRepairConversation_RejoinsOutOfSyncSubgroup() async throws {
@@ -1565,7 +1565,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // THEN
         // Verify expectation that the subgroup was rejoined
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     func test_FetchAndRepairConversation_DoesNothingIfSubgroupIsNotOutOfSync() async throws {
@@ -1606,7 +1606,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // THEN
         // Verify expectation that the subgroup was NOT rejoined
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     private func setMocksForConversationRepair(
@@ -1778,7 +1778,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         await sut.uploadKeyPackagesIfNeeded()
 
         // Then
-        await fulfillment(of: [countUnclaimedKeyPackages], timeout: 0.5)
+        await fulfillment(of: [countUnclaimedKeyPackages], timeout: 1)
     }
 
     enum TestError: Error {
@@ -1872,7 +1872,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         await sut.uploadKeyPackagesIfNeeded()
 
         // Then
-        await fulfillment(of: [countUnclaimedKeyPackages, uploadKeyPackages], timeout: 0.5)
+        await fulfillment(of: [countUnclaimedKeyPackages, uploadKeyPackages], timeout: 1)
     }
 
     // MARK: - Update key material

--- a/wire-ios-data-model/Tests/Source/Model/User/UserImageLocalCacheTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/UserImageLocalCacheTests.swift
@@ -88,7 +88,7 @@ final class UserImageLocalCacheTests: XCTestCase {
             completeImageArrived.fulfill()
         }
 
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
     // MARK: - Storing

--- a/wire-ios-link-preview/WireLinkPreviewTests/E2ETests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/E2ETests.swift
@@ -297,7 +297,7 @@ final class E2ETests: XCTestCase {
             completionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 60, handler: nil)
+        waitForExpectations(timeout: 60)
 
         if expected == nil {
             return XCTAssertNil(result, "Expected no OpenGraph data from \(mockData.urlString)", line: line)

--- a/wire-ios-link-preview/WireLinkPreviewTests/ImageDownloaderTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/ImageDownloaderTests.swift
@@ -43,7 +43,7 @@ class ImageDownloaderTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(mockSession.dataTaskWithURLClosureCallCount, 1)
         XCTAssertEqual(mockTask.resumeCallCount, 1)
     }
@@ -62,7 +62,7 @@ class ImageDownloaderTests: XCTestCase {
             completionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
     }
 
     func testThatItCreatesAndResumesADataTaskForAllURLs() {
@@ -91,7 +91,7 @@ class ImageDownloaderTests: XCTestCase {
         sut.downloadImages(fromURLs: urls) { _ in }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(mockSession.dataTaskWithURLClosureCallCount, 4)
         XCTAssertEqual(mockTask.resumeCallCount, 4)
     }
@@ -150,7 +150,7 @@ class ImageDownloaderTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
         if shouldReturn {
             XCTAssertEqual(result, data, line: line)
         } else {

--- a/wire-ios-link-preview/WireLinkPreviewTests/ImageDownloaderTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/ImageDownloaderTests.swift
@@ -43,7 +43,7 @@ class ImageDownloaderTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(mockSession.dataTaskWithURLClosureCallCount, 1)
         XCTAssertEqual(mockTask.resumeCallCount, 1)
     }
@@ -91,7 +91,7 @@ class ImageDownloaderTests: XCTestCase {
         sut.downloadImages(fromURLs: urls) { _ in }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(mockSession.dataTaskWithURLClosureCallCount, 4)
         XCTAssertEqual(mockTask.resumeCallCount, 4)
     }

--- a/wire-ios-link-preview/WireLinkPreviewTests/LinkAttachmentDetectorTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/LinkAttachmentDetectorTests.swift
@@ -66,7 +66,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 0)
         XCTAssertEqual(result, [])
     }
@@ -96,7 +96,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 1)
         XCTAssertEqual(
             previewDownloader.requestOpenGraphDataURLs,
@@ -120,7 +120,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
 
         guard let attachment = result.first else { return XCTFail("Wrong preview type") }
         XCTAssertEqual(attachment.type, .youTubeVideo)
@@ -144,7 +144,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
 
         guard let attachment = result.first else { return XCTFail("Wrong preview type") }
         XCTAssertEqual(attachment.type, .youTubeVideo)
@@ -181,7 +181,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
     }
 
 }

--- a/wire-ios-link-preview/WireLinkPreviewTests/LinkAttachmentDetectorTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/LinkAttachmentDetectorTests.swift
@@ -66,7 +66,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 0)
         XCTAssertEqual(result, [])
     }
@@ -96,7 +96,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 1)
         XCTAssertEqual(
             previewDownloader.requestOpenGraphDataURLs,
@@ -120,7 +120,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
 
         guard let attachment = result.first else { return XCTFail("Wrong preview type") }
         XCTAssertEqual(attachment.type, .youTubeVideo)
@@ -144,7 +144,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
 
         guard let attachment = result.first else { return XCTFail("Wrong preview type") }
         XCTAssertEqual(attachment.type, .youTubeVideo)
@@ -181,7 +181,7 @@ class LinkAttachmentDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
     }
 
 }

--- a/wire-ios-link-preview/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -70,7 +70,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 0)
         XCTAssertEqual(result, [])
     }
@@ -100,7 +100,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 1)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataURLs, [URL(string: "http://www.example.com")!])
         XCTAssertEqual(result, [])
@@ -121,7 +121,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(imageDownloader.downloadImageCallCount, 1)
         XCTAssertEqual(result.first?.imageURLs.first?.absoluteString, openGraphData.imageUrls.first)
         guard let article = result.first as? ArticleMetadata else { return XCTFail("Wrong preview type") }
@@ -146,7 +146,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(imageDownloader.downloadImageCallCount, 1)
         XCTAssertEqual(imageDownloader.downloadImagesCallCount, 0)
 
@@ -188,7 +188,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertTrue(result.isEmpty)
     }
 
@@ -208,7 +208,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
     }
 
 }

--- a/wire-ios-link-preview/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -70,7 +70,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 0)
         XCTAssertEqual(result, [])
     }
@@ -100,7 +100,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataCallCount, 1)
         XCTAssertEqual(previewDownloader.requestOpenGraphDataURLs, [URL(string: "http://www.example.com")!])
         XCTAssertEqual(result, [])
@@ -121,7 +121,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(imageDownloader.downloadImageCallCount, 1)
         XCTAssertEqual(result.first?.imageURLs.first?.absoluteString, openGraphData.imageUrls.first)
         guard let article = result.first as? ArticleMetadata else { return XCTFail("Wrong preview type") }
@@ -146,7 +146,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(imageDownloader.downloadImageCallCount, 1)
         XCTAssertEqual(imageDownloader.downloadImagesCallCount, 0)
 
@@ -188,7 +188,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertTrue(result.isEmpty)
     }
 
@@ -208,7 +208,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         }
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
     }
 
 }

--- a/wire-ios-link-preview/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -112,7 +112,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(secondBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertEqual(completionCallCount, 1)
     }
@@ -143,7 +143,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(secondBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
         XCTAssertEqual(completionCallCount, 1)
     }
@@ -160,7 +160,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
@@ -180,7 +180,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: error)
 
         // then
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
@@ -305,7 +305,7 @@ class PreviewDownloaderTests: XCTestCase {
             downloadExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 0.2)
+        waitForExpectations(timeout: 1)
         XCTAssertEqual(disposition, expected, line: line)
 
         if expected == .cancel {

--- a/wire-ios-link-preview/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -112,7 +112,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(secondBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertEqual(completionCallCount, 1)
     }
@@ -143,7 +143,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(secondBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
         XCTAssertEqual(completionCallCount, 1)
     }
@@ -160,7 +160,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
@@ -180,7 +180,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: error)
 
         // then
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
@@ -305,7 +305,7 @@ class PreviewDownloaderTests: XCTestCase {
             downloadExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 0.2)
         XCTAssertEqual(disposition, expected, line: line)
 
         if expected == .cancel {

--- a/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
+++ b/wire-ios-mocktransport/Tests/Source/Push Events/MockTransportSessionTeamEventsTests.swift
@@ -277,6 +277,7 @@ final class MockTransportSessionTeamEventsTests: MockTransportSessionTests {
             let user2 = session.insertUser(withName: "some user")
             _ = session.insertTeamConversation(to: team, with: [user1, user2, self.sut.selfUser], creator: user1)
         }
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // Then
         let events = pushChannelReceivedEvents as! [TestPushChannelEvent]
@@ -301,6 +302,7 @@ final class MockTransportSessionTeamEventsTests: MockTransportSessionTests {
             team.hasLegalHoldService = true
             XCTAssertTrue(user.requestLegalHold())
         }
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // THEN
         let events = pushChannelReceivedEvents as! [TestPushChannelEvent]

--- a/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Payloads/Processing/ConversationEventPayloadProcessorTests.swift
@@ -1172,7 +1172,7 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
         // when
         await internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 0)
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         // then
         XCTAssertTrue(mockMLSService.createSelfGroupFor_Invocations.isEmpty)
@@ -1194,7 +1194,7 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
         // when
         await internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 0)
-        await fulfillment(of: [didCallCreateGroup], timeout: 0.5)
+        await fulfillment(of: [didCallCreateGroup], timeout: 1)
 
         // then
         XCTAssertFalse(mockMLSService.createSelfGroupFor_Invocations.isEmpty)
@@ -1221,7 +1221,7 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
 
         // when
         await internalTest_UpdateOrCreate_withMLSSelfGroupEpoch(epoch: 1)
-        await fulfillment(of: [didJoinGroup], timeout: 0.5)
+        await fulfillment(of: [didJoinGroup], timeout: 1)
 
         // then
         XCTAssertFalse(mockMLSService.joinGroupWith_Invocations.isEmpty)
@@ -1319,7 +1319,7 @@ final class ConversationEventPayloadProcessorTests: MessagingTestBase {
             originalEvent: updateEvent,
             in: syncMOC
         )
-        await fulfillment(of: [wipeGroupExpectation], timeout: 0.5)
+        await fulfillment(of: [wipeGroupExpectation], timeout: 1)
 
         // Then
         let wipeGroupInvocations = mockMLSEventProcessor.wipeMLSGroupForConversationContext_Invocations

--- a/wire-ios-sync-engine/Tests/Source/Registration/CompanyLoginRequestDetectorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Registration/CompanyLoginRequestDetectorTests.swift
@@ -50,7 +50,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
             detectionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         // THEN
         XCTAssertEqual(detectedCode, "wire-46A17D7F-2351-495E-AEDA-E7C96AC74994")
@@ -69,7 +69,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
             detectionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         // THEN
         XCTAssertEqual(detectedCode, "wire-70488875-13DD-4BA7-9636-A983E1831F5F")
@@ -92,7 +92,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
             detectionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         // THEN
         XCTAssertEqual(detectedCode, "wire-A6AAA905-E42D-4220-A455-CFE8822DB690")
@@ -122,7 +122,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
             detectionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         // THEN
         XCTAssertNil(detectedCode)
@@ -141,7 +141,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
             detectionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         // THEN
         XCTAssertNil(detectedCode)
@@ -160,7 +160,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
             detectionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         // THEN
         XCTAssertNil(detectedCode)
@@ -180,7 +180,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
                 detectionExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 1, handler: nil)
+            waitForExpectations(timeout: 1)
         }
 
         do {
@@ -192,7 +192,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
                 detectionExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 1, handler: nil)
+            waitForExpectations(timeout: 1)
         }
 
         // WHEN
@@ -209,7 +209,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
                 detectionExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 1, handler: nil)
+            waitForExpectations(timeout: 1)
         }
     }
 
@@ -228,7 +228,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
                 detectionExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 1, handler: nil)
+            waitForExpectations(timeout: 1)
         }
 
         // WHEN
@@ -241,7 +241,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
                 detectionExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 1, handler: nil)
+            waitForExpectations(timeout: 1)
         }
 
         // THEN
@@ -254,7 +254,7 @@ final class CompanyLoginRequestDetectorTests: XCTestCase {
                 detectionExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 1, handler: nil)
+            waitForExpectations(timeout: 1)
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Registration/CompanyLoginRequesterTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Registration/CompanyLoginRequesterTests.swift
@@ -94,7 +94,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
     func testThatItReturnsInvalidCodeErrorFor404Response() {
@@ -119,7 +119,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
     func testThatItReturnsUnknownErrorForServerError() {
@@ -144,7 +144,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
     func testThatItReturnsUnknownErrorForTransportError() {
@@ -169,7 +169,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
     func testThatItReturnsUnknownErrorForInvalidResponse() {
@@ -191,7 +191,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
 }

--- a/wire-ios-sync-engine/Tests/Source/Registration/CompanyLoginRequesterTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Registration/CompanyLoginRequesterTests.swift
@@ -42,7 +42,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
 
         requester.delegate = delegate
         requester.requestIdentity(host: "localhost", token: userID)
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
 
         guard let validationToken = CompanyLoginVerificationToken.current(in: defaults)
         else { return XCTFail("no token") }
@@ -94,7 +94,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testThatItReturnsInvalidCodeErrorFor404Response() {
@@ -119,7 +119,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testThatItReturnsUnknownErrorForServerError() {
@@ -144,7 +144,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testThatItReturnsUnknownErrorForTransportError() {
@@ -169,7 +169,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
     func testThatItReturnsUnknownErrorForInvalidResponse() {
@@ -191,7 +191,7 @@ final class CompanyLoginRequesterTests: XCTestCase {
         }
 
         // Then
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/EvaluateOneOnOneConversationsStrategyTests.swift
@@ -81,7 +81,7 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
         }
 
         // then
-        await fulfillment(of: [expectation], timeout: 0.1)
+        await fulfillment(of: [expectation], timeout: 1)
 
         XCTAssertEqual(mockSyncStatus.finishCurrentSyncPhasePhase_Invocations.count, 1)
     }
@@ -104,7 +104,7 @@ final class EvaluateOneOnOneConversationsStrategyTests: XCTestCase {
         }
 
         // then
-        await fulfillment(of: [expectation], timeout: 0.1)
+        await fulfillment(of: [expectation], timeout: 1)
 
         XCTAssert(mockSyncStatus.finishCurrentSyncPhasePhase_Invocations.isEmpty)
     }

--- a/wire-ios-system/Tests/DispatchQueueHelperTests.swift
+++ b/wire-ios-system/Tests/DispatchQueueHelperTests.swift
@@ -41,6 +41,6 @@ final class DispatchQueueHelperTests: XCTestCase {
             groupExpectation.fulfill()
         }
 
-        await fulfillment(of: [groupExpectation], timeout: 0.1)
+        await fulfillment(of: [groupExpectation], timeout: 1)
     }
 }

--- a/wire-ios-system/Tests/ZMLogTests.swift
+++ b/wire-ios-system/Tests/ZMLogTests.swift
@@ -225,7 +225,7 @@ extension ZMLogTests {
         ZMSLog(tag: tag).error(message)
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token)
@@ -274,7 +274,7 @@ extension ZMLogTests {
         ZMSLog(tag: tag).warn(message)
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token)
@@ -325,7 +325,7 @@ extension ZMLogTests {
         ZMSLog(tag: tag).debug(message)
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token)
@@ -391,7 +391,7 @@ extension ZMLogTests {
         ZMSLog(tag: tag).error(message)
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
 
         // AFTER
         ZMSLog.removeLogHook(token: token1)

--- a/wire-ios-transport/Tests/Source/Background/BackgroundActivityFactoryTests.swift
+++ b/wire-ios-transport/Tests/Source/Background/BackgroundActivityFactoryTests.swift
@@ -117,7 +117,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         activityManager.triggerExpiration()
 
         // THEN
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)
@@ -137,7 +137,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         activityManager.triggerExpiration()
 
         // THEN
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)
@@ -156,7 +156,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         factory.endBackgroundActivity(activity)
 
         // THEN
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)
@@ -192,7 +192,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         simulateApplicationDidEnterBackground()
 
         // THEN
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 3)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)

--- a/wire-ios-transport/Tests/Source/Background/BackgroundActivityFactoryTests.swift
+++ b/wire-ios-transport/Tests/Source/Background/BackgroundActivityFactoryTests.swift
@@ -117,7 +117,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         activityManager.triggerExpiration()
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)
@@ -137,7 +137,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         activityManager.triggerExpiration()
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)
@@ -156,7 +156,7 @@ class BackgroundActivityFactoryTests: XCTestCase {
         factory.endBackgroundActivity(activity)
 
         // THEN
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
         XCTAssertFalse(factory.isActive)
         XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)

--- a/wire-ios-ziphy/ZiphyTests/ZiphyClientTests.swift
+++ b/wire-ios-ziphy/ZiphyTests/ZiphyClientTests.swift
@@ -50,7 +50,7 @@ class ZiphyClientTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -83,7 +83,7 @@ class ZiphyClientTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -114,7 +114,7 @@ class ZiphyClientTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 

--- a/wire-ios-ziphy/ZiphyTests/ZiphyPaginationControllerTests.swift
+++ b/wire-ios-ziphy/ZiphyTests/ZiphyPaginationControllerTests.swift
@@ -64,7 +64,7 @@ class ZiphyPaginationControllerTests: XCTestCase {
         }
 
         paginationController.updatePagination(page2, filter: nil)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -99,7 +99,7 @@ class ZiphyPaginationControllerTests: XCTestCase {
         }
 
         paginationController.updatePagination(.failure(.noMorePages), filter: nil)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -137,7 +137,7 @@ class ZiphyPaginationControllerTests: XCTestCase {
         _ = paginationController.fetchNewPage()
 
         // THEN
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 1)
     }
 
     // MARK: - Utilities

--- a/wire-ios-ziphy/ZiphyTests/ZiphySearchResultsControllerTests.swift
+++ b/wire-ios-ziphy/ZiphyTests/ZiphySearchResultsControllerTests.swift
@@ -56,7 +56,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -96,7 +96,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -136,7 +136,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         }
 
         sendDownloadResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -167,7 +167,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         var fetchResult: ZiphyResult<[Ziph]>?
         let nextFetchExpectation = expectation(description: "Next trending images are fetched.")
@@ -178,7 +178,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         }
 
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
 
@@ -221,7 +221,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
 
         request?.cancel()
         sendResponse(afterDelay: 1)
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
 
         // THEN
         XCTAssertNil(fetchResult)

--- a/wire-ios/Wire-iOS Tests/AccessoryTextField/ValidatedTextFieldTests.swift
+++ b/wire-ios/Wire-iOS Tests/AccessoryTextField/ValidatedTextFieldTests.swift
@@ -101,7 +101,7 @@ final class ValidatedTextFieldTests: XCTestCase {
         sut.text = "foo"
 
         // Then
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/BackupPasswordViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/BackupPasswordViewControllerTests.swift
@@ -70,7 +70,7 @@ final class BackupPasswordViewControllerTests: XCTestCase {
         )
 
         // THEN
-        waitForExpectations(timeout: 0.5) { error in
+        waitForExpectations(timeout: 2) { error in
             XCTAssertNil(error)
         }
     }

--- a/wire-ios/Wire-iOS Tests/DismissalTests.swift
+++ b/wire-ios/Wire-iOS Tests/DismissalTests.swift
@@ -66,7 +66,7 @@ final class DismissalTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
     }
 
     func testThatItAllowsDismissalForControllerInNavigationController() {
@@ -96,7 +96,7 @@ final class DismissalTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
     }
 
     // MARK: - Dismissal
@@ -113,7 +113,7 @@ final class DismissalTests: XCTestCase {
         }
 
         // THEN
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
     }
 
     func testThatItCallsHandlerForAlreadyDismissedViewController() {
@@ -129,7 +129,7 @@ final class DismissalTests: XCTestCase {
         }
 
         // THEN
-        waitForExpectations(timeout: 2, handler: nil)
+        waitForExpectations(timeout: 2)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/ImageCache/DecodeImageOperationTests.swift
+++ b/wire-ios/Wire-iOS Tests/ImageCache/DecodeImageOperationTests.swift
@@ -65,7 +65,7 @@ final class DecodeImageOperationTests: XCTestCase {
         }
 
         operationQueue.addOperation(decodeOperation)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
         sut.image = image
@@ -89,7 +89,7 @@ final class DecodeImageOperationTests: XCTestCase {
         }
 
         operationQueue.addOperation(decodeOperation)
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 5)
 
         // THEN
         XCTAssertNil(image)

--- a/wire-ios/Wire-iOS Tests/SavableImageTests.swift
+++ b/wire-ios/Wire-iOS Tests/SavableImageTests.swift
@@ -105,7 +105,7 @@ final class SavableImageTests: XCTestCase {
                 savableImage = nil
             }
 
-            self.waitForExpectations(timeout: 2, handler: nil)
+            self.waitForExpectations(timeout: 2)
 
         }
 
@@ -140,7 +140,7 @@ final class SavableImageTests: XCTestCase {
                 mockOwner = nil
             }
 
-            self.waitForExpectations(timeout: 2, handler: nil)
+            self.waitForExpectations(timeout: 2)
         }
 
         // THEN
@@ -166,7 +166,7 @@ final class SavableImageTests: XCTestCase {
                 savableImage = nil
             }
 
-            self.waitForExpectations(timeout: 2, handler: nil)
+            self.waitForExpectations(timeout: 2)
 
         }
 
@@ -209,7 +209,7 @@ final class SavableImageTests: XCTestCase {
                 mockOwner = nil
             }
 
-            self.waitForExpectations(timeout: 2, handler: nil)
+            self.waitForExpectations(timeout: 2)
         }
 
         // THEN

--- a/wire-ios/Wire-iOS Tests/SwitchBackendConfirmationViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/SwitchBackendConfirmationViewModelTests.swift
@@ -48,7 +48,7 @@ final class SwitchBackendConfirmationViewModelTests: XCTestCase {
         sut.handleEvent(.userDidConfirm)
 
         // Then
-        await fulfillment(of: [done], timeout: 0.5)
+        await fulfillment(of: [done], timeout: 1)
         XCTAssertTrue(didConfirm)
     }
 
@@ -66,7 +66,7 @@ final class SwitchBackendConfirmationViewModelTests: XCTestCase {
         sut.handleEvent(.userDidCancel)
 
         // Then
-        await fulfillment(of: [done], timeout: 0.5)
+        await fulfillment(of: [done], timeout: 1)
         XCTAssertFalse(didConfirm)
     }
 

--- a/wire-ios/Wire-iOS Tests/TypingIndicatorViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/TypingIndicatorViewTests.swift
@@ -95,6 +95,6 @@ final class TypingIndicatorViewSnapshotTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(sut.container.alpha, 1)
-        waitForExpectations(timeout: 0.5, handler: nil)
+        waitForExpectations(timeout: 0.5)
     }
 }

--- a/wire-ios/Wire-iOS Tests/TypingIndicatorViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/TypingIndicatorViewTests.swift
@@ -95,6 +95,6 @@ final class TypingIndicatorViewSnapshotTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(sut.container.alpha, 1)
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 1)
     }
 }

--- a/wire-ios/Wire-iOS Tests/UserProfile/ProfileViewControllerViewModelTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserProfile/ProfileViewControllerViewModelTests.swift
@@ -114,7 +114,7 @@ final class ProfileViewControllerViewModelTests: XCTestCase {
         sut.openOneToOneConversation()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         XCTAssertEqual(mockUserSession.createTeamOneOnOneWithCompletion_Invocations.count, 1)
         XCTAssertEqual(transitionCount, 1)
@@ -139,7 +139,7 @@ final class ProfileViewControllerViewModelTests: XCTestCase {
         sut.startOneToOneConversation()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         XCTAssertEqual(mockViewModelDelegate.startAnimatingActivity_Invocations.count, 1)
         XCTAssertEqual(mockUserSession.createTeamOneOnOneWithCompletion_Invocations.count, 1)
@@ -162,7 +162,7 @@ final class ProfileViewControllerViewModelTests: XCTestCase {
         sut.startOneToOneConversation()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
 
         XCTAssertEqual(mockViewModelDelegate.startAnimatingActivity_Invocations.count, 1)
         XCTAssertEqual(mockUserSession.createTeamOneOnOneWithCompletion_Invocations.count, 1)
@@ -186,7 +186,7 @@ final class ProfileViewControllerViewModelTests: XCTestCase {
         sut.updateActionsList()
 
         // Then
-        await fulfillment(of: [expectation], timeout: 0.5)
+        await fulfillment(of: [expectation], timeout: 1)
         XCTAssertEqual(mockViewModelDelegate.updateFooterActionsViews_Invocations.first, [.openOneToOne])
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15021" title="WPB-15021" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15021</a>  [iOS] Fix some flaky tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR:

- Fixes a couple of flaky tests in `MockTransportSessionTeamEventsTests` using the magical `waitForAllGroupsToBeEmpty`. These were tests that I could reproduce flakiness locally by repeating the tests suite 100 times.
- Sets the minimum timeout to 1 second for most uses of `waitForExpectations(timeout:)` & `await fulfillment(of:timeout:)`. 

#### Rational

Sub 1 second is often plenty of time locally but can be problematic when running tests on CI where resources can be extremely limited. In cases where we don't set `expectation.isInverted = true` the waiting will finish as soon as the expectation is met meaning that generally there will be no change in behavior setting longer timeouts.

Considering our full test suite now takes around 2 hours to run, a timeout can be very frustrating. Personally I don't see a reason not to set a minimum timeout of 5 seconds but I feel there may be some pushback so keeping it to 1 second. Looking at data dog, in the last month we have only had timeouts in cases of 0.5 sections so hopefully 1 second should be sufficient.

#### Note

I have left a few sub-second timeouts as they are in cases where I'm not confident that behavior isn't dependent on it.

### Testing

Run the automated tests

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.