### PR TITLE
refactor: generate notification connection request (pending, accepted) - WPB-11659

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionNotificationBuilder.swift
@@ -52,11 +52,9 @@ struct UserConnectionNotificationBuilder: NotificationBuilder {
         case .joined:
             buildUserJoinNotification()
         case .pending:
-            // TODO: [WPB-11659] To implement
-            UNMutableNotificationContent()
+            buildConnectionRequestNotification(isPending: true)
         case .accepted:
-            // TODO: [WPB-11659] To implement
-            UNMutableNotificationContent()
+            buildConnectionRequestNotification(isPending: false)
         }
     }
 
@@ -76,6 +74,22 @@ struct UserConnectionNotificationBuilder: NotificationBuilder {
         return content
     }
 
+    private func buildConnectionRequestNotification(
+        isPending: Bool
+    ) -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+
+        let body = NotificationBody.userConnection(
+            isPending ? .userWantsToConnect(username: context.username) : .usersConnected(username: context.username)
+        )
+
+        content.body = body.make()
+        content.categoryIdentifier = makeCategory()
+        content.sound = makeSound()
+
+        return content
+    }
+
     // MARK: - Helpers
 
     private func makeSound(type: NotificationSound = .default) -> UNNotificationSound {
@@ -85,11 +99,10 @@ struct UserConnectionNotificationBuilder: NotificationBuilder {
 
     private func makeCategory() -> String {
         switch context.connectionStatus {
-        case .joined:
+        case .joined, .accepted:
             NotificationCategory.nonActionable.rawValue
-        case .pending, .accepted:
-            // TODO: [WPB-11659] To implement
-            ""
+        case .pending:
+            NotificationCategory.incomingConnectionRequest.rawValue
         }
     }
 

--- a/WireDomain/Tests/WireDomainTests/Notifications/UserConnectionNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/UserConnectionNotificationBuilderTests.swift
@@ -16,22 +16,17 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireAPISupport
-import WireDataModel
-import WireDataModelSupport
-import WireTestingPackage
 import XCTest
-@testable import WireAPI
 @testable import WireDomain
-@testable import WireDomainSupport
 
 final class UserConnectionNotificationBuilderTests: XCTestCase {
     private var sut: UserConnectionNotificationBuilder!
 
     func testGenerateUserConnectionNotifications() async {
-
         let connectionStatuses: [UserConnectionNotificationBuilder.ConnectionStatus] = [
-            .joined
+            .joined,
+            .pending,
+            .accepted
         ]
 
         for connectionStatus in connectionStatuses {
@@ -42,18 +37,21 @@ final class UserConnectionNotificationBuilderTests: XCTestCase {
 
             let notification = await sut.buildContent()
 
+            XCTAssertEqual(notification.title, "")
+            XCTAssertEqual(notification.sound, UNNotificationSound(named: .init("default")))
+
             switch connectionStatus {
             case .joined:
-                XCTAssertEqual(notification.title, "")
                 XCTAssertEqual(notification.body, "\(Scaffolding.username) just joined Wire")
-                XCTAssertEqual(notification.sound, UNNotificationSound(named: .init("default")))
                 XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.nonActionable.rawValue)
 
             case .pending:
-                fatalError()
+                XCTAssertEqual(notification.body, "\(Scaffolding.username) wants to connect")
+                XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.incomingConnectionRequest.rawValue)
 
             case .accepted:
-                fatalError()
+                XCTAssertEqual(notification.body, "You and \(Scaffolding.username) are now connected")
+                XCTAssertEqual(notification.categoryIdentifier, NotificationCategory.nonActionable.rawValue)
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-11659" title="WPB-11659" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-11659</a>  [iOS] Generate UNNotificationContent for new user connection request
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Key points

This PR is about generating notification content related to the user connection (pending, accepted) populating the right data in the notification (title, body, sound, category..). 

### Testing

- [x] Notification for user connection pending and accepted is correctly populated.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.