### PR TITLE
fix: Creating team membership & tests - WPB-15043

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
@@ -59,13 +59,14 @@ public extension ZMUser {
             return
         }
 
+        let team: Team
         if isSelfUser {
-            let team = Team.fetchOrCreate(with: teamIdentifier, in: managedObjectContext)
+            team = Team.fetchOrCreate(with: teamIdentifier, in: managedObjectContext)
             team.needsToBeUpdatedFromBackend = true
             team.needsToRedownloadMembers = true
-        }
-
-        guard let team = Team.fetch(with: teamIdentifier, in: managedObjectContext) else {
+        } else if let existingTeam = Team.fetch(with: teamIdentifier, in: managedObjectContext) {
+            team = existingTeam
+        } else {
             return
         }
 

--- a/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Teams.swift
@@ -59,8 +59,15 @@ public extension ZMUser {
             return
         }
 
-        let team = Team.fetchOrCreate(with: teamIdentifier, in: managedObjectContext)
-        team.needsToBeUpdatedFromBackend = true
+        if isSelfUser {
+            let team = Team.fetchOrCreate(with: teamIdentifier, in: managedObjectContext)
+            team.needsToBeUpdatedFromBackend = true
+            team.needsToRedownloadMembers = true
+        }
+
+        guard let team = Team.fetch(with: teamIdentifier, in: managedObjectContext) else {
+            return
+        }
 
         if !isAccountDeleted {
             createMembership(in: team, context: managedObjectContext)

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -441,6 +441,28 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertNil(user.membership);
 }
 
+- (void)testThatItCreatesMembershipIfUserIsNotSelfUserButTeamExists
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.remoteIdentifier = uuid;
+    Team *team = [Team insertNewObjectInManagedObjectContext:self.uiMOC];
+    team.remoteIdentifier = teamId;
+
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = teamId.transportString;
+
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+
+    // then
+    XCTAssertNotNil(user.membership);
+}
+
 - (void)testThatItDeletesMembershipIfUserBelongsToSelfUserTeamOnAnExistingUserWhoIsMarkedAsDeleted
 {
     // given

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -281,7 +281,9 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     payload[@"team"] = teamId.transportString;
     
     // when
-    [user updateWithTransportData:payload authoritative:NO];
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
     
     // then
     XCTAssertEqualObjects(user.teamIdentifier.transportString, teamId.transportString);

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -399,6 +399,27 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertNil(user.membership);
 }
 
+- (void)testThatItCreatesTeamAndMembershipIfUserIsSelfUser
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    ZMUser *user = [ZMUser selfUserInContext:self.uiMOC];
+    user.remoteIdentifier = uuid;
+    XCTAssertNil(user.membership);
+
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = teamId.transportString;
+
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+
+    // then
+    XCTAssertEqualObjects(user.membership.team.remoteIdentifier, teamId);
+}
+
 - (void)testThatItDeletesMembershipIfUserBelongsToSelfUserTeamOnAnExistingUserWhoIsMarkedAsDeleted
 {
     // given

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests.m
@@ -420,6 +420,27 @@ static NSString *const ImageSmallProfileDataKey = @"imageSmallProfileData";
     XCTAssertEqualObjects(user.membership.team.remoteIdentifier, teamId);
 }
 
+- (void)testThatItDoesNotCreateTeamIfUserIsNotSelfUser
+{
+    // given
+    NSUUID *uuid = [NSUUID createUUID];
+    NSUUID *teamId = NSUUID.createUUID;
+    ZMUser *user = [ZMUser insertNewObjectInManagedObjectContext:self.uiMOC];
+    user.remoteIdentifier = uuid;
+
+    NSMutableDictionary *payload = [self samplePayloadForUserID:uuid];
+    payload[@"team"] = teamId.transportString;
+
+    // when
+    [self performPretendingUiMocIsSyncMoc:^{
+        [user updateWithTransportData:payload authoritative:NO];
+    }];
+
+    // then
+    XCTAssertNil([Team fetchWith:teamId in:self.uiMOC]);
+    XCTAssertNil(user.membership);
+}
+
 - (void)testThatItDeletesMembershipIfUserBelongsToSelfUserTeamOnAnExistingUserWhoIsMarkedAsDeleted
 {
     // given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15043" title="WPB-15043" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15043</a>  [iOS] Other clients don't discover newly created team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR:

- Fixes `-[ZMUserTests testThatItUpdatesTeamIdentifierOnExistingUser]`
- Updates implementation of `ZMUser.createOrDeleteMembershipIfBelongingToTeam()` fixing `-[ZMUserTests testThatItDoesNotCreateMembershipIfUserBelongsExternalTeamOnAnExistingUser]`
- Adds a few additional tests for `ZMUser.createOrDeleteMembershipIfBelongingToTeam()`.

@johnxnguyen determined the behavior of `ZMUser.createOrDeleteMembershipIfBelongingToTeam()` should be that:

- Calling this method on the self user will create its membership of the given team, creating the team if it doesn't exit.
- Calling this method on another user will only create its membership to the given team if it exists.

As we should only create a `Team` object that corresponds to the self users team, implicitly this means that:

- Calling this method on another user will only create its membership if the team is the **same** as the self users.

This should fix failing tests on `release/cycle-3.115`.

### Testing

Testing this is internal to the app by using the debugger, as there is no external way to verify that we don't create teams or memberships in the database for other teams.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
