### PR TITLE
fix: ignore new CoreCrypto error Other - WPB-16042

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -90,7 +90,8 @@ protocol DecryptedMessageBundle {
 extension DecryptedMessage: DecryptedMessageBundle {}
 extension BufferedDecryptedMessage: DecryptedMessageBundle {}
 
-private let commitForMissingProposal = "Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived."
+private let commitForMissingProposal =
+    "Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived."
 
 /// A class responsible for decrypting messages for MLS groups.
 /// It is also responsible for processing welcome messages and publishing events
@@ -220,9 +221,12 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
             // Message arrive in an unmerged group, it has been buffered and will be consumed later.
             case .UnmergedPendingGroup: return []
 
-            // Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.
+            // Incoming message is a commit for which we have not yet received all the proposals. Buffering until all
+            // proposals have arrived.
+            // Clients do not need to take any action in response to this message. This error simply indicates that the
+            // commit has been buffered, and will be automatically unbuffered when possible.
             case .Other(commitForMissingProposal): return []
-                
+
             case .Other, .ConversationAlreadyExists, .MessageEpochTooOld, .OrphanWelcome:
                 throw MLSMessageDecryptionError.failedToDecryptMessage
             }

--- a/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSDecryptionService.swift
@@ -90,6 +90,8 @@ protocol DecryptedMessageBundle {
 extension DecryptedMessage: DecryptedMessageBundle {}
 extension BufferedDecryptedMessage: DecryptedMessageBundle {}
 
+private let commitForMissingProposal = "Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived."
+
 /// A class responsible for decrypting messages for MLS groups.
 /// It is also responsible for processing welcome messages and publishing events
 /// when the epoch changes or new CRL distribution points are found.
@@ -218,7 +220,10 @@ public final class MLSDecryptionService: MLSDecryptionServiceInterface {
             // Message arrive in an unmerged group, it has been buffered and will be consumed later.
             case .UnmergedPendingGroup: return []
 
-            default:
+            // Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.
+            case .Other(commitForMissingProposal): return []
+                
+            case .Other, .ConversationAlreadyExists, .MessageEpochTooOld, .OrphanWelcome:
                 throw MLSMessageDecryptionError.failedToDecryptMessage
             }
         } catch {

--- a/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
@@ -92,6 +92,26 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         }
     }
 
+    func test_Decrypt_IgnoreOtherMissingCommitProposalError() async throws {
+        // Given
+        let groupID = MLSGroupID.random()
+        let message = Data.random().base64EncodedString()
+
+        mockMLSActionExecutor.mockDecryptMessage = { _, _ in
+            throw CoreCryptoError.Mls(MlsError.Other("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived."))
+        }
+
+        // When
+        let results = try await sut.decrypt(
+            message: message,
+            for: groupID,
+            subconversationType: nil
+        )
+        
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
     func test_Decrypt_ReturnsEmptyResult_WhenCoreCryptoReturnsNil() async throws {
 
         // Given

--- a/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSDecryptionServiceTests.swift
@@ -98,7 +98,13 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
         let message = Data.random().base64EncodedString()
 
         mockMLSActionExecutor.mockDecryptMessage = { _, _ in
-            throw CoreCryptoError.Mls(MlsError.Other("Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived."))
+            throw CoreCryptoError
+                .Mls(
+                    MlsError
+                        .Other(
+                            "Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived."
+                        )
+                )
         }
 
         // When
@@ -107,7 +113,7 @@ final class MLSDecryptionServiceTests: ZMConversationTestsBase {
             for: groupID,
             subconversationType: nil
         )
-        
+
         // Then
         XCTAssertTrue(results.isEmpty)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16042" title="WPB-16042" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16042</a>  [iOS] Bump CoreCrypto to 3.1.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following [comment](https://github.com/wireapp/wire-ios/pull/2555#issuecomment-2666312480), this ignores newly introduce error in 3.1.0:

```
[!NOTE] Decrypting a message can now potentially return a MlsError::Other variant with the message

Incoming message is a commit for which we have not yet received all the proposals. Buffering until all proposals have arrived.

Clients do not need to take any action in response to this message. This error simply indicates that the commit has been buffered, and will be automatically unbuffered when possible.
```

* Remove default case and use explicit case so new errors produce compile error.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
