### PR TITLE
fix: Crowdin configuration - WPB-15715

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -13,75 +13,87 @@
 # downloaded translation.
 
 files: [
- {
-  "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings",
-  "dest" : "/App/Wire-iOS/Resources/Localizable.strings",
-  "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/Accessibility.strings",
-  "dest" : "/App/Wire-iOS/Resources/Accessibility.strings",
-  "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict",
-  "dest" : "/App/Wire-iOS/Resources/Localizable.stringsdict",
-  "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/InfoPlist.strings",
-  "dest" : "/App/Wire-iOS/Resources/InfoPlist.strings",
-  "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/wire-ios/Wire-iOS Share Extension/Resources/Base.lproj/Localizable.strings",
-  "dest" : "/App/Wire-iOS Share Extension/Localizable.strings",
-  "translation" : "/wire-ios/Wire-iOS Share Extension/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/WireUI/Sources/WireSidebarUI/Resources/en.lproj/Localizable.strings",
-  "dest" : "/App/WireSidebarUI/Resources/Localizable.strings",
-  "translation" : "/WireUI/Sources/WireSidebarUI/Resources/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/WireUI/Sources/WireSidebarUI/Resources/en.lproj/Accessibility.strings",
-  "dest" : "/App/WireSidebarUI/Resources/Accessibility.strings",
-  "translation" : "/WireUI/Sources/WireSidebarUI/Resources/%osx_code%/%original_file_name%",
- },
- {
-  "source" : "/WireUI/Sources/WireMainNavigationUI/Resources/Localizable.xcstrings",
-  "dest" : "/App/WireMainNavigationUI/Resources/Localizable.xcstrings",
-  "translation" : "%original_path%/%original_file_name%",
-  "multilingual": true,
- },
- {
-   "source" : "/WireUI/Sources/WireMainNavigationUI/Resources/Accessibility.xcstrings",
-   "dest" : "/App/WireMainNavigationUI/Resources/Accessibility.xcstrings",
-   "translation" : "%original_path%/%original_file_name%",
-   "multilingual": true,
- },
- {
-  "source" : "/WireUI/Sources/WireFolderPickerUI/Resources/Localizable.xcstrings",
-  "dest" : "/App/WireFolderPickerUI/Resources/Localizable.xcstrings",
-  "translation" : "%original_path%/%original_file_name%",
-  "multilingual": true,
- },
- {
-   "source" : "/WireUI/Sources/WireFolderPickerUI/Resources/Accessibility.xcstrings",
-   "dest" : "/App/WireFolderPickerUI/Resources/Accessibility.xcstrings",
-   "translation" : "%original_path%/%original_file_name%",
-   "multilingual": true,
- },
   {
-  "source" : "/WireUI/Sources/WireMoveToFolderUI/Resources/Localizable.xcstrings",
-  "dest" : "/App/WireMoveToFolderUI/Resources/Localizable.xcstrings",
-  "translation" : "%original_path%/%original_file_name%",
-  "multilingual": true,
- },
+    "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.strings",
+    "dest" : "/App/Wire-iOS/Resources/Localizable.strings",
+    "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+  },
   {
-   "source" : "/WireUI/Sources/WireMoveToFolderUI/Resources/Accessibility.xcstrings",
-   "dest" : "/App/WireMoveToFolderUI/Resources/Accessibility.xcstrings",
-   "translation" : "%original_path%/%original_file_name%",
-   "multilingual": true,
- },
+    "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/Accessibility.strings",
+    "dest" : "/App/Wire-iOS/Resources/Accessibility.strings",
+    "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/Localizable.stringsdict",
+    "dest" : "/App/Wire-iOS/Resources/Localizable.stringsdict",
+    "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/wire-ios/Wire-iOS/Resources/Base.lproj/InfoPlist.strings",
+    "dest" : "/App/Wire-iOS/Resources/InfoPlist.strings",
+    "translation" : "/wire-ios/Wire-iOS/Resources/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/wire-ios/Wire-iOS Share Extension/Resources/Base.lproj/Localizable.strings",
+    "dest" : "/App/Wire-iOS Share Extension/Localizable.strings",
+    "translation" : "/wire-ios/Wire-iOS Share Extension/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/WireUI/Sources/WireSidebarUI/Resources/en.lproj/Localizable.strings",
+    "dest" : "/App/WireSidebarUI/Resources/Localizable.strings",
+    "translation" : "/WireUI/Sources/WireSidebarUI/Resources/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/WireUI/Sources/WireSidebarUI/Resources/en.lproj/Accessibility.strings",
+    "dest" : "/App/WireSidebarUI/Resources/Accessibility.strings",
+    "translation" : "/WireUI/Sources/WireSidebarUI/Resources/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/WireUI/Sources/WireMainNavigationUI/Resources/Localizable.xcstrings",
+    "dest" : "/App/WireMainNavigationUI/Resources/Localizable.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireMainNavigationUI/Resources/Accessibility.xcstrings",
+    "dest" : "/App/WireMainNavigationUI/Resources/Accessibility.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireFolderPickerUI/Resources/Localizable.xcstrings",
+    "dest" : "/App/WireFolderPickerUI/Resources/Localizable.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireFolderPickerUI/Resources/Accessibility.xcstrings",
+    "dest" : "/App/WireFolderPickerUI/Resources/Accessibility.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireIndividualToTeamMigrationUI/Resources/Localizable.xcstrings",
+    "dest" : "/App/WireIndividualToTeamMigrationUI/Resources/Localizable.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireIndividualToTeamMigrationUI/Resources/Accessibility.xcstrings",
+    "dest" : "/App/WireIndividualToTeamMigrationUI/Resources/Accessibility.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireMoveToFolderUI/Resources/Localizable.xcstrings",
+    "dest" : "/App/WireMoveToFolderUI/Resources/Localizable.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireMoveToFolderUI/Resources/Accessibility.xcstrings",
+    "dest" : "/App/WireMoveToFolderUI/Resources/Accessibility.xcstrings",
+    "translation" : "%original_path%/%original_file_name%",
+    "multilingual": true,
+  }
 ]

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,4 +16,4 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.115.1
+WIRE_SHORT_VERSION = 3.115.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15715" title="WPB-15715" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15715</a>  [iOS] Fix crowdin config
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds WireIndividualToTeamMigrationUI/Resources/Accessibility.xcstrings and WireIndividualToTeamMigrationUI/Resources/Localizable.xcstrings to crowdin.yml.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
