### PR TITLE
fix: perform quick sync in wrong epoch error recovery logic - WPB-15573

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1314,6 +1314,10 @@ public final class MLSService: MLSServiceInterface {
         do {
             logger.info("repairing out of sync conversation... (\(groupID.safeForLoggingDescription))")
 
+            // In case of `WrongEpoch` error, local and remote epochs have diverged so we may have missed events.
+            // This ensures we're on the latest state.
+            await syncStatus.performQuickSync()
+
             guard let conversationInfo = fetchConversationInfo(
                 with: groupID,
                 in: context

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -327,6 +327,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         let message = "foo"
         let error = MLSDecryptionService.MLSMessageDecryptionError.wrongEpoch
         mockDecryptionService.decryptMessageForSubconversationType_MockError = error
+        mockSyncStatus.mockPerformQuickSync = {}
 
         let expectation = XCTestExpectation(description: "repaired conversation")
         await uiMOC.perform {
@@ -1477,6 +1478,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             XCTFail("missing groupID")
             return
         }
+        mockSyncStatus.mockPerformQuickSync = {}
 
         let expectation = XCTestExpectation(description: "rejoined conversation")
 
@@ -1508,6 +1510,8 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             return
         }
 
+        mockSyncStatus.mockPerformQuickSync = {}
+
         let expectation = XCTestExpectation(description: "didn't rejoin conversation")
         expectation.isInverted = true
 
@@ -1535,6 +1539,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             XCTFail("missing groupID")
             return
         }
+        mockSyncStatus.mockPerformQuickSync = {}
         let subgroupID = MLSGroupID.random()
         let qualifiedID = await uiMOC.perform { conversation.qualifiedID }
 
@@ -1575,6 +1580,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             XCTFail("missing groupID")
             return
         }
+        mockSyncStatus.mockPerformQuickSync = {}
         let subgroupID = MLSGroupID.random()
         let qualifiedID = await uiMOC.perform { conversation.qualifiedID }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15573" title="WPB-15573" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15573</a>  [iOS] Missing messages in canary team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: We're sometimes missing MLS messages in a conversation, in app we get the following system message "You haven't used this device for a while. Some messages may not appear here"

**Causes**: Conversation local and remote epochs diverged resulting in a `WrongEpoch` error. 

In this case, we apply a recovery strategy to 1. sync the conversation with backend, 2. checks if we're out of sync (by comparing local and remote epochs) and if we are 3. display the system message. 

However, in this recovery strategy, we omit do fetch possible missed events (typically `conversation.mls-message-add` events) which could be the reason why local epoch count is behind the remote one.

**Solution**: Call `performQuickSync` to fetch and process possible missed events to ensure we're on the latest state.

Recovery strategy steps mentioned in the specs [here](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/678035678/Use+case+recover+from+epoch+getting+out+of+sync)

### Testing

To be tested during MLS playtests 

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.