### PR TITLE
fix: commit pending proposals - WPB-16557

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Decryption/MLSMessageDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/MLSMessageDecryptor.swift
@@ -73,7 +73,7 @@ struct MLSMessageDecryptor: MLSMessageDecryptorProtocol {
     func commitPendingProposalsIfNeeded() async {
         await mlsService.commitPendingProposalsIfNeeded()
     }
-    
+
     private func decryptMLSMessage(
         message: String,
         mlsGroupID: MLSGroupID,

--- a/WireDomain/Sources/WireDomain/Event Decryption/MLSMessageDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/MLSMessageDecryptor.swift
@@ -70,6 +70,10 @@ struct MLSMessageDecryptor: MLSMessageDecryptorProtocol {
         return decryptedEvent
     }
 
+    func commitPendingProposalsIfNeeded() async {
+        await mlsService.commitPendingProposalsIfNeeded()
+    }
+    
     private func decryptMLSMessage(
         message: String,
         mlsGroupID: MLSGroupID,
@@ -115,9 +119,9 @@ struct MLSMessageDecryptor: MLSMessageDecryptorProtocol {
                 )
 
             case let .proposal(commitDelay):
-                await conversationLocalStore.commitPendingProposals(
-                    conversation: mlsConversation,
+                await conversationLocalStore.updateCommitPendingProposal(
                     date: date ?? .now,
+                    for: mlsConversation,
                     commitDelay: commitDelay
                 )
             }

--- a/WireDomain/Sources/WireDomain/Event Decryption/Protocols/MLSMessageDecryptorProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/Protocols/MLSMessageDecryptorProtocol.swift
@@ -31,4 +31,5 @@ protocol MLSMessageDecryptorProtocol {
         from eventData: ConversationMLSMessageAddEvent
     ) async throws -> ConversationMLSMessageAddEvent
 
+    func commitPendingProposalsIfNeeded() async
 }

--- a/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
@@ -123,9 +123,11 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
         }
 
         Task.detached {
+            // we don't need to wait for this, as it can take a while to finish
+            // it should not block decryption
             await mlsMessageDecryptor.commitPendingProposalsIfNeeded()
         }
-        
+
         return decryptedEvents
     }
 

--- a/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
@@ -122,6 +122,10 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
             }
         }
 
+        Task.detached {
+            await mlsMessageDecryptor.commitPendingProposalsIfNeeded()
+        }
+        
         return decryptedEvents
     }
 

--- a/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
@@ -69,6 +69,7 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
         ]
 
         var decryptedEvents = [UpdateEvent]()
+        var shouldCommitPendingProposals = false
 
         for event in eventEnvelope.events {
             switch event {
@@ -105,6 +106,8 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
                     attributes: logAttributes
                 )
 
+                shouldCommitPendingProposals = true
+
                 do {
                     let decryptedEventData = try await mlsMessageDecryptor.decryptedEventData(from: eventData)
                     decryptedEvents.append(.conversation(.mlsMessageAdd(decryptedEventData)))
@@ -122,10 +125,12 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
             }
         }
 
-        Task.detached {
-            // we don't need to wait for this, as it can take a while to finish
-            // it should not block decryption
-            await mlsMessageDecryptor.commitPendingProposalsIfNeeded()
+        if shouldCommitPendingProposals {
+            Task.detached {
+                // we don't need to wait for this, as it can take a while to finish
+                // it should not block decryption
+                await mlsMessageDecryptor.commitPendingProposalsIfNeeded()
+            }
         }
 
         return decryptedEvents

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -498,9 +498,9 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         }
     }
 
-    public func commitPendingProposals(
-        conversation: ZMConversation,
+    public func updateCommitPendingProposal(
         date: Date,
+        for conversation: ZMConversation,
         commitDelay: UInt64
     ) async {
         let scheduledDate = date + TimeInterval(commitDelay)
@@ -508,8 +508,6 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         await context.perform {
             conversation.commitPendingProposalDate = scheduledDate
         }
-
-        await mlsService.commitPendingProposalsIfNeeded()
     }
 
     public func updateSecurityLevelAfterReceivingMessage(

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -284,13 +284,13 @@ public protocol ConversationLocalStoreProtocol {
     ) async -> (mlsGroupID: MLSGroupID, isMLSReady: Bool)?
 
     /// Commits pending proposals for a given conversation.
-    /// - Parameter conversation: The conversation to update the `date` flag for.
     /// - Parameter date: The date to update.
+    /// - Parameter conversation: The conversation to update the `date` flag for.
     /// - Parameter commitDelay: The commit delay.
 
-    func commitPendingProposals(
-        conversation: ZMConversation,
+    func updateCommitPendingProposal(
         date: Date,
+        for conversation: ZMConversation,
         commitDelay: UInt64
     ) async
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -675,19 +675,19 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
         }
     }
 
-    // MARK: - commitPendingProposals
+    // MARK: - updateCommitPendingProposal
 
-    public var commitPendingProposalsConversationDateCommitDelay_Invocations: [(conversation: ZMConversation, date: Date, commitDelay: UInt64)] = []
-    public var commitPendingProposalsConversationDateCommitDelay_MockMethod: ((ZMConversation, Date, UInt64) async -> Void)?
+    public var updateCommitPendingProposalDateForCommitDelay_Invocations: [(date: Date, conversation: ZMConversation, commitDelay: UInt64)] = []
+    public var updateCommitPendingProposalDateForCommitDelay_MockMethod: ((Date, ZMConversation, UInt64) async -> Void)?
 
-    public func commitPendingProposals(conversation: ZMConversation, date: Date, commitDelay: UInt64) async {
-        commitPendingProposalsConversationDateCommitDelay_Invocations.append((conversation: conversation, date: date, commitDelay: commitDelay))
+    public func updateCommitPendingProposal(date: Date, for conversation: ZMConversation, commitDelay: UInt64) async {
+        updateCommitPendingProposalDateForCommitDelay_Invocations.append((date: date, conversation: conversation, commitDelay: commitDelay))
 
-        guard let mock = commitPendingProposalsConversationDateCommitDelay_MockMethod else {
-            fatalError("no mock for `commitPendingProposalsConversationDateCommitDelay`")
+        guard let mock = updateCommitPendingProposalDateForCommitDelay_MockMethod else {
+            fatalError("no mock for `updateCommitPendingProposalDateForCommitDelay`")
         }
 
-        await mock(conversation, date, commitDelay)
+        await mock(date, conversation, commitDelay)
     }
 
     // MARK: - updateSecurityLevelAfterReceivingMessage
@@ -1328,6 +1328,21 @@ class MockMLSMessageDecryptorProtocol: MLSMessageDecryptorProtocol {
         } else {
             fatalError("no mock for `decryptedEventDataFrom`")
         }
+    }
+
+    // MARK: - commitPendingProposalsIfNeeded
+
+    var commitPendingProposalsIfNeeded_Invocations: [Void] = []
+    var commitPendingProposalsIfNeeded_MockMethod: (() async -> Void)?
+
+    func commitPendingProposalsIfNeeded() async {
+        commitPendingProposalsIfNeeded_Invocations.append(())
+
+        guard let mock = commitPendingProposalsIfNeeded_MockMethod else {
+            fatalError("no mock for `commitPendingProposalsIfNeeded`")
+        }
+
+        await mock()
     }
 
 }

--- a/WireDomain/Tests/WireDomainTests/Event Decryption/UpdateEventDecryptorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Decryption/UpdateEventDecryptorTests.swift
@@ -52,6 +52,7 @@ final class UpdateEventDecryptorTests: XCTestCase {
             mlsMessageDecryptor: mlsMessageDecryptor,
             messageRepository: messageRepository
         )
+        mlsMessageDecryptor.commitPendingProposalsIfNeeded_MockMethod = {}
     }
 
     override func tearDown() async throws {
@@ -165,6 +166,37 @@ final class UpdateEventDecryptorTests: XCTestCase {
         }
     }
 
+    func testWhenDecryptionOfMLSMessagesIsSuccessfulThenEventsAreReturned() async throws {
+        // Given some events.
+        let envelope = UpdateEventEnvelope(
+            id: UUID(),
+            events: [
+                .conversation(.mlsMessageAdd(Scaffolding.mlsMessage)),
+                .user(.pushRemove)
+            ],
+            isTransient: false
+        )
+
+        // Mock
+        mlsMessageDecryptor.decryptedEventDataFrom_MockMethod = { $0 }
+
+        // When
+        let events = try await sut.decryptEvents(in: envelope)
+
+        // Then the "decrypted" (the mock just passes them right back) are returned.
+        XCTAssertEqual(
+            events,
+            [
+                .conversation(.mlsMessageAdd(Scaffolding.mlsMessage)),
+                .user(.pushRemove)
+            ]
+        )
+
+        await Task.yield()
+
+        XCTAssertEqual(mlsMessageDecryptor.commitPendingProposalsIfNeeded_Invocations.count, 1)
+    }
+
 }
 
 private enum Scaffolding {
@@ -191,4 +223,17 @@ private enum Scaffolding {
         messageRecipientClientID: selfClientID
     )
 
+    static let mlsMessage = ConversationMLSMessageAddEvent(
+        conversationID: conversationID,
+        senderID: aliceID,
+        subconversation: "",
+        message: .init(messageContent),
+        timestamp: .now,
+        decryptedMessages: [.init(
+            message: Scaffolding.base64EncodedString,
+            senderClientID: UUID.mockID1.uuidString
+        )]
+    )
+
+    static let base64EncodedString = "CiQ5ZTU2NTQwOS0xODZiLTRlN2YtYTE4NC05NzE4MGE0MDAwMDQSDAoKRXZlcnl0aGluZw=="
 }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -142,6 +142,8 @@ extension EventDecoder {
         if let mlsService = await context.perform({ context.mlsService }),
            updateEvent.source == .webSocket {
             Task.detached { [mlsService] in
+                // we don't need to wait for this, as it can take a while to finish
+                // it should not block decryption
                 await mlsService.commitPendingProposalsIfNeeded()
             }
         }

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoder+MLS.swift
@@ -141,7 +141,9 @@ extension EventDecoder {
 
         if let mlsService = await context.perform({ context.mlsService }),
            updateEvent.source == .webSocket {
-            await mlsService.commitPendingProposalsIfNeeded()
+            Task.detached { [mlsService] in
+                await mlsService.commitPendingProposalsIfNeeded()
+            }
         }
 
         return events

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1086,6 +1086,7 @@ extension ZMUserSession: SyncAgentDelegate {
 
                 if !isRecovering, mlsFeature.isEnabled {
                     Task.detached { [mlsService] in
+                        // we don't need to wait for this, as it can take a while to finish
                         await mlsService.commitPendingProposalsIfNeeded()
                     }
                 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1085,7 +1085,9 @@ extension ZMUserSession: SyncAgentDelegate {
                 }
 
                 if !isRecovering, mlsFeature.isEnabled {
-                    await mlsService.commitPendingProposalsIfNeeded()
+                    Task.detached { [mlsService] in
+                        await mlsService.commitPendingProposalsIfNeeded()
+                    }
                 }
 
                 await calculateSelfSupportedProtocolsIfNeeded()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16557" title="WPB-16557" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16557</a>  [iOS] Move commitPendingProposalsIfNeeded to detached task
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The commitPendingProposalsIfNeeded() method is executed when decrypting mls messages from websocket. If we have a pendingProposal in the future the method will wait a certain amount blocking the decryption of following messages causing wrongEpoch errors.

Wrap the commitPendingProposalsIfNeeded in a detached Task in order not to block the execution.


* This also updates the new sync code path.

### Testing

N/A

---


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
