### PR TITLE
fix: no empty team - WPB-15273

### DIFF
--- a/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/TeamNameView.swift
+++ b/WireUI/Sources/WireIndividualToTeamMigrationUI/Views/TeamNameView.swift
@@ -29,6 +29,10 @@ struct TeamNameView: View {
     let actionCallback: (Action) -> Void
     @State private var teamName: String = ""
 
+    var validTeamName: String {
+        teamName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
             Text(String.localized(key: "individualToTeam.teamName.body", bundle: .module))
@@ -51,11 +55,11 @@ struct TeamNameView: View {
             Spacer()
 
             Button(
-                action: { actionCallback(.continue(teamName: teamName)) },
+                action: { actionCallback(.continue(teamName: validTeamName)) },
                 label: { Text(String.localized(key: "individualToTeam.button.continue", bundle: .module)) }
             )
             .wireButtonStyle(.primary)
-            .disabled(teamName.isEmpty)
+            .disabled(validTeamName.isEmpty)
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15273" title="WPB-15273" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15273</a>  [iOS] Do not allow empty Team name from the UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

* Trim team name for personal to team
* Continue button is disable if only white space is entered

### Testing


https://github.com/user-attachments/assets/ce82f3f9-41a6-4354-8626-3458e7f334c1


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
