### PR TITLE
fix: indiviual to team migration disable dismiss and remove close button on last step - WPB-15044

### DIFF
--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/IndividualToTeamMigrationViewController.swift
@@ -252,7 +252,7 @@ public class IndividualToTeamMigrationViewController: UIViewController {
                 onTransition: { @MainActor [weak self] in self?.transition(to: $0) }
             )
             childController.setViewControllers([vc], animated: true)
-            isModalInPresentation = false
+            isModalInPresentation = true
         case .toCompletionDismiss:
             analyticsFlowCompletionAction = nil
             actionCallback(.completionDismiss)
@@ -351,17 +351,21 @@ private func hostedView(
         .environment(\.wireTextStyleMapping, WireTextStyleMapping())
     )
     vc.title = step.title
-    vc.navigationItem.rightBarButtonItem = UIBarButtonItem.closeButton(
-        action: UIAction { _ in
-            switch step {
-            case .teamPlanSelection, .teamName, .confirmation:
-                transitionCallback(.toCancellationAlert)
-            case .completion:
-                transitionCallback(.toCompletionDismiss)
-            }
-        },
-        accessibilityLabel: step.closeButtonAccessibilityLabel
-    )
+    if case .completion = step {
+        vc.navigationItem.rightBarButtonItem = nil
+    } else {
+        vc.navigationItem.rightBarButtonItem = UIBarButtonItem.closeButton(
+            action: UIAction { _ in
+                switch step {
+                case .teamPlanSelection, .teamName, .confirmation:
+                    transitionCallback(.toCancellationAlert)
+                case .completion:
+                    transitionCallback(.toCompletionDismiss)
+                }
+            },
+            accessibilityLabel: step.closeButtonAccessibilityLabel
+        )
+    }
     // Hide navigation bar title
     vc.navigationItem.titleView = UIView()
     vc.navigationItem.rightBarButtonItem?.tintColor = ColorTheme.Backgrounds.onBackground


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15044" title="WPB-15044" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15044</a>  Manage team button not visible after completing flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The profile view doesn't properly update when dismissing the individual to team flow's modal once the user has migrated to a team account.
Updating it properly is time-consuming, so instead we simply removed the close button and disabled pull to dismiss on the last screen.

### Testing

Create a new account (staging backend, api v7).
Go through the individual to team flow.
Once you have successfully migrated, on the last screen, the close button is gone and the modal can only be dismissed through one of the two bottom buttons.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.