### PR TITLE
feat: implement `LoginViaEmailUseCase` - WPB-15923

### DIFF
--- a/WireAPI/Sources/WireAPI/Models/Authorization/AccessToken.swift
+++ b/WireAPI/Sources/WireAPI/Models/Authorization/AccessToken.swift
@@ -39,4 +39,11 @@ public struct AccessToken: Equatable, Sendable {
 
     public let expirationDate: Date
 
+    public init(userID: UUID, token: String, type: String, expirationDate: Date) {
+        self.userID = userID
+        self.token = token
+        self.type = type
+        self.expirationDate = expirationDate
+    }
+
 }

--- a/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponentDependency.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponentDependency.swift
@@ -18,6 +18,7 @@
 
 import NeedleFoundation
 import SwiftUI
+import WireAPI
 import WireAuthenticationAPI
 internal import WireAuthenticationUI
 internal import WireAuthenticationLogic
@@ -28,13 +29,14 @@ protocol LoginViaEmailComponentDependency: Dependency {
     @MainActor var router: any Router { get }
     var accountsURL: URL { get }
     var passwordValidator: any PasswordValidator { get }
+    var authenticationAPI: AuthenticationAPI { get }
 
 }
 
 class LoginViaEmailComponent: Component<LoginViaEmailComponentDependency>, LoginViaEmailBuilder {
 
     private var loginViaEmailUseCase: some LoginViaEmailUseCaseProtocol {
-        LoginViaEmailUseCase()
+        LoginViaEmailUseCase(authenticationAPI: dependency.authenticationAPI)
     }
 
     @MainActor

--- a/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
@@ -51,6 +51,9 @@ private class LoginViaEmailComponentDependency6f812ea9ca4f0322dd27Provider: Logi
     var passwordValidator: any PasswordValidator {
         return rootComponent.passwordValidator
     }
+    var authenticationAPI: AuthenticationAPI {
+        return rootComponent.authenticationAPI
+    }
     private let rootComponent: RootComponent
     init(rootComponent: RootComponent) {
         self.rootComponent = rootComponent
@@ -74,14 +77,15 @@ extension LoginViaEmailComponent: NeedleFoundation.Registration {
         keyPathToName[\LoginViaEmailComponentDependency.router] = "router-any Router"
         keyPathToName[\LoginViaEmailComponentDependency.accountsURL] = "accountsURL-URL"
         keyPathToName[\LoginViaEmailComponentDependency.passwordValidator] = "passwordValidator-any PasswordValidator"
+        keyPathToName[\LoginViaEmailComponentDependency.authenticationAPI] = "authenticationAPI-AuthenticationAPI"
     }
 }
 extension RootComponent: NeedleFoundation.Registration {
     public func registerItems() {
 
+        localTable["authenticationAPI-AuthenticationAPI"] = { [unowned self] in self.authenticationAPI as Any }
         localTable["accountsURL-URL"] = { [unowned self] in self.accountsURL as Any }
         localTable["passwordValidator-any PasswordValidator"] = { [unowned self] in self.passwordValidator as Any }
-        localTable["authenticationAPI-AuthenticationAPI"] = { [unowned self] in self.authenticationAPI as Any }
         localTable["router-any Router"] = { [unowned self] in self.router as Any }
     }
 }

--- a/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/LoginViaEmailUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/LoginViaEmailUseCase.swift
@@ -30,7 +30,7 @@ public protocol LoginViaEmailUseCaseProtocol {
 
 }
 
-public enum LoginViaEmailUseCaseFailure: Error {
+public enum LoginViaEmailUseCaseFailure: Error, Equatable {
 
     case invalidCredentials
     case twoFactorAuthenticationRequired

--- a/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/LoginViaEmailUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/LoginViaEmailUseCase.swift
@@ -18,11 +18,12 @@
 
 import Foundation
 
-public protocol LoginViaEmailUseCaseProtocol: Sendable {
+public protocol LoginViaEmailUseCaseProtocol {
 
     func invoke(
         email: String,
-        password: String
+        password: String,
+        verificationCode: String?
     ) async throws(LoginViaEmailUseCaseFailure)
 
 }
@@ -30,9 +31,11 @@ public protocol LoginViaEmailUseCaseProtocol: Sendable {
 public enum LoginViaEmailUseCaseFailure: Error {
 
     case invalidCredentials
-    case verificationCodeRequired
+    case twoFactorAuthenticationRequired
+    case twoFactorAuthenticationFailed
     case accountPendingActivation
     case accountSuspended
-    case other(message: String)
+    case noInternet
+    case other
 
 }

--- a/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/LoginViaEmailUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/Use cases/LoginViaEmailUseCase.swift
@@ -20,11 +20,13 @@ import Foundation
 
 public protocol LoginViaEmailUseCaseProtocol {
 
+    associatedtype AccessToken
+
     func invoke(
         email: String,
         password: String,
         verificationCode: String?
-    ) async throws(LoginViaEmailUseCaseFailure)
+    ) async throws(LoginViaEmailUseCaseFailure) -> ([HTTPCookie], AccessToken)
 
 }
 

--- a/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaEmailUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaEmailUseCase.swift
@@ -32,7 +32,7 @@ public struct LoginViaEmailUseCase: LoginViaEmailUseCaseProtocol {
         email: String,
         password: String,
         verificationCode: String?
-    ) async throws(LoginViaEmailUseCaseFailure)  -> ([HTTPCookie], AccessToken) {
+    ) async throws(LoginViaEmailUseCaseFailure) -> ([HTTPCookie], AccessToken) {
         do {
             return try await authenticationAPI.login(
                 email: email,

--- a/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaEmailUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaEmailUseCase.swift
@@ -17,17 +17,54 @@
 //
 
 import Foundation
+import WireAPI
 import WireAuthenticationAPI
 
 public struct LoginViaEmailUseCase: LoginViaEmailUseCaseProtocol {
 
-    typealias Failure = LoginViaEmailUseCaseFailure
+    private let authenticationAPI: AuthenticationAPI
 
-    public init() {}
+    public init(authenticationAPI: AuthenticationAPI) {
+        self.authenticationAPI = authenticationAPI
+    }
 
     public func invoke(
         email: String,
-        password: String
-    ) async throws(LoginViaEmailUseCaseFailure) {}
+        password: String,
+        verificationCode: String?
+    ) async throws(LoginViaEmailUseCaseFailure) {
+        do {
+            let result = try await authenticationAPI.login(
+                email: email,
+                password: password,
+                verificationCode: verificationCode,
+                label: nil
+            )
+        } catch let error as AuthenticationAPIError {
+            switch error {
+            case .twoFactorAuthenticationRequired:
+                throw .twoFactorAuthenticationRequired
+            case .twoFactorAuthenticationFailed:
+                throw .twoFactorAuthenticationFailed
+            case .accountPendingActivation:
+                throw .accountPendingActivation
+            case .accountSuspended:
+                throw .accountSuspended
+            case .invalidCredentials:
+                throw .invalidCredentials
+            default:
+                throw .other
+            }
+        } catch let error as URLError {
+            switch error.code {
+            case .notConnectedToInternet, .networkConnectionLost:
+                throw .noInternet
+            default:
+                throw .other
+            }
+        } catch {
+            throw .other
+        }
+    }
 
 }

--- a/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaEmailUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/LoginViaEmailUseCase.swift
@@ -32,9 +32,9 @@ public struct LoginViaEmailUseCase: LoginViaEmailUseCaseProtocol {
         email: String,
         password: String,
         verificationCode: String?
-    ) async throws(LoginViaEmailUseCaseFailure) {
+    ) async throws(LoginViaEmailUseCaseFailure)  -> ([HTTPCookie], AccessToken) {
         do {
-            let result = try await authenticationAPI.login(
+            return try await authenticationAPI.login(
                 email: email,
                 password: password,
                 verificationCode: verificationCode,

--- a/WireAuthentication/Sources/WireAuthenticationUI/MockDependencies.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/MockDependencies.swift
@@ -85,7 +85,7 @@ extension MockDependencies: LoginViaEmailUseCaseProtocol {
         password: String,
         verificationCode: String?
     ) async throws(LoginViaEmailUseCaseFailure) -> ([HTTPCookie], String) {
-        return ([], "")
+        ([], "")
     }
 
 }

--- a/WireAuthentication/Sources/WireAuthenticationUI/MockDependencies.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/MockDependencies.swift
@@ -82,9 +82,10 @@ extension MockDependencies: LoginViaEmailUseCaseProtocol {
 
     func invoke(
         email: String,
-        password: String
-    ) async throws(LoginViaEmailUseCaseFailure) {
-        // Success
+        password: String,
+        verificationCode: String?
+    ) async throws(LoginViaEmailUseCaseFailure) -> ([HTTPCookie], String) {
+        return ([], "")
     }
 
 }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailViewModel.swift
@@ -61,13 +61,14 @@ package final class LoginViaEmailViewModel: ObservableObject {
     func submitPassword(_ password: String) {
         Task.detached {
             do {
+                // TODO: [WPB-15924] Handle happy path
                 _ = try await self.loginViaEmailUseCase.invoke(
                     email: self.email,
                     password: password,
                     verificationCode: ""
                 )
             } catch {
-                // TODO: [WPB-15940] Error handling
+                // TODO: [WPB-15924] Error handling
                 print("error: \(error)")
             }
         }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailViewModel.swift
@@ -61,9 +61,10 @@ package final class LoginViaEmailViewModel: ObservableObject {
     func submitPassword(_ password: String) {
         Task.detached {
             do {
-                try await self.loginViaEmailUseCase.invoke(
+                _ = try await self.loginViaEmailUseCase.invoke(
                     email: self.email,
-                    password: password
+                    password: password,
+                    verificationCode: ""
                 )
             } catch {
                 // TODO: [WPB-15940] Error handling

--- a/WireAuthentication/Tests/WireAuthenticationLogicTests/LoginViaEmailUseCaseTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationLogicTests/LoginViaEmailUseCaseTests.swift
@@ -89,7 +89,7 @@ final class LoginViaEmailUseCaseTests: XCTestCase {
             (underlyingError: AuthenticationAPIError.invalidResponse, expected: .other),
             (underlyingError: AuthenticationAPIError.configNotFound, expected: .other),
             (underlyingError: AuthenticationAPIError.domainNotFound, expected: .other),
-            (underlyingError: URLError(.badServerResponse), expected: .other),
+            (underlyingError: URLError(.badServerResponse), expected: .other)
         ]
 
         for testCase in testCases {

--- a/WireAuthentication/Tests/WireAuthenticationLogicTests/LoginViaEmailUseCaseTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationLogicTests/LoginViaEmailUseCaseTests.swift
@@ -1,0 +1,104 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireAPI
+import WireAPISupport
+import WireAuthenticationAPI
+import WireTestingPackage
+import XCTest
+
+@testable import WireAuthenticationLogic
+
+final class LoginViaEmailUseCaseTests: XCTestCase {
+
+    private var mockAuthenticationAPI: MockAuthenticationAPI!
+    private var sut: LoginViaEmailUseCase!
+
+    override func setUp() {
+        mockAuthenticationAPI = MockAuthenticationAPI()
+
+        sut = LoginViaEmailUseCase(
+            authenticationAPI: mockAuthenticationAPI
+        )
+    }
+
+    override func tearDown() {
+        mockAuthenticationAPI = nil
+        sut = nil
+    }
+
+    func testInvoke_whenSuccess() async throws {
+        // given
+        let accessToken = AccessToken(userID: UUID(), token: "token", type: "type", expirationDate: Date())
+        let cookie = HTTPCookie(properties: [
+            .name: "some name",
+            .path: "some path",
+            .value: "some value",
+            .domain: "some domain"
+        ])!
+        mockAuthenticationAPI
+            .loginEmailPasswordVerificationCodeLabel_MockValue = ([cookie], accessToken)
+
+        // when
+        let result = try await sut.invoke(email: "email", password: "password", verificationCode: "code")
+
+        // then
+        XCTAssertEqual(result.0, [cookie])
+        XCTAssertEqual(result.1, accessToken)
+        let invocations = mockAuthenticationAPI.loginEmailPasswordVerificationCodeLabel_Invocations
+        try XCTAssertCount(invocations, count: 1)
+        XCTAssertEqual(invocations[0].email, "email")
+        XCTAssertEqual(invocations[0].password, "password")
+        XCTAssertEqual(invocations[0].verificationCode, "code")
+    }
+
+    func testInvoke_whenFailure() async throws {
+        // given
+        let testCases: [(underlyingError: any Error, expected: LoginViaEmailUseCaseFailure)] = [
+            (underlyingError: AuthenticationAPIError.invalidCredentials, expected: .invalidCredentials),
+            (
+                underlyingError: AuthenticationAPIError.twoFactorAuthenticationRequired,
+                expected: .twoFactorAuthenticationRequired
+            ),
+            (
+                underlyingError: AuthenticationAPIError.twoFactorAuthenticationFailed,
+                expected: .twoFactorAuthenticationFailed
+            ),
+            (underlyingError: AuthenticationAPIError.accountPendingActivation, expected: .accountPendingActivation),
+            (underlyingError: AuthenticationAPIError.accountSuspended, expected: .accountSuspended),
+            (underlyingError: URLError(.notConnectedToInternet), expected: .noInternet),
+            (underlyingError: URLError(.networkConnectionLost), expected: .noInternet),
+            (underlyingError: AuthenticationAPIError.unsupportedEndpointForAPIVersion, expected: .other),
+            (underlyingError: AuthenticationAPIError.invalidDomain, expected: .other),
+            (underlyingError: AuthenticationAPIError.invalidRequestBody, expected: .other),
+            (underlyingError: AuthenticationAPIError.invalidResponse, expected: .other),
+            (underlyingError: AuthenticationAPIError.configNotFound, expected: .other),
+            (underlyingError: AuthenticationAPIError.domainNotFound, expected: .other),
+            (underlyingError: URLError(.badServerResponse), expected: .other),
+        ]
+
+        for testCase in testCases {
+            mockAuthenticationAPI.loginEmailPasswordVerificationCodeLabel_MockError = testCase.underlyingError
+
+            // when, then
+            await XCTAssertThrowsErrorAsync(testCase.expected) { [self] in
+                _ = try await sut.invoke(email: "email", password: "password", verificationCode: "code")
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15923" title="WPB-15923" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15923</a>  [iOS] Implement use case to log in via email
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR implements `LoginViaEmailUseCase` which has very little functionality - it calls the underlying network API, and maps its error responses to `LoginViaEmailUseCaseFailure`.

One interesting thing is that `LoginViaEmailUseCase` needs to return an `AuthToken` which is defined in `WireAPI`. As we don't want to import `WireAPI` into `WireAuthenticationAPI` I have chosen to  use an associated type. This will be type erased by the `LoginViaEmailViewModel` so not to need generics everywhere. This is easy to do because we don't actually need to read the contents of `AuthToken`, we just need to pass it around.

### Testing

Run automated tests.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.