### PR TITLE
fix: gesture recognizers handling in stack cell - WPB-16361

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -162,8 +162,10 @@ final class ConversationMessageCellTableViewAdapter<
     private func onSingleTap(_ gestureRecognizer: UITapGestureRecognizer) {
         guard gestureRecognizer.state == .recognized else { return }
 
-        if let actionController = actionController(for: gestureRecognizer.location(in:)) {
-            actionController.performSingleTapAction()
+        if let cellDescription = nestedCellDescription(
+            using: gestureRecognizer.location(in:)
+        ), cellDescription.supportsActions {
+            cellDescription.actionController?.performSingleTapAction()
         } else if cellDescription?.supportsActions == true {
             cellDescription?.actionController?.performSingleTapAction()
         }
@@ -175,27 +177,30 @@ final class ConversationMessageCellTableViewAdapter<
     private func onDoubleTap(_ gestureRecognizer: UITapGestureRecognizer) {
         guard gestureRecognizer.state == .recognized else { return }
 
-        if let actionController = actionController(for: gestureRecognizer.location(in:)) {
-            actionController.performDoubleTapAction()
+        if let cellDescription = nestedCellDescription(
+            using: gestureRecognizer.location(in:)
+        ), cellDescription.supportsActions {
+            cellDescription.actionController?.performDoubleTapAction()
         } else if cellDescription?.supportsActions == true {
             cellDescription?.actionController?.performDoubleTapAction()
         }
     }
 
-    private func actionController(for locationInCell: (UIView?) -> CGPoint) -> ConversationMessageActionController? {
-        if
+    /// For stack cells get the cell description of the arranged subview.
+    /// If no view matches, the top level cell description is returned.
+    private func nestedCellDescription(using locationInCell: (UIView?) -> CGPoint) -> AnyConversationMessageCellDescription? {
+        guard
             let cellView = cellView as? ConversationStackMessageContentView,
-            let cellDescription = cellDescription as? StackViewCellDescription {
-            for (index, cell) in cellView.conversationMessageCells.enumerated() {
-                let location = locationInCell(cell)
-                if cell.bounds.contains(location) {
-                    let stackedCellDescription = cellDescription.cellDescriptions[index]
-                    if stackedCellDescription.supportsActions {
-                        return stackedCellDescription.actionController
-                    }
-                }
+            let cellDescription = cellDescription as? StackViewCellDescription
+        else { return nil }
+
+        for (index, cell) in cellView.conversationMessageCells.enumerated() {
+            let location = locationInCell(cell)
+            if cell.bounds.contains(location) {
+                return cellDescription.cellDescriptions[index]
             }
         }
+
         return nil
     }
 
@@ -235,8 +240,8 @@ final class ConversationMessageCellTableViewAdapter<
 
         // We fail the single tap gesture recognizer if there's no single tap action to perform, which gives
         // other gesture recognizers the opportunity to fire.
-        if let actionController = actionController(for: gestureRecognizer.location(in:)) {
-            return actionController.singleTapAction != nil
+        if let cellDescription = nestedCellDescription(using: gestureRecognizer.location(in:)) {
+            return cellDescription.supportsActions && cellDescription.actionController?.singleTapAction != nil
         } else {
             return cellDescription?.actionController?.singleTapAction != nil
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -188,7 +188,9 @@ final class ConversationMessageCellTableViewAdapter<
 
     /// For stack cells get the cell description of the arranged subview.
     /// If no view matches, the top level cell description is returned.
-    private func nestedCellDescription(using locationInCell: (UIView?) -> CGPoint) -> AnyConversationMessageCellDescription? {
+    private func nestedCellDescription(
+        using locationInCell: (UIView?) -> CGPoint
+    ) -> AnyConversationMessageCellDescription? {
         guard
             let cellView = cellView as? ConversationStackMessageContentView,
             let cellDescription = cellDescription as? StackViewCellDescription

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -162,19 +162,8 @@ final class ConversationMessageCellTableViewAdapter<
     private func onSingleTap(_ gestureRecognizer: UITapGestureRecognizer) {
         guard gestureRecognizer.state == .recognized else { return }
 
-        if
-            let cellView = cellView as? ConversationStackMessageContentView,
-            let cellDescription = cellDescription as? StackViewCellDescription {
-            for (index, cell) in cellView.conversationMessageCells.enumerated() {
-                let location = gestureRecognizer.location(in: cell)
-                if cell.bounds.contains(location) {
-                    let stackedCellDescription = cellDescription.cellDescriptions[index]
-                    if stackedCellDescription.supportsActions {
-                        stackedCellDescription.actionController?.performSingleTapAction()
-                    }
-                }
-            }
-
+        if let actionController = actionController(for: gestureRecognizer.location(in:)) {
+            actionController.performSingleTapAction()
         } else if cellDescription?.supportsActions == true {
             cellDescription?.actionController?.performSingleTapAction()
         }
@@ -186,22 +175,28 @@ final class ConversationMessageCellTableViewAdapter<
     private func onDoubleTap(_ gestureRecognizer: UITapGestureRecognizer) {
         guard gestureRecognizer.state == .recognized else { return }
 
+        if let actionController = actionController(for: gestureRecognizer.location(in:)) {
+            actionController.performDoubleTapAction()
+        } else if cellDescription?.supportsActions == true {
+            cellDescription?.actionController?.performDoubleTapAction()
+        }
+    }
+
+    private func actionController(for locationInCell: (UIView?) -> CGPoint) -> ConversationMessageActionController? {
         if
             let cellView = cellView as? ConversationStackMessageContentView,
             let cellDescription = cellDescription as? StackViewCellDescription {
             for (index, cell) in cellView.conversationMessageCells.enumerated() {
-                let location = gestureRecognizer.location(in: cell)
+                let location = locationInCell(cell)
                 if cell.bounds.contains(location) {
                     let stackedCellDescription = cellDescription.cellDescriptions[index]
                     if stackedCellDescription.supportsActions {
-                        stackedCellDescription.actionController?.performDoubleTapAction()
+                        return stackedCellDescription.actionController
                     }
                 }
             }
-
-        } else if cellDescription?.supportsActions == true {
-            cellDescription?.actionController?.performDoubleTapAction()
         }
+        return nil
     }
 
     // MARK: - SelectableView
@@ -240,7 +235,11 @@ final class ConversationMessageCellTableViewAdapter<
 
         // We fail the single tap gesture recognizer if there's no single tap action to perform, which gives
         // other gesture recognizers the opportunity to fire.
-        return cellDescription?.actionController?.singleTapAction != nil
+        if let actionController = actionController(for: gestureRecognizer.location(in:)) {
+            return actionController.singleTapAction != nil
+        } else {
+            return cellDescription?.actionController?.singleTapAction != nil
+        }
     }
 
     override func prepareForReuse() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16361" title="WPB-16361" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16361</a>  [iOS] Reactions are presented vertically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes tapping on reactions.

When using a stack view cell, we first need to get the correct cell description for handling gesture events.

### Testing

Add and remove message reactions.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
