### PR TITLE
fix: Never ending syncing when MLS feature is enabled - WPB-15026

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSClientManager.swift
+++ b/wire-ios-data-model/Source/MLS/MLSClientManager.swift
@@ -68,7 +68,6 @@ public final class MLSClientManager: MLSClientManagerProtocol {
     // MARK: - Private Implentation
 
     private func performsMLSClientUpdates() async {
-        // these operations are not dependent and should not be executed in same do/catch
         do {
             try await mlsService.performPendingJoins()
         } catch {

--- a/wire-ios-data-model/Source/MLS/MLSClientManager.swift
+++ b/wire-ios-data-model/Source/MLS/MLSClientManager.swift
@@ -1,0 +1,89 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireLogging
+
+// sourcery: AutoMockable
+public protocol MLSClientManagerProtocol {
+
+    func initializeMLSClientIfNeeded(
+        for qualifiedClientID: QualifiedClientID,
+        hasRegisteredMLSClient: Bool,
+        mlsFeature: Feature.MLS
+    ) async
+
+}
+
+public final class MLSClientManager: MLSClientManagerProtocol {
+
+    // MARK: - Properties
+
+    private let coreCryptoProvider: CoreCryptoProviderProtocol
+    private let mlsService: MLSServiceInterface
+
+    // MARK: - Initialize
+
+    public init(
+        coreCryptoProvider: CoreCryptoProviderProtocol,
+        mlsService: any MLSServiceInterface
+    ) {
+        self.coreCryptoProvider = coreCryptoProvider
+        self.mlsService = mlsService
+    }
+
+    // MARK: - Public Implementation
+
+    public func initializeMLSClientIfNeeded(
+        for qualifiedClientID: QualifiedClientID,
+        hasRegisteredMLSClient: Bool,
+        mlsFeature: Feature.MLS
+    ) async {
+        guard BackendInfo.isMLSEnabled, mlsFeature.isEnabled else {
+            WireLogger.mls.info("MLS feature in not enabled")
+            return
+        }
+
+        if !hasRegisteredMLSClient {
+            let mlsClientID = MLSClientID(qualifiedClientID: qualifiedClientID)
+            await createMLSClient(mlsClientID: mlsClientID)
+        }
+        await performsMLSClientUpdates()
+    }
+
+    // MARK: - Private Implentation
+
+    private func performsMLSClientUpdates() async {
+        // these operations are not dependent and should not be executed in same do/catch
+        do {
+            try await mlsService.performPendingJoins()
+        } catch {
+            WireLogger.mls.error("Failed to performPendingJoins: \(String(reflecting: error))")
+        }
+        await mlsService.uploadKeyPackagesIfNeeded()
+        await mlsService.updateKeyMaterialForAllStaleGroupsIfNeeded()
+    }
+
+    private func createMLSClient(mlsClientID: MLSClientID) async {
+        do {
+            try await coreCryptoProvider.initialiseMLSWithBasicCredentials(mlsClientID: mlsClientID)
+        } catch {
+            WireLogger.mls.error("Failed to initialise mls client: \(error)")
+        }
+    }
+
+}

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4050,6 +4050,30 @@ class MockMLSActionsProviderProtocol: MLSActionsProviderProtocol {
 
 }
 
+public class MockMLSClientManagerProtocol: MLSClientManagerProtocol {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - initializeMLSClientIfNeeded
+
+    public var initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_Invocations: [(qualifiedClientID: QualifiedClientID, hasRegisteredMLSClient: Bool, mlsFeature: Feature.MLS)] = []
+    public var initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod: ((QualifiedClientID, Bool, Feature.MLS) async -> Void)?
+
+    public func initializeMLSClientIfNeeded(for qualifiedClientID: QualifiedClientID, hasRegisteredMLSClient: Bool, mlsFeature: Feature.MLS) async {
+        initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_Invocations.append((qualifiedClientID: qualifiedClientID, hasRegisteredMLSClient: hasRegisteredMLSClient, mlsFeature: mlsFeature))
+
+        guard let mock = initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod else {
+            fatalError("no mock for `initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature`")
+        }
+
+        await mock(qualifiedClientID, hasRegisteredMLSClient, mlsFeature)
+    }
+
+}
+
 public class MockMLSDecryptionServiceInterface: MLSDecryptionServiceInterface {
 
     // MARK: - Life cycle

--- a/wire-ios-data-model/Tests/MLS/MLSClientManagerTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSClientManagerTests.swift
@@ -1,0 +1,219 @@
+//
+// Wire
+// Copyright (C) 2024 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+@testable import WireDataModelSupport
+@testable import WireRequestStrategy
+
+class MLSClientManagerTests: ZMBaseManagedObjectTest {
+
+    // MARK: - Properties
+
+    private var sut: MLSClientManager!
+    private var mockCoreCryptoProvider: MockCoreCryptoProviderProtocol!
+    private var mockMLService: MockMLSServiceInterface!
+    private var mockFeatureRepository: MockFeatureRepositoryInterface!
+
+    // MARK: - Life cycle
+
+    override func setUp() {
+        super.setUp()
+
+        mockFeatureRepository = MockFeatureRepositoryInterface()
+        mockCoreCryptoProvider = MockCoreCryptoProviderProtocol()
+        mockMLService = MockMLSServiceInterface()
+        sut = MLSClientManager(
+            coreCryptoProvider: mockCoreCryptoProvider,
+            mlsService: mockMLService
+        )
+    }
+
+    override func tearDown() {
+        mockFeatureRepository = nil
+        mockCoreCryptoProvider = nil
+        mockMLService = nil
+        sut = nil
+
+        super.tearDown()
+    }
+
+    func test_InitializeMLSClient_Success() async {
+        // Mock
+        mockFeatureRepository.fetchMLS_MockValue = Feature.MLS(
+            status: .enabled,
+            config: .init(defaultCipherSuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+        )
+        mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_MockMethod = { _ in }
+        mockMLService.performPendingJoins_MockMethod = {}
+        mockMLService.uploadKeyPackagesIfNeeded_MockMethod = {}
+        mockMLService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
+
+        // Given
+        BackendInfo.isMLSEnabled = true
+        let mlsFeature = mockFeatureRepository.fetchMLS()
+        await syncMOC.perform {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.domain = "example.domain.com"
+        }
+        let selfClient = await syncMOC.perform {
+            self.createSelfClient(onMOC: self.syncMOC)
+        }
+        let hasRegisteredMLSClient = await syncMOC.perform {
+            selfClient.hasRegisteredMLSClient
+        }
+        let qualifiedID = await syncMOC.perform {
+            selfClient.qualifiedClientID
+        }
+
+        // When
+        XCTAssertFalse(hasRegisteredMLSClient)
+        await sut.initializeMLSClientIfNeeded(
+            for: qualifiedID!,
+            hasRegisteredMLSClient: hasRegisteredMLSClient,
+            mlsFeature: mlsFeature
+        )
+
+        // Then
+        XCTAssertEqual(mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_Invocations.count, 1)
+    }
+
+    func test_InitializeMLSClient_Failed_MLSFeatureIsDisabled() async {
+        // Mock
+        mockFeatureRepository.fetchMLS_MockValue = Feature.MLS(
+            status: .disabled,
+            config: .init()
+        )
+        mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_MockMethod = { _ in }
+        mockMLService.performPendingJoins_MockMethod = {}
+        mockMLService.uploadKeyPackagesIfNeeded_MockMethod = {}
+        mockMLService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
+
+        // Given
+        BackendInfo.isMLSEnabled = true
+        let mlsFeature = mockFeatureRepository.fetchMLS()
+        await syncMOC.perform {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.domain = "example.domain.com"
+        }
+        let selfClient = await syncMOC.perform {
+            self.createSelfClient(onMOC: self.syncMOC)
+        }
+        let hasRegisteredMLSClient = await syncMOC.perform {
+            selfClient.hasRegisteredMLSClient
+        }
+        let qualifiedID = await syncMOC.perform {
+            selfClient.qualifiedClientID
+        }
+
+        // When
+        XCTAssertFalse(hasRegisteredMLSClient)
+        await sut.initializeMLSClientIfNeeded(
+            for: qualifiedID!,
+            hasRegisteredMLSClient: hasRegisteredMLSClient,
+            mlsFeature: mlsFeature
+        )
+
+        // Then
+        XCTAssertEqual(mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_Invocations.count, 0)
+    }
+
+    func test_InitializeMLSClient_Failed_MLSClientAlreadyExists() async {
+        // Mock
+        mockFeatureRepository.fetchMLS_MockValue = Feature.MLS(
+            status: .enabled,
+            config: .init(defaultCipherSuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+        )
+        mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_MockMethod = { _ in }
+        mockMLService.performPendingJoins_MockMethod = {}
+        mockMLService.uploadKeyPackagesIfNeeded_MockMethod = {}
+        mockMLService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
+
+        // Given
+        BackendInfo.isMLSEnabled = true
+        let mlsFeature = mockFeatureRepository.fetchMLS()
+        await syncMOC.perform {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.domain = "example.domain.com"
+        }
+        let selfClient = await syncMOC.perform {
+            self.createSelfClient(onMOC: self.syncMOC)
+        }
+        let qualifiedID = await syncMOC.perform {
+            selfClient.qualifiedClientID
+        }
+
+        // When
+        let hasRegisteredMLSClient = await syncMOC.perform {
+            selfClient.mlsPublicKeys = UserClient.MLSPublicKeys(ed25519: "somekey")
+            selfClient.needsToUploadMLSPublicKeys = false
+            return selfClient.hasRegisteredMLSClient
+        }
+        XCTAssertTrue(hasRegisteredMLSClient)
+
+        await sut.initializeMLSClientIfNeeded(
+            for: qualifiedID!,
+            hasRegisteredMLSClient: hasRegisteredMLSClient,
+            mlsFeature: mlsFeature
+        )
+
+        // Then
+        XCTAssertEqual(mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_Invocations.count, 0)
+    }
+
+    func test_InitializeMLSClient_Failed_MLSIsDisabledOnBackend() async {
+        // Mock
+        mockFeatureRepository.fetchMLS_MockValue = Feature.MLS(
+            status: .enabled,
+            config: .init(defaultCipherSuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
+        )
+        mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_MockMethod = { _ in }
+        mockMLService.performPendingJoins_MockMethod = {}
+        mockMLService.uploadKeyPackagesIfNeeded_MockMethod = {}
+        mockMLService.updateKeyMaterialForAllStaleGroupsIfNeeded_MockMethod = {}
+
+        // Given
+        BackendInfo.isMLSEnabled = false
+        let mlsFeature = mockFeatureRepository.fetchMLS()
+        await syncMOC.perform {
+            let selfUser = ZMUser.selfUser(in: self.syncMOC)
+            selfUser.domain = "example.domain.com"
+        }
+        let selfClient = await syncMOC.perform {
+            self.createSelfClient(onMOC: self.syncMOC)
+        }
+        let hasRegisteredMLSClient = await syncMOC.perform {
+            selfClient.hasRegisteredMLSClient
+        }
+        let qualifiedID = await syncMOC.perform {
+            selfClient.qualifiedClientID
+        }
+
+        // When
+        XCTAssertFalse(hasRegisteredMLSClient)
+        await sut.initializeMLSClientIfNeeded(
+            for: qualifiedID!,
+            hasRegisteredMLSClient: hasRegisteredMLSClient,
+            mlsFeature: mlsFeature
+        )
+
+        // Then
+        XCTAssertEqual(mockCoreCryptoProvider.initialiseMLSWithBasicCredentialsMlsClientID_Invocations.count, 0)
+    }
+
+}

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		06D33FCF2525D368004B9BC1 /* store2-86-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 06D33FCE2525D368004B9BC1 /* store2-86-0.wiredatabase */; };
 		06D48735241F930A00881B08 /* GenericMessage+Obfuscation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D48734241F930A00881B08 /* GenericMessage+Obfuscation.swift */; };
 		06D48737241FB3F700881B08 /* ZMClientMessage+Obfuscate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D48736241FB3F700881B08 /* ZMClientMessage+Obfuscate.swift */; };
+		06D4B5152D22A024004627EB /* MLSClientManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D4B5142D22A021004627EB /* MLSClientManager.swift */; };
+		06D4B5172D22A07A004627EB /* MLSClientManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D4B5162D22A077004627EB /* MLSClientManagerTests.swift */; };
 		06D5423C26399C33006B0C5A /* UserType+External.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D5423B26399C32006B0C5A /* UserType+External.swift */; };
 		06E1C835244F1A2300CA4EF2 /* ZMOTRMessage+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E1C834244F1A2300CA4EF2 /* ZMOTRMessage+Helper.swift */; };
 		06E2ABBD2B8C9D2C0094F567 /* UpdateMLSGroupVerificationStatusUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E2ABBC2B8C9D2C0094F567 /* UpdateMLSGroupVerificationStatusUseCaseTests.swift */; };
@@ -1015,6 +1017,8 @@
 		06D33FCE2525D368004B9BC1 /* store2-86-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-86-0.wiredatabase"; sourceTree = "<group>"; };
 		06D48734241F930A00881B08 /* GenericMessage+Obfuscation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericMessage+Obfuscation.swift"; sourceTree = "<group>"; };
 		06D48736241FB3F700881B08 /* ZMClientMessage+Obfuscate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+Obfuscate.swift"; sourceTree = "<group>"; };
+		06D4B5142D22A021004627EB /* MLSClientManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSClientManager.swift; sourceTree = "<group>"; };
+		06D4B5162D22A077004627EB /* MLSClientManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSClientManagerTests.swift; sourceTree = "<group>"; };
 		06D5423B26399C32006B0C5A /* UserType+External.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserType+External.swift"; sourceTree = "<group>"; };
 		06E1C834244F1A2300CA4EF2 /* ZMOTRMessage+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOTRMessage+Helper.swift"; sourceTree = "<group>"; };
 		06E2ABBC2B8C9D2C0094F567 /* UpdateMLSGroupVerificationStatusUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateMLSGroupVerificationStatusUseCaseTests.swift; sourceTree = "<group>"; };
@@ -2339,6 +2343,7 @@
 		63B1333929A503D000009D84 /* MLS */ = {
 			isa = PBXGroup;
 			children = (
+				06D4B5142D22A021004627EB /* MLSClientManager.swift */,
 				EEF09CA52B1DE09800D729A1 /* OneOnOne */,
 				63B1333A29A503D000009D84 /* MLSGroup.swift */,
 				63B1333B29A503D000009D84 /* MLSActionsProvider.swift */,
@@ -2637,6 +2642,7 @@
 		EE98879028882C6D002340D2 /* MLS */ = {
 			isa = PBXGroup;
 			children = (
+				06D4B5162D22A077004627EB /* MLSClientManagerTests.swift */,
 				639971C02B28C5FA009DD5CF /* CommitSenderTests.swift */,
 				EEFAAC3328DDE27F009940E7 /* CoreCryptoCallbacksTests.swift */,
 				63C07014291144F70075D598 /* CoreCryptoConfigProviderTests.swift */,
@@ -4190,6 +4196,7 @@
 				5E771F382080BB0000575629 /* PBMessage+Validation.swift in Sources */,
 				16313D621D227DC1001B2AB3 /* LinkPreview+ProtocolBuffer.swift in Sources */,
 				63C2EABF2A93B1E7008A0AB7 /* RemoveParticipantAction.swift in Sources */,
+				06D4B5152D22A024004627EB /* MLSClientManager.swift in Sources */,
 				F1FDF2F721B152BC00E037A1 /* GenericMessage+Helper.swift in Sources */,
 				16030DC521AEE25500F8032E /* ZMOTRMessage+Confirmations.swift in Sources */,
 				D5FA30C52063DC2D00716618 /* BackupMetadata.swift in Sources */,
@@ -4807,6 +4814,7 @@
 				EF9A4703210A026600085102 /* ZMConversationTests+Language.swift in Sources */,
 				F9A7083F1CAEEB7500C2F5FE /* PersistentChangeTrackingTests.m in Sources */,
 				16E70FA7270F212100718E5D /* ZMConnection+Helper.m in Sources */,
+				06D4B5172D22A07A004627EB /* MLSClientManagerTests.swift in Sources */,
 				1672A6162344A14E00380537 /* LabelObserverTests.swift in Sources */,
 				BF1B980B1EC31D6100DE033B /* TeamDeletionRuleTests.swift in Sources */,
 				EEFAAC3528DDE2B1009940E7 /* CoreCryptoCallbacksTests.swift in Sources */,

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategy.swift
@@ -23,6 +23,8 @@ public final class FeatureConfigRequestStrategy: AbstractRequestStrategy {
 
     // MARK: - Properties
 
+    let mlsClientManager: MLSClientManagerProtocol
+
     // Slow Sync
 
     private unowned var syncStatus: SyncProgress
@@ -43,11 +45,13 @@ public final class FeatureConfigRequestStrategy: AbstractRequestStrategy {
     public init(
         withManagedObjectContext managedObjectContext: NSManagedObjectContext,
         applicationStatus: ApplicationStatus,
-        syncProgress: SyncProgress
+        syncProgress: SyncProgress,
+        mlsClientManager: MLSClientManagerProtocol
     ) {
         self.actionHandler = GetFeatureConfigsActionHandler(context: managedObjectContext)
         self.actionSync = EntityActionSync(actionHandlers: [actionHandler])
         self.syncStatus = syncProgress
+        self.mlsClientManager = mlsClientManager
 
         super.init(
             withManagedObjectContext: managedObjectContext,
@@ -138,7 +142,9 @@ extension FeatureConfigRequestStrategy: ZMEventConsumer {
             try processor.processEventPayload(
                 data: payloadData,
                 featureName: featureName,
-                repository: repository
+                repository: repository,
+                mlsClientManager: mlsClientManager,
+                in: managedObjectContext
             )
 
             WireLogger.featureConfigs.info("Finished processing update event \(name)")

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/FeatureConfigRequestStrategyTests.swift
@@ -18,6 +18,7 @@
 
 import WireRequestStrategySupport
 import XCTest
+@testable import WireDataModelSupport
 @testable import WireRequestStrategy
 
 final class FeatureConfigRequestStrategyTests: MessagingTestBase {
@@ -26,6 +27,7 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
 
     var sut: FeatureConfigRequestStrategy!
     var mockApplicationStatus: MockApplicationStatus!
+    var mockMLSClientManager: MockMLSClientManagerProtocol!
     var featureRepository: FeatureRepository!
 
     // MARK: - Life cycle
@@ -33,12 +35,14 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     override func setUp() {
         super.setUp()
         mockApplicationStatus = MockApplicationStatus()
+        mockMLSClientManager = MockMLSClientManagerProtocol()
         mockApplicationStatus.mockSynchronizationState = .slowSyncing
 
         sut = FeatureConfigRequestStrategy(
             withManagedObjectContext: syncMOC,
             applicationStatus: mockApplicationStatus,
-            syncProgress: MockSyncProgress()
+            syncProgress: MockSyncProgress(),
+            mlsClientManager: mockMLSClientManager
         )
 
         featureRepository = .init(context: syncMOC)
@@ -54,6 +58,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     // MARK: - Processing events
 
     func test_ItProcessesEvent_AppLock() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             let appLock = Feature.AppLock(
@@ -96,6 +103,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_FileSharing() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             self.featureRepository.storeFileSharing(.init(status: .disabled))
@@ -127,6 +137,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_SelfDeletingMessages() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             let selfDeletingMessages = Feature.SelfDeletingMessages(
@@ -168,6 +181,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_ConferenceCalling() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             self.featureRepository.storeConferenceCalling(.init(status: .disabled))
@@ -199,6 +215,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_ConversationGuestLinks() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             self.featureRepository.storeConversationGuestLinks(.init(status: .disabled))
@@ -230,6 +249,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_DigitalSignature() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             self.featureRepository.storeDigitalSignature(.init(status: .disabled))
@@ -261,6 +283,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_ClassifiedDomains() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         syncMOC.performGroupedAndWait {
             // Given
             let classifiedDomains = Feature.ClassifiedDomains(status: .disabled, config: .init())
@@ -298,6 +323,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_MLS() throws {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         // Given
         try syncMOC.performAndWait {
             let mls = Feature.MLS(status: .disabled, config: .init())
@@ -337,6 +365,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_MLS_defaultProtocolIsMLS() throws {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         // Given
         try syncMOC.performAndWait {
             let mls = Feature.MLS(status: .disabled, config: .init())
@@ -376,6 +407,9 @@ final class FeatureConfigRequestStrategyTests: MessagingTestBase {
     }
 
     func test_ItProcessesEvent_MLSMigration() {
+        // Mock
+        mockMLSClientManager.initializeMLSClientIfNeededForHasRegisteredMLSClientMlsFeature_MockMethod = { _, _, _ in }
+
         // Given
         let startTime = "2023-10-27T12:43:48.000Z"
         let finaliseTime = "2023-11-02T12:43:48.000Z"

--- a/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/Payload/FeatureConfigsPayloadProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Feature configurations/Payload/FeatureConfigsPayloadProcessor.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import protocol WireDataModel.FeatureRepositoryInterface
+import WireLogging
 
 struct FeatureConfigsPayloadProcessor {
 
@@ -207,7 +208,9 @@ struct FeatureConfigsPayloadProcessor {
     func processEventPayload(
         data: Data,
         featureName: Feature.Name,
-        repository: FeatureRepositoryInterface
+        repository: FeatureRepositoryInterface,
+        mlsClientManager: MLSClientManagerProtocol,
+        in context: NSManagedObjectContext
     ) throws {
         switch featureName {
         case .conferenceCalling:
@@ -256,6 +259,14 @@ struct FeatureConfigsPayloadProcessor {
         case .mls:
             let response = try decoder.decode(FeatureStatusWithConfig<Feature.MLS.Config>.self, from: data)
             repository.storeMLS(.init(status: response.status, config: response.config))
+            Task {
+                let mlsFeature = await repository.fetchMLS()
+                await processMLSFeatureConfigChanges(
+                    mlsClientManager: mlsClientManager,
+                    context: context,
+                    mlsFeature: mlsFeature
+                )
+            }
 
         case .mlsMigration:
             let response = try decoder.decode(FeatureStatusWithConfig<Feature.MLSMigration.Config>.self, from: data)
@@ -265,5 +276,26 @@ struct FeatureConfigsPayloadProcessor {
             let response = try decoder.decode(FeatureStatusWithConfig<Feature.E2EI.Config>.self, from: data)
             repository.storeE2EI(.init(status: response.status, config: response.config))
         }
+    }
+
+    private func processMLSFeatureConfigChanges(
+        mlsClientManager: MLSClientManagerProtocol,
+        context: NSManagedObjectContext,
+        mlsFeature: Feature.MLS
+    ) async {
+        let (qualifiedSelfClientID, hasRegisteredMLSClient) = await context.perform {
+            let selfClient = ZMUser.selfUser(in: context).selfClient()
+            return (selfClient?.qualifiedClientID, selfClient?.hasRegisteredMLSClient ?? false)
+        }
+
+        guard let qualifiedSelfClientID else {
+            WireLogger.mls.warn("`qualifiedClientID` is missing for selfClient")
+            return
+        }
+        await mlsClientManager.initializeMLSClientIfNeeded(
+            for: qualifiedSelfClientID,
+            hasRegisteredMLSClient: hasRegisteredMLSClient,
+            mlsFeature: mlsFeature
+        )
     }
 }

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -142,6 +142,10 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             migrator: OneOnOneMigrator(mlsService: mlsService),
             isMLSEnabled: mlsFeature.isEnabled
         )
+        let mlsClientManager = MLSClientManager(
+            coreCryptoProvider: coreCryptoProvider,
+            mlsService: mlsService
+        )
 
         return [
 
@@ -357,7 +361,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             FeatureConfigRequestStrategy(
                 withManagedObjectContext: syncMOC,
                 applicationStatus: applicationStatusDirectory,
-                syncProgress: applicationStatusDirectory.syncStatus
+                syncProgress: applicationStatusDirectory.syncStatus,
+                mlsClientManager: mlsClientManager
             ),
             FetchBackendMLSPublicKeysRequestStrategy(
                 withManagedObjectContext: syncMOC,

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -352,6 +352,11 @@ public final class ZMUserSession: NSObject {
     public lazy var changeUsername: ChangeUsernameUseCaseProtocol =
         ChangeUsernameUseCase(userProfile: applicationStatusDirectory.userProfileUpdateStatus)
 
+    private lazy var  mlsClientManager = MLSClientManager(
+        coreCryptoProvider: coreCryptoProvider,
+        mlsService: mlsService
+    )
+
     // MARK: Dependency Injection
 
     let dependencies: UserSessionDependencies
@@ -937,18 +942,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
             context: notificationContext
         ).post()
 
-        func performsMLSClientUpdates() async {
-            // these operations are not dependent and should not be executed in same do/catch
-            do {
-                // rework implementation of following method - WPB-6053
-                try await mlsService.performPendingJoins()
-            } catch {
-                WireLogger.mls.error("Failed to performPendingJoins: \(String(reflecting: error))")
-            }
-            await mlsService.uploadKeyPackagesIfNeeded()
-            await mlsService.updateKeyMaterialForAllStaleGroupsIfNeeded()
-        }
-
         WaitingGroupTask(context: syncContext) { [self] in
             await fetchBackendMLSPublicKeys()
             await fetchAndStoreFeatureConfig()
@@ -959,18 +952,14 @@ extension ZMUserSession: ZMSyncStateDelegate {
                 return (selfClient?.qualifiedClientID, hasRegisteredMLSClient)
             }
 
-            if hasRegisteredMLSClient {
-                await performsMLSClientUpdates()
+            if let qualifiedSelfClientID {
+                await mlsClientManager.initializeMLSClientIfNeeded(
+                    for: qualifiedSelfClientID,
+                    hasRegisteredMLSClient: hasRegisteredMLSClient,
+                    mlsFeature: mlsFeature
+                )
             } else {
-                // If we discover that
-                // there are MLS public keys on the backend, the MLS feature is enabled and there is no registered MLS
-                // client,
-                // we should create one.
-                let needsToRegisterMLSClient = BackendInfo.isMLSEnabled && mlsFeature.isEnabled
-                if let qualifiedSelfClientID, needsToRegisterMLSClient {
-                    await createMLSClient(qualifiedID: qualifiedSelfClientID)
-                    await performsMLSClientUpdates()
-                }
+                WireLogger.mls.warn("`qualifiedClientID` is missing for selfClient")
             }
 
             if mlsFeature.isEnabled {
@@ -1052,17 +1041,6 @@ extension ZMUserSession: ZMSyncStateDelegate {
             BackendInfo.isMLSEnabled = hasValidKeys
         } catch {
             WireLogger.mls.info("Backend doesn't have MLS public keys: \(String(reflecting: error))")
-        }
-    }
-
-    private func createMLSClient(qualifiedID: QualifiedClientID) async {
-        let mlsClientID = await syncContext.perform {
-            MLSClientID(qualifiedClientID: qualifiedID)
-        }
-        do {
-            try await coreCryptoProvider.initialiseMLSWithBasicCredentials(mlsClientID: mlsClientID)
-        } catch {
-            WireLogger.mls.error("Failed to initialise mls client: \(error)")
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -482,6 +482,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
             let selfUserClient = createSelfClient()
             selfUserClient.mlsPublicKeys = UserClient.MLSPublicKeys(ed25519: "somekey")
             selfUserClient.needsToUploadMLSPublicKeys = false
+            ZMUser.selfUser(in: self.syncMOC).domain = "anta.com"
             syncMOC.saveOrRollback()
 
             // WHEN


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15026" title="WPB-15026" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15026</a>  [iOS] Never ending syncing when MLS feature is enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Never ending syncing when MLS feature is enabled.

Solution

The solution is to create the MLS client after saving the feature config change to the db. To achieve this:

- inject `MLSClientManager`, which is responsible for initializing the MLS client if needed,  into `FeatureConfigRequestStrategy`.

**Note:** https://github.com/wireapp/wire-ios/pull/2329 has the wrong base branch, this PR is a duplicate and should be merged.

### Testing


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
