### PR TITLE
fix: report error - WPB-15166

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -307,6 +307,7 @@ platform :ios do
             write_tests_info_to_summary("🤖 Testing scheme #{scheme} with plan #{testplan}")
             begin
                 test_plan(build, scheme, testplan)
+                schema_errors[scheme] = false
             rescue => e
                 write_tests_info_to_summary("❌ Scheme: #{scheme} failed with errors: #{e.to_s}")
                 if !is_nightly_build
@@ -314,7 +315,6 @@ platform :ios do
                 end
                 schema_errors[scheme] = true
             end
-            schema_errors[scheme] = false
         end
        
         # report errors so Github action fails

--- a/wire-ios-canvas/WireCanvas.xcodeproj/project.pbxproj
+++ b/wire-ios-canvas/WireCanvas.xcodeproj/project.pbxproj
@@ -291,6 +291,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphonesimulator*]" = (
+					arm64,
+					x86_64,
+				);
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -360,6 +364,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphonesimulator*]" = (
+					x86_64,
+					arm64,
+				);
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15166" title="WPB-15166" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15166</a>  CI job failure are not reported correctly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following  #2322, this PR fixes:

- reporting failing scheme, see [log](https://github.com/wireapp/wire-ios/actions/runs/12640280319)
- issue with running WireCanvas tests (simulator architecture)
