### PR TITLE
fix: enable Countly for AppStore builds - WPB-15419

### DIFF
--- a/.github/workflows/public_app_release.yml
+++ b/.github/workflows/public_app_release.yml
@@ -9,5 +9,6 @@ jobs:
   public_app_release:
     uses: ./.github/workflows/_reusable_app_release.yml
     with:
+      countly_enabled: true
       fastlane_action: appstore_public
     secrets: inherit

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,4 +16,4 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.115.0
+WIRE_SHORT_VERSION = 3.115.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15419" title="WPB-15419" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15419</a>  Manage hotfix release iOS 3.115.1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently AppStore builds don't enable Countly.
This PR fixes it.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
