### PR TITLE
fix: SwiftGen config for Wire Share Extension - WPB-16381

### DIFF
--- a/wire-ios/swiftgenShareExtension.yml
+++ b/wire-ios/swiftgenShareExtension.yml
@@ -7,7 +7,7 @@ output_dir: Wire-iOS Share Extension/Generated/
 
 strings:
   inputs:
-    - Resources/Base.lproj/Localizable.strings
+    - Resources/Localization/Base.lproj/Localizable.strings
   filter:
   outputs:
     templateName: structured-swift5


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16381" title="WPB-16381" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16381</a>  [iOS] Fix SwiftGen configuration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a missing path component to the SwiftGen config.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
