### PR TITLE
fix: MLS account not being deleted when logging out - WPB-15774

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -889,17 +889,15 @@ public final class SessionManager: NSObject, SessionManagerType {
 
         requireInternal(activeUserSession.userId == account.userIdentifier, "User session and account are different")
 
-        delegate?.sessionManagerWillLogout(error: error, userSessionCanBeTornDown: { [dispatchGroup] in
-            dispatchGroup.enter()
-
+        delegate?.sessionManagerWillLogout(error: error) { [weak self] in
             activeUserSession.close(deleteCookie: deleteCookie) {
                 if deleteAccount {
-                    self.deleteAccountData(for: account)
+                    self?.deleteAccountData(for: account)
                 }
-                dispatchGroup.leave()
             }
-            self.activeUserSession = nil
-        })
+
+            self?.activeUserSession = nil
+        }
     }
 
     /// Loads a session for a given account

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Authentication.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Authentication.swift
@@ -77,10 +77,11 @@ extension ZMUserSession {
             deleteUserKeychainItems()
         }
 
-        syncManagedObjectContext.dispatchGroup?.notify(on: .main) {
+        syncManagedObjectContext.perform {
             self.tearDown()
-            completion()
         }
+
+        completion()
     }
 
     public func logout(credentials: UserEmailCredentials, _ completion: @escaping (Result<Void, Error>) -> Void) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15774" title="WPB-15774" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15774</a>  [iOS] Logging out consistently doesn't work (Canary)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Context: When logging out from MLS account (userA) and logging in with other account (userB) and logging out again it will results in weird behavior (crashes, session corrupted popup or login screen showing expired session message..)
-> app behaves inconsistently when logging out from MLS account.

Causes: When logging out from MLS account, we're deleting everything related to the active session except the account itself because some completion block is not called whereas it should be - whether it is a MLS or Proteus account (works fine if we only test with Proteus accounts).

Solution: Ensure the code responsible to delete account data is properly called when logging out from a MLS account by removing usage of dispatch group.

### Testing

Log in with MLS account
Log out
Log in with other account (MLS or Proteus)
Log out
..
-> app should behave consistently when logging in / out from MLS or Proteus accounts (no corrupted session pop up, no crash, no expired session message on login screen..)

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

