### PR TITLE
refactor: decouple self team id from TeamRepository - WPB-15440

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Team/Protocols/TeamLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/Protocols/TeamLocalStoreProtocol.swift
@@ -31,6 +31,11 @@ public protocol TeamLocalStoreProtocol {
 
     func selfUserID() async -> UUID
 
+    /// Fetches the self team ID, if it exist.
+    /// - returns: The id of the self user's team.
+
+    func selfTeamID() async -> UUID?
+
     /// Fetches the user membership.
     /// - parameter user: A given user.
     /// - returns: The user membership.

--- a/WireDomain/Sources/WireDomain/Repositories/Team/TeamLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/TeamLocalStore.swift
@@ -64,6 +64,14 @@ public final class TeamLocalStore: TeamLocalStoreProtocol {
         }
     }
 
+    public func selfTeamID() async -> UUID? {
+        let selfUser = await userLocalStore.fetchSelfUser()
+
+        return await context.perform {
+            selfUser.teamIdentifier
+        }
+    }
+
     public func userMembership(
         user: ZMUser
     ) async -> Member? {

--- a/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepository.swift
@@ -24,7 +24,6 @@ public class TeamRepository: TeamRepositoryProtocol {
 
     // MARK: - Properties
 
-    private let selfTeamID: UUID
     private let userRepository: any UserRepositoryProtocol
     private let teamsAPI: any TeamsAPI
     private let teamLocalStore: any TeamLocalStoreProtocol
@@ -36,12 +35,10 @@ public class TeamRepository: TeamRepositoryProtocol {
     // MARK: - Object lifecycle
 
     public init(
-        selfTeamID: UUID,
         userRepository: any UserRepositoryProtocol,
         teamLocalStore: any TeamLocalStoreProtocol,
         teamsAPI: any TeamsAPI
     ) {
-        self.selfTeamID = selfTeamID
         self.userRepository = userRepository
         self.teamLocalStore = teamLocalStore
         self.teamsAPI = teamsAPI
@@ -62,18 +59,22 @@ public class TeamRepository: TeamRepositoryProtocol {
     // MARK: - Public
 
     public func pullSelfTeam() async throws {
+        let selfTeamID = try await getSelfTeamID()
         try await pullSelfTeamSync.pull(selfTeamID: selfTeamID)
     }
 
     public func pullSelfTeamRoles() async throws {
+        let selfTeamID = try await getSelfTeamID()
         try await pullSelfTeamRolesSync.pull(selfTeamID: selfTeamID)
     }
 
     public func pullSelfTeamMembers() async throws {
+        let selfTeamID = try await getSelfTeamID()
         try await pullSelfTeamMembersSync.pull(selfTeamID: selfTeamID)
     }
 
     public func fetchSelfLegalholdStatus() async throws -> LegalholdStatus {
+        let selfTeamID = try await getSelfTeamID()
         let selfUserID = await teamLocalStore.selfUserID()
 
         return try await teamsAPI.getLegalholdInfo(
@@ -150,12 +151,20 @@ public class TeamRepository: TeamRepositoryProtocol {
     }
 
     public func fetchSelfLegalholdInfo() async throws -> TeamMemberLegalholdInfo {
+        let selfTeamID = try await getSelfTeamID()
         let (selfUserID, _) = await teamLocalStore.selfUserInfo()
 
         return try await teamsAPI.getLegalholdInfo(
             for: selfTeamID,
             userID: selfUserID
         )
+    }
+
+    private func getSelfTeamID() async throws -> UUID {
+        guard let selfTeamID = await teamLocalStore.selfTeamID() else {
+            throw TeamRepositoryError.selfUserIsNotATeamMember
+        }
+        return selfTeamID
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepositoryError.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Team/TeamRepositoryError.swift
@@ -22,6 +22,10 @@ import Foundation
 
 enum TeamRepositoryError: Error {
 
+    /// The self user does not belong to any team.
+
+    case selfUserIsNotATeamMember
+
     /// Failed to fetch data from the server.
 
     case failedToFetchRemotely(Error)

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2246,6 +2246,24 @@ public class MockTeamLocalStoreProtocol: TeamLocalStoreProtocol {
         }
     }
 
+    // MARK: - selfTeamID
+
+    public var selfTeamID_Invocations: [Void] = []
+    public var selfTeamID_MockMethod: (() async -> UUID?)?
+    public var selfTeamID_MockValue: UUID??
+
+    public func selfTeamID() async -> UUID? {
+        selfTeamID_Invocations.append(())
+
+        if let mock = selfTeamID_MockMethod {
+            return await mock()
+        } else if let mock = selfTeamID_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `selfTeamID`")
+        }
+    }
+
     // MARK: - userMembership
 
     public var userMembershipUser_Invocations: [ZMUser] = []

--- a/WireDomain/Tests/WireDomainTests/Repositories/TeamRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/TeamRepositoryTests.swift
@@ -48,11 +48,12 @@ final class TeamRepositoryTests: XCTestCase {
         teamLocalStore = MockTeamLocalStoreProtocol()
 
         sut = TeamRepository(
-            selfTeamID: Scaffolding.selfTeamID,
             userRepository: userRespository,
             teamLocalStore: teamLocalStore,
             teamsAPI: teamsAPI
         )
+
+        teamLocalStore.selfTeamID_MockValue = Scaffolding.selfTeamID
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15440" title="WPB-15440" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15440</a>  [iOS] Integrate quick sync with in the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
The `TeamRepository` requires the self team id to be injected, but not all users have a team. This PR decouples the self team id from the repository, instead fetching it via the self user.

This will make it easier to initialize dependencies for the incremental sync.


### Testing
N/A (code paths not live)

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
