### PR TITLE
fix: ensure answer/start AVS call is triggered after joining subgroup and before setting the epoch - WPB-16001

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -756,7 +756,7 @@ public extension WireCallCenterV3 {
                         parentQualifiedID: parentQualifiedID,
                         parentID: parentGroupID
                     )
-                    
+
                     try completion()
 
                     // Generate and set the conference information for the subgroup

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -756,6 +756,8 @@ public extension WireCallCenterV3 {
                         parentQualifiedID: parentQualifiedID,
                         parentID: parentGroupID
                     )
+                    
+                    try completion()
 
                     // Generate and set the conference information for the subgroup
                     let initialConferenceInfo = try await mlsService.generateConferenceInfo(
@@ -767,8 +769,6 @@ public extension WireCallCenterV3 {
                         conversationId: conversationID,
                         info: initialConferenceInfo
                     )
-
-                    try completion()
 
                     // Set up a task to observe changes in the conference information
                     // and update AVS accordingly

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -608,7 +608,7 @@ public extension WireCallCenterV3 {
                conversationType == .mlsConference {
                 try setUpMLSConference(
                     in: conversation,
-                    completion: avsAnswerCallHandler
+                    avsCallHandler: avsAnswerCallHandler
                 )
             } else {
                 try avsAnswerCallHandler()
@@ -699,7 +699,7 @@ public extension WireCallCenterV3 {
             if conversationType == .mlsConference {
                 try setUpMLSConference(
                     in: conversation,
-                    completion: avsStartCallHandler
+                    avsCallHandler: avsStartCallHandler
                 )
             } else {
                 try avsStartCallHandler()
@@ -719,13 +719,14 @@ public extension WireCallCenterV3 {
     /// Sets up the MLS conference for a given conversation.
     ///
     /// - Parameter conversation: The conversation to set up the MLS conference for.
+    /// - Parameter avsCallHandler: Triggers `wcall_start` or `wcall_answer` from AVS.
     ///
     /// See documentation:
     /// https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/692027483/Use+case+Join+conference+sub-conversation+MLS
 
     private func setUpMLSConference(
         in conversation: ZMConversation,
-        completion: @escaping () throws -> Void
+        avsCallHandler: @escaping () throws -> Void
     ) throws {
         guard let conversationID = conversation.avsIdentifier else {
             throw Failure.failedToSetupMLSConference
@@ -757,7 +758,7 @@ public extension WireCallCenterV3 {
                         parentID: parentGroupID
                     )
 
-                    try completion()
+                    try avsCallHandler()
 
                     // Generate and set the conference information for the subgroup
                     let initialConferenceInfo = try await mlsService.generateConferenceInfo(

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -566,16 +566,6 @@ public extension WireCallCenterV3 {
             isConferenceCall: isConferenceCall(conversationId: conversationId)
         )
 
-        let answered = avsWrapper.answerCall(
-            conversationId: conversationId,
-            callType: callType,
-            useCBR: useConstantBitRateAudio
-        )
-
-        guard answered else {
-            throw Failure.unknown
-        }
-
         let callState: CallState = .answered(degraded: isDegraded(conversationId: conversationId))
 
         let previousSnapshot = callSnapshots[conversationId]
@@ -595,18 +585,34 @@ public extension WireCallCenterV3 {
             ).post(in: context.notificationContext)
         }
 
+        let avsAnswerCallHandler: () throws -> Void = { [weak self] in
+            guard let self else { return }
+
+            let answered = avsWrapper.answerCall(
+                conversationId: conversationId,
+                callType: callType,
+                useCBR: useConstantBitRateAudio
+            )
+
+            guard answered else {
+                throw Failure.unknown
+            }
+        }
+
         switch conversation.messageProtocol {
         case .proteus, .mixed:
-            break
+            try avsAnswerCallHandler()
 
         case .mls:
-            guard
-                let conversationType = getAVSConversationType(for: conversation),
-                conversationType == .mlsConference
-            else {
-                return
+            if let conversationType = getAVSConversationType(for: conversation),
+               conversationType == .mlsConference {
+                try setUpMLSConference(
+                    in: conversation,
+                    completion: avsAnswerCallHandler
+                )
+            } else {
+                try avsAnswerCallHandler()
             }
-            try setUpMLSConference(in: conversation)
         }
     }
 
@@ -648,17 +654,6 @@ public extension WireCallCenterV3 {
             throw Failure.missingConferencingPermission
         }
 
-        let started = avsWrapper.startCall(
-            conversationId: conversationId,
-            callType: callType,
-            conversationType: conversationType,
-            useCBR: useConstantBitRateAudio
-        )
-
-        guard started else {
-            throw Failure.unknown
-        }
-
         let callState: CallState = .outgoing(isVideo: isVideo, degraded: isDegraded(conversationId: conversationId))
         let previousCallState = callSnapshots[conversationId]?.callState
 
@@ -682,12 +677,33 @@ public extension WireCallCenterV3 {
             ).post(in: context.notificationContext)
         }
 
+        let avsStartCallHandler: () throws -> Void = { [weak self] in
+            guard let self else { return }
+
+            let started = avsWrapper.startCall(
+                conversationId: conversationId,
+                callType: callType,
+                conversationType: conversationType,
+                useCBR: useConstantBitRateAudio
+            )
+
+            guard started else {
+                throw Failure.unknown
+            }
+        }
+
         switch conversation.messageProtocol {
         case .proteus, .mixed:
-            break
+            try avsStartCallHandler()
         case .mls:
-            guard conversationType == .mlsConference else { return }
-            try setUpMLSConference(in: conversation)
+            if conversationType == .mlsConference {
+                try setUpMLSConference(
+                    in: conversation,
+                    completion: avsStartCallHandler
+                )
+            } else {
+                try avsStartCallHandler()
+            }
         }
     }
 
@@ -707,7 +723,10 @@ public extension WireCallCenterV3 {
     /// See documentation:
     /// https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/692027483/Use+case+Join+conference+sub-conversation+MLS
 
-    private func setUpMLSConference(in conversation: ZMConversation) throws {
+    private func setUpMLSConference(
+        in conversation: ZMConversation,
+        completion: @escaping () throws -> Void
+    ) throws {
         guard let conversationID = conversation.avsIdentifier else {
             throw Failure.failedToSetupMLSConference
         }
@@ -748,6 +767,8 @@ public extension WireCallCenterV3 {
                         conversationId: conversationID,
                         info: initialConferenceInfo
                     )
+
+                    try completion()
 
                     // Set up a task to observe changes in the conference information
                     // and update AVS accordingly

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -963,9 +963,6 @@ final class WireCallCenterV3Tests: MessagingTest {
     }
 
     func testThatItAnswersACall_conference_mls() throws {
-        // TODO: [WPB-7346]: enable this (flaky) test again
-        throw XCTSkip()
-
         // given
         sut.handleIncomingCall(
             conversationId: groupConversationID,
@@ -983,10 +980,15 @@ final class WireCallCenterV3Tests: MessagingTest {
             expectedCallerID: otherUserID,
             expectedConversationID: groupConversationID
         ) {
-            // when
             _ = try sut.answerCall(conversation: groupConversation, video: false)
 
-            // then
+            XCTAssertNil(mockAVSWrapper.answerCallArguments)
+
+            XCTAssert(
+                waitForCustomExpectations(withTimeout: 0.5)
+            )
+
+            // then, once subgroup has been joined and epoch has been set, avs answer call should be triggered
             XCTAssertEqual(mockAVSWrapper.answerCallArguments?.callType, AVSCallType.normal)
         }
     }
@@ -1070,19 +1072,23 @@ final class WireCallCenterV3Tests: MessagingTest {
         }
     }
 
-    func testThatItStartsACall_conference_mls() throws {
-        // TODO: [WPB-7346]: enable this (flaky) test again
-        throw XCTSkip()
+    var subscription: AnyCancellable?
 
+    func testThatItStartsACall_conference_mls() throws {
         try assertMLSConference(
             expectedCallState: .outgoing(isVideo: false, degraded: false),
             expectedCallerID: selfUserID,
             expectedConversationID: groupConversationID
         ) {
-            // when
             try sut.startCall(in: groupConversation, isVideo: false)
 
-            // then
+            XCTAssertNil(mockAVSWrapper.startCallArguments)
+
+            XCTAssert(
+                waitForCustomExpectations(withTimeout: 0.5)
+            )
+
+            // then, once subgroup has been joined, epoch has been set, avs start call should be triggered
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.mlsConference)
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
         }
@@ -1169,19 +1175,6 @@ final class WireCallCenterV3Tests: MessagingTest {
             // when
             try block()
         }
-
-        XCTAssert(
-            waitForCustomExpectations(withTimeout: 0.5),
-            "[6] waitForCustomExpectations failed",
-            file: file,
-            line: line
-        )
-        XCTAssert(
-            waitForAllGroupsToBeEmpty(withTimeout: 0.5),
-            "[7] waitForAllGroupsToBeEmpty failed",
-            file: file,
-            line: line
-        )
 
         let didSetConferenceInfo2 = customExpectation(description: "didSetConferenceInfo2")
         mockAVSWrapper.mockSetMLSConferenceInfo = {

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -988,7 +988,7 @@ final class WireCallCenterV3Tests: MessagingTest {
                 waitForCustomExpectations(withTimeout: 0.5)
             )
 
-            // then, once subgroup has been joined and epoch has been set, avs answer call should be triggered
+            // then, once subgroup has been joined, avs answer call should be triggered
             XCTAssertEqual(mockAVSWrapper.answerCallArguments?.callType, AVSCallType.normal)
         }
     }
@@ -1086,7 +1086,7 @@ final class WireCallCenterV3Tests: MessagingTest {
                 waitForCustomExpectations(withTimeout: 0.5)
             )
 
-            // then, once subgroup has been joined, epoch has been set, avs start call should be triggered
+            // then, once subgroup has been joined avs start call should be triggered
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.conversationType, AVSConversationType.mlsConference)
             XCTAssertEqual(mockAVSWrapper.startCallArguments?.callType, AVSCallType.normal)
         }

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -1072,8 +1072,6 @@ final class WireCallCenterV3Tests: MessagingTest {
         }
     }
 
-    var subscription: AnyCancellable?
-
     func testThatItStartsACall_conference_mls() throws {
         try assertMLSConference(
             expectedCallState: .outgoing(isVideo: false, degraded: false),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16001" title="WPB-16001" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16001</a>  [iOS] No audio when joining call on canary team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…setting epoch

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When answering a call for a MLS group, currently we follow these steps (as mentionned [here](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/616792280/Use+case+answer+a+call+incoming)):
1. wcall_answer
2. join sub-conv
3. wcall_set_epoch_info

Logic should from now on be:
1. join sub-conv
2. wcall_answer
3. wcall_set_epoch_info

Same logic was applied to starting a call (`wcall_start`) 

Reason why we should call wcall_answer after having joined the sub-conv is that SFT requests authorization of clients, and unfortunately it seems that the join sub-conv can take several seconds some times, so when the SFT asks for authorization, we don't know of any authorized clients (since set_epoch_info was not called yet) and then it takes until the next timeout fo authorize.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
