### PR TITLE
refactor: return ids when pulling self user - WPB-10801

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullSelfUserSyncProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullSelfUserSyncProtocol.swift
@@ -16,8 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import Foundation
+
 protocol PullSelfUserSyncProtocol {
 
-    func pull() async throws
+    @discardableResult
+    func pull() async throws -> (id: UUID, domain: String?, teamID: UUID?)
 
 }

--- a/WireDomain/Sources/WireDomain/Synchronization/PullSelfUserSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullSelfUserSync.swift
@@ -38,11 +38,16 @@ struct PullSelfUserSync: PullSelfUserSyncProtocol {
     /// Fetch the self user from remote, then create or update
     /// it locally.
 
-    func pull() async throws {
+    @discardableResult
+    func pull() async throws -> (id: UUID, domain: String?, teamID: UUID?) {
         let remoteSelfUser = try await api.getSelfUser()
+        let localSelfUser = remoteSelfUser.toDomainModel()
+        await store.persistUser(userInfo: localSelfUser)
 
-        await store.persistUser(
-            userInfo: remoteSelfUser.toDomainModel()
+        return (
+            id: localSelfUser.userID.uuid,
+            domain: localSelfUser.userID.domain,
+            teamID: localSelfUser.teamID
         )
     }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSyncTests.swift
@@ -46,7 +46,7 @@ final class PullSelfUserSyncTests: XCTestCase {
         store.persistUserUserInfo_MockMethod = { _ in }
 
         // When
-        try await sut.pull()
+        let result = try await sut.pull()
 
         // Then
         XCTAssertEqual(api.getSelfUser_Invocations.count, 1)
@@ -54,6 +54,10 @@ final class PullSelfUserSyncTests: XCTestCase {
         let storeInvocations = store.persistUserUserInfo_Invocations
         try XCTAssertCount(storeInvocations, count: 1)
         XCTAssertEqual(storeInvocations[0], Scaffolding.localSelfUser)
+
+        XCTAssertEqual(result.id, Scaffolding.remoteSelfUser.qualifiedID.uuid)
+        XCTAssertEqual(result.domain, Scaffolding.remoteSelfUser.qualifiedID.domain)
+        XCTAssertEqual(result.teamID, Scaffolding.remoteSelfUser.teamID)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10801" title="WPB-10801" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10801</a>  [iOS] Integrate new slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When running the initial sync we'll need to obtain some data about the self user, such as their team id. This is useful to know whether we need to pull team metadata. This PR returns the relevant data when pulling the self user.

### Testing
Code path not live yet, no testing possible at the moment.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
