### PR TITLE
refactor: make selfClientID optional when pulling last update event - WPB-10801

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPI.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPI.swift
@@ -27,7 +27,7 @@ public protocol UpdateEventsAPI {
     /// - Parameter selfClientID: The id of the self client.
     /// - Returns: An update envelope containing the last update event.
 
-    func getLastUpdateEvent(selfClientID: String) async throws -> UpdateEventEnvelope
+    func getLastUpdateEvent(selfClientID: String?) async throws -> UpdateEventEnvelope
 
     /// Get all update events for the self client since a particular event.
     ///
@@ -38,7 +38,7 @@ public protocol UpdateEventsAPI {
     /// - Returns: A pager of events since (but not including) the specified event.
 
     func getUpdateEvents(
-        selfClientID: String,
+        selfClientID: String?,
         sinceEventID: UUID
     ) -> PayloadPager<UpdateEventEnvelope>
 

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
@@ -36,13 +36,19 @@ class UpdateEventsAPIV0: UpdateEventsAPI, VersionedAPI {
 
     // MARK: - Get last update event
 
-    func getLastUpdateEvent(selfClientID: String) async throws -> UpdateEventEnvelope {
-        var path = "\(pathPrefix)\(basePath)/last"
+    func getLastUpdateEvent(selfClientID: String?) async throws -> UpdateEventEnvelope {
+        let path = "\(pathPrefix)\(basePath)/last"
 
-        let request = try URLRequestBuilder(path: path)
-            .withMethod(.get)
-            .withQueryItem(name: "client", value: selfClientID)
-            .build()
+        var requestBuilder = try URLRequestBuilder(path: path).withMethod(.get)
+
+        if let selfClientID {
+            requestBuilder = requestBuilder.withQueryItem(
+                name: "client",
+                value: selfClientID
+            )
+        }
+
+        let request = requestBuilder.build()
 
         let (data, response) = try await apiService.executeRequest(
             request,
@@ -59,19 +65,25 @@ class UpdateEventsAPIV0: UpdateEventsAPI, VersionedAPI {
     // MARK: - Get events since
 
     func getUpdateEvents(
-        selfClientID: String,
+        selfClientID: String?,
         sinceEventID: UUID
     ) -> PayloadPager<UpdateEventEnvelope> {
         let resourcePath = "\(pathPrefix)\(basePath)"
 
         return PayloadPager(start: sinceEventID.transportString()) { nextSince in
-
-            let request = try URLRequestBuilder(path: resourcePath)
+            var requestBuilder = try URLRequestBuilder(path: resourcePath)
                 .withMethod(.get)
-                .withQueryItem(name: "client", value: selfClientID)
                 .withQueryItem(name: "since", value: nextSince)
                 .withQueryItem(name: "size", value: "500")
-                .build()
+
+            if let selfClientID {
+                requestBuilder = requestBuilder.withQueryItem(
+                    name: "client",
+                    value: selfClientID
+                )
+            }
+
+            let request = requestBuilder.build()
 
             let (data, response) = try await self.apiService.executeRequest(
                 request,

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV5.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV5.swift
@@ -28,13 +28,20 @@ class UpdateEventsAPIV5: UpdateEventsAPIV4 {
         "/notifications"
     }
 
-    override func getLastUpdateEvent(selfClientID: String) async throws -> UpdateEventEnvelope {
+    override func getLastUpdateEvent(selfClientID: String?) async throws -> UpdateEventEnvelope {
         let path = "\(pathPrefix)\(basePath)/last"
 
-        let request = try URLRequestBuilder(path: path)
+        var requestBuilder = try URLRequestBuilder(path: path)
             .withMethod(.get)
-            .withQueryItem(name: "client", value: selfClientID)
-            .build()
+
+        if let selfClientID {
+            requestBuilder = requestBuilder.withQueryItem(
+                name: "client",
+                value: selfClientID
+            )
+        }
+
+        let request = requestBuilder.build()
 
         let (data, response) = try await apiService.executeRequest(
             request,
@@ -51,18 +58,25 @@ class UpdateEventsAPIV5: UpdateEventsAPIV4 {
     // MARK: - Get events since
 
     override func getUpdateEvents(
-        selfClientID: String,
+        selfClientID: String?,
         sinceEventID: UUID
     ) -> PayloadPager<UpdateEventEnvelope> {
         let resourcePath = "\(pathPrefix)\(basePath)"
 
         return PayloadPager(start: sinceEventID.transportString()) { nextSince in
-            let request = try URLRequestBuilder(path: resourcePath)
+            var requestBuilder = try URLRequestBuilder(path: resourcePath)
                 .withMethod(.get)
-                .withQueryItem(name: "client", value: selfClientID)
                 .withQueryItem(name: "since", value: nextSince)
                 .withQueryItem(name: "size", value: "500")
-                .build()
+
+            if let selfClientID {
+                requestBuilder = requestBuilder.withQueryItem(
+                    name: "client",
+                    value: selfClientID
+                )
+            }
+
+            let request = requestBuilder.build()
 
             let (data, response) = try await self.apiService.executeRequest(
                 request,

--- a/WireDomain/Sources/WireDomain/Synchronization/PullLastUpdateEventIDSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullLastUpdateEventIDSync.swift
@@ -31,12 +31,12 @@ protocol PullLastUpdateEventIDSyncProtocol {
 
 struct PullLastUpdateEventIDSync: PullLastUpdateEventIDSyncProtocol {
 
-    private let selfClientID: String
+    private let selfClientID: String?
     private let api: any UpdateEventsAPI
     private let store: any UpdateEventsLocalStoreProtocol
 
     init(
-        selfClientID: String,
+        selfClientID: String?,
         api: any UpdateEventsAPI,
         store: any UpdateEventsLocalStoreProtocol
     ) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10801" title="WPB-10801" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10801</a>  [iOS] Integrate new slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently pulling the last update event id requires the self client id, but this is actually an optional parameter in the request to the backend. This PR makes the self client id optional so that we can also pull the event id in cases where we haven't yet created a self client.

### Testing

N/A
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
