### PR TITLE
refactor: add sync to pull self user settings - WPB-10801

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullSelfUserSettingsSyncProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullSelfUserSettingsSyncProtocol.swift
@@ -1,0 +1,31 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+// sourcery: AutoMockable
+/// An object to keep the local self user settings (e.g read receipts)
+/// up to date with the remote self user settings.
+protocol PullSelfUserSettingsSyncProtocol {
+
+    /// Fetch the self user settings from remote, then store them
+    /// locally.
+
+    func pull() async throws
+
+}

--- a/WireDomain/Sources/WireDomain/Synchronization/PullSelfUserSettingsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullSelfUserSettingsSync.swift
@@ -1,0 +1,42 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAPI
+
+struct PullSelfUserSettingsSync: PullSelfUserSettingsSyncProtocol {
+
+    private let api: any UserPropertiesAPI
+    private let store: any UserLocalStoreProtocol
+
+    init(
+        api: any UserPropertiesAPI,
+        store: any UserLocalStoreProtocol
+    ) {
+        self.api = api
+        self.store = store
+    }
+
+    func pull() async throws {
+        let areReadReceiptsEnabled = try await api.areReadReceiptsEnabled
+        await store.updateSelfUserReadReceipts(
+            isReadReceiptsEnabled: areReadReceiptsEnabled,
+            isReadReceiptsEnabledChangedRemotely: false
+        )
+    }
+
+}

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -1597,6 +1597,34 @@ public class MockPullSelfUserClientsProtocol: PullSelfUserClientsProtocol {
 
 }
 
+class MockPullSelfUserSettingsSyncProtocol: PullSelfUserSettingsSyncProtocol {
+
+    // MARK: - Life cycle
+
+
+
+    // MARK: - pull
+
+    var pull_Invocations: [Void] = []
+    var pull_MockError: Error?
+    var pull_MockMethod: (() async throws -> Void)?
+
+    func pull() async throws {
+        pull_Invocations.append(())
+
+        if let error = pull_MockError {
+            throw error
+        }
+
+        guard let mock = pull_MockMethod else {
+            fatalError("no mock for `pull`")
+        }
+
+        try await mock()
+    }
+
+}
+
 public class MockPushSupportedProtocolsSyncProtocol: PushSupportedProtocolsSyncProtocol {
 
     // MARK: - Life cycle

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSettingsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSettingsSyncTests.swift
@@ -1,0 +1,60 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAPISupport
+import XCTest
+@testable import WireAPI
+@testable import WireDomain
+@testable import WireDomainSupport
+
+final class PullSelfUserSettingsSyncTests: XCTestCase {
+
+    private var sut: PullSelfUserSettingsSync!
+    private var api: MockUserPropertiesAPI!
+    private var store: MockUserLocalStoreProtocol!
+
+    override func setUp() async throws {
+        api = MockUserPropertiesAPI()
+        store = MockUserLocalStoreProtocol()
+        sut = PullSelfUserSettingsSync(api: api, store: store)
+    }
+
+    override func tearDown() async throws {
+        api = nil
+        store = nil
+        sut = nil
+    }
+
+    func testPull() async throws {
+        // Mock
+        api.areReadReceiptsEnabledClosure = { true }
+        store.updateSelfUserReadReceiptsIsReadReceiptsEnabledIsReadReceiptsEnabledChangedRemotely_MockMethod = { _, _ in }
+
+        // When
+        try await sut.pull()
+
+        // Then
+        XCTAssertEqual(api.areReadReceiptsEnabledCallsCount, 1)
+
+        let storeInvocations = store.updateSelfUserReadReceiptsIsReadReceiptsEnabledIsReadReceiptsEnabledChangedRemotely_Invocations
+        try XCTAssertCount(storeInvocations, count: 1)
+        XCTAssertEqual(storeInvocations[0].isReadReceiptsEnabled, true)
+        XCTAssertEqual(storeInvocations[0].isReadReceiptsEnabledChangedRemotely, false)
+    }
+
+}

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSettingsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSettingsSyncTests.swift
@@ -43,7 +43,7 @@ final class PullSelfUserSettingsSyncTests: XCTestCase {
     func testPull() async throws {
         // Mock
         api.areReadReceiptsEnabledClosure = { true }
-        // swiftlint:disable:next line_length
+        // swiftformat:disable:next wrap
         store.updateSelfUserReadReceiptsIsReadReceiptsEnabledIsReadReceiptsEnabledChangedRemotely_MockMethod = { _, _ in }
 
         // When
@@ -52,7 +52,7 @@ final class PullSelfUserSettingsSyncTests: XCTestCase {
         // Then
         XCTAssertEqual(api.areReadReceiptsEnabledCallsCount, 1)
 
-        // swiftlint:disable:next line_length
+        // swiftformat:disable:next wrap
         let storeInvocations = store.updateSelfUserReadReceiptsIsReadReceiptsEnabledIsReadReceiptsEnabledChangedRemotely_Invocations
         try XCTAssertCount(storeInvocations, count: 1)
         XCTAssertEqual(storeInvocations[0].isReadReceiptsEnabled, true)

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSettingsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserSettingsSyncTests.swift
@@ -43,6 +43,7 @@ final class PullSelfUserSettingsSyncTests: XCTestCase {
     func testPull() async throws {
         // Mock
         api.areReadReceiptsEnabledClosure = { true }
+        // swiftlint:disable:next line_length
         store.updateSelfUserReadReceiptsIsReadReceiptsEnabledIsReadReceiptsEnabledChangedRemotely_MockMethod = { _, _ in }
 
         // When
@@ -51,6 +52,7 @@ final class PullSelfUserSettingsSyncTests: XCTestCase {
         // Then
         XCTAssertEqual(api.areReadReceiptsEnabledCallsCount, 1)
 
+        // swiftlint:disable:next line_length
         let storeInvocations = store.updateSelfUserReadReceiptsIsReadReceiptsEnabledIsReadReceiptsEnabledChangedRemotely_Invocations
         try XCTAssertCount(storeInvocations, count: 1)
         XCTAssertEqual(storeInvocations[0].isReadReceiptsEnabled, true)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10801" title="WPB-10801" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-10801</a>  [iOS] Integrate new slow sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Part of the initial sync is to fetch and store the self user's read receipt settings. This PR adds a pull sync to achieve this.

### Testing

Code path isn't live yet so it can't be tested at the moment.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
