### PR TITLE
fix: notifications stop working when switching backend - WPB-15127

### DIFF
--- a/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -24,12 +24,11 @@ private let zmsLog = ZMSLog(tag: "backend-environment")
 public extension BackendEnvironment {
     static let backendSwitchNotification = Notification.Name("backendEnvironmentSwitchNotification")
     static var shared: BackendEnvironment = {
-        let environmentType: EnvironmentType
-        if let typeOverride = AutomationHelper.sharedHelper.backendEnvironmentTypeOverride() {
-            environmentType = EnvironmentType(stringValue: typeOverride)
+        let environmentType = if let typeOverride = AutomationHelper.sharedHelper.backendEnvironmentTypeOverride() {
+            EnvironmentType(stringValue: typeOverride)
         } else {
             // read from userDefaults first
-            environmentType = EnvironmentType(userDefaults: .applicationGroup)
+            EnvironmentType(userDefaults: .applicationGroup)
         }
 
         guard let environment = BackendEnvironment(type: environmentType) else {

--- a/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -24,7 +24,8 @@ private let zmsLog = ZMSLog(tag: "backend-environment")
 public extension BackendEnvironment {
     static let backendSwitchNotification = Notification.Name("backendEnvironmentSwitchNotification")
     static var shared: BackendEnvironment = {
-        var environmentType: EnvironmentType?
+        // read from userDefaults first
+        var environmentType: EnvironmentType? = EnvironmentType(userDefaults: .applicationGroup)
         if let typeOverride = AutomationHelper.sharedHelper.backendEnvironmentTypeOverride() {
             environmentType = EnvironmentType(stringValue: typeOverride)
         }

--- a/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
+++ b/wire-ios/WireCommonComponents/BackendEnvironment+Shared.swift
@@ -24,10 +24,12 @@ private let zmsLog = ZMSLog(tag: "backend-environment")
 public extension BackendEnvironment {
     static let backendSwitchNotification = Notification.Name("backendEnvironmentSwitchNotification")
     static var shared: BackendEnvironment = {
-        // read from userDefaults first
-        var environmentType: EnvironmentType? = EnvironmentType(userDefaults: .applicationGroup)
+        let environmentType: EnvironmentType
         if let typeOverride = AutomationHelper.sharedHelper.backendEnvironmentTypeOverride() {
             environmentType = EnvironmentType(stringValue: typeOverride)
+        } else {
+            // read from userDefaults first
+            environmentType = EnvironmentType(userDefaults: .applicationGroup)
         }
 
         guard let environment = BackendEnvironment(type: environmentType) else {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15127" title="WPB-15127" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15127</a>  [iOS] Notifications stop working
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When switching backend after logging out from an account and then log to a new account, the NSE will not work because the cookie is invalid.

This is due to the fact that the `environmentType` (prod, staging,...), although it is correctly saved to applicationGroup UserDefaults for the NSE to work correctly, it does not read from the `UserDefaults`. Therefore it falls back to production and invalidates the session.

Solution:

Read environmentType from applicationGroup in BackendEnvironment.shared.

### Testing

- [x] See steps in ticket to reproduce

Note: as the code is in a static variable it is hard to add a unit test.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
