### PR TITLE
chore: import strings related to backup/restore - WPB-16078

### DIFF
--- a/WireUI/Sources/WireReusableUIComponents/Resources/ar.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ar.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/be.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/be.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/bg.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/bg.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/bn.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/bn.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ca.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ca.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/cs.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/cs.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/da.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/da.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/de.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Passwort eingeben";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/el.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/el.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/es.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/es.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/et.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/et.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/eu.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/eu.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/fa.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/fa.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/fi.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/fi.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/fr.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/fr.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/he.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/he.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/hr.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/hr.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/hu.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/hu.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/id.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/id.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/is.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/is.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/it.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/it.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ja.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ja.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ka.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ka.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ko.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ko.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/lt.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/lt.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/lv.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/lv.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ms.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ms.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/my.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/my.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/nl.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/nl.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/no.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/no.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/pl.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/pl.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/pt-BR.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/pt.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/pt.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ro.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ro.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ru.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ru.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Пароль (НЕОБЯЗАТЕЛЬНО)";
+"passwordtextfield.preview.placeholder" = "Введите пароль";
+"passwordtextfield.preview.passwordrules" = "Используйте как минимум 8 символов, включая одну строчную букву, одну заглавную букву, цифру и специальный символ.";
+"passwordtextfield.hide_password" = "Скрыть пароль";
+"passwordtextfield.show_password" = "Показать пароль";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/si.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/si.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/sk.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/sk.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/sl.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/sl.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/sr-Latn.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/sr-Latn.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/sr.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/sr.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/sv.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/sv.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Ange lösenord";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/th.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/th.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/tr.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/tr.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/uk.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/uk.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/ur.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/ur.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/vi.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/vi.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireReusableUIComponents/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+"passwordtextfield.preview.title" = "Password (OPTIONAL)";
+"passwordtextfield.preview.placeholder" = "Enter password";
+"passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"passwordtextfield.hide_password" = "Hide password";
+"passwordtextfield.show_password" = "Show password";

--- a/WireUI/Sources/WireSettingsUI/Resources/de.lproj/Accessibility.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/de.lproj/Accessibility.strings
@@ -16,7 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-"exportBackup.cancel.label" = "Cancel backup";
+"exportBackup.cancel.label" = "Backup abbrechen";
 "importBackup.cancel.label" = "Cancel restore";
-"backup.password.show.label" = "Show password";
-"backup.password.hide.label" = "Hide password";
+"backup.password.show.label" = "Passwort anzeigen";
+"backup.password.hide.label" = "Passwort ausblenden";

--- a/WireUI/Sources/WireSettingsUI/Resources/de.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/de.lproj/Localizable.strings
@@ -16,52 +16,53 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-"backup.export.action" = "Back Up Now";
-"backup.export.description" = "Create a backup to preserve your conversation history. You can use this to restore history if you lose your computer or switch to a new one. The backup file is not protected by Wire end-to-end encryption, so store it in a safe place.";
+"backup.export.action" = "Jetzt sichern";
+"backup.export.description" = "Erstellen Sie ein Datensicherung, um Ihren Gesprächsverlauf zu erhalten. Sie können damit den Verlauf wiederherstellen, wenn Sie Ihr Gerät verlieren oder zu einem neuen wechseln.
+Die Sicherungsdatei ist nicht durch eine Ende-zu-Ende-Verschlüsselung geschützt, also bewahren Sie sie an einem sicheren Ort auf.";
 
-"backup.import.action" = "Restore from Backup";
-"backup.import.description" = "The existing history on this device remains and will be completed by the new backup. You can restore history from all your devices and different platforms but not from another account.";
+"backup.import.action" = "Backup wiederherstellen";
+"backup.import.description" = "Der vorhandene Gesprächsverlauf auf diesem Gerät bleibt erhalten und wird durch das neue Backup ergänzt. Sie können den Verlauf von all Ihren Geräten und verschiedenen Plattformen wiederherstellen, aber nicht von einem anderen Benutzerkonto.";
 
 "exportBackup.title" = "Passwort festlegen";
-"exportBackup.description" = "The backup will be compressed. If you use a password, Wire also encrypts the backup file. Make sure to store the password in a secure place.";
-"exportBackup.button" = "Back Up Now";
-"exportBackup.setBackupPassword.title" = "Password (OPTIONAL)";
+"exportBackup.description" = "Das Backup wird komprimiert. Wenn Sie ein Passwort verwenden, verschlüsselt Wire auch die Datei. Bitte achten Sie darauf, das Passwort an einem sicheren Ort aufzubewahren.";
+"exportBackup.button" = "Jetzt sichern";
+"exportBackup.setBackupPassword.title" = "Passwort (OPTIONAL)";
 "exportBackup.setBackupPassword.placeholder" = "Passwort eingeben";
-"exportBackup.setBackupPassword.rules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
+"exportBackup.setBackupPassword.rules" = "Verwenden Sie mindestens 8 Zeichen mit einem Kleinbuchstaben, einem Großbuchstaben, einer Zahl und einem Sonderzeichen.";
 
 "exportBackup.cancel.title" = "Abbrechen";
 "exportBackup.errorAlert.title" = "Ein Fehler ist aufgetreten";
-"exportBackup.errorAlert.message" = "The backup could not be created. Please try again or contact Wire support.";
+"exportBackup.errorAlert.message" = "Sicherung konnte nicht erstellt werden. Bitte versuchen Sie es erneut oder kontaktieren Sie den Wire Support.";
 "exportBackup.errorAlert.ok" = "OK";
 
-"exportBackup.creatingBackup.title" = "Creating Backup";
-"exportBackup.creatingBackup.saving" = "Saving conversation history…";
-"exportBackup.creatingBackup.success" = "Backup successfully created.";
-"exportBackup.creatingBackup.saveButton.title" = "Save File";
+"exportBackup.creatingBackup.title" = "Backup erstellen";
+"exportBackup.creatingBackup.saving" = "Gesprächsverlauf sichern…";
+"exportBackup.creatingBackup.success" = "Backup erfolgreich erstellt.";
+"exportBackup.creatingBackup.saveButton.title" = "Datei speichern";
 
 "importBackup.cancel.title" = "Abbrechen";
 
-"importBackup.overwriteConfirmation.title" = "File overwrites your history";
-"importBackup.overwriteConfirmation.message" = "The backup contents will replace the current conversation history on this device.";
+"importBackup.overwriteConfirmation.title" = "Datei überschreibt Ihren Verlauf";
+"importBackup.overwriteConfirmation.message" = "Der Inhalt der Datei wird den aktuellen Gesprächsverlauf auf diesem Gerät ersetzen.";
 "importBackup.overwriteConfirmation.cancel" = "Abbrechen";
 "importBackup.overwriteConfirmation.proceed" = "Fortfahren";
 
 "importBackup.alert.ok" = "OK";
 "importBackup.alert.success.title" = "Success";
-"importBackup.alert.success.message" = "Your history is restored.";
+"importBackup.alert.success.message" = "Ihr Verlauf wurde wiederhergestellt.";
 "importBackup.alert.genericError.title" = "Ein Fehler ist aufgetreten";
-"importBackup.alert.genericError.message" = "Your history could not be restored. Please try again or contact the Wire customer support.";
-"importBackup.alert.incompatibleBackupError.title" = "Incompatible backup";
-"importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
-"importBackup.alert.wrongFileError.title" = "Wrong backup file";
-"importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.genericError.message" = "Ihr Gesprächsverlauf konnte nicht wiederhergestellt werden. Bitte versuchen Sie es erneut oder kontaktieren Sie Wire Support.";
+"importBackup.alert.incompatibleBackupError.title" = "Inkompatibles Backup";
+"importBackup.alert.incompatibleBackupError.message" = "Diese Backup-Datei wurde von einer anderen Version von Wire erstellt und kann deshalb nicht wiederhergestellt werden.";
+"importBackup.alert.wrongFileError.title" = "Falsche Backup-Datei";
+"importBackup.alert.wrongFileError.message" = "Der Gesprächsverlauf eines anderen Kontos kann nicht wiederhergestellt werden.";
 
 "importBackup.enterPassword.title" = "Passwort eingeben";
-"importBackup.enterPassword.description" = "This backup is password protected.";
+"importBackup.enterPassword.description" = "Dieses Backup ist passwortgeschützt.";
 "importBackup.enterPassword.textField.title" = "Passwort";
 "importBackup.enterPassword.textField.placeholder" = "Passwort eingeben";
-"importBackup.enterPassword.wrongPassword" = "Wrong password. Please verify your input and try again";
+"importBackup.enterPassword.wrongPassword" = "Falsches Passwort. Bitte überprüfen Sie Ihre Eingabe und versuchen Sie es erneut";
 "importBackup.enterPassword.button.title" = "Weiter";
 
-"importBackup.restoringHistory.title" = "Restoring history…";
-"importBackup.restoringHistory.message" = "Loading conversations…";
+"importBackup.restoringHistory.title" = "Verlauf wird wiederhergestellt…";
+"importBackup.restoringHistory.message" = "Unterhaltungen werden geladen…";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16078" title="WPB-16078" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16078</a>  [iOS, iPad] Minor left-over bugs in Backup/Restore
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR imports strings from develop.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
