### PR TITLE
fix: add WireSettingsUI strings to crowdin.yml - WPB-16078

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -105,5 +105,15 @@ files: [
     "dest" : "/App/WireMoveToFolderUI/Resources/Accessibility.xcstrings",
     "translation" : "%original_path%/%original_file_name%",
     "multilingual": true,
+  },
+  {
+    "source" : "/WireUI/Sources/WireSettingsUI/Resources/en.lproj/Accessibility.strings",
+    "dest" : "/App/WireSettingsUI/Resources/Accessibility.strings",
+    "translation" : "/WireUI/Sources/WireSettingsUI/Resources/%osx_code%/%original_file_name%",
+  },
+  {
+    "source" : "/WireUI/Sources/WireSettingsUI/Resources/en.lproj/Localizable.strings",
+    "dest" : "/App/WireSettingsUI/Resources/Localizable.strings",
+    "translation" : "/WireUI/Sources/WireSettingsUI/Resources/%osx_code%/%original_file_name%",
   }
 ]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16078" title="WPB-16078" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16078</a>  [iOS, iPad] Minor left-over bugs in Backup/Restore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

New string files currently aren't processed by crowdin, because PR https://github.com/wireapp/wire-ios/pull/2523 hasn't updated the config file.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
