### PR TITLE
fix: prevent drag to dismiss on all but last screens of the personal to team migration flow - WPB-15051

### DIFF
--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -130,6 +130,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
         self.useCase = useCase
         self.userProfileName = userProfileName
         super.init(nibName: nil, bundle: nil)
+        isModalInPresentation = true
     }
 
     public convenience init(
@@ -178,6 +179,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
                 }
             )
             childController.present(alert, animated: true)
+            isModalInPresentation = true
         case .toPlans:
             let step = Step.teamPlanSelection(features: features)
             currentStep = step
@@ -190,6 +192,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             childController.pushViewController(vc, animated: false) { [analyticsEventTracker] in
                 analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowStarted(at: .disclaimer))
             }
+            isModalInPresentation = true
         case .toLearnMoreAboutPlans:
             actionCallback(.toLearnMoreAboutPlans)
         case .toTeamName:
@@ -204,6 +207,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             childController.pushViewController(vc, animated: true) { [analyticsEventTracker] in
                 analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowStarted(at: .teamName))
             }
+            isModalInPresentation = true
         case let .toConfirmation(teamName):
             let step = Step.confirmation(
                 teamName: teamName,
@@ -220,6 +224,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             childController.pushViewController(vc, animated: true) { [analyticsEventTracker] in
                 analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowStarted(at: .confirmation))
             }
+            isModalInPresentation = true
         case let .toTeamCreation(teamName: teamName):
             createTeam(named: teamName)
         case let .toError(error as IndividualToTeamMigrationError):
@@ -236,6 +241,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
                 onTransition: { @MainActor [weak self] in self?.transition(to: $0) }
             )
             childController.setViewControllers([vc], animated: true)
+            isModalInPresentation = false
         case .toApp:
             analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .backToWire))
             actionCallback(.completionGoToApp)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15051" title="WPB-15051" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15051</a>  [iOS] Missing alert when swiping down the migration flow modal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When going through the personal to team flow, users could dismiss the modal by dragging, without seeing the confirmation alert.

### Testing

Create a new individual account.
Open your account view.
Go through the personal to team migration flow.
On the first three screens, attempt to drag the view to dismiss the modal. The view should not be dismissed.
On the last screen, attempt to drag the view to dismiss the modal. The view should be dismissed.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.

