### PR TITLE
fix: crash dismissPresentedViewController - WPB-15345

### DIFF
--- a/WireUI/Package.swift
+++ b/WireUI/Package.swift
@@ -27,8 +27,7 @@ let package = Package(
         .package(path: "../WireAnalytics"),
         .package(name: "WireDomainPackage", path: "../WireDomain"),
         .package(name: "WireFoundation", path: "../WireFoundation"),
-        .package(path: "../WirePlugins"),
-        .package(path: "../WireLogging")
+        .package(path: "../WirePlugins")
     ],
     targets: [
         .target(

--- a/WireUI/Package.swift
+++ b/WireUI/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
         .package(path: "../WireAnalytics"),
         .package(name: "WireDomainPackage", path: "../WireDomain"),
         .package(name: "WireFoundation", path: "../WireFoundation"),
-        .package(path: "../WirePlugins")
+        .package(path: "../WirePlugins"),
+        .package(path: "../WireLogging")
     ],
     targets: [
         .target(

--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
@@ -17,7 +17,6 @@
 //
 
 import UIKit
-import WireLogging
 
 /// Manages the main navigation and the layout changes of the application after a successful login.
 ///
@@ -292,8 +291,6 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
         await withCheckedContinuation { continuation in
             if splitViewController != nil {
                 splitViewController.dismiss(animated: true, completion: continuation.resume)
-            } else {
-                WireLogger.ui.warn("unexpected nil value for splitViewController, skip dismissPresentedViewController")
             }
         }
     }

--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
@@ -194,7 +194,8 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
         conversation: ConversationModel,
         message: ConversationMessageModel?
     ) {
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
             if mainSplitViewState == .expanded, splitViewController.splitBehavior == .overlay {
                 splitViewController.hideSidebar()
             }
@@ -288,7 +289,9 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
 
     public func dismissPresentedViewController() async {
         await withCheckedContinuation { continuation in
-            splitViewController.dismiss(animated: true, completion: continuation.resume)
+            if splitViewController != nil {
+                splitViewController.dismiss(animated: true, completion: continuation.resume)
+            }
         }
     }
 

--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import WireLogging
 
 /// Manages the main navigation and the layout changes of the application after a successful login.
 ///
@@ -291,6 +292,8 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
         await withCheckedContinuation { continuation in
             if splitViewController != nil {
                 splitViewController.dismiss(animated: true, completion: continuation.resume)
+            } else {
+                WireLogger.ui.warn("unexpected nil value for splitViewController, skip dismissPresentedViewController")
             }
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15345" title="WPB-15345" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15345</a>  [iOS] Crash dismissPresentedViewController
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

There's a crash on production app, when we try to dismiss the presentedViewController. It happens because SplitViewController is nil and it's a implicitly unwrapped value. 

![Screenshot 2025-01-28 at 16 31 56](https://github.com/user-attachments/assets/109865b0-0a2c-41ea-b99d-f78749fc329b)


### Testing

I couldn't have it repoduced, so I mainly avoid the crash for now.

Also looking at the stacktrace, I haven't been able to link `openFileMessage(:)` to `dismissPresentedViewController`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
