### PR TITLE
chore: Migrate away from deprecated interface orientation methods - WPB-11498

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -224,15 +224,6 @@ final class CollectionsViewController: UIViewController {
         wr_supportedInterfaceOrientations
     }
 
-    override var shouldAutorotate: Bool {
-        switch traitCollection.horizontalSizeClass {
-        case .compact:
-            false
-        default:
-            true
-        }
-    }
-
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         .portrait
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Collections/CollectionsViewController.swift
@@ -220,7 +220,6 @@ final class CollectionsViewController: UIViewController {
 
     // MARK: - device orientation
 
-    /// Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (.regular in iOS11).
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         wr_supportedInterfaceOrientations
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/FullscreenImageViewController.swift
@@ -166,10 +166,6 @@ final class FullscreenImageViewController: UIViewController {
         .all
     }
 
-    override var shouldAutorotate: Bool {
-        true
-    }
-
     override var canBecomeFirstResponder: Bool {
         true
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/RotationAwareNavigationController.swift
@@ -20,14 +20,6 @@ import UIKit
 
 final class RotationAwareNavigationController: UINavigationController {
 
-    override var shouldAutorotate: Bool {
-        if let topController = viewControllers.last {
-            topController.shouldAutorotate
-        } else {
-            super.shouldAutorotate
-        }
-    }
-
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if let topController = viewControllers.last {
             topController.supportedInterfaceOrientations

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/KeyboardAvoidingViewController.swift
@@ -45,10 +45,6 @@ class KeyboardAvoidingViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override var shouldAutorotate: Bool {
-        viewController.shouldAutorotate
-    }
-
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         viewController.supportedInterfaceOrientations
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -323,10 +323,6 @@ final class ConversationContentViewController: UIViewController {
         }
     }
 
-    override var shouldAutorotate: Bool {
-        true
-    }
-
     override func didReceiveMemoryWarning() {
         zmLog.warn("Received system memory warning.")
         super.didReceiveMemoryWarning()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
@@ -109,9 +109,9 @@ final class MessagePresenter: NSObject {
         }
     }
 
-    // MARK: - AVPlayerViewController dismissial
+    // MARK: - AVPlayerViewController dismissal
 
-    fileprivate func observePlayerDismissial() {
+    fileprivate func observePlayerDismissal() {
         videoPlayerObserver = NotificationCenter.default.addObserver(
             forName: .dismissingAVPlayer,
             object: nil,
@@ -173,7 +173,7 @@ final class MessagePresenter: NSObject {
             let playerViewController = AVPlayerViewController()
             playerViewController.player = player
 
-            observePlayerDismissial()
+            observePlayerDismissal()
 
             targetViewController?.present(playerViewController, animated: true) {
                 player.play()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessagePresenter.swift
@@ -119,8 +119,6 @@ final class MessagePresenter: NSObject {
         ) { _ in
             self.mediaPlayerController?.tearDown()
 
-            UIViewController.attemptRotationToDeviceOrientation()
-
             if let videoPlayerObserver = self.videoPlayerObserver {
                 NotificationCenter.default.removeObserver(videoPlayerObserver)
                 self.videoPlayerObserver = nil

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -287,10 +287,6 @@ final class ConversationViewController: UIViewController {
 
     // MARK: - Device orientation
 
-    override var shouldAutorotate: Bool {
-        true
-    }
-
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if UIDevice.current.userInterfaceIdiom == .phone {
             .portrait

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Message Details/MessageDetailsViewController.swift
@@ -269,10 +269,6 @@ final class MessageDetailsViewController: UIViewController {
 
     // MARK: - Orientation
 
-    override var shouldAutorotate: Bool {
-        false
-    }
-
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         wr_supportedInterfaceOrientations
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Orientation.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Orientation.swift
@@ -20,16 +20,14 @@ import UIKit
 
 extension UIViewController {
 
-    /// return the default supported interface orientations of a view controller
-    /// return .all only if the idiom is .pad and size class is .regular
+    /// The default supported interface orientations of a view controller
+    /// - returns: `.all` for iPad otherwise `.portrait`.
     var wr_supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        switch (UIDevice.current.userInterfaceIdiom, traitCollection.horizontalSizeClass) {
-        case (.pad, .regular),
-             // Notice: for iPad with iOS9 in landscape mode, horizontalSizeClass is .unspecified (it is .regular in iOS11).
-             (.pad, .unspecified):
-            .all
+        switch UIDevice.current.userInterfaceIdiom {
+        case .pad:
+            return .all
         default:
-            .portrait
+            return .portrait
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Orientation.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/UIViewController+Orientation.swift
@@ -25,9 +25,9 @@ extension UIViewController {
     var wr_supportedInterfaceOrientations: UIInterfaceOrientationMask {
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:
-            return .all
+            .all
         default:
-            return .portrait
+            .portrait
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Sketchpad/CanvasViewController.swift
@@ -66,13 +66,8 @@ final class CanvasViewController: UIViewController, UINavigationControllerDelega
 
     // MARK: - Override methods
 
-    override var shouldAutorotate: Bool {
-        switch UIDevice.current.userInterfaceIdiom {
-        case .pad:
-            true
-        default:
-            false
-        }
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        wr_supportedInterfaceOrientations
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11498" title="WPB-11498" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11498</a>  [iOS] Migration of interface orientation methods deprecated in iOS 16
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR addresses our use of the following methods that were deprecated in iOS 16:

- [`UIViewController.shouldAutorotate`](https://developer.apple.com/documentation/uikit/uiviewcontroller/shouldautorotate)
- [`UIViewController.attemptRotationToDeviceOrientation()`](https://developer.apple.com/documentation/uikit/uiviewcontroller/attemptrotationtodeviceorientation())

It includes the following changes:

- `UIViewController.wr_supportedInterfaceOrientations` was simplified as the current implementation didn't make sense. See commit message in bc7bf8f804167652b461259bab270dad7fc95f92.
- Removed all instances of `UIViewController.shouldAutorotate`. These were either just providing default behavior (returning true), or their behavior is already defined within the implementation of `UIViewController.supportedInterfaceOrientations` (this is incidentally the advised migration path).
- Removes the only call to `UIViewController.attemptRotationToDeviceOrientation()` because after testing on iPhone & iPad on iOS 16 & iOS 18:
    - I am unable to workout its behavior in our app.
    - Therefore, I'm unable to determine how to replace it.
    - I could not find any issues with removing it.

**Please review commit by commit noting my commit messages.**

### Testing

Exploratory test on iPhone & iPad on looking for any issues with **SCREEN ROTATION**.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
