### PR TITLE
fix: rename system message - WPB-14824

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -67,7 +67,8 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
             do {
                 let payload = try eventPayloadDecoder.decode(
                     Payload.ConversationEvent<Payload.UpdateConversationName>.self,
-                    from: event.payload)
+                    from: event.payload
+                )
 
                 processor.processPayload(
                     payload,
@@ -75,7 +76,8 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
                     in: context
                 )
             } catch {
-                WireLogger.eventProcessing.error("error processing UpdateConversationName: \(error.localizedDescription)")
+                WireLogger.eventProcessing
+                    .error("error processing UpdateConversationName: \(error.localizedDescription)")
             }
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -56,12 +56,24 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
 
     // MARK: - Methods
 
-    func processPayload(_ payload: ZMTransportData) {
+    /// Process Conversation Rename event
+    /// - Parameter payload: payload containing the event
+    /// - Note: This method needs to be synchronous because it's used by a request Strategy
+    /// This can be removed once ConversationRequestStrategy is removed
+    func processConversationRenamePayload(_ payload: ZMTransportData) {
         // here's no uuid is needed since we process it directly it's just convenience to get the payload
         if let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil) {
-            Task {
-                await processConversationEvents([event])
-            }
+            guard let payload = try? eventPayloadDecoder.decode(
+                Payload.ConversationEvent<Payload.UpdateConversationName>.self,
+                from: event.payload
+            ) else { return }
+            
+            
+            self.processor.processPayload(
+                payload,
+                originalEvent: event,
+                in: self.context
+            )
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -67,12 +67,11 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
                 Payload.ConversationEvent<Payload.UpdateConversationName>.self,
                 from: event.payload
             ) else { return }
-            
-            
-            self.processor.processPayload(
+
+            processor.processPayload(
                 payload,
                 originalEvent: event,
-                in: self.context
+                in: context
             )
         }
     }

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationEventProcessor.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireDataModel
+import WireLogging
 
 public class ConversationEventProcessor: NSObject, ConversationEventProcessorProtocol, ZMEventAsyncConsumer {
 
@@ -63,16 +64,19 @@ public class ConversationEventProcessor: NSObject, ConversationEventProcessorPro
     func processConversationRenamePayload(_ payload: ZMTransportData) {
         // here's no uuid is needed since we process it directly it's just convenience to get the payload
         if let event = ZMUpdateEvent(fromEventStreamPayload: payload, uuid: nil) {
-            guard let payload = try? eventPayloadDecoder.decode(
-                Payload.ConversationEvent<Payload.UpdateConversationName>.self,
-                from: event.payload
-            ) else { return }
+            do {
+                let payload = try eventPayloadDecoder.decode(
+                    Payload.ConversationEvent<Payload.UpdateConversationName>.self,
+                    from: event.payload)
 
-            processor.processPayload(
-                payload,
-                originalEvent: event,
-                in: context
-            )
+                processor.processPayload(
+                    payload,
+                    originalEvent: event,
+                    in: context
+                )
+            } catch {
+                WireLogger.eventProcessing.error("error processing UpdateConversationName: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Conversation/ConversationRequestStrategy.swift
@@ -399,7 +399,7 @@ extension ConversationRequestStrategy: ZMUpstreamTranscoder {
         // 1) selfUser edits the conversation name: a save will be enqueue when user is done editing
         // Note: when another user edited the conversation name, ConversationEventProcessor is called directly as
         // EventAsyncConsumer and a save will be done in EventProcessor
-        conversationEventProcessor.processPayload(payload)
+        conversationEventProcessor.processConversationRenamePayload(payload)
 
         return false
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14824" title="WPB-14824" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14824</a>  [iOS] No system message if a group name is changed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When the self user renames a conversation, no system message is shown in his/her conversation.

The reason is that by the time we process the event response of renaming the group, the modifiedKey of the conversation (userDefined) is not present, therefore we don't add the system message.

In the ConversationRequestStrategy the `processEvent` method was calling an async method in a Task that finished after we reset the modifiedKeys in the `ZMUpstreamModifiedObjectSync`.

Solution:

Call the processRenameConverationEvent as a synchronous method so modifiedKeys are reset after the processing is finished.

### Testing

1. be admin of a group on iOS device
2. rename the group
3. check that the system message is inserted
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
