### PR TITLE
chore: enable SwiftGen for Accessibility.strings - WPB-15211

### DIFF
--- a/WireUI/Sources/WireSettingsUI/.swiftgen.yml
+++ b/WireUI/Sources/WireSettingsUI/.swiftgen.yml
@@ -7,6 +7,7 @@ output_dir: ${GENERATED}/
 
 strings:
   inputs:
+    - Resources/en.lproj/Accessibility.strings
     - Resources/en.lproj/Localizable.strings
   filter:
   outputs:

--- a/WireUI/Sources/WireSettingsUI/Account/Backup/Views/BackupActionsView.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/Backup/Views/BackupActionsView.swift
@@ -31,13 +31,13 @@ public struct BackupActionsView: View {
     public var body: some View {
         List {
             Section(
-                footer: Text(L10n.ExportBackup.description)
+                footer: Text(L10n.Localizable.ExportBackup.description)
             ) {
                 Button(action: {
                     isBackupSheetPresented.toggle()
                 }, label: {
                     HStack {
-                        Text(L10n.Settings.ExportBackup.action)
+                        Text(L10n.Localizable.Settings.ExportBackup.action)
                             .font(.textStyle(.body2))
                             .foregroundStyle(Color.primaryText)
                         Spacer()

--- a/WireUI/Sources/WireSettingsUI/Account/Backup/Views/ExportBackupView.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/Backup/Views/ExportBackupView.swift
@@ -45,7 +45,7 @@ public struct ExportBackupView: View {
         .background(Color.viewBackground)
         .scrollContentBackground(.hidden)
         .navigationTitle(
-            Text(L10n.ExportBackup.title)
+            Text(L10n.Localizable.ExportBackup.title)
         )
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -86,7 +86,7 @@ private struct SetBackupPasswordView: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            Text(L10n.ExportBackup.description)
+            Text(L10n.Localizable.ExportBackup.description)
                 .font(.textStyle(.body1))
                 .foregroundStyle(Color.primaryText)
                 .multilineTextAlignment(.leading)
@@ -107,7 +107,7 @@ private struct SetBackupPasswordView: View {
                     dismiss()
                 },
                 label: {
-                    Text(L10n.ExportBackup.button)
+                    Text(L10n.Localizable.ExportBackup.button)
                 }
             )
             .wireButtonStyle(.primary)
@@ -134,7 +134,7 @@ private struct ExportBackupPreview: View {
                 isPresented.toggle()
             },
             label: {
-                Text(L10n.ExportBackup.button)
+                Text(L10n.Localizable.ExportBackup.button)
             }
         )
         .sheet(isPresented: $isPresented) {

--- a/WireUI/Sources/WireSettingsUI/Account/Backup/Views/PasswordFieldView.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/Backup/Views/PasswordFieldView.swift
@@ -27,14 +27,14 @@ struct PasswordFieldView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(L10n.ExportBackup.SetBackupPassword.title)
+            Text(L10n.Localizable.ExportBackup.SetBackupPassword.title)
                 .font(.subheadline)
                 .foregroundColor(isPasswordValid ? ColorTheme.Base.secondaryText.color : ColorTheme.Base.error.color)
 
             ZStack {
                 if isPasswordVisible {
                     TextField(
-                        L10n.ExportBackup.SetBackupPassword.placeholder, text: $password
+                        L10n.Localizable.ExportBackup.SetBackupPassword.placeholder, text: $password
                     )
                     .font(.textStyle(.body1))
                     .textFieldStyle(RoundedBorderTextFieldStyle())
@@ -46,7 +46,7 @@ struct PasswordFieldView: View {
                             )
                     )
                 } else {
-                    SecureField(L10n.ExportBackup.SetBackupPassword.placeholder, text: $password)
+                    SecureField(L10n.Localizable.ExportBackup.SetBackupPassword.placeholder, text: $password)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .overlay(
                             RoundedRectangle(cornerRadius: 5)
@@ -84,7 +84,7 @@ struct PasswordFieldView: View {
         password: .constant(""),
         isPasswordValid: false,
         isPasswordVisible: .constant(false),
-        passwordRules: Text(L10n.ExportBackup.SetBackupPassword.rules)
+        passwordRules: Text(L10n.Localizable.ExportBackup.SetBackupPassword.rules)
     )
 }
 
@@ -94,7 +94,7 @@ struct PasswordFieldView: View {
         password: .constant("ValidPassword1!"),
         isPasswordValid: false,
         isPasswordVisible: .constant(true),
-        passwordRules: Text(L10n.ExportBackup.SetBackupPassword.rules)
+        passwordRules: Text(L10n.Localizable.ExportBackup.SetBackupPassword.rules)
     )
 }
 
@@ -104,7 +104,7 @@ struct PasswordFieldView: View {
         password: .constant("ValidPassword1!"),
         isPasswordValid: true,
         isPasswordVisible: .constant(false),
-        passwordRules: Text(L10n.ExportBackup.SetBackupPassword.rules)
+        passwordRules: Text(L10n.Localizable.ExportBackup.SetBackupPassword.rules)
     )
 }
 
@@ -114,6 +114,6 @@ struct PasswordFieldView: View {
         password: .constant("ValidPassword1!"),
         isPasswordValid: true,
         isPasswordVisible: .constant(true),
-        passwordRules: Text(L10n.ExportBackup.SetBackupPassword.rules)
+        passwordRules: Text(L10n.Localizable.ExportBackup.SetBackupPassword.rules)
     )
 }

--- a/WireUI/Sources/WireSidebarUI/.swiftgen.yml
+++ b/WireUI/Sources/WireSidebarUI/.swiftgen.yml
@@ -7,6 +7,7 @@ output_dir: ${GENERATED}/
 
 strings:
   inputs:
+    - Resources/en.lproj/Accessibility.strings
     - Resources/en.lproj/Localizable.strings
   filter:
   outputs:

--- a/WireUI/Sources/WireSidebarUI/Views/SidebarAccountInfoView.swift
+++ b/WireUI/Sources/WireSidebarUI/Views/SidebarAccountInfoView.swift
@@ -71,7 +71,7 @@ struct SidebarAccountInfoView<AccountImageView: View, LegalHoldIndicatorView: Vi
                 Text(displayName)
                     .wireTextStyle(.h3)
                     .foregroundStyle(displayNameColor)
-                    .accessibilityLabel(Text("sidebar.name.description", tableName: "Accessibility", bundle: .module))
+                    .accessibilityLabel(Text(L10n.Accessibility.Sidebar.Name.description))
                     .accessibilityValue(displayName)
                 if isE2EICertified {
                     Image(.certificateValid)
@@ -85,7 +85,7 @@ struct SidebarAccountInfoView<AccountImageView: View, LegalHoldIndicatorView: Vi
             Text(username)
                 .wireTextStyle(.subline1)
                 .foregroundStyle(usernameColor)
-                .accessibilityLabel(Text("sidebar.handle.description", tableName: "Accessibility", bundle: .module))
+                .accessibilityLabel(Text(L10n.Accessibility.Sidebar.Handle.description))
                 .accessibilityValue(username)
         }
     }

--- a/WireUI/Sources/WireSidebarUI/Views/SidebarView.swift
+++ b/WireUI/Sources/WireSidebarUI/Views/SidebarView.swift
@@ -118,7 +118,7 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
 
     @ViewBuilder private var scrollableMenuItems: some View {
         VStack(alignment: .leading, spacing: 0) {
-            menuItemHeader(L10n.Sidebar.ConversationFilter.title, addTopPadding: false)
+            menuItemHeader(L10n.Localizable.Sidebar.ConversationFilter.title, addTopPadding: false)
             let conversationFilters: [SidebarSelectableMenuItem] = [
                 .all,
                 .favorites,
@@ -131,7 +131,7 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
                 selectableMenuItem(conversationFilter)
             }
 
-            menuItemHeader(L10n.Sidebar.Contacts.title)
+            menuItemHeader(L10n.Localizable.Sidebar.Contacts.title)
             nonselectableMenuItem(.connect)
         }
         .padding(.horizontal, 16)
@@ -160,14 +160,14 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
         let action: () -> Void
         switch menuItem {
         case .connect:
-            text = Text(L10n.Sidebar.Contacts.Connect.title)
+            text = Text(L10n.Localizable.Sidebar.Contacts.Connect.title)
             accessibilityLabel = Text("sidebar.contacts.connect.title", bundle: .module)
             icon = "person.badge.plus"
             isLink = false
             action = connectAction
 
         case .support:
-            text = Text(L10n.Sidebar.Support.title)
+            text = Text(L10n.Localizable.Sidebar.Support.title)
             accessibilityLabel = Text("sidebar.support.description", tableName: "Accessibility", bundle: .module)
             icon = "questionmark.circle"
             isLink = true
@@ -204,22 +204,22 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
         let accessibilityLabel: Text
         switch menuItem {
         case .all:
-            text = Text(L10n.Sidebar.ConversationFilter.All.title)
+            text = Text(L10n.Localizable.Sidebar.ConversationFilter.All.title)
             icon = "text.bubble"
-            accessibilityLabel = Text(L10n.Sidebar.ConversationFilter.All.title)
+            accessibilityLabel = Text(L10n.Localizable.Sidebar.ConversationFilter.All.title)
 
         case .favorites:
-            text = Text(L10n.Sidebar.ConversationFilter.Favorites.title)
+            text = Text(L10n.Localizable.Sidebar.ConversationFilter.Favorites.title)
             icon = "star"
-            accessibilityLabel = Text(L10n.Sidebar.ConversationFilter.Favorites.title)
+            accessibilityLabel = Text(L10n.Localizable.Sidebar.ConversationFilter.Favorites.title)
 
         case .groups:
-            text = Text(L10n.Sidebar.ConversationFilter.Groups.title)
+            text = Text(L10n.Localizable.Sidebar.ConversationFilter.Groups.title)
             icon = "person.3"
-            accessibilityLabel = Text(L10n.Sidebar.ConversationFilter.Groups.title)
+            accessibilityLabel = Text(L10n.Localizable.Sidebar.ConversationFilter.Groups.title)
 
         case .oneOnOne:
-            text = Text(L10n.Sidebar.ConversationFilter.OneOnOneConversations.title)
+            text = Text(L10n.Localizable.Sidebar.ConversationFilter.OneOnOneConversations.title)
             icon = "person"
             accessibilityLabel = Text(
                 "sidebar.conversation_filter.oneOnOneConversations.description",
@@ -228,17 +228,17 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
             )
 
         case .folders:
-            text = Text(L10n.Sidebar.ConversationFilter.Folders.title)
+            text = Text(L10n.Localizable.Sidebar.ConversationFilter.Folders.title)
             icon = "folder"
-            accessibilityLabel = Text(L10n.Sidebar.ConversationFilter.Folders.title)
+            accessibilityLabel = Text(L10n.Localizable.Sidebar.ConversationFilter.Folders.title)
 
         case .archive:
-            text = Text(L10n.Sidebar.ConversationFilter.Archived.title)
+            text = Text(L10n.Localizable.Sidebar.ConversationFilter.Archived.title)
             icon = "archivebox"
-            accessibilityLabel = Text(L10n.Sidebar.ConversationFilter.Archived.title)
+            accessibilityLabel = Text(L10n.Localizable.Sidebar.ConversationFilter.Archived.title)
 
         case .settings:
-            text = Text(L10n.Sidebar.Settings.title)
+            text = Text(L10n.Localizable.Sidebar.Settings.title)
             icon = "gearshape"
             accessibilityLabel = Text("sidebar.settings.description", tableName: "Accessibility", bundle: .module)
         }

--- a/WireUI/Sources/WireSidebarUI/Views/SidebarView.swift
+++ b/WireUI/Sources/WireSidebarUI/Views/SidebarView.swift
@@ -168,7 +168,7 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
 
         case .support:
             text = Text(L10n.Localizable.Sidebar.Support.title)
-            accessibilityLabel = Text("sidebar.support.description", tableName: "Accessibility", bundle: .module)
+            accessibilityLabel = Text(L10n.Accessibility.Sidebar.Support.description)
             icon = "questionmark.circle"
             isLink = true
             action = supportAction
@@ -221,11 +221,7 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
         case .oneOnOne:
             text = Text(L10n.Localizable.Sidebar.ConversationFilter.OneOnOneConversations.title)
             icon = "person"
-            accessibilityLabel = Text(
-                "sidebar.conversation_filter.oneOnOneConversations.description",
-                tableName: "Accessibility",
-                bundle: .module
-            )
+            accessibilityLabel = Text(L10n.Accessibility.Sidebar.ConversationFilter.OneOnOneConversations.description)
 
         case .folders:
             text = Text(L10n.Localizable.Sidebar.ConversationFilter.Folders.title)
@@ -240,7 +236,7 @@ public struct SidebarView<AccountImageView: View, LegalHoldIndicatorView: View>:
         case .settings:
             text = Text(L10n.Localizable.Sidebar.Settings.title)
             icon = "gearshape"
-            accessibilityLabel = Text("sidebar.settings.description", tableName: "Accessibility", bundle: .module)
+            accessibilityLabel = Text(L10n.Accessibility.Sidebar.Settings.description)
         }
 
         return SidebarMenuItemView(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15211" title="WPB-15211" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15211</a>  [iOS] Update the UI for backup export
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In WireUI we currently have SwiftGen only enabled for Localizable.strings.
This PR adds Accessibility.strings to the .swiftgen.yml configuration.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
