### PR TITLE
fix: showing datadog label in support mail - WPB-15997

### DIFF
--- a/WireAnalytics/Sources/WireDatadog/WireFakeDatadog.swift
+++ b/WireAnalytics/Sources/WireDatadog/WireFakeDatadog.swift
@@ -21,8 +21,8 @@ public import WireLogging
 
 public final class WireDatadog {
 
-    public var userIdentifier: String {
-        ""
+    public var userIdentifier: String? {
+        nil
     }
 
     public init(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/LogFilesProvider.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/LogFilesProvider.swift
@@ -144,7 +144,7 @@ struct LogFilesProvider: LogFilesProviding {
         return url
     }
 
-    private func createInfoFile(at url: URL) throws -> URL {
+    var info: String {
         let date = Date()
 
         var body = """
@@ -159,10 +159,13 @@ struct LogFilesProvider: LogFilesProviding {
             // display only when enabled
             body.append("\nDatadog ID: \(datadogUserIdentifier)")
         }
+        return body
+    }
 
+    private func createInfoFile(at url: URL) throws -> URL {
         let infoFileURL = url.appendingPathComponent("info.txt")
 
-        try body.write(
+        try info.write(
             to: infoFileURL,
             atomically: true,
             encoding: .utf8

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/MFMailComposeViewController+Logs.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/MFMailComposeViewController+Logs.swift
@@ -25,24 +25,12 @@ import WireSystem
 extension MFMailComposeViewController {
 
     func prefilledBody(withMessage message: String = "") -> String {
-        let date = Date()
-        let device = UIDevice.current.zm_model()
-
         var body = """
         --DO NOT EDIT--
-        App Version: \(Bundle.main.appInfo.fullVersion)
-        Bundle id: \(Bundle.main.bundleIdentifier ?? "-")
-        Device: \(device)
-        iOS version: \(UIDevice.current.systemVersion)
-        Date: \(date.transportString())
+        \(LogFilesProvider().info)
+        ---------------\n
         """
 
-        if let datadogUserIdentifier = WireAnalytics.Datadog.userIdentifier {
-            // display only when enabled
-            body.append("\nDatadog ID: \(datadogUserIdentifier)")
-        }
-
-        body.append("\n---------------\n")
         typealias l10n = L10n.Localizable.Self.Settings.TechnicalReport.MailBody
         let details = """
         \(l10n.firstline)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15997" title="WPB-15997" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15997</a>  Datadog ID showing in support email
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This is a manual cherry-pick of a fix done on 3.117.0 that was not ported to 3.118