### PR TITLE
chore: remove no ticket option for PR - WPB-15279

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           BASE_BRANCH=${GITHUB_REF#refs/heads/}
           HEAD_BRANCH="chore/update-localization"
-          TITLE="chore: Update localization - no ticket"
+          TITLE="chore: Update localization - WPB-15278"
           BODY="This PR pulls in the latest localization translations from Crowdin."
 
           git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/jira_lint_and_link.yml
+++ b/.github/workflows/jira_lint_and_link.yml
@@ -20,4 +20,4 @@ jobs:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-base-url: https://wearezeta.atlassian.net
           skip-branches: '^(production-release|main|master|release\/v\d+)$' #optional
-          fail-when-jira-issue-not-found: false
+          fail-when-jira-issue-not-found: true

--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -54,14 +54,14 @@ jobs:
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: false
           
-          subjectPattern: ^(.*) - ((WPB-\d+)|(no ticket))$
+          subjectPattern: ^(.*) - (WPB-\d+)$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            contains a ticket with "- WPB-XXX" or "- no ticket" for urgent cases.
+            contains a ticket with "- WPB-XXX".
       - name: Add Failure Label
         if: failure()
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15279" title="WPB-15279" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15279</a>  Remove no ticket option
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

All PRs should reference a JIRA ticket. This PR removes the `no ticket` hack

* update crowdin to use a ticket
* fail jira link action if no ticket

### Testing

* [x] This PR with - no ticket should add the label
* [x] this PR with a ticket WPB- should be valid 
