### PR TITLE
refactor: generate notification conversation member join - WPB-11661

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -137,7 +137,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         return content
     }
-    
+
     private func buildMemberJoinNotification() -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -90,8 +90,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
         case let .memberLeave(removedUserIDs):
             removedUserIDs.contains(context.selfUserID)
         case let .memberJoin(addedUserIDs):
-            // TODO: [WPB-11661]
-            true
+            addedUserIDs.contains(context.selfUserID)
         case .conversationCreated, .conversationDeleted, .messageTimerUpdate:
             true
         }
@@ -101,11 +100,10 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
         switch context.systemMessage {
         case .memberLeave:
             return buildMemberLeaveNotification()
+        case .memberJoin:
+            return buildMemberJoinNotification()
         case .conversationCreated:
             // TODO: [WPB-11657]
-            break
-        case .memberJoin:
-            // TODO: [WPB-11661]
             break
         case .conversationDeleted:
             // TODO: [WPB-11658]
@@ -129,6 +127,26 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         let body = NotificationBody.newSystemMessage(
             .removedYou(senderName: context.senderName)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+        content.userInfo = makeUserInfo()
+        content.threadIdentifier = context.conversationID.uuid.transportString()
+
+        return content
+    }
+    
+    private func buildMemberJoinNotification() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        if let title = makeTitle() {
+            content.title = title
+        }
+
+        let body = NotificationBody.newSystemMessage(
+            .addedYou(senderName: context.senderName)
         )
 
         content.body = body.make()

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
@@ -24,22 +24,21 @@ struct NewSystemMessageNotificationBodyComposer {
     // TODO: [WPB-15153] - Localize strings
     func make() -> String {
         switch format {
-        case let .createdConversation(senderName):
-            // TODO: [WPB-11657]
-            ""
         case let .removedYou(senderName):
             senderName != nil ? "\(senderName!) removed you" : "Someone removed you"
-        case let .setMessageTimer(senderName):
-            // TODO: [WPB-11663]
-            ""
         case let .addedYou(senderName):
-            // TODO: [WPB-11661]
+            senderName != nil ? "\(senderName!) added you" : "Someone added you"
+        case let .createdConversation(senderName):
+            // TODO: [WPB-11657]
             ""
         case let .turnedOffMessageTimer(senderName):
             // TODO: [WPB-11663]
             ""
         case let .deletedGroup(senderName):
             // TODO: [WPB-11658]
+            ""
+        case let .setMessageTimer(senderName):
+            // TODO: [WPB-11663]
             ""
         }
     }

--- a/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
@@ -119,7 +119,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .memberJoin(addedUserIDs: [.mockID4]) // concerns self user
         ]
 
         for systemMessage in systemMessages {
@@ -154,7 +155,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .memberJoin(addedUserIDs: [.mockID4]) // concerns self user
         ]
 
         for systemMessage in systemMessages {
@@ -189,7 +191,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID3)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [UUID()]) // doesn't concern self user
+            .memberLeave(removedUserIDs: [UUID()]), // doesn't concern self user
+            .memberJoin(addedUserIDs: [UUID()]) // doesn't concern self user
         ]
 
         for systemMessage in systemMessages {
@@ -201,7 +204,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
 
             let shouldBuildNotification = await sut.shouldBuildNotification()
 
-            XCTAssertEqual(shouldBuildNotification, false) // user is not self user
+            XCTAssertEqual(shouldBuildNotification, false) // because user is not self user
         }
     }
 
@@ -231,9 +234,9 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         switch systemMessage {
         case .memberLeave:
             XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) removed you")
-        case .conversationCreated:
-            break
         case .memberJoin:
+            XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) added you")
+        case .conversationCreated:
             break
         case .conversationDeleted:
             break


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11661" title="WPB-11661" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11661</a>  [iOS] Generate UNNotificationContent for conversation member join
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is about generating notification content related to the member join event populating the right data in the notification (title, body, sound, category..). 

A notification should be generated only if the member join event concerns the self user.

### Testing

- [x] Notification for member join is correctly populated when it concerns self user
- [x] When it doesn't concern self user, the flag `shouldBuildNotification` returns false.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.