### PR TITLE
fix: unable to complete SSO flow - WPB-15164

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+SwitchBackend.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+SwitchBackend.swift
@@ -33,9 +33,13 @@ public extension SessionManager {
         return nil
     }
 
-    func switchBackend(to environment: BackendEnvironment) {
+    func switchBackend(
+        to environment: BackendEnvironment,
+        completion: @escaping ((any Error)?) -> Void = { _ in }
+    ) {
         self.environment = environment
         unauthenticatedSession = nil
+        resolveAPIVersion(completion: completion)
     }
 
     func fetchBackendEnvironment(

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -283,6 +283,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     public internal(set) var environment: BackendEnvironmentProvider {
         didSet {
+            apiVersionResolver = nil
             reachability.tearDown()
             reachability = environment.reachabilityWrapper()
             authenticatedSessionFactory.environment = environment

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -330,9 +330,14 @@ extension CompanyLoginController {
             case let .success(backendEnvironment):
                 requestUserConfirmationForBackendSwitch(to: backendEnvironment) { didConfirm in
                     guard didConfirm else { return }
-                    sessionManager.switchBackend(to: backendEnvironment)
-                    BackendEnvironment.shared = backendEnvironment
-                    self.startAutomaticSSOFlow(promptOnError: false)
+                    sessionManager.switchBackend(to: backendEnvironment) { [weak self] error in
+                        if let error {
+                            self?.presentCompanyLoginAlert(error: .unknown)
+                        }
+
+                        BackendEnvironment.shared = backendEnvironment
+                        self?.startAutomaticSSOFlow(promptOnError: false)
+                    }
                 }
             case let .failure(error):
                 if case .loggedInAccounts = error as? SessionManager.SwitchBackendError {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -332,6 +332,7 @@ extension CompanyLoginController {
                     guard didConfirm else { return }
                     sessionManager.switchBackend(to: backendEnvironment) { error in
                         if let error {
+                            WireLogger.authentication.error("sso login flow failed due to backend switch error: \(String(describing: error))")
                             self.presentCompanyLoginAlert(error: .unknown)
                         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/CompanyLoginController.swift
@@ -330,13 +330,13 @@ extension CompanyLoginController {
             case let .success(backendEnvironment):
                 requestUserConfirmationForBackendSwitch(to: backendEnvironment) { didConfirm in
                     guard didConfirm else { return }
-                    sessionManager.switchBackend(to: backendEnvironment) { [weak self] error in
+                    sessionManager.switchBackend(to: backendEnvironment) { error in
                         if let error {
-                            self?.presentCompanyLoginAlert(error: .unknown)
+                            self.presentCompanyLoginAlert(error: .unknown)
                         }
 
                         BackendEnvironment.shared = backendEnvironment
-                        self?.startAutomaticSSOFlow(promptOnError: false)
+                        self.startAutomaticSSOFlow(promptOnError: false)
                     }
                 }
             case let .failure(error):


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15164" title="WPB-15164" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15164</a>  [iOS] Users not redirected to IdP after enterprise login
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Some users are not able to complete the SSO login flow.

### Cause

The SSO flow includes a redirect to an on-prem backend, but we were not re-resolving the api version for the new backend. Since the cloud backend has advanced compared to the on-prem backend, the resolved api version (for cloud) was higher than what was available on the on-prem backend. As a result, when trying to fetch the SSO settings from the on-prem backend we were getting a 404 not found error.

### Solution

After switching backends, re-resolve the api version against the new backend.

### Testing

See the linked ticket for steps.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
