### PR TITLE
refactor: generate notification conversation deleted - WPB-11658

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/NewSystemMessageNotificationBuilder.swift
@@ -108,8 +108,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
             // TODO: [WPB-11661]
             break
         case .conversationDeleted:
-            // TODO: [WPB-11658]
-            break
+            return buildDeletedConversationNotification()
         case .messageTimerUpdate:
             // TODO: [WPB-11663]
             break
@@ -129,6 +128,26 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
 
         let body = NotificationBody.newSystemMessage(
             .removedYou(senderName: context.senderName)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+        content.userInfo = makeUserInfo()
+        content.threadIdentifier = context.conversationID.uuid.transportString()
+
+        return content
+    }
+
+    private func buildDeletedConversationNotification() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        if let title = makeTitle() {
+            content.title = title
+        }
+
+        let body = NotificationBody.newSystemMessage(
+            .deletedGroup(senderName: context.senderName)
         )
 
         content.body = body.make()

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/NewSystemMessageNotificationBodyComposer.swift
@@ -39,8 +39,7 @@ struct NewSystemMessageNotificationBodyComposer {
             // TODO: [WPB-11663]
             ""
         case let .deletedGroup(senderName):
-            // TODO: [WPB-11658]
-            ""
+            senderName != nil ? "\(senderName!) deleted the group" : "Someone deleted the group"
         }
     }
 }

--- a/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/NewSystemMessageNotificationBuilderTests.swift
@@ -119,7 +119,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .conversationDeleted
         ]
 
         for systemMessage in systemMessages {
@@ -154,7 +155,8 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
         let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
-            .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
+            .memberLeave(removedUserIDs: [.mockID4]), // concerns self user
+            .conversationDeleted
         ]
 
         for systemMessage in systemMessages {
@@ -236,7 +238,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
         case .memberJoin:
             break
         case .conversationDeleted:
-            break
+            XCTAssertEqual(notificationContent.body, "\(Scaffolding.senderName) deleted the group")
         case .messageTimerUpdate:
             break
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11658" title="WPB-11658" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11658</a>  [iOS] Generate UNNotificationContent for deleted conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is about generating notification content related to the conversation deleted event populating the right data in the notification (title, body, sound, category..). 

### Testing

- [x] Notification for deleted conversation is correctly populated

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
