### PR TITLE
fix: MLS add message decryption error - WPB-15646

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Decryption/MLSMessageDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/MLSMessageDecryptor.swift
@@ -50,7 +50,7 @@ struct MLSMessageDecryptor: MLSMessageDecryptorProtocol {
             throw MLSMessageDecryptorError.mlsConversationNotReady
         }
 
-        let decryptionResults = await decryptMLSMessage(
+        let decryptionResults = try await decryptMLSMessage(
             message: eventData.message,
             mlsGroupID: mlsGroupID,
             subconversation: eventData.subconversation
@@ -74,33 +74,24 @@ struct MLSMessageDecryptor: MLSMessageDecryptorProtocol {
         message: String,
         mlsGroupID: MLSGroupID,
         subconversation: String?
-    ) async -> [MLSDecryptResult] {
-        do {
-            let subconvType = subconversation != nil ? SubgroupType(rawValue: subconversation!) : nil
+    ) async throws -> [MLSDecryptResult] {
+        let subconvType = subconversation != nil ? SubgroupType(rawValue: subconversation!) : nil
 
-            let results = try await mlsDecryptionService.decrypt(
-                message: message,
-                for: mlsGroupID,
-                subconversationType: subconvType
-            )
+        let results = try await mlsDecryptionService.decrypt(
+            message: message,
+            for: mlsGroupID,
+            subconversationType: subconvType
+        )
 
-            if results.isEmpty {
-                WireLogger.mls.info(
-                    "successfully decrypted mls message but no result was returned"
-                )
-
-                return []
-            }
-
-            return results
-
-        } catch {
-            WireLogger.mls.error(
-                "failed to decrypt mls message: \(String(describing: error))"
+        if results.isEmpty {
+            WireLogger.mls.info(
+                "successfully decrypted mls message but no result was returned"
             )
 
             return []
         }
+
+        return results
     }
 
     private func processMLSMessageDecryptionResults(

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireLogging
 
 extension EventDecoder {
-    
+
     enum Failure: Error {
         case mlsDecodingError
         case missingMLSGroupID

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -22,7 +22,6 @@ import WireLogging
 extension EventDecoder {
 
     enum Failure: Error {
-        case mlsDecodingError
         case missingMLSGroupID
     }
 
@@ -70,10 +69,10 @@ extension EventDecoder {
         }
 
         let decoder = EventPayloadDecoder()
-        guard let payload = try? decoder
-            .decode(Payload.UpdateConversationMLSMessageAdd.self, from: updateEvent.payload) else {
-            throw Failure.mlsDecodingError
-        }
+        let payload = try decoder.decode(
+            Payload.UpdateConversationMLSMessageAdd.self,
+            from: updateEvent.payload
+        )
 
         var conversation: ZMConversation?
         let groupID: MLSGroupID? = await context.perform {

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -56,7 +56,7 @@ extension EventDecoder {
     func decryptMlsMessage(
         from updateEvent: ZMUpdateEvent,
         context: NSManagedObjectContext
-    ) async -> [ZMUpdateEvent] {
+    ) async throws -> [ZMUpdateEvent] {
         WireLogger.mls.info("decrypting mls message")
 
         guard let decryptionService = await context.perform({ context.mlsDecryptionService }) else {
@@ -136,7 +136,7 @@ extension EventDecoder {
 
         } catch {
             WireLogger.mls.warn("failed to decrypt mls message: \(String(describing: error))")
-            return []
+            throw error
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -20,6 +20,11 @@ import Foundation
 import WireLogging
 
 extension EventDecoder {
+    
+    enum Failure: Error {
+        case mlsDecodingError
+        case missingMLSGroupID
+    }
 
     func processWelcomeMessage(
         from updateEvent: ZMUpdateEvent,
@@ -67,8 +72,7 @@ extension EventDecoder {
         let decoder = EventPayloadDecoder()
         guard let payload = try? decoder
             .decode(Payload.UpdateConversationMLSMessageAdd.self, from: updateEvent.payload) else {
-            WireLogger.mls.error("failed to decrypt mls message: invalid update event payload")
-            return []
+            throw Failure.mlsDecodingError
         }
 
         var conversation: ZMConversation?
@@ -92,8 +96,7 @@ extension EventDecoder {
         }
 
         guard let groupID else {
-            WireLogger.mls.error("failed to decrypt mls message: missing MLS group ID")
-            return []
+            throw Failure.missingMLSGroupID
         }
 
         let results = try await decryptionService.decrypt(

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -96,48 +96,43 @@ extension EventDecoder {
             return []
         }
 
-        do {
-            let results = try await decryptionService.decrypt(
-                message: payload.data,
-                for: groupID,
-                subconversationType: payload.subconversationType
-            )
+        let results = try await decryptionService.decrypt(
+            message: payload.data,
+            for: groupID,
+            subconversationType: payload.subconversationType
+        )
 
-            if results.isEmpty {
-                WireLogger.mls.info("successfully decrypted mls message but no result was returned")
-                return []
-            }
+        if results.isEmpty {
+            WireLogger.mls.info("successfully decrypted mls message but no result was returned")
+            return []
+        }
 
-            var events = [ZMUpdateEvent]()
-            for result in results {
+        var events = [ZMUpdateEvent]()
+        for result in results {
 
-                switch result {
-                case let .message(decryptedData, senderClientID):
-                    if let event = updateEvent.decryptedMLSEvent(
-                        decryptedData: decryptedData,
-                        senderClientID: senderClientID
-                    ) {
-                        events.append(event)
-                    }
+            switch result {
+            case let .message(decryptedData, senderClientID):
+                if let event = updateEvent.decryptedMLSEvent(
+                    decryptedData: decryptedData,
+                    senderClientID: senderClientID
+                ) {
+                    events.append(event)
+                }
 
-                case let .proposal(commitDelay):
-                    let scheduledDate = (updateEvent.timestamp ?? Date()) + TimeInterval(commitDelay)
-                    let mlsService = await context.perform {
-                        conversation?.commitPendingProposalDate = scheduledDate
-                        return context.mlsService
-                    }
+            case let .proposal(commitDelay):
+                let scheduledDate = (updateEvent.timestamp ?? Date()) + TimeInterval(commitDelay)
+                let mlsService = await context.perform {
+                    conversation?.commitPendingProposalDate = scheduledDate
+                    return context.mlsService
+                }
 
-                    if let mlsService, updateEvent.source == .webSocket {
-                        mlsService.commitPendingProposalsIfNeeded()
-                    }
+                if let mlsService, updateEvent.source == .webSocket {
+                    mlsService.commitPendingProposalsIfNeeded()
                 }
             }
-            return events
-
-        } catch {
-            WireLogger.mls.warn("failed to decrypt mls message: \(String(describing: error))")
-            throw error
         }
+
+        return events
     }
 
 }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -228,7 +228,10 @@ extension EventDecoder {
             return decryptedEvents
 
         } catch {
-            // MLS message decryption failed
+            WireLogger.mls.warn(
+                "failed to decrypt mls message: \(String(describing: error))"
+            )
+
             return []
         }
     }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -229,11 +229,6 @@ extension EventDecoder {
 
         } catch let error as Failure {
             switch error {
-            case .mlsDecodingError:
-                WireLogger.mls.error(
-                    "failed to decrypt mls message: invalid update event payload"
-                )
-
             case .missingMLSGroupID:
                 WireLogger.mls.error(
                     "failed to decrypt mls message: missing MLS group ID"

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -227,6 +227,20 @@ extension EventDecoder {
 
             return decryptedEvents
 
+        } catch let error as Failure {
+            switch error {
+            case .mlsDecodingError:
+                WireLogger.mls.error(
+                    "failed to decrypt mls message: invalid update event payload"
+                )
+
+            case .missingMLSGroupID:
+                WireLogger.mls.error(
+                    "failed to decrypt mls message: missing MLS group ID"
+                )
+            }
+
+            return []
         } catch {
             WireLogger.mls.warn(
                 "failed to decrypt mls message: \(String(describing: error))"

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -198,30 +198,46 @@ extension EventDecoder {
         publicKeys: EARPublicKeys?,
         proteusService: ProteusServiceInterface
     ) async -> [ZMUpdateEvent] {
-        let decryptedEvents = await decryptEvent(event: event, publicKeys: publicKeys, proteusService: proteusService)
+        do {
+            let decryptedEvents = try await decryptEvent(
+                event: event,
+                publicKeys: publicKeys,
+                proteusService: proteusService
+            )
 
-        guard !decryptedEvents.isEmpty else {
+            // MLS message decryption operations, even successful, could result in empty decrypted events.
+            // Adding a condition to skip the guard for that specific usecase.
+            guard !decryptedEvents.isEmpty || event.type == .conversationMLSMessageAdd else {
+                return []
+            }
+
+            await eventMOC.perform {
+                self.storeUpdateEvents(
+                    decryptedEvents,
+                    startingAtIndex: index,
+                    publicKeys: publicKeys
+                )
+            }
+
+            await syncMOC.perform {
+                if let eventUUID = event.uuid, !event.isTransient {
+                    self.lastEventIDRepository.storeLastEventID(eventUUID)
+                }
+            }
+            
+            return decryptedEvents
+            
+        } catch {
+            // MLS message decryption failed
             return []
         }
-
-        await eventMOC.perform {
-            self.storeUpdateEvents(decryptedEvents, startingAtIndex: index, publicKeys: publicKeys)
-        }
-
-        await syncMOC.perform {
-            if let eventUUID = event.uuid, !event.isTransient {
-                self.lastEventIDRepository.storeLastEventID(eventUUID)
-            }
-        }
-
-        return decryptedEvents
     }
 
     private func decryptEvent(
         event: ZMUpdateEvent,
         publicKeys: EARPublicKeys?,
         proteusService: ProteusServiceInterface
-    ) async -> [ZMUpdateEvent] {
+    ) async throws -> [ZMUpdateEvent] {
         switch event.type {
         case .conversationOtrMessageAdd, .conversationOtrAssetAdd:
             let proteusEvent = await decryptProteusEventAndAddClient(event, in: syncMOC) { sessionID, encryptedData in
@@ -237,7 +253,7 @@ extension EventDecoder {
             return [event]
 
         case .conversationMLSMessageAdd:
-            return await decryptMlsMessage(from: event, context: syncMOC)
+            return try await decryptMlsMessage(from: event, context: syncMOC)
 
         default:
             return [event]
@@ -276,8 +292,8 @@ extension EventDecoder {
                     decryptedEvents.append(event)
 
                 case .conversationMLSMessageAdd:
-                    let events = await decryptMlsMessage(from: event, context: syncMOC)
-                    decryptedEvents.append(contentsOf: events)
+                    let events = try? await decryptMlsMessage(from: event, context: syncMOC)
+                    decryptedEvents.append(contentsOf: events ?? [])
 
                 default:
                     decryptedEvents.append(event)

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder.swift
@@ -224,9 +224,9 @@ extension EventDecoder {
                     self.lastEventIDRepository.storeLastEventID(eventUUID)
                 }
             }
-            
+
             return decryptedEvents
-            
+
         } catch {
             // MLS message decryption failed
             return []

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -511,7 +511,10 @@ extension EventDecoderTest {
     func test_MLSEventDecryptionDoesNotStoreLastEventIdIfFails() async throws {
 
         // Given
-        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        DeveloperFlag.proteusViaCoreCrypto.enable(true, storage: .temporary())
+        defer {
+            DeveloperFlag.proteusViaCoreCrypto.enable(false, storage: .standard)
+        }
         let mockProteusService = MockProteusServiceInterface()
 
         mockProteusService.decryptDataForSession_MockMethod = { data, _ in
@@ -528,8 +531,6 @@ extension EventDecoderTest {
                 groupID: .random()
             )
         }
-
-        proteusViaCoreCrypto.isOn = true
 
         await syncMOC.perform {
             self.syncMOC.proteusService = mockProteusService
@@ -549,7 +550,10 @@ extension EventDecoderTest {
     func test_MLSEventDecryptionStoresLastEventIdIfDecryptionSuccessWithEmptyResults() async throws {
 
         // Given
-        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        DeveloperFlag.proteusViaCoreCrypto.enable(true, storage: .temporary())
+        defer {
+            DeveloperFlag.proteusViaCoreCrypto.enable(false, storage: .standard)
+        }
         let mockProteusService = MockProteusServiceInterface()
 
         mockProteusService.decryptDataForSession_MockMethod = { data, _ in
@@ -565,8 +569,6 @@ extension EventDecoderTest {
                 eventID: eventID
             )
         }
-
-        proteusViaCoreCrypto.isOn = true
 
         await syncMOC.perform {
             self.syncMOC.proteusService = mockProteusService
@@ -597,7 +599,10 @@ extension EventDecoderTest {
     func test_MLSEventDecryptionStoresLastEventIdIfDecryptionSuccessWithProposalResult() async throws {
 
         // Given
-        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        DeveloperFlag.proteusViaCoreCrypto.enable(true, storage: .temporary())
+        defer {
+            DeveloperFlag.proteusViaCoreCrypto.enable(false, storage: .standard)
+        }
         let mockProteusService = MockProteusServiceInterface()
 
         mockProteusService.decryptDataForSession_MockMethod = { data, _ in
@@ -613,8 +618,6 @@ extension EventDecoderTest {
                 eventID: eventID
             )
         }
-
-        proteusViaCoreCrypto.isOn = true
 
         await syncMOC.perform {
             self.syncMOC.proteusService = mockProteusService

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -507,6 +507,121 @@ extension EventDecoderTest {
         XCTAssertEqual(mockProteusService.decryptDataForSession_Invocations.count, 1)
         XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 0)
     }
+    
+    
+    func test_MLSEventDecryptionDoesNotStoreLastEventIdIfFails() async throws {
+        
+        // Given
+        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        let mockProteusService = MockProteusServiceInterface()
+
+        mockProteusService.decryptDataForSession_MockMethod = { data, _ in
+            (didCreateNewSession: false, decryptedData: data)
+        }
+        
+        mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
+            throw MLSDecryptionService.MLSMessageDecryptionError.failedToDecryptMessage
+        }
+
+        let mlsEvent: ZMUpdateEvent = await syncMOC.perform { [self] in
+            mlsMessageAddEvent(
+                data: Data.random().base64EncodedString(),
+                groupID: .random()
+            )
+        }
+
+        proteusViaCoreCrypto.isOn = true
+
+        await syncMOC.perform {
+            self.syncMOC.proteusService = mockProteusService
+        }
+        
+        do {
+            // When
+            _ = try await sut.decryptAndStoreEvents([mlsEvent])
+        } catch let error as MLSDecryptionService.MLSMessageDecryptionError {
+            // Then
+            XCTAssert(error == .failedToDecryptMessage)
+            XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 0)
+        }
+        
+    }
+    
+    func test_MLSEventDecryptionStoresLastEventIdIfDecryptionSuccessWithEmptyResults() async throws {
+        
+        // Given
+        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        let mockProteusService = MockProteusServiceInterface()
+
+        mockProteusService.decryptDataForSession_MockMethod = { data, _ in
+            (didCreateNewSession: false, decryptedData: data)
+        }
+
+        let mlsEvent: ZMUpdateEvent = await syncMOC.perform { [self] in
+            mlsMessageAddEvent(
+                data: Data.random().base64EncodedString(),
+                groupID: .random()
+            )
+        }
+
+        proteusViaCoreCrypto.isOn = true
+
+        await syncMOC.perform {
+            self.syncMOC.proteusService = mockProteusService
+        }
+        
+        mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
+            [] // decryption success with empty results
+        }
+        
+        // When
+        let decryptedEvents = try await sut.decryptAndStoreEvents([mlsEvent])
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // Then
+        XCTAssertEqual(decryptedEvents.isEmpty, true) // no decrypted events
+        XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 1) // last event ID updated locally because MLS decryption was successful
+        
+    }
+    
+    func test_MLSEventDecryptionStoresLastEventIdIfDecryptionSuccessWithProposalResult() async throws {
+        
+        // Given
+        var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
+        let mockProteusService = MockProteusServiceInterface()
+
+        mockProteusService.decryptDataForSession_MockMethod = { data, _ in
+            (didCreateNewSession: false, decryptedData: data)
+        }
+
+        let mlsEvent: ZMUpdateEvent = await syncMOC.perform { [self] in
+            mlsMessageAddEvent(
+                data: Data.random().base64EncodedString(),
+                groupID: .random()
+            )
+        }
+
+        proteusViaCoreCrypto.isOn = true
+
+        await syncMOC.perform {
+            self.syncMOC.proteusService = mockProteusService
+        }
+        
+        mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
+            [.proposal(10)] // decryption success with result of type `proposal`
+        }
+        
+        // When
+        let decryptedEvents = try await sut.decryptAndStoreEvents([mlsEvent])
+        
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        
+        // Then
+        XCTAssertEqual(decryptedEvents.isEmpty, true) // no decrypted events because decryption result is `proposal`
+        XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 1) // last event ID updated locally because MLS decryption was successful
+        
+    }
 
     func test_ProteusEventDecryption_Legacy() async throws {
         var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
@@ -536,7 +651,7 @@ extension EventDecoderTest {
 // MARK: - MLS Event Decryption
 
 extension EventDecoderTest {
-    func test_DecryptMLSMessage_ReturnsDecryptedEvent() async {
+    func test_DecryptMLSMessage_ReturnsDecryptedEvent() async throws {
         // Given
         let messageData = Data.random()
         let senderClientID = "clientID"
@@ -550,7 +665,7 @@ extension EventDecoderTest {
             )
         }
         // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = try await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
         let decryptedEvent = decryptedEvents.first
@@ -581,7 +696,7 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = try await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
         XCTAssertTrue(decryptedEvents.isEmpty)
@@ -596,7 +711,7 @@ extension EventDecoderTest {
         }
     }
 
-    func test_DecryptMLSMessage_CommitsPendingsProposals_WhenReceivingProposalOnWebsocket() async {
+    func test_DecryptMLSMessage_CommitsPendingsProposals_WhenReceivingProposalOnWebsocket() async throws {
         // Given
         let commitDelay: UInt64 = 5
         let event: ZMUpdateEvent = await syncMOC.perform { [self] in
@@ -611,7 +726,7 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = try await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
         XCTAssertTrue(decryptedEvents.isEmpty)
@@ -619,7 +734,7 @@ extension EventDecoderTest {
         XCTAssertEqual(1, mockMLSService.commitPendingProposalsIfNeeded_Invocations.count)
     }
 
-    func test_DecryptMLSMessage_CommitsPendingsProposalsIsNotCalled_WhenReceivingProposalViaDownload() async {
+    func test_DecryptMLSMessage_CommitsPendingsProposalsIsNotCalled_WhenReceivingProposalViaDownload() async throws {
         // Given
         let commitDelay: UInt64 = 5
         let mlsGroupID = MLSGroupID.random()
@@ -635,7 +750,7 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = try await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
         XCTAssertTrue(decryptedEvents.isEmpty)
@@ -643,20 +758,22 @@ extension EventDecoderTest {
         XCTAssertTrue(mockMLSService.commitPendingProposalsIfNeeded_Invocations.isEmpty)
     }
 
-    func test_DecryptMLSMessage_ReturnsNoEvent_WhenPayloadIsInvalid() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenPayloadIsInvalid() async throws {
         // Given
         let invalidDataPayload = ["invalidKey": ""]
         let event = await syncMOC.perform { self.mlsMessageAddEvent(data: invalidDataPayload) }
 
-        // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
-
-        // Then
-        XCTAssertTrue(decryptedEvents.isEmpty)
+        do {
+            // When
+            _ = try await sut.decryptMlsMessage(from: event, context: syncMOC)
+        } catch let error as EventDecoder.Failure {
+            // Then
+            XCTAssert(error == .mlsDecodingError)
+        }
 
     }
 
-    func test_DecryptMLSMessage_ReturnsNoEvent_WhenGroupIDIsMissing() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenGroupIDIsMissing() async throws {
         // Given
         let event = await syncMOC.perform { [self] in
             mlsMessageAddEvent(
@@ -665,14 +782,16 @@ extension EventDecoderTest {
             )
         }
 
-        // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
-
-        // Then
-        XCTAssertTrue(decryptedEvents.isEmpty)
+        do {
+            // When
+            _ = try await sut.decryptMlsMessage(from: event, context: syncMOC)
+        } catch let error as EventDecoder.Failure {
+            // Then
+            XCTAssert(error == .missingMLSGroupID)
+        }
     }
 
-    func test_DecryptMLSMessage_ReturnsNoEvent_WhenDecryptedDataIsNil() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenDecryptedDataIsNil() async throws {
         // Given
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
             []
@@ -686,13 +805,13 @@ extension EventDecoderTest {
         }
 
         // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
+        let decryptedEvents = try await sut.decryptMlsMessage(from: event, context: syncMOC)
 
         // Then
         XCTAssertTrue(decryptedEvents.isEmpty)
     }
 
-    func test_DecryptMLSMessage_ReturnsNoEvent_WhenmlsServiceThrows() async {
+    func test_DecryptMLSMessage_ReturnsNoEvent_WhenmlsServiceThrows() async throws {
         // Given
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
             throw MLSDecryptionService.MLSMessageDecryptionError.failedToDecryptMessage
@@ -704,12 +823,14 @@ extension EventDecoderTest {
                 groupID: .random()
             )
         }
-
-        // When
-        let decryptedEvents = await sut.decryptMlsMessage(from: event, context: syncMOC)
-
-        // Then
-        XCTAssertTrue(decryptedEvents.isEmpty)
+        
+        do {
+            // When
+            _ = try await sut.decryptMlsMessage(from: event, context: syncMOC)
+        } catch let error as MLSDecryptionService.MLSMessageDecryptionError {
+            // Then
+            XCTAssert(error == .failedToDecryptMessage)
+        }
     }
 
     func test_DecryptWelcomeMessage_ReturnsEvent() async throws {
@@ -796,7 +917,7 @@ extension EventDecoderTest {
         return ZMUpdateEvent(fromEventStreamPayload: payload!, uuid: UUID().create())!
     }
 
-    /// Returns a `conversation.mls-message-add` event
+    /// Returns a `conversation.mls-welcome` event
     func mlsWelcomeMessageEvent(data: Data, conversationID: QualifiedID) -> ZMUpdateEvent {
         let payload = payloadForMessage(
             conversationID: conversationID.uuid,

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -507,10 +507,9 @@ extension EventDecoderTest {
         XCTAssertEqual(mockProteusService.decryptDataForSession_Invocations.count, 1)
         XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 0)
     }
-    
-    
+
     func test_MLSEventDecryptionDoesNotStoreLastEventIdIfFails() async throws {
-        
+
         // Given
         var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
         let mockProteusService = MockProteusServiceInterface()
@@ -518,7 +517,7 @@ extension EventDecoderTest {
         mockProteusService.decryptDataForSession_MockMethod = { data, _ in
             (didCreateNewSession: false, decryptedData: data)
         }
-        
+
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
             throw MLSDecryptionService.MLSMessageDecryptionError.failedToDecryptMessage
         }
@@ -535,7 +534,7 @@ extension EventDecoderTest {
         await syncMOC.perform {
             self.syncMOC.proteusService = mockProteusService
         }
-        
+
         do {
             // When
             _ = try await sut.decryptAndStoreEvents([mlsEvent])
@@ -544,11 +543,11 @@ extension EventDecoderTest {
             XCTAssert(error == .failedToDecryptMessage)
             XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 0)
         }
-        
+
     }
-    
+
     func test_MLSEventDecryptionStoresLastEventIdIfDecryptionSuccessWithEmptyResults() async throws {
-        
+
         // Given
         var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
         let mockProteusService = MockProteusServiceInterface()
@@ -569,24 +568,27 @@ extension EventDecoderTest {
         await syncMOC.perform {
             self.syncMOC.proteusService = mockProteusService
         }
-        
+
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
             [] // decryption success with empty results
         }
-        
+
         // When
         let decryptedEvents = try await sut.decryptAndStoreEvents([mlsEvent])
 
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // Then
         XCTAssertEqual(decryptedEvents.isEmpty, true) // no decrypted events
-        XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 1) // last event ID updated locally because MLS decryption was successful
-        
+        XCTAssertEqual(
+            lastEventIDRepository.storeLastEventID_Invocations.count,
+            1
+        ) // last event ID updated locally because MLS decryption was successful
+
     }
-    
+
     func test_MLSEventDecryptionStoresLastEventIdIfDecryptionSuccessWithProposalResult() async throws {
-        
+
         // Given
         var proteusViaCoreCrypto = DeveloperFlag.proteusViaCoreCrypto
         let mockProteusService = MockProteusServiceInterface()
@@ -607,20 +609,23 @@ extension EventDecoderTest {
         await syncMOC.perform {
             self.syncMOC.proteusService = mockProteusService
         }
-        
+
         mockMLSService.decryptMessageForSubconversationType_MockMethod = { _, _, _ in
             [.proposal(10)] // decryption success with result of type `proposal`
         }
-        
+
         // When
         let decryptedEvents = try await sut.decryptAndStoreEvents([mlsEvent])
-        
+
         XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-        
+
         // Then
         XCTAssertEqual(decryptedEvents.isEmpty, true) // no decrypted events because decryption result is `proposal`
-        XCTAssertEqual(lastEventIDRepository.storeLastEventID_Invocations.count, 1) // last event ID updated locally because MLS decryption was successful
-        
+        XCTAssertEqual(
+            lastEventIDRepository.storeLastEventID_Invocations.count,
+            1
+        ) // last event ID updated locally because MLS decryption was successful
+
     }
 
     func test_ProteusEventDecryption_Legacy() async throws {
@@ -823,7 +828,7 @@ extension EventDecoderTest {
                 groupID: .random()
             )
         }
-        
+
         do {
             // When
             _ = try await sut.decryptMlsMessage(from: event, context: syncMOC)

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -556,10 +556,13 @@ extension EventDecoderTest {
             (didCreateNewSession: false, decryptedData: data)
         }
 
+        let eventID = UUID.create()
+
         let mlsEvent: ZMUpdateEvent = await syncMOC.perform { [self] in
             mlsMessageAddEvent(
                 data: Data.random().base64EncodedString(),
-                groupID: .random()
+                groupID: .random(),
+                eventID: eventID
             )
         }
 
@@ -584,6 +587,10 @@ extension EventDecoderTest {
             lastEventIDRepository.storeLastEventID_Invocations.count,
             1
         ) // last event ID updated locally because MLS decryption was successful
+        XCTAssertEqual(
+            lastEventIDRepository.storeLastEventID_Invocations.first,
+            eventID
+        )
 
     }
 
@@ -597,10 +604,13 @@ extension EventDecoderTest {
             (didCreateNewSession: false, decryptedData: data)
         }
 
+        let eventID = UUID.create()
+
         let mlsEvent: ZMUpdateEvent = await syncMOC.perform { [self] in
             mlsMessageAddEvent(
                 data: Data.random().base64EncodedString(),
-                groupID: .random()
+                groupID: .random(),
+                eventID: eventID
             )
         }
 
@@ -625,7 +635,10 @@ extension EventDecoderTest {
             lastEventIDRepository.storeLastEventID_Invocations.count,
             1
         ) // last event ID updated locally because MLS decryption was successful
-
+        XCTAssertEqual(
+            lastEventIDRepository.storeLastEventID_Invocations.first,
+            eventID
+        )
     }
 
     func test_ProteusEventDecryption_Legacy() async throws {
@@ -771,9 +784,9 @@ extension EventDecoderTest {
         do {
             // When
             _ = try await sut.decryptMlsMessage(from: event, context: syncMOC)
-        } catch let error as EventDecoder.Failure {
+        } catch {
             // Then
-            XCTAssert(error == .mlsDecodingError)
+            XCTAssert(error is DecodingError)
         }
 
     }
@@ -906,7 +919,7 @@ extension EventDecoderTest {
     }
 
     /// Returns a `conversation.mls-message-add` event
-    func mlsMessageAddEvent(data: Any, groupID: MLSGroupID? = nil) -> ZMUpdateEvent {
+    func mlsMessageAddEvent(data: Any, groupID: MLSGroupID? = nil, eventID: UUID = .create()) -> ZMUpdateEvent {
         let conversation = ZMConversation.insertNewObject(in: syncMOC)
         conversation.remoteIdentifier = UUID.create()
         conversation.mlsGroupID = groupID
@@ -919,7 +932,7 @@ extension EventDecoderTest {
             time: Date()
         )
 
-        return ZMUpdateEvent(fromEventStreamPayload: payload!, uuid: UUID().create())!
+        return ZMUpdateEvent(fromEventStreamPayload: payload!, uuid: eventID)!
     }
 
     /// Returns a `conversation.mls-welcome` event


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15646" title="WPB-15646" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15646</a>  [iOS] Decryption error wrong epoch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When processing a MLS add message event, decryption operations can result in empty decrypted events (i.e a proposal) however, while the decryption operation is successful, we omit to store the last event ID in database. 

As a consequence, when fetching the stored events from the database again, we use a wrong event ID and try to process an already decrypted event which results in a CoreCrypto wrong epoch error specifically because  the epoch value was incremented but the message is still on a previous epoch.

**Solution**
1. Properly propagating the errors back to the EventDecoder
2. When MLS decryption successful, we ensure the last event ID is updated even if the decrypted events are empty.
3. When MLS decryption fails, we explicitly catch the errors and we do not update the last event ID locally.

### Testing
- [x] When MLS decryption fails, we do not update the last event ID locally
- [x] When MLS decryption succeed with empty decrypted events, we do update the last event ID locally

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
