### PR TITLE
fix: other clients don't discover new team - WPB-15043

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
@@ -54,11 +54,13 @@ public extension ZMUser {
     func createOrDeleteMembershipIfBelongingToTeam() {
         guard
             let teamIdentifier,
-            let managedObjectContext,
-            let team = Team.fetch(with: teamIdentifier, in: managedObjectContext)
+            let managedObjectContext
         else {
             return
         }
+
+        let team = Team.fetchOrCreate(with: teamIdentifier, in: managedObjectContext)
+        team.needsToBeUpdatedFromBackend = true
 
         if !isAccountDeleted {
             createMembership(in: team, context: managedObjectContext)

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/TeamDownloadRequestStrategy.swift
@@ -16,6 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireLogging
+
 struct TeamListPayload: Decodable {
     let hasMore: Bool
     let teams: [TeamPayload]
@@ -31,17 +33,17 @@ struct TeamPayload: Decodable {
     let identifier: UUID
     let name: String
     let creator: UUID
-    let binding: Bool
     let icon: String
     let iconKey: String?
+    let splashScreen: String?
 
     private enum CodingKeys: String, CodingKey {
         case identifier = "id"
         case name
         case creator
-        case binding
         case icon
         case iconKey = "icon_key"
+        case splashScreen = "splash_screen"
     }
 
 }
@@ -67,10 +69,6 @@ extension TeamPayload {
         team.creator = ZMUser.fetchOrCreate(with: creator, domain: nil, in: managedObjectContext)
         team.pictureAssetId = icon
         team.pictureAssetKey = iconKey
-
-        if !binding {
-            managedObjectContext.delete(team)
-        }
     }
 
 }
@@ -155,10 +153,15 @@ public final class TeamDownloadRequestStrategy: AbstractRequestStrategy, ZMConte
     }
 
     private func createTeam(with event: ZMUpdateEvent) {
-        // With the new multi-account model this event should not be sent anymore,
-        // and if it is we should not act on it.
-        // An account will either have a team since registration or not,
-        // currently there is no way to get added to a team after registering.
+        guard
+            let data = event.dataPayload,
+            let team = TeamPayload(data)
+        else {
+            WireLogger.updateEvent.error("failed to process team.create event")
+            return
+        }
+
+        _ = team.createOrUpdateTeam(in: managedObjectContext)
     }
 
     private func deleteTeam(with event: ZMUpdateEvent) {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -499,6 +499,12 @@ public final class ZMUserSession: NSObject {
         restoreDebugCommandsState()
         configureRecurringActions()
 
+        // Proactively keep the self user in sync, which helps add resilience
+        // in cases where the self client may otherwise only have limited
+        // one time opportunities to discover important changes.
+        let selfUser = ZMUser.selfUser(in: managedObjectContext)
+        selfUser.needsToBeUpdatedFromBackend = true
+
         if let clientId = selfUserClient?.safeRemoteIdentifier.safeForLoggingDescription {
             WireLogger.authentication.addTag(.selfClientId, value: clientId)
         }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategy+EventsTests.swift
@@ -56,40 +56,22 @@ final class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
 
     // The team.create update event is only sent to the creator of the team
 
-    func testThatItDoesNotCreateALocalTeamWhenReceivingTeamCreateUpdateEvent() {
+    func testThatItCreatesALocalTeamWhenReceivingTeamCreateUpdateEvent() {
         // given
-        let teamId = UUID.create()
-        let payload: [String: Any] = [
-            "type": "team.create",
-            "team": teamId.transportString(),
-            "time": Date().transportString(),
-            "data": NSNull()
-        ]
-
-        // when
-        processEvent(fromPayload: payload)
-
-        // then
-        XCTAssertNil(Team.fetch(with: teamId, in: uiMOC))
-    }
-
-    func testThatItDoesNotSetNeedsToBeUpdatedFromBackendForExistingTeamWhenReceivingTeamCreateUpdateEvent() {
-        // given
-        let teamId = UUID.create()
-
-        syncMOC.performGroupedBlock {
-            _ = Team.fetchOrCreate(
-                with: teamId,
-                in: self.syncMOC
-            )
-            XCTAssert(self.syncMOC.saveOrRollback())
-        }
+        let teamID = UUID()
+        let creatorID = UUID()
 
         let payload: [String: Any] = [
             "type": "team.create",
-            "team": teamId.transportString(),
+            "team": teamID.transportString(),
             "time": Date().transportString(),
-            "data": NSNull()
+            "data": [
+                "creator": creatorID.transportString(),
+                "icon": "default",
+                "id": teamID.transportString(),
+                "name": "iOS Team",
+                "splash_screen": "default"
+            ]
         ]
 
         // when
@@ -97,12 +79,16 @@ final class TeamDownloadRequestStrategy_EventsTests: MessagingTest {
 
         // then
         guard let team = Team.fetch(
-            with: teamId,
+            with: teamID,
             in: uiMOC
         ) else {
             return XCTFail("No team created")
         }
 
+        XCTAssertEqual(team.remoteIdentifier, teamID)
+        XCTAssertEqual(team.name, "iOS Team")
+        XCTAssertEqual(team.creator?.remoteIdentifier, creatorID)
+        XCTAssertEqual(team.pictureAssetId, "default")
         XCTAssertFalse(team.needsToBeUpdatedFromBackend)
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/TeamDownloadRequestStrategyTests.swift
@@ -207,11 +207,6 @@ final class TeamDownloadRequestStrategyTests: MessagingTest {
         }
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.2))
-
-        syncMOC.performGroupedAndWait {
-            // then
-            XCTAssertTrue(team == nil || team.isZombieObject)
-        }
     }
 
     func testThatItCreatesNoNewRequestAfterReceivingAResponse() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15043" title="WPB-15043" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15043</a>  [iOS] Other clients don't discover newly created team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If the user has more than one device and upgrades their personal account to a team account, then the other devices don't know about the new team because they don't process the team creation event.

### Testing

1. Be logged in to a personal account on devices A and B.
2. Upgrade to team account on device A
3. Assert that device B discovers the team, by seeing the "manage team" button in the self profile.
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
