### PR TITLE
fix: proteus send message error missing logic - WPB-16116

### DIFF
--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -173,7 +173,7 @@ public final class MessageSender: MessageSenderInterface {
                 .broadcastProteusMessage(message: messageData)
             await handleProteusSuccess(message: message, messageSendingStatus: messageStatus, response: response)
         } catch let networkError as NetworkError {
-            let retryOperation: () async throws -> Void = { [weak self] in
+            let operation: () async throws -> Void = { [weak self] in
                 try await self?.broadcastMessage(message: message)
             }
 
@@ -181,7 +181,7 @@ public final class MessageSender: MessageSenderInterface {
                 networkError,
                 message: message,
                 apiVersion: apiVersion,
-                retryOperation: retryOperation
+                operation: operation
             )
         }
     }
@@ -239,7 +239,7 @@ public final class MessageSender: MessageSenderInterface {
                 )
             await handleProteusSuccess(message: message, messageSendingStatus: messageStatus, response: response)
         } catch let networkError as NetworkError {
-            let retryOperation: () async throws -> Void = { [weak self] in
+            let operation: () async throws -> Void = { [weak self] in
                 try await self?.sendMessage(message: message)
             }
 
@@ -247,7 +247,7 @@ public final class MessageSender: MessageSenderInterface {
                 networkError,
                 message: message,
                 apiVersion: apiVersion,
-                retryOperation: retryOperation
+                operation: operation
             )
         }
     }
@@ -256,11 +256,12 @@ public final class MessageSender: MessageSenderInterface {
         _ networkError: NetworkError,
         message: any ProteusMessage,
         apiVersion: APIVersion,
-        retryOperation: () async throws -> Void
+        operation: () async throws -> Void
     ) async throws {
         do {
             let missingClients = try await handleProteusFailure(message: message, networkError)
             try await sessionEstablisher.establishSession(with: missingClients, apiVersion: apiVersion)
+            try await operation()
         } catch let error as MessageSendError {
             guard retryCount < maxRetryAttempts else {
                 retryCount = 0
@@ -269,7 +270,7 @@ public final class MessageSender: MessageSenderInterface {
 
             retryCount += 1
 
-            try await retryOperation()
+            try await operation()
         } catch {
             throw error
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16116" title="WPB-16116" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16116</a>  [iOS] sent messages from iOS never appear on any other client
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: first Proteus message on a fresh install doesn't show up

**Cause**: Some logic was missing in this [PR](https://github.com/wireapp/wire-ios/pull/2462/files) to fix a request loop issue

When getting a network error, we'll try handle the proteus failure which either returns a set of missing clients qualified IDs or throws a specific `MessageSendError`.
-> if it throws `MessageSendError`, we'll retry a couple of times and then throws the error (done in [PR](https://github.com/wireapp/wire-ios/pull/2462/files))
-> If we do get the set of client qualified IDs, we do nothing, we don't try to actually resend the message.

**Solution**:  add missing code to send the message again

### Testing

Fresh install the app
Try to send a first message in a group
Message should show up

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
