### PR TITLE
fix: dismiss to conversations on "Back To Wire" and "Go To Team Management - WPB-15082

### DIFF
--- a/WireAnalytics/Sources/WireAnalytics/Events/Predefined/AnalyticsEvent+User.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Events/Predefined/AnalyticsEvent+User.swift
@@ -92,17 +92,15 @@ public extension AnalyticsEvent {
         public static func personalTeamCreationFlowCompleted(
             action: IndividualToTeamMigration.CompletedAction?
         ) -> AnalyticsEvent {
-            let segment: SegmentationEntry? = switch action {
+            let segment: [SegmentationEntry] = switch action {
             case .none:
-                nil
+                []
             case .backToWire:
-                SegmentationEntry(key: "modal_back-to-wire-clicked", value: true)
+                [SegmentationEntry(key: "modal_back-to-wire-clicked", value: true)]
             case .openTeamManagement:
-                SegmentationEntry(key: "modal_open-tm-clicked", value: true)
+                [SegmentationEntry(key: "modal_open-tm-clicked", value: true)]
             }
-            return AnalyticsEvent(name: "user.personal-team-creation-flow-completed") {
-                if let segment { segment }
-            }
+            return AnalyticsEvent(name: "user.personal-team-creation-flow-completed", segmentation: segment)
         }
     }
 }

--- a/WireAnalytics/Sources/WireAnalytics/Events/Predefined/AnalyticsEvent+User.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Events/Predefined/AnalyticsEvent+User.swift
@@ -90,17 +90,19 @@ public extension AnalyticsEvent {
         /// An event tracking when the user taps a button in the final confirmation screen.
 
         public static func personalTeamCreationFlowCompleted(
-            action: IndividualToTeamMigration.CompletedAction
+            action: IndividualToTeamMigration.CompletedAction?
         ) -> AnalyticsEvent {
-            AnalyticsEvent(name: "user.personal-team-creation-flow-completed") {
-                switch action {
-                case .backToWire:
-                    SegmentationEntry(key: "modal_back-to-wire-clicked", value: true)
-                case .openTeamManagement:
-                    SegmentationEntry(key: "modal_open-tm-clicked", value: true)
-                }
+            let segment: SegmentationEntry? = switch action {
+            case .none:
+                nil
+            case .backToWire:
+                SegmentationEntry(key: "modal_back-to-wire-clicked", value: true)
+            case .openTeamManagement:
+                SegmentationEntry(key: "modal_open-tm-clicked", value: true)
+            }
+            return AnalyticsEvent(name: "user.personal-team-creation-flow-completed") {
+                if let segment { segment }
             }
         }
     }
-
 }

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -27,7 +27,8 @@ public class IndividualToTeamMigrationViewController: UIViewController {
     public enum Action: Sendable {
         case cancel
         case toLearnMoreAboutPlans
-        case completionGoToApp
+        case completionDismiss
+        case completionGoToConversations
         case completionGoToTeamManagement
     }
 
@@ -94,7 +95,8 @@ public class IndividualToTeamMigrationViewController: UIViewController {
         case toTeamCreation(teamName: String)
         case toError(error: any Error)
         case toCompletion(teamName: String)
-        case toApp
+        case toDismiss
+        case toConversations
         case toTeamManagement
     }
 
@@ -217,7 +219,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             currentStep = step
             let vc = hostedView(
                 for: step,
-                stepIndex: 4,
+                stepIndex: childController.viewControllers.count + 1,
                 stepCount: 4,
                 onTransition: { @MainActor [weak self] in self?.transition(to: $0) }
             )
@@ -236,15 +238,19 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             currentStep = step
             let vc = hostedView(
                 for: step,
-                stepIndex: childController.viewControllers.count + 1,
+                stepIndex: 4,
                 stepCount: 4,
                 onTransition: { @MainActor [weak self] in self?.transition(to: $0) }
             )
             childController.setViewControllers([vc], animated: true)
             isModalInPresentation = false
-        case .toApp:
+        case .toDismiss:
+            // TODO: track event
             analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .backToWire))
-            actionCallback(.completionGoToApp)
+            actionCallback(.completionDismiss)
+        case .toConversations:
+            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .backToWire))
+            actionCallback(.completionGoToConversations)
         case .toTeamManagement:
             analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .openTeamManagement))
             actionCallback(.completionGoToTeamManagement)
@@ -343,7 +349,7 @@ private func hostedView(
             case .teamPlanSelection, .teamName, .confirmation:
                 transitionCallback(.toCancellationAlert)
             case .completion:
-                transitionCallback(.toApp)
+                transitionCallback(.toDismiss)
             }
         },
         accessibilityLabel: step.closeButtonAccessibilityLabel
@@ -397,7 +403,7 @@ private func viewFor(
         CompletionView(profileName: profileName, teamName: teamName) { action in
             switch action {
             case .goBack:
-                transitionCallback(.toApp)
+                transitionCallback(.toConversations)
             case .goToTeamManagement:
                 transitionCallback(.toTeamManagement)
             }

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -95,7 +95,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
         case toTeamCreation(teamName: String)
         case toError(error: any Error)
         case toCompletion(teamName: String)
-        case toDismiss
+        case toCompletionDismiss
         case toConversations
         case toTeamManagement
     }
@@ -244,9 +244,8 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             )
             childController.setViewControllers([vc], animated: true)
             isModalInPresentation = false
-        case .toDismiss:
-            // TODO: track event
-            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .backToWire))
+        case .toCompletionDismiss:
+            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: nil))
             actionCallback(.completionDismiss)
         case .toConversations:
             analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .backToWire))
@@ -349,7 +348,7 @@ private func hostedView(
             case .teamPlanSelection, .teamName, .confirmation:
                 transitionCallback(.toCancellationAlert)
             case .completion:
-                transitionCallback(.toDismiss)
+                transitionCallback(.toCompletionDismiss)
             }
         },
         accessibilityLabel: step.closeButtonAccessibilityLabel

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -172,7 +172,8 @@ public class IndividualToTeamMigrationViewController: UIViewController {
     public override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         if isBeingDismissed {
-            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: analyticsFlowCompletionAction))
+            analyticsEventTracker?
+                .trackEvent(.User.personalTeamCreationFlowCompleted(action: analyticsFlowCompletionAction))
         }
     }
 

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -421,4 +421,3 @@ private func viewFor(
 #Preview {
     featurePreview()
 }
-Í

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -112,6 +112,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
     let privacyPolicyURL: String
     let useCase: any IndividualToTeamMigrationUseCase
     let userProfileName: String
+    private var analyticsFlowCompletionAction: AnalyticsEvent.User.IndividualToTeamMigration.CompletedAction?
     private let analyticsEventTracker: (any AnalyticsEventTracker)?
 
     public init(
@@ -166,6 +167,13 @@ public class IndividualToTeamMigrationViewController: UIViewController {
         childController.didMove(toParent: self)
         childController.navigationBar.tintColor = ColorTheme.Backgrounds.onBackground
         transition(to: .toPlans)
+    }
+
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        if isBeingDismissed {
+            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: analyticsFlowCompletionAction))
+        }
     }
 
     @MainActor
@@ -245,13 +253,13 @@ public class IndividualToTeamMigrationViewController: UIViewController {
             childController.setViewControllers([vc], animated: true)
             isModalInPresentation = false
         case .toCompletionDismiss:
-            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: nil))
+            analyticsFlowCompletionAction = nil
             actionCallback(.completionDismiss)
         case .toConversations:
-            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .backToWire))
+            analyticsFlowCompletionAction = .backToWire
             actionCallback(.completionGoToConversations)
         case .toTeamManagement:
-            analyticsEventTracker?.trackEvent(.User.personalTeamCreationFlowCompleted(action: .openTeamManagement))
+            analyticsFlowCompletionAction = .openTeamManagement
             actionCallback(.completionGoToTeamManagement)
         }
     }
@@ -413,3 +421,4 @@ private func viewFor(
 #Preview {
     featurePreview()
 }
+Í

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -281,7 +281,10 @@ final class SelfProfileViewController: UIViewController {
                             presentedViewController?.dismiss(animated: true)
                         case .toLearnMoreAboutPlans:
                             _ = WireURLs.shared.wireEnterpriseInfo.open()
-                        case .completionGoToApp:
+                        case .completionDismiss:
+                            dismissIndividualToTeamMigrationBanner()
+                            presentedViewController?.dismiss(animated: true)
+                        case .completionGoToConversations:
                             dismissIndividualToTeamMigrationBanner()
                             if let presentingViewController {
                                 presentingViewController.dismiss(animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -283,12 +283,20 @@ final class SelfProfileViewController: UIViewController {
                             _ = WireURLs.shared.wireEnterpriseInfo.open()
                         case .completionGoToApp:
                             dismissIndividualToTeamMigrationBanner()
-                            presentedViewController?.dismiss(animated: true)
+                            if let presentingViewController {
+                                presentingViewController.dismiss(animated: true)
+                            } else {
+                                presentedViewController?.dismiss(animated: true)
+                            }
                         case .completionGoToTeamManagement:
                             dismissIndividualToTeamMigrationBanner()
-                            presentedViewController?.dismiss(animated: true, completion: { [weak self] in
-                                self?.navigateToTeam()
-                            })
+                            if let presentingViewController {
+                                presentingViewController.dismiss(animated: true) {
+                                    URL.manageTeam(source: .settings).open()
+                                }
+                            } else {
+                                presentedViewController?.dismiss(animated: true)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15082" title="WPB-15082" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15082</a>  [iOS] Back to wire option after creating a team is not taking user to conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When completing the individual to team migration flow, on selecting either "Back To Wire" or "Go To Team Management",  the current modal would be dismissed and, if the user had tapped on "Go To Team Management", the appropriate URL would be opened using the browser.

Instead, when selecting either "Back To Wire" or "Go To Team Management", both the current and the profile's modals should be dismissed (before opening the appropriate browser if the user has tapped on "Go To Team Management").

### Testing

Sign up on staging using a personal account with v7 as the preferred API (when v7 is enabled in staging).
Go through the personal to teams flows.
At the end, tap on "Back To Wire". Both the current and the profile's modals should be dismissed.


Sign up on staging using a personal account with v7 as the preferred API (when v7 is enabled in staging).
Go through the personal to teams flows.
At the end, tap on "Go To Team Management". Both the current and the profile's modals should be dismissed. The team management URL should be opened in your selected browser.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
