### PR TITLE
chore: add developer flag for new initial sync - WPB-10801

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -29,6 +29,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case debugDuplicateObjects
     case decryptAndStoreEventsSleep
     case forceCRLExpiryAfterOneMinute
+    case newInitialSync
 
     public var description: String {
         switch self {
@@ -52,6 +53,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .forceCRLExpiryAfterOneMinute:
             "Turn on to force CRLs to expire after 1 minute"
+
+        case .newInitialSync:
+            "Use the new and improved 'Initial Sync™' (formerly slow sync)"
         }
     }
 
@@ -80,16 +84,14 @@ public enum DeveloperFlag: String, CaseIterable {
 
     var bundleKey: String? {
         switch self {
-        case .showCreateMLSGroupToggle:
-            nil
         case .proteusViaCoreCrypto:
             "ProteusByCoreCryptoEnabled"
         case .forceDatabaseLoadingFailure:
             "ForceDatabaseLoadingFailure"
-        case .debugDuplicateObjects, .forceCRLExpiryAfterOneMinute, .decryptAndStoreEventsSleep:
-            nil
         case .ignoreIncomingEvents:
             "IgnoreIncomingEventsEnabled"
+        default:
+            nil
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10801" title="WPB-10801" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10801</a>  [iOS] Integrate new slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In preparation for the new initial sync (replacing slow sync), we add a developer flag which will be control when the initial sync runs.

### Testing

None
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
