### PR TITLE
fix: Doesn't display "email already in use" error alert - WPB-15936

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
@@ -75,7 +75,7 @@ package struct DetermineAuthMethodUseCase: DetermineAuthMethodUseCaseProtocol {
         }
 
         switch configuration.domainRedirect {
-        case .none where configuration.isCloudAccountAlreadyRegistered == true:
+        case .noRegistration where configuration.isCloudAccountAlreadyRegistered == true:
             // The email domain has been claimed by an on-prem backend,
             // but there's already an existing cloud account registered.
             return .loginViaEmail(email: email, didDetectDomainConflict: true)

--- a/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
@@ -98,7 +98,7 @@ final class DetermineAuthMethodUseCaseTests: XCTestCase {
         let testCases: [(config: DomainRegistrationConfiguration, expected: AuthenticationMethod)] = [
             (config: .make(domainRedirect: .none), expected: .loginOrRegisterViaEmail(email: email)),
             (
-                config: .make(domainRedirect: .none, isCloudAccountAlreadyRegistered: true),
+                config: .make(domainRedirect: .noRegistration, isCloudAccountAlreadyRegistered: true),
                 expected: .loginViaEmail(email: email, didDetectDomainConflict: true)
             ),
             (config: .make(domainRedirect: .locked), expected: .loginOrRegisterViaEmail(email: email)),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15936" title="WPB-15936" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15936</a>  [iOS] Path 3b: Implement "email already in use" error alert
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Use case:**
If a cloud user with the email exists and if
The domain is configured to redirect to another backend
Or if the domain is configured to SSO, but the user does not belong to the team that owns the domain
Doesn't display "email already in use" error alert.

### Solution

The [tech spec](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1587150890/Use+case+Initiate+login+or+registration) was changed, the requirements to display the alert is
`domain_redirect=no-registration` and `due_to_existing_account=true`

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
