### PR TITLE
fix: create persistent login cookie - WPB-16044

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV0.swift
@@ -54,6 +54,7 @@ class AuthenticationAPIV0: AuthenticationAPI, VersionedAPI {
         let request = try URLRequestBuilder(path: path)
             .withBody(encodedJSON, contentType: .json)
             .withMethod(.post)
+            .withQueryItem(name: "persist", value: "true")
             .build()
 
         let (data, response) = try await networkService.executeRequest(request)

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v0.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/login"
+	"/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v1.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v1.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v1/login"
+	"/v1/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v2.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v2.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v2/login"
+	"/v2/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v3.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v3.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v3/login"
+	"/v3/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v4.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v4.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v4/login"
+	"/v4/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v5.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v5.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v5/login"
+	"/v5/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v6.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v6.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v6/login"
+	"/v6/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v7.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v7.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v7/login"
+	"/v7/login?persist=true"

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v8.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testLoginViaEmailRequest.request-0-v8.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\",\"password\":\"123456\"}" \
-	"/v8/login"
+	"/v8/login?persist=true"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16044" title="WPB-16044" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16044</a>  [iOS] Integrate authentication flow completion into legacy code
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When logging in via the new WireAuthentication login flow, the cookie returned from logging in via email is only a temporary session cookie. Instead, we want to create a a persistent cookie (one that can be used up until the expiry date) by setting the `persist` query parameter to `true`.

### Testing
N/A

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
