### PR TITLE
refactor: generate notification conversation timer update - WPB-11663

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -110,9 +110,18 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
         case .conversationDeleted:
             // TODO: [WPB-11658]
             break
-        case .messageTimerUpdate:
-            // TODO: [WPB-11663]
-            break
+        case let .messageTimerUpdate(timeoutValue):
+            var timeoutStrValue: String?
+            
+            if let timeoutValue {
+                let timerInMilliseconds = Double(timeoutValue)
+                let timeoutValue = timerInMilliseconds / 1000
+                let timeout: MessageDestructionTimeoutValue = .init(rawValue: timeoutValue)
+                
+                timeoutStrValue = timeout.displayString
+            }
+            
+            return buildTimerUpdateNotification(timeout: timeoutStrValue)
         }
 
         return UNMutableNotificationContent()
@@ -129,6 +138,32 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         let body = NotificationBody.newSystemMessage(
             .removedYou(senderName: context.senderName)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+        content.userInfo = makeUserInfo()
+        content.threadIdentifier = context.conversationID.uuid.transportString()
+
+        return content
+    }
+    
+    private func buildTimerUpdateNotification(timeout: String?) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        if let title = makeTitle() {
+            content.title = title
+        }
+        
+        let bodyFormat: NotificationBody.SystemMessageBodyFormat = if let timeout {
+            .setMessageTimer(senderName: context.senderName, timeoutValue: timeout)
+        } else {
+            .turnedOffMessageTimer(senderName: context.senderName)
+        }
+
+        let body = NotificationBody.newSystemMessage(
+            bodyFormat
         )
 
         content.body = body.make()

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -112,15 +112,15 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
             break
         case let .messageTimerUpdate(timeoutValue):
             var timeoutStrValue: String?
-            
+
             if let timeoutValue {
                 let timerInMilliseconds = Double(timeoutValue)
                 let timeoutValue = timerInMilliseconds / 1000
                 let timeout: MessageDestructionTimeoutValue = .init(rawValue: timeoutValue)
-                
+
                 timeoutStrValue = timeout.displayString
             }
-            
+
             return buildTimerUpdateNotification(timeout: timeoutStrValue)
         }
 
@@ -148,14 +148,14 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         return content
     }
-    
+
     private func buildTimerUpdateNotification(timeout: String?) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
 
         if let title = makeTitle() {
             content.title = title
         }
-        
+
         let bodyFormat: NotificationBody.SystemMessageBodyFormat = if let timeout {
             .setMessageTimer(senderName: context.senderName, timeoutValue: timeout)
         } else {

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
@@ -30,7 +30,8 @@ struct NewSystemMessageNotificationBodyComposer {
         case let .removedYou(senderName):
             senderName != nil ? "\(senderName!) removed you" : "Someone removed you"
         case let .setMessageTimer(senderName, timeoutValue):
-            senderName != nil ? "\(senderName!) set the message timer to \(timeoutValue)" : "Someone set the message timer to \(timeoutValue)"
+            senderName != nil ? "\(senderName!) set the message timer to \(timeoutValue)" :
+                "Someone set the message timer to \(timeoutValue)"
         case let .addedYou(senderName):
             // TODO: [WPB-11661]
             ""

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
@@ -29,15 +29,13 @@ struct NewSystemMessageNotificationBodyComposer {
             ""
         case let .removedYou(senderName):
             senderName != nil ? "\(senderName!) removed you" : "Someone removed you"
-        case let .setMessageTimer(senderName):
-            // TODO: [WPB-11663]
-            ""
+        case let .setMessageTimer(senderName, timeoutValue):
+            senderName != nil ? "\(senderName!) set the message timer to \(timeoutValue)" : "Someone set the message timer to \(timeoutValue)"
         case let .addedYou(senderName):
             // TODO: [WPB-11661]
             ""
         case let .turnedOffMessageTimer(senderName):
-            // TODO: [WPB-11663]
-            ""
+            senderName != nil ? "\(senderName!) turned off the message timer" : "Someone turned off the message timer"
         case let .deletedGroup(senderName):
             // TODO: [WPB-11658]
             ""

--- a/WireDomain/Sources/WireDomain/Notifications/NotificationBody.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/NotificationBody.swift
@@ -89,7 +89,7 @@ extension NotificationBody {
         case removedYou(senderName: String?)
         /// `[sender name] set the message timer to [value]` or `Someone set the message timer to [value]` if sender is
         /// nil
-        case setMessageTimer(senderName: String?)
+        case setMessageTimer(senderName: String?, timeoutValue: String)
         /// `[sender name] turned off the message timer` or `Someone turned off the message timer` if sender is nil
         case turnedOffMessageTimer(senderName: String?)
         /// `[sender name] deleted the group` or `Someone deleted the group` if sender is nil

--- a/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
@@ -74,7 +74,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         }
     }
 
-    func testGenerateNewSystemMessageNotifications_Is_Group_Conversation_And_Is_Team_User() async throws {
+    func testGenerateNewSystemMessageNotifications_For_Group_Conversation_And_Team_User() async throws {
 
         // Mock
 
@@ -84,7 +84,9 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .messageTimerUpdate(newTimer: Scaffolding.timeoutValue), // enabled timer
+            .messageTimerUpdate(newTimer: nil) // disabled timer
         ]
 
         for systemMessage in systemMessages {
@@ -109,7 +111,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         }
     }
 
-    func testGenerateNewSystemMessageNotifications_Is_Group_Conversation_And_Is_Personal_User() async throws {
+    func testGenerateNewSystemMessageNotifications_For_Group_Conversation_And_Personal_User() async throws {
 
         // Mock
 
@@ -119,7 +121,9 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .messageTimerUpdate(newTimer: Scaffolding.timeoutValue), // enabled timer
+            .messageTimerUpdate(newTimer: nil) // disabled timer
         ]
 
         for systemMessage in systemMessages {
@@ -144,7 +148,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         }
     }
 
-    func testGenerateNewSystemMessageNotifications_Is_OneOnOne_Conversation_And_Team() async throws {
+    func testGenerateNewSystemMessageNotifications_For_OneOnOne_Conversation_And_Team() async throws {
 
         // Mock
 
@@ -154,7 +158,9 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .messageTimerUpdate(newTimer: Scaffolding.timeoutValue), // enabled timer
+            .messageTimerUpdate(newTimer: nil) // disabled timer
         ]
 
         for systemMessage in systemMessages {
@@ -237,8 +243,12 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
             break
         case .conversationDeleted:
             break
-        case .messageTimerUpdate:
-            break
+        case .messageTimerUpdate(let timeoutValue):
+            if let timeoutValue {
+                XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) set the message timer to \(timeoutValue / 1000) seconds")
+            } else {
+                XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) turned off the message timer")
+            }
         }
 
         // Category
@@ -295,6 +305,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
     }
 
     private enum Scaffolding {
+        static let timeoutValue: Int64 = 10_000
         static let senderName = "User1"
         static let conversationName = "Conversation1"
         static let teamName = "Team1"

--- a/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
@@ -243,9 +243,12 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
             break
         case .conversationDeleted:
             break
-        case .messageTimerUpdate(let timeoutValue):
+        case let .messageTimerUpdate(timeoutValue):
             if let timeoutValue {
-                XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) set the message timer to \(timeoutValue / 1000) seconds")
+                XCTAssertEqual(
+                    notificationContent.body,
+                    "\(Scaffolding.senderName) set the message timer to \(timeoutValue / 1000) seconds"
+                )
             } else {
                 XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) turned off the message timer")
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11663" title="WPB-11663" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11663</a>  [iOS] Generate UNNotificationContent for conversation timer update
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is about generating notification content related to timer update event (enabling/disabling self destructed messages) populating the right data in the notification (title, body, sound, category..). 

### Testing

- [x] Notification for timer update is correctly populated when the timer is enabled
- [x] Notification for timer update is correctly populated when the timer is disabled

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
