### PR TITLE
fix: various endpoints used in initial sync - WPB-10801

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
@@ -35,7 +35,7 @@ class ConnectionsAPIV0: ConnectionsAPI, VersionedAPI {
     }
 
     var resourcePath: String {
-        "\(pathPrefix)/list-connections/"
+        "\(pathPrefix)/list-connections"
     }
 
     func getConnections() async throws -> PayloadPager<Connection> {

--- a/WireAPI/Sources/WireAPI/APIs/SelfUserAPI/SelfUserAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/SelfUserAPI/SelfUserAPIV0.swift
@@ -31,7 +31,7 @@ class SelfUserAPIV0: SelfUserAPI, VersionedAPI {
     }
 
     var resourcePath: String {
-        "\(pathPrefix)/self/"
+        "\(pathPrefix)/self"
     }
 
     func getSelfUser() async throws -> SelfUser {

--- a/WireAPI/Sources/WireAPI/APIs/SelfUserAPI/SelfUserAPIV5.swift
+++ b/WireAPI/Sources/WireAPI/APIs/SelfUserAPI/SelfUserAPIV5.swift
@@ -28,7 +28,7 @@ class SelfUserAPIV5: SelfUserAPIV4 {
         let encoder = JSONEncoder.defaultEncoder
         let payload = SupportedProtocolsPayloadV5(supportedProtocols: supportedProtocols)
         let body = try encoder.encode(payload)
-        let path = resourcePath + "supported-protocols"
+        let path = resourcePath + "/supported-protocols"
 
         let request = try URLRequestBuilder(path: path)
             .withMethod(.put)

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v0.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/list-connections/"
+	"/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v1.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v1.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v1/list-connections/"
+	"/v1/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v2.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v2.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v2/list-connections/"
+	"/v2/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v3.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v3.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v3/list-connections/"
+	"/v3/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v4.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v4.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v4/list-connections/"
+	"/v4/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v5.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v5.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v5/list-connections/"
+	"/v5/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v6.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v6.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v6/list-connections/"
+	"/v6/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v7.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnectionsRequest.request-0-v7.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/v7/list-connections/"
+	"/v7/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnections_MultiplePages_SuccessResponse_V0.request-0-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnections_MultiplePages_SuccessResponse_V0.request-0-v0.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"size\":500}" \
-	"/list-connections/"
+	"/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnections_MultiplePages_SuccessResponse_V0.request-1-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnections_MultiplePages_SuccessResponse_V0.request-1-v0.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"paging_state\":\"first\",\"size\":500}" \
-	"/list-connections/"
+	"/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnections_MultiplePages_SuccessResponse_V0.request-2-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/ConnectionsAPI/__Snapshots__/ConnectionsAPITests/testGetConnections_MultiplePages_SuccessResponse_V0.request-2-v0.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"paging_state\":\"second\",\"size\":500}" \
-	"/list-connections/"
+	"/list-connections"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v0.txt
@@ -1,2 +1,2 @@
 curl \
-	"/self/"
+	"/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v1.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v1.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v1/self/"
+	"/v1/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v2.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v2.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v2/self/"
+	"/v2/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v3.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v3.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v3/self/"
+	"/v3/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v4.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v4.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v4/self/"
+	"/v4/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v5.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v5.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v5/self/"
+	"/v5/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v6.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v6.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v6/self/"
+	"/v6/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v7.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUserRequest.request-0-v7.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v7/self/"
+	"/v7/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUser_SuccessResponse_200_V0_Then_VerifyRequests.request-0-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUser_SuccessResponse_200_V0_Then_VerifyRequests.request-0-v0.txt
@@ -1,2 +1,2 @@
 curl \
-	"/self/"
+	"/self"

--- a/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUser_SuccessResponse_200_V4_Then_VerifyRequests.request-0-v4.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/SelfUserAPI/__Snapshots__/SelfUserAPITests/testGetSelfUser_SuccessResponse_200_V4_Then_VerifyRequests.request-0-v4.txt
@@ -1,2 +1,2 @@
 curl \
-	"/v4/self/"
+	"/v4/self"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10801" title="WPB-10801" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10801</a>  [iOS] Integrate new slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

A few endpoint paths involved in initial sync were incorrect.

### Testing

Code paths aren't live yet.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
