### PR TITLE
fix: notifications received form selfUser - WPB-16080

### DIFF
--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -193,7 +193,7 @@ private class ConversationCreateEventNotificationBuilder: EventNotificationBuild
     }
 
     override func shouldCreateNotification() -> Bool {
-        // if there is a sender, it's not the selfUser
+        // if there is a sender, make sure it's not the selfUser (no notification for self)
         if let sender, sender.isSelfUser { return false }
 
         if conversation == nil {

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -195,8 +195,7 @@ private class ConversationCreateEventNotificationBuilder: EventNotificationBuild
     override func shouldCreateNotification() -> Bool {
         // if there is a sender, it's not the selfUser
         if let sender, sender.isSelfUser { return false }
-        
-        
+
         if conversation == nil {
             // WPB-8946: fixes bug: notifications shown even though availability is busy or away
             let availability = moc.performAndWait { ZMUser.selfUser(in: moc).availability }

--- a/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
+++ b/wire-ios-request-strategy/Sources/Notifications/Push Notifications/Notification Types/Content/ZMLocalNotification+Events.swift
@@ -193,6 +193,10 @@ private class ConversationCreateEventNotificationBuilder: EventNotificationBuild
     }
 
     override func shouldCreateNotification() -> Bool {
+        // if there is a sender, it's not the selfUser
+        if let sender, sender.isSelfUser { return false }
+        
+        
         if conversation == nil {
             // WPB-8946: fixes bug: notifications shown even though availability is busy or away
             let availability = moc.performAndWait { ZMUser.selfUser(in: moc).availability }
@@ -326,6 +330,12 @@ private class NewMessageNotificationBuilder: EventNotificationBuilder {
     }
 
     override func shouldCreateNotification() -> Bool {
+        let selfUser = ZMUser.selfUser(in: moc)
+        guard selfUser.remoteIdentifier != event.senderUUID else {
+            // message comes from selfUser, discard
+            return false
+        }
+
         if let conversation,
            let senderUUID = event.senderUUID,
            conversation.isMessageSilenced(message, senderID: senderUUID) {
@@ -338,10 +348,6 @@ private class NewMessageNotificationBuilder: EventNotificationBuilder {
             // WPB-8946: fixes bug: notifications shown even though availability is busy or away
             let availability = moc.performAndWait { ZMUser.selfUser(in: moc).availability }
             return [.none, .available].contains(availability)
-        }
-
-        if ZMUser.selfUser(in: moc).remoteIdentifier == event.senderUUID {
-            return false
         }
 
         if let timeStamp = event.timestamp,

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -128,7 +128,24 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
             XCTAssertEqual(note!.body, "Super User created a conversation")
         }
     }
+    
+    func testThatItDoesNotCreatesConversationCreateNotification_WhenSenderIsSelf() {
+        syncMOC.performGroupedAndWait {
+            // "push.notification.conversation.create" = "%1$@ created a group conversation with you"
 
+            // when
+            let note = self.noteWithPayload(
+                nil,
+                from: self.selfUser,
+                in: self.groupConversation,
+                type: self.EventConversationCreate
+            )
+
+            // then
+            XCTAssertNil(note)
+        }
+    }
+    
     func testThatItCreatesConversationCreateNotification_NoUsername() {
         syncMOC.performGroupedAndWait {
             // "push.notification.conversation.create.nousername" = "Someone created a group conversation with you"

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Event.swift
@@ -128,7 +128,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
             XCTAssertEqual(note!.body, "Super User created a conversation")
         }
     }
-    
+
     func testThatItDoesNotCreatesConversationCreateNotification_WhenSenderIsSelf() {
         syncMOC.performGroupedAndWait {
             // "push.notification.conversation.create" = "%1$@ created a group conversation with you"
@@ -145,7 +145,7 @@ final class ZMLocalNotificationTests_Event: ZMLocalNotificationTests {
             XCTAssertNil(note)
         }
     }
-    
+
     func testThatItCreatesConversationCreateNotification_NoUsername() {
         syncMOC.performGroupedAndWait {
             // "push.notification.conversation.create.nousername" = "Someone created a group conversation with you"

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -146,7 +146,7 @@ final class ZMLocalNotificationTests_Message: ZMLocalNotificationTests {
             XCTAssertEqual(note!.content.threadIdentifier, "")
         }
     }
-    
+
     func testThatItDoesNotCreateANotificationForText_FromSelf() {
         // given
         syncMOC.performGroupedAndWait {

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -146,6 +146,16 @@ final class ZMLocalNotificationTests_Message: ZMLocalNotificationTests {
             XCTAssertEqual(note!.content.threadIdentifier, "")
         }
     }
+    
+    func testThatItDoesNotCreateANotificationForText_FromSelf() {
+        // given
+        syncMOC.performGroupedAndWait {
+            let note = self.textNotification(self.oneOnOneConversation, sender: self.selfUser, isEphemeral: false)
+
+            // then
+            XCTAssertNil(note)
+        }
+    }
 
     func testItCreatesMessageNotificationsCorrectly() {
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16080" title="WPB-16080" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16080</a>  [iOS] Receiving notifications for new messages sent by self
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When connecting to someone, with a second device B, I receive notification or messages on my device A.


### Testing

- [x] retest

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
