### PR TITLE
fix: use client id from legal hold info payload - WPB-10801

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
@@ -325,19 +325,30 @@ struct LegalHoldLastPrekeyV0: Decodable, ToAPIModelConvertible {
 
 struct TeamMemberLegalholdResponseV0: Decodable, ToAPIModelConvertible {
 
-    let lastPrekey: LegalHoldLastPrekeyV0
     let status: LegalholdStatusV0
+    let client: LegalholdClientV0?
+    let lastPrekey: LegalHoldLastPrekeyV0?
 
     enum CodingKeys: String, CodingKey {
+
         case status
+        case client
         case lastPrekey = "last_prekey"
+
     }
 
     func toAPIModel() -> TeamMemberLegalholdInfo {
         TeamMemberLegalholdInfo(
             status: status.toAPIModel(),
-            prekey: lastPrekey.toAPIModel()
+            clientID: client.map(\.id),
+            prekey: lastPrekey.map { $0.toAPIModel() }
         )
     }
+
+}
+
+struct LegalholdClientV0: Decodable {
+
+    let id: String
 
 }

--- a/WireAPI/Sources/WireAPI/Models/Team/TeamMemberLegalholdInfo.swift
+++ b/WireAPI/Sources/WireAPI/Models/Team/TeamMemberLegalholdInfo.swift
@@ -18,22 +18,28 @@
 
 public typealias LegalholdPrekey = Prekey
 
-/// The team member legal hold.
+/// The team member legalhold.
 public struct TeamMemberLegalholdInfo: Equatable, Sendable {
 
-    /// The legal hold status
+    /// The legalhold status.
 
     public let status: LegalholdStatus
 
-    /// The legal hold prekey
+    /// The legalhold client id.
 
-    public let prekey: LegalholdPrekey
+    public let clientID: String?
+
+    /// The legalhold prekey.
+
+    public let prekey: LegalholdPrekey?
 
     public init(
         status: LegalholdStatus,
-        prekey: LegalholdPrekey
+        clientID: String?,
+        prekey: LegalholdPrekey?
     ) {
         self.status = status
+        self.clientID = clientID
         self.prekey = prekey
     }
 }

--- a/WireAPI/Tests/WireAPITests/APIs/TeamsAPI/Resources/GetLegalHoldInfoSuccessResponseV0.json
+++ b/WireAPI/Tests/WireAPITests/APIs/TeamsAPI/Resources/GetLegalHoldInfoSuccessResponseV0.json
@@ -1,5 +1,8 @@
 {
   "status": "pending",
+  "client": {
+      "id": "abc123"
+  },
   "last_prekey": {
       "id": 12345,
       "key": "foo"

--- a/WireAPI/Tests/WireAPITests/APIs/TeamsAPI/TeamsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/TeamsAPI/TeamsAPITests.swift
@@ -301,6 +301,7 @@ final class TeamsAPITests: XCTestCase {
                 result,
                 TeamMemberLegalholdInfo(
                     status: .pending,
+                    clientID: "abc123",
                     prekey: .init(id: 12_345, base64EncodedKey: "foo")
                 )
             )

--- a/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
@@ -171,7 +171,6 @@ public class TeamRepository: TeamRepositoryProtocol {
         )
     }
 
-
     public func pullSelfLegalholdInfo() async throws {
         let selfUser = await userRepository.fetchSelfUser()
 

--- a/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
@@ -171,6 +171,7 @@ public class TeamRepository: TeamRepositoryProtocol {
         )
     }
 
+
     public func pullSelfLegalholdInfo() async throws {
         let selfUser = await userRepository.fetchSelfUser()
 
@@ -180,14 +181,17 @@ public class TeamRepository: TeamRepositoryProtocol {
 
         switch selfUserLegalHold.status {
         case .pending:
-            guard let selfClientID else {
+            guard
+                let clientID = selfUserLegalHold.clientID,
+                let lastPrekey = selfUserLegalHold.prekey
+            else {
                 return
             }
 
             await userRepository.addLegalHoldRequest(
                 userID: selfUserID,
-                clientID: selfClientID,
-                lastPrekey: selfUserLegalHold.prekey
+                clientID: clientID,
+                lastPrekey: lastPrekey
             )
 
         case .disabled:

--- a/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
@@ -172,10 +172,7 @@ public class TeamRepository: TeamRepositoryProtocol {
     }
 
     public func pullSelfLegalholdInfo() async throws {
-        let selfUser = await userRepository.fetchSelfUser()
-
-        let (selfUserID, selfClientID) = await teamLocalStore.selfUserInfo()
-
+        let (selfUserID, _) = await teamLocalStore.selfUserInfo()
         let selfUserLegalHold = try await fetchSelfLegalholdInfo()
 
         switch selfUserLegalHold.status {

--- a/WireDomain/Sources/WireDomain/Synchronization/PullSelfLegalholdInfoSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullSelfLegalholdInfoSync.swift
@@ -18,11 +18,18 @@
 
 import Foundation
 import WireAPI
-import WireLogging
 
 protocol PullSelfLegalholdInfoSyncProtocol {
 
     func pull(selfTeamID: UUID) async throws
+
+}
+
+enum PullSelfLegalholdInfoSyncError: Error {
+
+    case missingClientID
+    case missingPrekey
+    case invalidPrekey
 
 }
 
@@ -32,18 +39,15 @@ protocol PullSelfLegalholdInfoSyncProtocol {
 struct PullSelfLegalholdInfoSync: PullSelfLegalholdInfoSyncProtocol {
 
     private let selfUserID: UUID
-    private let selfClientID: String
     private let api: any TeamsAPI
     private let store: any UserLocalStoreProtocol
 
     init(
         selfUserID: UUID,
-        selfClientID: String,
         api: any TeamsAPI,
         store: any UserLocalStoreProtocol
     ) {
         self.selfUserID = selfUserID
-        self.selfClientID = selfClientID
         self.api = api
         self.store = store
     }
@@ -62,16 +66,21 @@ struct PullSelfLegalholdInfoSync: PullSelfLegalholdInfoSyncProtocol {
 
         switch remoteLegalholdInfo.status {
         case .pending:
-            let lastPrekey = remoteLegalholdInfo.prekey
+            guard let clientID = remoteLegalholdInfo.clientID else {
+                throw PullSelfLegalholdInfoSyncError.missingClientID
+            }
+
+            guard let lastPrekey = remoteLegalholdInfo.prekey else {
+                throw PullSelfLegalholdInfoSyncError.missingPrekey
+            }
+
             guard let mappedPrekey = lastPrekey.toDomainModel() else {
-                return WireLogger.eventProcessing.error(
-                    "Invalid legal hold request payload: invalid base64 encoded key \(lastPrekey.base64EncodedKey)"
-                )
+                throw PullSelfLegalholdInfoSyncError.invalidPrekey
             }
 
             await store.addSelfLegalHoldRequest(
                 userID: selfUserID,
-                clientID: selfClientID,
+                clientID: clientID,
                 lastPrekey: mappedPrekey
             )
 

--- a/WireDomain/Tests/WireDomainTests/Repositories/TeamRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/TeamRepositoryTests.swift
@@ -300,6 +300,7 @@ final class TeamRepositoryTests: XCTestCase {
 
         static let teamMemberLegalhold = TeamMemberLegalholdInfo(
             status: .pending,
+            clientID: "abc123",
             prekey: prekey
         )
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfLegalholdInfoSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfLegalholdInfoSyncTests.swift
@@ -34,7 +34,6 @@ final class PullSelfLegalholdInfoSyncTests: XCTestCase {
         store = MockUserLocalStoreProtocol()
         sut = PullSelfLegalholdInfoSync(
             selfUserID: Scaffolding.selfUserID,
-            selfClientID: Scaffolding.selfClientID,
             api: api,
             store: store
         )
@@ -63,7 +62,7 @@ final class PullSelfLegalholdInfoSyncTests: XCTestCase {
         let storeInvocations = store.addSelfLegalHoldRequestUserIDClientIDLastPrekey_Invocations
         try XCTAssertCount(storeInvocations, count: 1)
         XCTAssertEqual(storeInvocations[0].userID, Scaffolding.selfUserID)
-        XCTAssertEqual(storeInvocations[0].clientID, Scaffolding.selfClientID)
+        XCTAssertEqual(storeInvocations[0].clientID, Scaffolding.clientID)
         XCTAssertEqual(storeInvocations[0].lastPrekey, Scaffolding.localPrekey)
     }
 
@@ -117,9 +116,8 @@ final class PullSelfLegalholdInfoSyncTests: XCTestCase {
 private enum Scaffolding {
 
     static let selfUserID = UUID()
-    static let selfClientID = "abc123"
     static let selfTeamID = UUID()
-
+    static let clientID = "abc123"
     static let prekeyData = Data.random()
     static let prekey = LegalholdPrekey(
         id: 0,
@@ -129,6 +127,7 @@ private enum Scaffolding {
     static func remoteLegalholdInfo(status: LegalholdStatus) -> TeamMemberLegalholdInfo {
         .init(
             status: status,
+            clientID: clientID,
             prekey: prekey
         )
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10801" title="WPB-10801" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10801</a>  [iOS] Integrate new slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When fetching the legal hold info for the self user, the legal hold client id inside the response payload is ignored and instead the self client id is used instead, which is wrong (according to the existing implementation. In this PR, I fix the decoding of the response payload and remove the dependency on the self client id.

### Testing

N/A
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
