### PR TITLE
fix: don't remove mls if previously supported mls - WPB-16253

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -276,7 +276,8 @@ public final class ClientSessionComponent {
         let pushSupportedProtocolsUseCase = PushSupportedProtocolsUseCase(
             featureConfigRepository: featureConfigRepository,
             pushSupportedProtocolsSync: pushSupportedProtocolsSync,
-            userClientsLocalStore: userClientsLocalStore
+            userClientsLocalStore: userClientsLocalStore,
+            userLocalStore: userLocalStore
         )
 
         return InitialSync(

--- a/WireDomain/Sources/WireDomain/Repositories/User/Protocols/UserLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/Protocols/UserLocalStoreProtocol.swift
@@ -136,8 +136,7 @@ public protocol UserLocalStoreProtocol {
     /// - returns: A list of users' qualified IDs.
 
     func fetchAllUserIDsWithOneOnOneConversation() async throws -> [WireDataModel.QualifiedID]
-    
-    
+
     /// Fetch the self user Supported Protocols
 
     func fetchSelfUserSupportedProtocols() async -> Set<WireDataModel.MessageProtocol>

--- a/WireDomain/Sources/WireDomain/Repositories/User/Protocols/UserLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/Protocols/UserLocalStoreProtocol.swift
@@ -136,4 +136,9 @@ public protocol UserLocalStoreProtocol {
     /// - returns: A list of users' qualified IDs.
 
     func fetchAllUserIDsWithOneOnOneConversation() async throws -> [WireDataModel.QualifiedID]
+    
+    
+    /// Fetch the self user Supported Protocols
+
+    func fetchSelfUserSupportedProtocols() async -> Set<WireDataModel.MessageProtocol>
 }

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
@@ -288,4 +288,10 @@ public final class UserLocalStore: UserLocalStoreProtocol {
             user.isPendingMetadataRefresh = false
         }
     }
+    
+    public func fetchSelfUserSupportedProtocols() async -> Set<WireDataModel.MessageProtocol> {
+        await context.perform { [context] in
+            ZMUser.selfUser(in: context).supportedProtocols
+        }
+    }
 }

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
@@ -288,7 +288,7 @@ public final class UserLocalStore: UserLocalStoreProtocol {
             user.isPendingMetadataRefresh = false
         }
     }
-    
+
     public func fetchSelfUserSupportedProtocols() async -> Set<WireDataModel.MessageProtocol> {
         await context.perform { [context] in
             ZMUser.selfUser(in: context).supportedProtocols

--- a/WireDomain/Sources/WireDomain/UseCases/PushSupportedProtocolsUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/PushSupportedProtocolsUseCase.swift
@@ -39,7 +39,8 @@ public struct PushSupportedProtocolsUseCase: PushSupportedProtocolsUseCaseProtoc
     let featureConfigRepository: any FeatureConfigRepositoryProtocol
     let pushSupportedProtocolsSync: any PushSupportedProtocolsSyncProtocol
     let userClientsLocalStore: any UserClientsLocalStoreProtocol
-
+    let userLocalStore: any UserLocalStoreProtocol
+    
     private let logger = WireLogger(tag: "supported-protocols")
 
     public func invoke() async throws {
@@ -53,6 +54,7 @@ public struct PushSupportedProtocolsUseCase: PushSupportedProtocolsUseCaseProtoc
         let remoteProtocols = await remotelySupportedProtocols()
         let migrationState = await currentMigrationState()
         let allClientsMLSReady = await userClientsLocalStore.allSelfUserClientsAreActiveMLSClients()
+        let currentSelfUserSupportedProtocols = await userLocalStore.fetchSelfUserSupportedProtocols()
 
         logger.debug(
             "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady)"
@@ -65,6 +67,11 @@ public struct PushSupportedProtocolsUseCase: PushSupportedProtocolsUseCaseProtoc
             result.insert(.proteus)
         }
 
+        // SelfUser supports mls (other client) at the moment, so we should not remove it
+        if currentSelfUserSupportedProtocols.contains(.mls) {
+            result.insert(.mls)
+        }
+        
         /// We support mls if the backend does and all MLS clients are ready.
         if remoteProtocols.contains(.mls), allClientsMLSReady {
             result.insert(.mls)

--- a/WireDomain/Sources/WireDomain/UseCases/PushSupportedProtocolsUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/PushSupportedProtocolsUseCase.swift
@@ -40,7 +40,7 @@ public struct PushSupportedProtocolsUseCase: PushSupportedProtocolsUseCaseProtoc
     let pushSupportedProtocolsSync: any PushSupportedProtocolsSyncProtocol
     let userClientsLocalStore: any UserClientsLocalStoreProtocol
     let userLocalStore: any UserLocalStoreProtocol
-    
+
     private let logger = WireLogger(tag: "supported-protocols")
 
     public func invoke() async throws {
@@ -71,7 +71,7 @@ public struct PushSupportedProtocolsUseCase: PushSupportedProtocolsUseCaseProtoc
         if currentSelfUserSupportedProtocols.contains(.mls) {
             result.insert(.mls)
         }
-        
+
         /// We support mls if the backend does and all MLS clients are ready.
         if remoteProtocols.contains(.mls), allClientsMLSReady {
             result.insert(.mls)

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -3525,6 +3525,24 @@ public class MockUserLocalStoreProtocol: UserLocalStoreProtocol {
         }
     }
 
+    // MARK: - fetchSelfUserSupportedProtocols
+
+    public var fetchSelfUserSupportedProtocols_Invocations: [Void] = []
+    public var fetchSelfUserSupportedProtocols_MockMethod: (() async -> Set<WireDataModel.MessageProtocol>)?
+    public var fetchSelfUserSupportedProtocols_MockValue: Set<WireDataModel.MessageProtocol>?
+
+    public func fetchSelfUserSupportedProtocols() async -> Set<WireDataModel.MessageProtocol> {
+        fetchSelfUserSupportedProtocols_Invocations.append(())
+
+        if let mock = fetchSelfUserSupportedProtocols_MockMethod {
+            return await mock()
+        } else if let mock = fetchSelfUserSupportedProtocols_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `fetchSelfUserSupportedProtocols`")
+        }
+    }
+
 }
 
 public class MockUserRepositoryProtocol: UserRepositoryProtocol {

--- a/WireDomain/Tests/WireDomainTests/UseCases/PushSupportedProtocolsUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/PushSupportedProtocolsUseCaseTests.swift
@@ -37,7 +37,7 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
     private var modelHelper: ModelHelper!
 
     private var selfUser: ZMUser!
-    
+
     private var context: NSManagedObjectContext {
         stack.syncContext
     }
@@ -53,7 +53,7 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
         mockPushSupportedProtocolsSync = MockPushSupportedProtocolsSyncProtocol()
         userClientsLocalStore = MockUserClientsLocalStoreProtocol()
         userLocalStore = MockUserLocalStoreProtocol()
-        
+
         sut = PushSupportedProtocolsUseCase(
             featureConfigRepository: FeatureConfigRepository(
                 featureConfigsAPI: MockFeatureConfigsAPI(),
@@ -63,7 +63,7 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
             userClientsLocalStore: userClientsLocalStore,
             userLocalStore: userLocalStore
         )
-        
+
         selfUser = await context.perform { [context] in
             self.modelHelper.createSelfUser(in: context)
         }
@@ -99,7 +99,7 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
         // Then
         XCTAssertEqual([WireAPI.MessageProtocol.mls, WireAPI.MessageProtocol.proteus], pushedProtocols)
     }
-    
+
     func test_CalculateSupportedProtocols_AllActiveMLSClients_RemoteProteus() async throws {
         // Given
         await setup(remoteSupportedProtocols: [.proteus])

--- a/WireDomain/Tests/WireDomainTests/UseCases/PushSupportedProtocolsUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/PushSupportedProtocolsUseCaseTests.swift
@@ -30,11 +30,14 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
     private var sut: PushSupportedProtocolsUseCase!
     private var mockPushSupportedProtocolsSync: MockPushSupportedProtocolsSyncProtocol!
     private var userClientsLocalStore: MockUserClientsLocalStoreProtocol!
+    private var userLocalStore: MockUserLocalStoreProtocol!
 
     private var coreDataStackHelper: CoreDataStackHelper!
     private var stack: CoreDataStack!
     private var modelHelper: ModelHelper!
 
+    private var selfUser: ZMUser!
+    
     private var context: NSManagedObjectContext {
         stack.syncContext
     }
@@ -49,19 +52,28 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
 
         mockPushSupportedProtocolsSync = MockPushSupportedProtocolsSyncProtocol()
         userClientsLocalStore = MockUserClientsLocalStoreProtocol()
-
+        userLocalStore = MockUserLocalStoreProtocol()
+        
         sut = PushSupportedProtocolsUseCase(
             featureConfigRepository: FeatureConfigRepository(
                 featureConfigsAPI: MockFeatureConfigsAPI(),
                 featureConfigLocalStore: FeatureConfigLocalStore(context: context)
             ),
             pushSupportedProtocolsSync: mockPushSupportedProtocolsSync,
-            userClientsLocalStore: userClientsLocalStore
+            userClientsLocalStore: userClientsLocalStore,
+            userLocalStore: userLocalStore
         )
+        
+        selfUser = await context.perform { [context] in
+            self.modelHelper.createSelfUser(in: context)
+        }
+        userLocalStore.fetchSelfUser_MockValue = selfUser
+        userLocalStore.fetchSelfUserSupportedProtocols_MockValue = Set()
     }
 
     override func tearDown() async throws {
         try await super.tearDown()
+        selfUser = nil
         sut = nil
         stack = nil
         modelHelper = nil
@@ -74,6 +86,20 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
 
     // MARK: - Tests
 
+    func test_CalculateSupportedProtocols_PreviousSupportedProtocolMLS_DoesNotRemoveMLS() async throws {
+        // Given
+        await setup(remoteSupportedProtocols: [.proteus, .mls])
+
+        userLocalStore.fetchSelfUserSupportedProtocols_MockValue = [.proteus, .mls]
+        userClientsLocalStore.allSelfUserClientsAreActiveMLSClients_MockValue = false
+        mockPushSupportedProtocolsSync.pushSupportedProtocols_MockMethod = { _ in }
+
+        try await sut.invoke()
+        let pushedProtocols = try XCTUnwrap(mockPushSupportedProtocolsSync.pushSupportedProtocols_Invocations.last)
+        // Then
+        XCTAssertEqual([WireAPI.MessageProtocol.mls, WireAPI.MessageProtocol.proteus], pushedProtocols)
+    }
+    
     func test_CalculateSupportedProtocols_AllActiveMLSClients_RemoteProteus() async throws {
         // Given
         await setup(remoteSupportedProtocols: [.proteus])
@@ -212,7 +238,6 @@ final class PushSupportedProtocolsUseCaseTests: XCTestCase {
     func test_CalculateSupportedProtocols_NotAllActiveMLSClients_RemoteMLS() async throws {
         // Given
         await setup(remoteSupportedProtocols: [.mls])
-
         mockPushSupportedProtocolsSync.pushSupportedProtocols_MockMethod = { _ in }
         userClientsLocalStore.allSelfUserClientsAreActiveMLSClients_MockValue = false
 

--- a/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
@@ -35,7 +35,7 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
     private let featureRepository: FeatureRepositoryInterface
     private let selfUserProvider: SelfUserProviderProtocol
     private let logger = WireLogger.supportedProtocols
-    
+
     // MARK: - Life cycle
 
     public convenience init(context: NSManagedObjectContext) {
@@ -62,7 +62,7 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
         let migrationState = currentMigrationState()
         let allClientsMLSReady = allSelfUserClientsAreActiveMLSClients()
         let currentSelfUserSupportedProtocols = selfUserSupportedProtocols()
-        
+
         logger
             .debug(
                 "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady)"
@@ -79,7 +79,7 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
         if currentSelfUserSupportedProtocols.contains(.mls) {
             result.insert(.mls)
         }
-        
+
         // All clients are mls ready so we support it if the backend does.
         if remoteProtocols.contains(.mls), allClientsMLSReady {
             result.insert(.mls)

--- a/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/SupportedProtocolsService.swift
@@ -35,7 +35,7 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
     private let featureRepository: FeatureRepositoryInterface
     private let selfUserProvider: SelfUserProviderProtocol
     private let logger = WireLogger.supportedProtocols
-
+    
     // MARK: - Life cycle
 
     public convenience init(context: NSManagedObjectContext) {
@@ -61,7 +61,8 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
         let remoteProtocols = remotelySupportedProtocols()
         let migrationState = currentMigrationState()
         let allClientsMLSReady = allSelfUserClientsAreActiveMLSClients()
-
+        let currentSelfUserSupportedProtocols = selfUserSupportedProtocols()
+        
         logger
             .debug(
                 "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady)"
@@ -74,6 +75,11 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
             result.insert(.proteus)
         }
 
+        // SelfUser supports mls (other client) at the moment, so we should not remove it
+        if currentSelfUserSupportedProtocols.contains(.mls) {
+            result.insert(.mls)
+        }
+        
         // All clients are mls ready so we support it if the backend does.
         if remoteProtocols.contains(.mls), allClientsMLSReady {
             result.insert(.mls)
@@ -157,6 +163,9 @@ public final class SupportedProtocolsService: SupportedProtocolsServiceInterface
         selfUserProvider.fetchSelfUser().clients.all(\.isActiveMLSClient)
     }
 
+    private func selfUserSupportedProtocols() -> Set<MessageProtocol> {
+        selfUserProvider.fetchSelfUser().supportedProtocols
+    }
 }
 
 // MARK: -

--- a/wire-ios-sync-engine/Tests/Source/Services/SupportedProtocolsServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Services/SupportedProtocolsServiceTests.swift
@@ -168,6 +168,19 @@ final class SupportedProtocolsServiceTests: XCTestCase {
 
     // MARK: - Tests
 
+    func test_CalculateSupportedProtocols_PreviousSupportedProtocolMLS_DoesNotRemoveMLS() async throws {
+        try syncContext.performAndWait {
+            // Given
+            try mock(allActiveMLSClients: false)
+            mock(remoteSupportedProtocols: [.proteus, .mls])
+            mock(migrationState: .disabled)
+            ZMUser.selfUser(in: syncContext).supportedProtocols = [.proteus, .mls]
+
+            // When / then
+            XCTAssertEqual(sut.calculateSupportedProtocols(), [.proteus, .mls])
+        }
+    }
+
     func test_CalculateSupportedProtocols_AllActiveMLSClients_RemoteProteus() throws {
         try syncContext.performAndWait {
             // Given


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16253" title="WPB-16253" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16253</a>  [iOS] Prevent removal of MLS from supported protocols if it was previously supported
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If a user supports MLS but at some point adds an old Proteus client, this will break his 1:1 conversations because the supported protocols will result back to proteus (the allMLSClients condition would not be satisfied).

Solution:

Prevent from removing MLS if the user supported mls previously.

### Testing

Note: this will be tested tomorrow for the playtest

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
