### PR TITLE
fix: Ensure contact requests are first in conversation list - WPB-15098

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ListContent/ConversationListContentController/ViewModel/ConversationListViewModel.swift
@@ -347,16 +347,15 @@ final class ConversationListViewModel: NSObject {
         case .favorites:
             [.favorites]
         case .oneOnOne:
-            [.contacts, .contactRequests]
+            [.contactRequests, .contacts]
         case let .folder(id, _):
             if let folder = conversationDirectory.nonDeletedFolders.first(where: { $0.remoteIdentifier == id }) {
                 [.folder(label: folder)]
             } else {
-                // FIXME: [WPB-13905] Log invalid state once WPB-13905 is implemented
                 []
             }
         case .none:
-            [.conversations, .contactRequests]
+            [.contactRequests, .conversations]
         }
 
         let sections = kinds.map { kind in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15098" title="WPB-15098" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15098</a>  [iOS]Incoming connection requests are listed after all other conversations effectively hiding them
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently contact requests appear at the bottom of the list of conversations. This means they can easily go unnoticed. This PR moves contact requests to the to of the conversation list:

| All conversations | 1:1 conversations |
| --- | --- |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-17 at 15 39 48](https://github.com/user-attachments/assets/3c68caef-764a-47a3-b644-3e7718ad55fa) |  ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-12-17 at 15 39 58](https://github.com/user-attachments/assets/52077298-3378-4dfc-91e8-79d8045b7bf3) |

### Testing

0. User B create a contact request to User A
1. Navigate to `Conversations` tab
2. Verify that the contact request is the first item in the list of conversations.

**NOTE** Automated tests are a WIP and will follow in another PR as we would like to get this merged ASAP but there is some effort necessary to write a test for it.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.