### PR TITLE
fix: replace mlsDecryptionService by mlsService to recover from wrong epoch error - WPB-15573

### DIFF
--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -123,12 +123,11 @@ extension EventDecoder {
 
             case let .proposal(commitDelay):
                 let scheduledDate = (updateEvent.timestamp ?? Date()) + TimeInterval(commitDelay)
-                let mlsService = await context.perform {
+                await context.perform {
                     conversation?.commitPendingProposalDate = scheduledDate
-                    return context.mlsService
                 }
 
-                if let mlsService, updateEvent.source == .webSocket {
+                if updateEvent.source == .webSocket {
                     mlsService.commitPendingProposalsIfNeeded()
                 }
             }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -63,8 +63,8 @@ extension EventDecoder {
     ) async throws -> [ZMUpdateEvent] {
         WireLogger.mls.info("decrypting mls message")
 
-        guard let decryptionService = await context.perform({ context.mlsDecryptionService }) else {
-            WireLogger.mls.critical("failed to decrypt mls message: mlsDecyptionService is missing")
+        guard let mlsService = await context.perform({ context.mlsService }) else {
+            WireLogger.mls.critical("failed to decrypt mls message: mlsService is missing")
             fatalError("failed to decrypt mls message: mlsService is missing")
         }
 
@@ -98,7 +98,7 @@ extension EventDecoder {
             throw Failure.missingMLSGroupID
         }
 
-        let results = try await decryptionService.decrypt(
+        let results = try await mlsService.decrypt(
             message: payload.data,
             for: groupID,
             subconversationType: payload.subconversationType


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->
WPB-15573
<!--jira-description-action-hidden-marker-end-->

### Issue

**Context**

Some MLS messages are missing due to wrong epoch error.

![Screenshot 2025-02-05 at 14 39 03](https://github.com/user-attachments/assets/160230dc-8249-4ee4-be5f-c3bd658225ec)

**Probable cause**

 Group epoch and client's local epoch may diverged, in this case no message will be decrypted and will result in a CC `WrongEpoch` error. In iOS codebase, we use the `MLSDecryptionService` which throws the error however we don't apply any recovery strategy: we simply log the error and return an empty update events array.

**Solution**

As mentioned in engineering specs [here](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/678035678/Use+case+recover+from+epoch+getting+out+of+sync#Step-2%3A-Insert-missed-message-system-message), a recovery strategy should be applied when a `WrongEpoch` error is thrown. 
This recovery strategy already exists in `MLSService` but is not currently used. 
Consequently, this PR simply replaces usage of `MLSDecryptionService` by `MLSService` in the `EventDecoder`.
When a `WrongEpoch` error is thrown, it will now try to recover.

**Disclaimer**

 I was not able to reproduce the issue yet so the issue might still be occurring however this PR introduces compliance with the engineering specs. 

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
