### PR TITLE
chore: disable ui.clicked-profile event - WPB-15245

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -348,7 +348,9 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
         // analytics
         let isNotificationsBadgeVisible = viewModel.hideProfileNotificationsBadge
         let analyticsEventTracker = viewModel.userSession.analyticsEventTracker
-        analyticsEventTracker?.trackEvent(.UI.openSelfProfile(isMigrationDotActive: isNotificationsBadgeVisible))
+        #if false // [WPB-15245] This event has temporarily been disabled.
+            analyticsEventTracker?.trackEvent(.UI.openSelfProfile(isMigrationDotActive: isNotificationsBadgeVisible))
+        #endif
 
         // open profile
         Task {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/SidebarViewControllerDelegate.swift
@@ -47,7 +47,9 @@ final class SidebarViewControllerDelegate: WireSidebarUI.SidebarViewControllerDe
         // analytics
         let isNotificationsBadgeVisible = viewController.accountInfo.showNotificationsBadge
         let analyticsEventTracker = analyticsEventTracker()
-        analyticsEventTracker?.trackEvent(.UI.openSelfProfile(isMigrationDotActive: isNotificationsBadgeVisible))
+        #if false // [WPB-15245] This event has temporarily been disabled.
+            analyticsEventTracker?.trackEvent(.UI.openSelfProfile(isMigrationDotActive: isNotificationsBadgeVisible))
+        #endif
 
         // open profile
         Task { @MainActor in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15245" title="WPB-15245" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15245</a>  Disabling Countly tracking of profile page
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The `ui.clicked-profile` event is currently triggered so many times that it isn't useful to be tracked.
This PR temporarily disables sending it.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
