### PR TITLE
refactor: generate notification user contact join - WPB-11660

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationNotificationBuilder.swift
@@ -85,7 +85,7 @@ struct ConversationNotificationBuilder: NotificationBuilder {
                 return UNMutableNotificationContent()
             }
 
-            builder = await NewUserMessageNotificationBuilder(
+            builder = await ConversationUserMessageNotificationBuilder(
                 message: genericMessage,
                 conversationID: mlsMessageEvent.conversationID,
                 senderID: mlsMessageEvent.senderID
@@ -103,7 +103,7 @@ struct ConversationNotificationBuilder: NotificationBuilder {
                 return UNMutableNotificationContent()
             }
 
-            builder = await NewUserMessageNotificationBuilder(
+            builder = await ConversationUserMessageNotificationBuilder(
                 message: genericMessage,
                 conversationID: proteusMessageEvent.conversationID,
                 senderID: proteusMessageEvent.senderID
@@ -112,7 +112,7 @@ struct ConversationNotificationBuilder: NotificationBuilder {
         case let .memberLeave(memberLeaveEvent):
             let removedUserIDs = Set(memberLeaveEvent.removedUserIDs.compactMap(\.uuid))
 
-            builder = await NewSystemMessageNotificationBuilder(
+            builder = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: .memberLeave(removedUserIDs: removedUserIDs),
                 conversationID: memberLeaveEvent.conversationID,
                 senderID: memberLeaveEvent.senderID
@@ -121,7 +121,7 @@ struct ConversationNotificationBuilder: NotificationBuilder {
         case let .memberJoin(memberJoinEvent):
             let addedUserIDs = Set(memberJoinEvent.members.compactMap(\.id))
 
-            builder = await NewSystemMessageNotificationBuilder(
+            builder = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: .memberJoin(addedUserIDs: addedUserIDs),
                 conversationID: memberJoinEvent.conversationID,
                 senderID: memberJoinEvent.senderID
@@ -129,7 +129,7 @@ struct ConversationNotificationBuilder: NotificationBuilder {
 
         case let .create(conversationCreateEvent):
 
-            builder = await NewSystemMessageNotificationBuilder(
+            builder = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: .conversationCreated,
                 conversationID: conversationCreateEvent.conversationID,
                 senderID: conversationCreateEvent.senderID
@@ -137,7 +137,7 @@ struct ConversationNotificationBuilder: NotificationBuilder {
 
         case let .delete(conversationDeleteEvent):
 
-            builder = await NewSystemMessageNotificationBuilder(
+            builder = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: .conversationDeleted,
                 conversationID: conversationDeleteEvent.conversationID,
                 senderID: conversationDeleteEvent.senderID
@@ -145,13 +145,13 @@ struct ConversationNotificationBuilder: NotificationBuilder {
 
         case let .messageTimerUpdate(messageTimerUpdateEvent):
 
-            builder = await NewSystemMessageNotificationBuilder(
+            builder = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: .messageTimerUpdate(newTimer: messageTimerUpdateEvent.newTimer),
                 conversationID: messageTimerUpdateEvent.conversationID,
                 senderID: messageTimerUpdateEvent.senderID
             )
 
-        default: // TODO: [WPB-11175] - Generate notifications for other events
+        default:
             return UNMutableNotificationContent()
         }
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationSystemMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationSystemMessageNotificationBuilder.swift
@@ -19,7 +19,7 @@
 import WireAPI
 import WireDataModel
 
-struct NewSystemMessageNotificationBuilder: NotificationBuilder {
+struct ConversationSystemMessageNotificationBuilder: NotificationBuilder {
 
     enum SystemMessage {
         case memberLeave(removedUserIDs: Set<UUID>)
@@ -127,7 +127,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
             content.title = title
         }
 
-        let body = NotificationBody.newSystemMessage(
+        let body = NotificationBody.conversationSystemMessage(
             .removedYou(senderName: context.senderName)
         )
 
@@ -167,7 +167,7 @@ struct NewSystemMessageNotificationBuilder: NotificationBuilder {
         }
 
         return NotificationTitle
-            .newMessage(format)
+            .conversationMessage(format)
             .make()
     }
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationUserMessageNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationUserMessageNotificationBuilder.swift
@@ -19,7 +19,7 @@
 import WireAPI
 import WireDataModel
 
-struct NewUserMessageNotificationBuilder: NotificationBuilder {
+struct ConversationUserMessageNotificationBuilder: NotificationBuilder {
 
     private enum AssetType {
         case image
@@ -143,19 +143,19 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
 
         let body: NotificationBody = switch assetType {
         case .image:
-            .newUserMessage(
+            .conversationUserMessage(
                 .sharedPicture(senderName: isGroupConversation ? senderName : nil)
             )
         case .video:
-            .newUserMessage(
+            .conversationUserMessage(
                 .sharedVideo(senderName: isGroupConversation ? senderName : nil)
             )
         case .audio:
-            .newUserMessage(
+            .conversationUserMessage(
                 .sharedAudio(senderName: isGroupConversation ? senderName : nil)
             )
         case .fileUpload:
-            .newUserMessage(
+            .conversationUserMessage(
                 .sharedFile(senderName: isGroupConversation ? senderName : nil)
             )
         }
@@ -177,7 +177,7 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
             content.title = title
         }
 
-        let body = NotificationBody.newUserMessage(
+        let body = NotificationBody.conversationUserMessage(
             .ping(senderName: context.isGroupConversation ? senderName : nil)
         )
 
@@ -194,7 +194,7 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
         let content = UNMutableNotificationContent()
 
         // No title for hidden message, only a body.
-        let body: NotificationBody = .newUserMessage(.hidden)
+        let body: NotificationBody = .conversationUserMessage(.hidden)
         content.body = body.make()
         content.categoryIdentifier = makeCategory()
         content.sound = makeSound()
@@ -241,7 +241,7 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
             .text(content: text, senderName: senderName)
         }
 
-        let body = NotificationBody.newUserMessage(
+        let body = NotificationBody.conversationUserMessage(
             format
         )
 
@@ -263,7 +263,7 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
             content.title = title
         }
 
-        let body = NotificationBody.newUserMessage(
+        let body = NotificationBody.conversationUserMessage(
             .sharedLocation(senderName: isGroupConversation ? senderName : nil)
         )
 
@@ -310,7 +310,7 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
             .sentWithUnknownSender
         }
 
-        let body = NotificationBody.newUserMessage(
+        let body = NotificationBody.conversationUserMessage(
             format
         )
 
@@ -351,7 +351,7 @@ struct NewUserMessageNotificationBuilder: NotificationBuilder {
         }
 
         return NotificationTitle
-            .newMessage(format)
+            .conversationMessage(format)
             .make()
     }
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionNotificationBuilder.swift
@@ -52,11 +52,9 @@ struct UserConnectionNotificationBuilder: NotificationBuilder {
         case .joined:
             buildUserJoinNotification()
         case .pending:
-            // TODO: [WPB-11659] To implement
-            UNMutableNotificationContent()
+            buildConnectionRequestNotification(isPending: true)
         case .accepted:
-            // TODO: [WPB-11659] To implement
-            UNMutableNotificationContent()
+            buildConnectionRequestNotification(isPending: false)
         }
     }
 
@@ -76,6 +74,22 @@ struct UserConnectionNotificationBuilder: NotificationBuilder {
         return content
     }
 
+    private func buildConnectionRequestNotification(
+        isPending: Bool
+    ) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        let body = NotificationBody.userConnection(
+            isPending ? .userWantsToConnect(username: context.username) : .usersConnected(username: context.username)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+
+        return content
+    }
+
     // MARK: - Helpers
 
     private func makeSound(type: NotificationSound = .default) -> UNNotificationSound {
@@ -85,11 +99,10 @@ struct UserConnectionNotificationBuilder: NotificationBuilder {
 
     private func makeCategory() -> String {
         switch context.connectionStatus {
-        case .joined:
+        case .joined, .accepted:
             NotificationCategory.nonActionable.rawValue
-        case .pending, .accepted:
-            // TODO: [WPB-11659] To implement
-            ""
+        case .pending:
+            NotificationCategory.incomingConnectionRequest.rawValue
         }
     }
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionNotificationBuilder.swift
@@ -1,0 +1,96 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UserNotifications
+
+struct UserConnectionNotificationBuilder: NotificationBuilder {
+
+    enum ConnectionStatus {
+        case joined
+        case pending
+        case accepted
+    }
+
+    struct Context {
+        let connectionStatus: ConnectionStatus
+        let username: String
+    }
+
+    private let context: Context
+
+    init(
+        connectionStatus: ConnectionStatus,
+        username: String
+    ) {
+        self.context = Context(
+            connectionStatus: connectionStatus,
+            username: username
+        )
+    }
+
+    func shouldBuildNotification() async -> Bool {
+        true
+    }
+
+    func buildContent() async -> UNMutableNotificationContent {
+        switch context.connectionStatus {
+        case .joined:
+            buildUserJoinNotification()
+        case .pending:
+            // TODO: [WPB-11659] To implement
+            UNMutableNotificationContent()
+        case .accepted:
+            // TODO: [WPB-11659] To implement
+            UNMutableNotificationContent()
+        }
+    }
+
+    // MARK: - Build notifications
+
+    private func buildUserJoinNotification() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        let body = NotificationBody.userConnection(
+            .userJoined(username: context.username)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+
+        return content
+    }
+
+    // MARK: - Helpers
+
+    private func makeSound(type: NotificationSound = .default) -> UNNotificationSound {
+        let notificationSoundName = UNNotificationSoundName(type.rawValue)
+        return UNNotificationSound(named: notificationSoundName)
+    }
+
+    private func makeCategory() -> String {
+        switch context.connectionStatus {
+        case .joined:
+            NotificationCategory.nonActionable.rawValue
+        case .pending, .accepted:
+            // TODO: [WPB-11659] To implement
+            ""
+        }
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserNotificationBuilder.swift
@@ -1,0 +1,67 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UserNotifications
+import WireAPI
+import WireDataModel
+
+struct UserNotificationBuilder: NotificationBuilder {
+
+    private let event: UserEvent
+
+    init(
+        event: UserEvent
+    ) {
+        self.event = event
+    }
+
+    func shouldBuildNotification() async -> Bool {
+        true
+    }
+
+    func buildContent() async -> UNMutableNotificationContent {
+        let builder: NotificationBuilder
+
+        switch event {
+        case let .connection(userConnectionEvent):
+            let isPending = userConnectionEvent.connection.status == .pending
+
+            builder = UserConnectionNotificationBuilder(
+                connectionStatus: isPending ? .pending : .accepted,
+                username: userConnectionEvent.userName
+            )
+
+        case let .contactJoin(userContactJoinEvent):
+
+            builder = UserConnectionNotificationBuilder(
+                connectionStatus: .joined,
+                username: userContactJoinEvent.name
+            )
+
+        default:
+            return UNMutableNotificationContent()
+        }
+
+        guard await builder.shouldBuildNotification() else {
+            return UNMutableNotificationContent()
+        }
+
+        return await builder.buildContent()
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/Conversation/ConversationMessageNotificationTitleComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/Conversation/ConversationMessageNotificationTitleComposer.swift
@@ -18,29 +18,21 @@
 
 import Foundation
 
-struct NewSystemMessageNotificationBodyComposer {
-    let format: NotificationBody.SystemMessageBodyFormat
+struct ConversationMessageNotificationTitleComposer {
+    let format: NotificationTitle.MessageTitleFormat
 
     // TODO: [WPB-15153] - Localize strings
     func make() -> String {
         switch format {
-        case let .createdConversation(senderName):
-            // TODO: [WPB-11657]
-            ""
-        case let .removedYou(senderName):
-            senderName != nil ? "\(senderName!) removed you" : "Someone removed you"
-        case let .setMessageTimer(senderName):
-            // TODO: [WPB-11663]
-            ""
-        case let .addedYou(senderName):
-            // TODO: [WPB-11661]
-            ""
-        case let .turnedOffMessageTimer(senderName):
-            // TODO: [WPB-11663]
-            ""
-        case let .deletedGroup(senderName):
-            // TODO: [WPB-11658]
-            ""
+        case let .sender(sender):
+            "\(sender)"
+        case let .senderInTeam(sender, team):
+            "\(sender) in \(team)"
+        case let .conversation(conversation):
+            "\(conversation)"
+        case let .conversationInTeam(conversation, team):
+            "\(conversation) in \(team)"
         }
     }
+
 }

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/Conversation/ConversationSystemMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/Conversation/ConversationSystemMessageNotificationBodyComposer.swift
@@ -18,21 +18,29 @@
 
 import Foundation
 
-struct NewMessageNotificationTitleComposer {
-    let format: NotificationTitle.MessageTitleFormat
+struct ConversationSystemMessageNotificationBodyComposer {
+    let format: NotificationBody.SystemMessageBodyFormat
 
     // TODO: [WPB-15153] - Localize strings
     func make() -> String {
         switch format {
-        case let .sender(sender):
-            "\(sender)"
-        case let .senderInTeam(sender, team):
-            "\(sender) in \(team)"
-        case let .conversation(conversation):
-            "\(conversation)"
-        case let .conversationInTeam(conversation, team):
-            "\(conversation) in \(team)"
+        case let .createdConversation(senderName):
+            // TODO: [WPB-11657]
+            ""
+        case let .removedYou(senderName):
+            senderName != nil ? "\(senderName!) removed you" : "Someone removed you"
+        case let .setMessageTimer(senderName):
+            // TODO: [WPB-11663]
+            ""
+        case let .addedYou(senderName):
+            // TODO: [WPB-11661]
+            ""
+        case let .turnedOffMessageTimer(senderName):
+            // TODO: [WPB-11663]
+            ""
+        case let .deletedGroup(senderName):
+            // TODO: [WPB-11658]
+            ""
         }
     }
-
 }

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/Conversation/ConversationUserMessageNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/Conversation/ConversationUserMessageNotificationBodyComposer.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-struct NewUserMessageNotificationBodyComposer {
+struct ConversationUserMessageNotificationBodyComposer {
     let format: NotificationBody.UserMessageBodyFormat
 
     // TODO: [WPB-15153] - Localize strings

--- a/WireDomain/Sources/WireDomain/Notifications/Composers/User/UserConnectionNotificationBodyComposer.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Composers/User/UserConnectionNotificationBodyComposer.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+struct UserConnectionNotificationBodyComposer {
+    let format: NotificationBody.UserConnectionBodyFormat
+
+    // TODO: [WPB-15153] - Localize strings
+    func make() -> String {
+        switch format {
+        case let .userJoined(username):
+            "\(username) just joined Wire"
+        case let .userWantsToConnect(username):
+            "\(username) wants to connect"
+        case let .usersConnected(username):
+            "You and \(username) are now connected"
+        }
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Notifications/NotificationBody.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/NotificationBody.swift
@@ -20,25 +20,33 @@ import Foundation
 
 enum NotificationBody {
 
-    case newUserMessage(UserMessageBodyFormat)
-    case newSystemMessage(SystemMessageBodyFormat)
+    case conversationUserMessage(UserMessageBodyFormat)
+    case conversationSystemMessage(SystemMessageBodyFormat)
+    case userConnection(UserConnectionBodyFormat)
     case bundled(messagesCount: Int)
 
     func make() -> String {
         switch self {
-        case let .newUserMessage(userMessageBodyFormat):
-            let newUserMessageBodyComposer = NewUserMessageNotificationBodyComposer(
+        case let .conversationUserMessage(userMessageBodyFormat):
+            let conversationUserMessageBodyComposer = ConversationUserMessageNotificationBodyComposer(
                 format: userMessageBodyFormat
             )
 
-            return newUserMessageBodyComposer.make()
+            return conversationUserMessageBodyComposer.make()
 
-        case let .newSystemMessage(systemMessageBodyFormat):
-            let newSystemMessageBodyComposer = NewSystemMessageNotificationBodyComposer(
+        case let .conversationSystemMessage(systemMessageBodyFormat):
+            let conversationSystemMessageBodyComposer = ConversationSystemMessageNotificationBodyComposer(
                 format: systemMessageBodyFormat
             )
 
-            return newSystemMessageBodyComposer.make()
+            return conversationSystemMessageBodyComposer.make()
+
+        case let .userConnection(userConnectionBodyFormat):
+            let userConnectionBodyComposer = UserConnectionNotificationBodyComposer(
+                format: userConnectionBodyFormat
+            )
+
+            return userConnectionBodyComposer.make()
 
         case let .bundled(count):
             return "\(count) new messages."
@@ -49,7 +57,7 @@ enum NotificationBody {
 
 extension NotificationBody {
 
-    /// The expected formats for the body of a new user message notification.
+    /// The expected formats for the body of a new conversation user message notification.
     enum UserMessageBodyFormat {
         /// `Someone sent a message`
         case sentWithUnknownSender
@@ -79,7 +87,7 @@ extension NotificationBody {
         case hidden
     }
 
-    /// The expected formats for the body of a new system message notification.
+    /// The expected formats for the body of a new conversation system message notification.
     enum SystemMessageBodyFormat {
         /// `[sender name] created a conversation` or `Someone created a conversation` if sender is nil
         case createdConversation(senderName: String?)
@@ -94,6 +102,16 @@ extension NotificationBody {
         case turnedOffMessageTimer(senderName: String?)
         /// `[sender name] deleted the group` or `Someone deleted the group` if sender is nil
         case deletedGroup(senderName: String?)
+    }
+
+    /// The expected formats for the body of a new user connection notification.
+    enum UserConnectionBodyFormat {
+        /// `[username]` just joined Wire
+        case userJoined(username: String)
+        /// `[username]` wants to connect
+        case userWantsToConnect(username: String)
+        /// You and `[username]` are now connected
+        case usersConnected(username: String)
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Notifications/NotificationSession.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/NotificationSession.swift
@@ -92,19 +92,18 @@ final class NotificationSession {
 
             switch event {
             case let .conversation(conversationEvent):
+
                 notificationBuilder = await ConversationNotificationBuilder(
                     event: conversationEvent
                 )
-            // TODO: [WPB-10218] - Generate notif for other update events
-            case let .featureConfig(featureConfigEvent):
-                continue
-            case let .federation(federationEvent):
-                continue
+
             case let .user(userEvent):
-                continue
-            case let .team(teamEvent):
-                continue
-            case let .unknown(eventType):
+
+                notificationBuilder = UserNotificationBuilder(
+                    event: userEvent
+                )
+
+            default:
                 continue
             }
 

--- a/WireDomain/Sources/WireDomain/Notifications/NotificationTitle.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/NotificationTitle.swift
@@ -20,16 +20,16 @@ import Foundation
 
 enum NotificationTitle {
 
-    case newMessage(MessageTitleFormat)
+    case conversationMessage(MessageTitleFormat)
 
     func make() -> String {
         switch self {
-        case let .newMessage(messageFormat):
-            let newMessageTitleComposer = NewMessageNotificationTitleComposer(
+        case let .conversationMessage(messageFormat):
+            let conversationMessageTitleComposer = ConversationMessageNotificationTitleComposer(
                 format: messageFormat
             )
 
-            return newMessageTitleComposer.make()
+            return conversationMessageTitleComposer.make()
         }
     }
 

--- a/WireDomain/Tests/WireDomainTests/Notifications/ConversationSystemMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/ConversationSystemMessageNotificationBuilderTests.swift
@@ -25,8 +25,8 @@ import XCTest
 @testable import WireDomain
 @testable import WireDomainSupport
 
-final class NewSystemMessageNotificationBuilderTests: XCTestCase {
-    private var sut: NewSystemMessageNotificationBuilder!
+final class ConversationSystemMessageNotificationBuilderTests: XCTestCase {
+    private var sut: ConversationSystemMessageNotificationBuilder!
     private var conversationLocalStore: MockConversationLocalStoreProtocol!
     private var messageLocalStore: MockMessageLocalStoreProtocol!
     private var userLocalStore: MockUserLocalStoreProtocol!
@@ -83,12 +83,12 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
 
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
-        let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
+        let systemMessages: [ConversationSystemMessageNotificationBuilder.SystemMessage] = [
             .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
         ]
 
         for systemMessage in systemMessages {
-            sut = await NewSystemMessageNotificationBuilder(
+            sut = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: systemMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID
@@ -118,12 +118,12 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
 
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
-        let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
+        let systemMessages: [ConversationSystemMessageNotificationBuilder.SystemMessage] = [
             .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
         ]
 
         for systemMessage in systemMessages {
-            sut = await NewSystemMessageNotificationBuilder(
+            sut = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: systemMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID
@@ -153,12 +153,12 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
 
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID4)
 
-        let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
+        let systemMessages: [ConversationSystemMessageNotificationBuilder.SystemMessage] = [
             .memberLeave(removedUserIDs: [.mockID4]) // concerns self user
         ]
 
         for systemMessage in systemMessages {
-            sut = await NewSystemMessageNotificationBuilder(
+            sut = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: systemMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID
@@ -188,12 +188,12 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
 
         await setupMock(isGroup: isGroup, isTeam: isTeam, selfUserID: .mockID3)
 
-        let systemMessages: [NewSystemMessageNotificationBuilder.SystemMessage] = [
+        let systemMessages: [ConversationSystemMessageNotificationBuilder.SystemMessage] = [
             .memberLeave(removedUserIDs: [UUID()]) // doesn't concern self user
         ]
 
         for systemMessage in systemMessages {
-            sut = await NewSystemMessageNotificationBuilder(
+            sut = await ConversationSystemMessageNotificationBuilder(
                 systemMessage: systemMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID
@@ -207,7 +207,7 @@ final class NewSystemMessageNotificationBuilderTests: XCTestCase {
 
     private func internalTest_assertNotificationContent(
         _ notificationContent: UNMutableNotificationContent,
-        systemMessage: NewSystemMessageNotificationBuilder.SystemMessage,
+        systemMessage: ConversationSystemMessageNotificationBuilder.SystemMessage,
         isGroup: Bool,
         isTeam: Bool
     ) async throws {

--- a/WireDomain/Tests/WireDomainTests/Notifications/ConversationUserMessageNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/ConversationUserMessageNotificationBuilderTests.swift
@@ -25,8 +25,8 @@ import XCTest
 @testable import WireDomain
 @testable import WireDomainSupport
 
-final class NewUserMessageNotificationBuilderTests: XCTestCase {
-    private var sut: NewUserMessageNotificationBuilder!
+final class ConversationUserMessageNotificationBuilderTests: XCTestCase {
+    private var sut: ConversationUserMessageNotificationBuilder!
     private var conversationLocalStore: MockConversationLocalStoreProtocol!
     private var messageLocalStore: MockMessageLocalStoreProtocol!
     private var userLocalStore: MockUserLocalStoreProtocol!
@@ -87,7 +87,7 @@ final class NewUserMessageNotificationBuilderTests: XCTestCase {
         for messageCapable in messagesCapable {
             let genericMessage = GenericMessage(content: messageCapable)
 
-            sut = await NewUserMessageNotificationBuilder(
+            sut = await ConversationUserMessageNotificationBuilder(
                 message: genericMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID
@@ -120,7 +120,7 @@ final class NewUserMessageNotificationBuilderTests: XCTestCase {
 
         for messageCapable in messagesCapable {
             let genericMessage = GenericMessage(content: messageCapable)
-            sut = await NewUserMessageNotificationBuilder(
+            sut = await ConversationUserMessageNotificationBuilder(
                 message: genericMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID
@@ -153,7 +153,7 @@ final class NewUserMessageNotificationBuilderTests: XCTestCase {
 
         for messageCapable in messagesCapable {
             let genericMessage = GenericMessage(content: messageCapable)
-            sut = await NewUserMessageNotificationBuilder(
+            sut = await ConversationUserMessageNotificationBuilder(
                 message: genericMessage,
                 conversationID: Scaffolding.conversationID,
                 senderID: Scaffolding.userID

--- a/WireDomain/Tests/WireDomainTests/Notifications/UserConnectionNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/UserConnectionNotificationBuilderTests.swift
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAPISupport
+import WireDataModel
+import WireDataModelSupport
+import WireTestingPackage
+import XCTest
+@testable import WireAPI
+@testable import WireDomain
+@testable import WireDomainSupport
+
+final class UserConnectionNotificationBuilderTests: XCTestCase {
+    private var sut: UserConnectionNotificationBuilder!
+
+    func testGenerateUserConnectionNotifications() async {
+
+        let connectionStatuses: [UserConnectionNotificationBuilder.ConnectionStatus] = [
+            .joined
+        ]
+
+        for connectionStatus in connectionStatuses {
+            sut = UserConnectionNotificationBuilder(
+                connectionStatus: connectionStatus,
+                username: Scaffolding.username
+            )
+
+            let notification = await sut.buildContent()
+
+            switch connectionStatus {
+            case .joined:
+                XCTAssertEqual(notification.title, "")
+                XCTAssertEqual(notification.body, "\(Scaffolding.username) just joined Wire")
+                XCTAssertEqual(notification.sound, UNNotificationSound(named: .init("default")))
+                XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.nonActionable.rawValue)
+
+            case .pending:
+                fatalError()
+
+            case .accepted:
+                fatalError()
+            }
+        }
+    }
+
+    private enum Scaffolding {
+        static let username = "username1"
+    }
+
+}

--- a/WireDomain/Tests/WireDomainTests/Notifications/UserConnectionNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/UserConnectionNotificationBuilderTests.swift
@@ -16,22 +16,17 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireAPISupport
-import WireDataModel
-import WireDataModelSupport
-import WireTestingPackage
 import XCTest
-@testable import WireAPI
 @testable import WireDomain
-@testable import WireDomainSupport
 
 final class UserConnectionNotificationBuilderTests: XCTestCase {
     private var sut: UserConnectionNotificationBuilder!
 
     func testGenerateUserConnectionNotifications() async {
-
         let connectionStatuses: [UserConnectionNotificationBuilder.ConnectionStatus] = [
-            .joined
+            .joined,
+            .pending,
+            .accepted
         ]
 
         for connectionStatus in connectionStatuses {
@@ -42,18 +37,21 @@ final class UserConnectionNotificationBuilderTests: XCTestCase {
 
             let notification = await sut.buildContent()
 
+            XCTAssertEqual(notification.title, "")
+            XCTAssertEqual(notification.sound, UNNotificationSound(named: .init("default")))
+
             switch connectionStatus {
             case .joined:
-                XCTAssertEqual(notification.title, "")
                 XCTAssertEqual(notification.body, "\(Scaffolding.username) just joined Wire")
-                XCTAssertEqual(notification.sound, UNNotificationSound(named: .init("default")))
                 XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.nonActionable.rawValue)
 
             case .pending:
-                fatalError()
+                XCTAssertEqual(notification.body, "\(Scaffolding.username) wants to connect")
+                XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.incomingConnectionRequest.rawValue)
 
             case .accepted:
-                fatalError()
+                XCTAssertEqual(notification.body, "You and \(Scaffolding.username) are now connected")
+                XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.nonActionable.rawValue)
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11660" title="WPB-11660" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11660</a>  [iOS] Generate UNNotificationContent for user contact join
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is about generating notification content related to the user join event (connections) populating the right data in the notification (title, body, sound, category..). 

### Testing

- [x] Notification for user join is correctly populated.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.