### PR TITLE
fix: restore checkout action in semantic commit lint - WPB-15214

### DIFF
--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -62,7 +62,7 @@ jobs:
             contains a ticket with "- WPB-XXX" or "- no ticket" for urgent cases.
 
       - name: Checkout
-        if: ${{ success() || failure() }}
+        if: always()
         uses: actions/checkout@v4
 
       - name: Add Failure Label

--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -21,7 +21,7 @@ jobs:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
       - name: Run Semantic Commint Linter
-        uses: amannn/action-semantic-pull-request@v5.5.2
+        uses: amannn/action-semantic-pull-request@v5.5.3
         with:
           # Configure which types are allowed.
           # Default: https://github.com/commitizen/conventional-commit-types
@@ -60,11 +60,17 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             contains a ticket with "- WPB-XXX" or "- no ticket" for urgent cases.
+
+      - name: Checkout
+        if: ${{ success() || failure() }}
+        uses: actions/checkout@v4
+
       - name: Add Failure Label
         if: failure()
         run: |
           gh api repos/{owner}/{repo}/labels -f name="${CUSTOM_PR_LABEL}" -f color="FF0000" || true
           gh pr edit "${HEAD}" --add-label "${CUSTOM_PR_LABEL}"
+
       - name: Remove Failure Label
         if: success()
         run: |

--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Checkout
         if: always()
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
 
       - name: Add Failure Label
         if: failure()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15214" title="WPB-15214" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15214</a>  [iOS] - CI shouldn't run for draft PRs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cloning the repo is not needed for verifying the pr title, however, for setting a label it is.
This PR fixes an issue introduced in PR https://github.com/wireapp/wire-ios/pull/2333 by restoring the checkout action.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
