### PR TITLE
fix: read receipts setting not synchronized after login - WPB-11738

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
@@ -333,7 +333,6 @@ extension UserPropertyRequestStrategy: ZMSingleRequestTranscoder {
             )
         default:
             logger.warn("unhandled user property (\(property.propertyName)) response: \(response.result)")
-            break
         }
     }
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireTransport
+import WireLogging
 
 private enum UserProperty: CaseIterable {
     case readReceiptsEnabled
@@ -128,6 +129,7 @@ public class UserPropertyRequestStrategy: AbstractRequestStrategy {
     var downstreamSync: ZMSingleRequestSync!
     fileprivate var propertiesToFetch: Set<UserProperty> = Set()
     fileprivate var fetchedProperty: UserProperty?
+    private let logger = WireLogger(tag: "user-properties")
 
     public override init(
         withManagedObjectContext managedObjectContext: NSManagedObjectContext,
@@ -304,18 +306,34 @@ extension UserPropertyRequestStrategy: ZMSingleRequestTranscoder {
             return
         }
 
-        if response.result == .permanentError {
-            property.parseUpdate(
-                for: ZMUser.selfUser(in: managedObjectContext),
-                updateType: (.slowSync, .delete),
-                payload: nil
-            )
-        } else if response.result == .success, let payload = response.payload {
+        switch response.result {
+        case .success:
+            guard
+                let data = response.rawData,
+                let payload = try? JSONSerialization.jsonObject(
+                    with: data,
+                    options: .fragmentsAllowed
+                )
+            else {
+                logger.error("failed to parse user property (\(property.propertyName)) response")
+                return
+            }
+
             property.parseUpdate(
                 for: ZMUser.selfUser(in: managedObjectContext),
                 updateType: (.slowSync, .set),
                 payload: payload
             )
+        case .permanentError:
+            logger.error("failed to parse user property (\(property.propertyName)) response due to permanent error")
+            property.parseUpdate(
+                for: ZMUser.selfUser(in: managedObjectContext),
+                updateType: (.slowSync, .delete),
+                payload: nil
+            )
+        default:
+            logger.warn("unhandled user property (\(property.propertyName)) response: \(response.result)")
+            break
         }
     }
 }

--- a/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/User/UserPropertyRequestStrategy.swift
@@ -17,8 +17,8 @@
 //
 
 import Foundation
-import WireTransport
 import WireLogging
+import WireTransport
 
 private enum UserProperty: CaseIterable {
     case readReceiptsEnabled

--- a/wire-ios-transport/Source/Requests/ZMTransportResponse.m
+++ b/wire-ios-transport/Source/Requests/ZMTransportResponse.m
@@ -63,12 +63,12 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
         default:
         {
             self = [self initWithPayload:nil HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields apiVersion:apiVersion];
-            self.rawData = data;
             break;
         }
     }
     
     self.rawResponse = HTTPResponse;
+    self.rawData = data;
     return self;
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsTableViewController.swift
@@ -358,7 +358,7 @@ extension SettingsTableViewController {
 
 extension SettingsTableViewController: UserObserving {
     func userDidChange(_ note: UserChangeInfo) {
-        if note.accentColorValueChanged {
+        if note.accentColorValueChanged || note.readReceiptsEnabledChanged {
             refreshData()
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11738" title="WPB-11738" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-11738</a>  [iOS] Read receipt updates from web is not synchronized in iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

After a fresh login, the read receipts setting (under Settings > Account) is always false, even if it is true on other clients. Furthermore, when the setting is changed on other clients, the value is received on iOS but the UI doesn't refresh unless dismissing it and reloading it.

The first problem is due to not correctly parsing the response payload to fetch the initial value: the payload is simply a boolean integer which is not parsed as a json object and consequently we return early. The fix is to deserialize the json object with an additional option to allow root level values.

The second issue is due to not reacting to the read receipt changes in the settings view controler.

### Testing

1. Log in with user A on web. Enable read receipts
2. Login with user A on iOS. Assert the read receipt settings is enabled.
3. While the account settings is open on iOS, on web change the read receipt settings. Assert on iOS the toggle updates accordingly.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
