### PR TITLE
refactor: generate notification conversation created - WPB-11657

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -138,7 +138,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         return content
     }
-    
+
     private func buildConversationCreatedNotification() -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -102,8 +102,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
         case .memberLeave:
             return buildMemberLeaveNotification()
         case .conversationCreated:
-            // TODO: [WPB-11657]
-            break
+            return buildConversationCreatedNotification()
         case .memberJoin:
             // TODO: [WPB-11661]
             break
@@ -129,6 +128,26 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         let body = NotificationBody.newSystemMessage(
             .removedYou(senderName: context.senderName)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+        content.userInfo = makeUserInfo()
+        content.threadIdentifier = context.conversationID.uuid.transportString()
+
+        return content
+    }
+    
+    private func buildConversationCreatedNotification() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        if let title = makeTitle() {
+            content.title = title
+        }
+
+        let body = NotificationBody.newSystemMessage(
+            .createdConversation(senderName: context.senderName)
         )
 
         content.body = body.make()

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
@@ -25,8 +25,7 @@ struct NewSystemMessageNotificationBodyComposer {
     func make() -> String {
         switch format {
         case let .createdConversation(senderName):
-            // TODO: [WPB-11657]
-            ""
+            senderName != nil ? "\(senderName!) created a conversation" : "Someone created a conversation"
         case let .removedYou(senderName):
             senderName != nil ? "\(senderName!) removed you" : "Someone removed you"
         case let .setMessageTimer(senderName):

--- a/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
@@ -84,7 +84,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .conversationCreated
         ]
 
         for systemMessage in systemMessages {
@@ -119,7 +120,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .conversationCreated
         ]
 
         for systemMessage in systemMessages {
@@ -154,7 +156,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .conversationCreated
         ]
 
         for systemMessage in systemMessages {
@@ -232,7 +235,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         case .memberLeave:
             XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) removed you")
         case .conversationCreated:
-            break
+            XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) created a conversation")
         case .memberJoin:
             break
         case .conversationDeleted:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11657" title="WPB-11657" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11657</a>  [iOS] Generate UNNotificationContent for new conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is about generating notification content related to the conversation created event populating the right data in the notification (title, body, sound, category..). 

### Testing

- [x] Notification for conversation created is correctly populated

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
