### PR TITLE
fix: match secondary and tertiary buttons to figma design system - WPB-14957

### DIFF
--- a/WireFoundation/Sources/WireFoundation/Design/WireTextStyle/WireTextStyle.swift
+++ b/WireFoundation/Sources/WireFoundation/Design/WireTextStyle/WireTextStyle.swift
@@ -32,5 +32,4 @@ public enum WireTextStyle: CaseIterable, Sendable {
     case subline1
     case buttonSmall
     case buttonBig
-
 }

--- a/WireUI/Sources/WireDesign/Buttons/ButtonStyles.swift
+++ b/WireUI/Sources/WireDesign/Buttons/ButtonStyles.swift
@@ -22,6 +22,7 @@ public enum WireButtonStyle: String, CaseIterable {
     case primary
     case secondary
     case tertiary
+    case link
 }
 
 enum ButtonState: CaseIterable {
@@ -41,6 +42,8 @@ struct WireButtonStyleModifier: ViewModifier {
             content().buttonStyle(SecondaryButtonStyle())
         case .tertiary:
             content().buttonStyle(TertiaryButtonStyle())
+        case .link:
+            content().buttonStyle(LinkButtonStyle())
         }
     }
 

--- a/WireUI/Sources/WireDesign/Buttons/LinkButtonStyle.swift
+++ b/WireUI/Sources/WireDesign/Buttons/LinkButtonStyle.swift
@@ -18,23 +18,30 @@
 
 import SwiftUI
 
-struct TertiaryButtonStyle: SwiftUI.ButtonStyle {
+struct LinkButtonStyle: SwiftUI.ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.isFocused) var isFocused
 
-    typealias Theme = ColorTheme.Buttons.Tertiary
+    typealias Theme = ColorTheme.Buttons.Link
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .lineLimit(1)
+            .underline()
             .padding(8)
-            .background(isEnabled ? Theme.enabled.color : Theme.disabled.color)
-            .foregroundStyle(isEnabled ? Theme.onEnabled.color : Theme.onDisabled.color)
-            .wireTextStyle(.buttonSmall)
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(isEnabled ? Theme.enabledOutline.color : Theme.disabledOutline.color, lineWidth: 1)
-            }
-            .clipShape(.rect(cornerRadius: 12))
+            .foregroundStyle(foregroundColor(for: isEnabled, and: isFocused))
+            .wireTextStyle(.body1)
+    }
+}
+
+
+private func foregroundColor(for isEnabled: Bool, and isFocused: Bool) -> Color {
+    switch (isEnabled, isFocused) {
+    case (false, _):
+        return ColorTheme.Buttons.Link.onDisabled.color
+    case (true, true):
+        return ColorTheme.Buttons.Link.onFocus.color
+    case (true, false):
+        return ColorTheme.Buttons.Link.onEnabled.color
     }
 }

--- a/WireUI/Sources/WireDesign/Buttons/LinkButtonStyle.swift
+++ b/WireUI/Sources/WireDesign/Buttons/LinkButtonStyle.swift
@@ -20,7 +20,7 @@ import SwiftUI
 
 struct LinkButtonStyle: SwiftUI.ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
-    @Environment(\.isFocused) var isFocused
+    @Environment(\.isFocused) private var isFocused
 
     typealias Theme = ColorTheme.Buttons.Link
 

--- a/WireUI/Sources/WireDesign/Buttons/LinkButtonStyle.swift
+++ b/WireUI/Sources/WireDesign/Buttons/LinkButtonStyle.swift
@@ -34,14 +34,13 @@ struct LinkButtonStyle: SwiftUI.ButtonStyle {
     }
 }
 
-
 private func foregroundColor(for isEnabled: Bool, and isFocused: Bool) -> Color {
     switch (isEnabled, isFocused) {
     case (false, _):
-        return ColorTheme.Buttons.Link.onDisabled.color
+        ColorTheme.Buttons.Link.onDisabled.color
     case (true, true):
-        return ColorTheme.Buttons.Link.onFocus.color
+        ColorTheme.Buttons.Link.onFocus.color
     case (true, false):
-        return ColorTheme.Buttons.Link.onEnabled.color
+        ColorTheme.Buttons.Link.onEnabled.color
     }
 }

--- a/WireUI/Sources/WireDesign/Colors/ColorTheme.swift
+++ b/WireUI/Sources/WireDesign/Colors/ColorTheme.swift
@@ -109,19 +109,31 @@ public enum ColorTheme {
 
         enum Tertiary {
 
-            public static let enabled = UIColor.clear
+            static let enabled = UIColor(light: .white, dark: .gray90)
             public static let onEnabled = UIColor(light: .black, dark: .white)
+            static let enabledOutline = UIColor(light: .gray40, dark: .gray90)
 
-            public static let disabled = UIColor.clear
-            public static let onDisabled = UIColor(light: .gray60, dark: .gray60)
+            static let disabled = UIColor(light: .gray20, dark: .gray95)
+            static let onDisabled = UIColor(light: .gray70, dark: .gray50)
+            static let disabledOutline = UIColor(light: .gray40, dark: .gray95)
 
-            public static let focus = UIColor(light: .gray30, dark: .gray90)
-            public static let onFocus = UIColor(light: .black, dark: .white)
-            public static let focusOutline = UIColor(light: .blue500Light, dark: .blue500Dark)
+            static let focus = UIColor(light: .gray30, dark: .blue800Dark)
+            static let onFocus = UIColor(light: .black, dark: .white)
+            static let focusOutline = UIColor(light: .blue500Light, dark: .blue500Dark)
 
-            public static let selected = UIColor(light: .blue50Light, dark: .gray95)
-            public static let onSelected = UIColor(light: .blue500Light, dark: .blue500Dark)
-            public static let selectedOutline = UIColor(light: .blue300Light, dark: .gray90)
+            static let selected = UIColor(light: .blue50Light, dark: .blue800Dark)
+            static let onSelected = UIColor(light: .blue500Light, dark: .white)
+            static let selectedOutline = UIColor(light: .blue300Light, dark: .blue800Dark)
+        }
+
+        enum Link {
+            public static let onEnabled = Backgrounds.onSurface
+
+            static let onDisabled = Base.secondaryText
+
+            static let onFocus = Base.primary
+
+            static let onSelected = Base.primary
         }
     }
 

--- a/WireUI/Sources/WireDesign/Typography/Font+WireTextStyle.swift
+++ b/WireUI/Sources/WireDesign/Typography/Font+WireTextStyle.swift
@@ -49,7 +49,7 @@ public extension Font {
         case .subline1:
             .caption
         case .buttonSmall:
-            fatalError("not implemented")
+            .system(size: 14, weight: .semibold)
         case .buttonBig:
             .title3.weight(.semibold)
         }

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/SelfProfileViewCallToActionBanner.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/SelfProfileViewCallToActionBanner.swift
@@ -38,6 +38,7 @@ public struct SelfProfileViewCallToActionBanner: View {
         contentView(actionCallback: actionCallback)
             .padding(8)
             .bannerBackground()
+            .environment(\.wireTextStyleMapping, WireTextStyleMapping())
     }
 }
 
@@ -53,9 +54,8 @@ private func contentView(
         }, icon: {
             Image.infoCircle
         })
-        .fontWeight(.bold)
         Text(String.localized(key: "individualToTeam.banner.body", bundle: .module))
-            .wireTextStyle(.subline1)
+            .wireTextStyle(.body1)
             .lineLimit(nil)
 
         Button(
@@ -64,8 +64,7 @@ private func contentView(
                 Text(String.localized(key: "individualToTeam.banner.button", bundle: .module))
             }
         )
-        .wireButtonStyle(.secondary)
-        .fixedSize()
+        .wireButtonStyle(.tertiary)
     }
 }
 

--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/TeamPlanSelectionView.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/TeamPlanSelectionView.swift
@@ -61,7 +61,7 @@ struct TeamPlanSelectionView: View {
                         .lineLimit(nil)
                 }
             )
-            .wireButtonStyle(.tertiary)
+            .wireButtonStyle(.link)
             .padding(.top, 4)
             Spacer()
             Button(

--- a/WireUI/Tests/WireDesignTests/Buttons/LinkButtonStyleUITests.swift
+++ b/WireUI/Tests/WireDesignTests/Buttons/LinkButtonStyleUITests.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2025 Wire Swiss GmbH
+// Copyright (C) 2024 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/WireUI/Tests/WireDesignTests/Buttons/LinkButtonStyleUITests.swift
+++ b/WireUI/Tests/WireDesignTests/Buttons/LinkButtonStyleUITests.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WireTestingPackage
+import XCTest
+
+@testable import WireDesign
+
+final class LinkButtonStyleSnapshotTests: XCTestCase {
+
+    private var snapshotHelper: SnapshotHelper!
+
+    @MainActor
+    func test() {
+        // TODO: [WPB-14957] implement snapshot tests
+    }
+}

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -112,16 +112,22 @@ final class SelfProfileViewController: UIViewController {
             userSession.enqueue {
                 selfUser.refreshTeamData()
             }
-        } else if
-            let backendInfoApiVersion = BackendInfo.apiVersion,
-            let apiVersion = WireAPI.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
-            apiVersion >= .v7 {
-            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
-                actionCallback: { [weak self] action in
-                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)
-                }
-            )
         }
+//        else if
+//            let backendInfoApiVersion = BackendInfo.apiVersion,
+//            let apiVersion = WireAPI.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
+//            apiVersion >= .v7 {
+//            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
+//                actionCallback: { [weak self] action in
+//                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)
+//                }
+//            )
+//        }
+        self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
+            actionCallback: { [weak self] action in
+                self?.onTeamCreationBannerInteraction(action, apiVersion: .v7)
+            }
+        )
     }
 
     @available(*, unavailable)
@@ -253,11 +259,15 @@ final class SelfProfileViewController: UIViewController {
         case .createWireTeam:
             let sessionContextProvider = userSession.contextProvider
             let user = ZMUser.selfUser(inUserSession: sessionContextProvider)
-            guard let userName = user.normalizedName,
-                  let useCase = SessionManager.shared?.activeUserSession?
-                  .createIndividualToTeamMigrationUseCase(apiVersion: apiVersion) else {
+//            guard let userName = user.normalizedName,
+//                  let useCase = SessionManager.shared?.activeUserSession?
+//                  .createIndividualToTeamMigrationUseCase(apiVersion: apiVersion) else {
+//                return
+//            }
+            guard let userName = user.normalizedName else {
                 return
             }
+            let useCase = MockUseCase.success()
             userDidTapCreateTeam(useCase: useCase, userName: userName)
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -113,21 +113,16 @@ final class SelfProfileViewController: UIViewController {
                 selfUser.refreshTeamData()
             }
         }
-//        else if
-//            let backendInfoApiVersion = BackendInfo.apiVersion,
-//            let apiVersion = WireAPI.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
-//            apiVersion >= .v7 {
-//            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
-//                actionCallback: { [weak self] action in
-//                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)
-//                }
-//            )
-//        }
-        self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
-            actionCallback: { [weak self] action in
-                self?.onTeamCreationBannerInteraction(action, apiVersion: .v7)
-            }
-        )
+        else if
+            let backendInfoApiVersion = BackendInfo.apiVersion,
+            let apiVersion = WireAPI.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
+            apiVersion >= .v7 {
+            self.teamMigrationBanner = SelfProfileViewCallToActionBannerHostingController(
+                actionCallback: { [weak self] action in
+                    self?.onTeamCreationBannerInteraction(action, apiVersion: apiVersion)
+                }
+            )
+        }
     }
 
     @available(*, unavailable)
@@ -259,15 +254,11 @@ final class SelfProfileViewController: UIViewController {
         case .createWireTeam:
             let sessionContextProvider = userSession.contextProvider
             let user = ZMUser.selfUser(inUserSession: sessionContextProvider)
-//            guard let userName = user.normalizedName,
-//                  let useCase = SessionManager.shared?.activeUserSession?
-//                  .createIndividualToTeamMigrationUseCase(apiVersion: apiVersion) else {
-//                return
-//            }
-            guard let userName = user.normalizedName else {
+            guard let userName = user.normalizedName,
+                  let useCase = SessionManager.shared?.activeUserSession?
+                  .createIndividualToTeamMigrationUseCase(apiVersion: apiVersion) else {
                 return
             }
-            let useCase = MockUseCase.success()
             userDidTapCreateTeam(useCase: useCase, userName: userName)
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -112,8 +112,7 @@ final class SelfProfileViewController: UIViewController {
             userSession.enqueue {
                 selfUser.refreshTeamData()
             }
-        }
-        else if
+        } else if
             let backendInfoApiVersion = BackendInfo.apiVersion,
             let apiVersion = WireAPI.APIVersion(rawValue: UInt(backendInfoApiVersion.rawValue)),
             apiVersion >= .v7 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14957" title="WPB-14957" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14957</a>  [iOS] UI Issues for the flow personal user creating a team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The tertiary button (used by the individual to team banner CTA) and the link styles did not match the Figma reference.

![Screenshot 2024-12-23 at 19 32 36](https://github.com/user-attachments/assets/d067f744-88c4-4a5b-92d8-aa0026bd3871)

![Screenshot 2024-12-23 at 19 32 24](https://github.com/user-attachments/assets/01a9bf20-2410-42f6-8f67-b85846d2569e)

### Testing

Create a new individual account with the staging backend and the v7 api.
Go through the individual to teams flow.
The profile's banner's call to action button and the link in the first screen now match the reference figma.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
