### PR TITLE
refactor: connect WireAuthentication to existing registration flow - WPB-16279

### DIFF
--- a/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
@@ -91,9 +91,14 @@ class LoginViaEmailComponent: Component<LoginViaEmailComponentDependency> {
             passwordValidator: dependency.passwordValidator,
             canCreateAccount: canCreateAccount,
             didDetectDomainConflict: didDetectDomainConflict,
-            onCreateAccount: { [dependency] in
-                dependency?.router.dismissSheet()
-                dependency?.bridge.sendOutboundEvent(.accountRegistrationRequested(email: email))
+            onCreateAccount: { [dependency, backendEnvironment] in
+                guard let dependency else { return }
+                dependency.router.dismissSheet()
+                dependency.bridge.sendOutboundEvent(.accountRegistrationRequested(
+                        email: email,
+                        backendEnvironment
+                    )
+                )
             }
         )
     }

--- a/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
@@ -27,7 +27,6 @@ import WireReusableUIComponents
 protocol LoginViaEmailComponentDependency: Dependency {
 
     @MainActor var router: any Router { get }
-    var accountsURL: URL { get }
     var passwordValidator: any PasswordValidator { get }
     var networkService: NetworkService { get }
     var environmentType: BackendEnvironmentType { get }
@@ -87,7 +86,6 @@ class LoginViaEmailComponent: Component<LoginViaEmailComponentDependency> {
             loginViaEmailUseCase: loginViaEmailUseCase,
             backendEnvironment: backendEnvironment,
             email: email,
-            accountsURL: dependency.accountsURL,
             passwordValidator: dependency.passwordValidator,
             canCreateAccount: canCreateAccount,
             didDetectDomainConflict: didDetectDomainConflict,

--- a/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
@@ -92,7 +92,8 @@ class LoginViaEmailComponent: Component<LoginViaEmailComponentDependency> {
             onCreateAccount: { [dependency, backendEnvironment] in
                 guard let dependency else { return }
                 dependency.router.dismissSheet()
-                dependency.bridge.sendOutboundEvent(.accountRegistrationRequested(
+                dependency.bridge.sendOutboundEvent(
+                    .accountRegistrationRequested(
                         email: email,
                         backendEnvironment
                     )

--- a/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
@@ -92,6 +92,7 @@ class LoginViaEmailComponent: Component<LoginViaEmailComponentDependency> {
             canCreateAccount: canCreateAccount,
             didDetectDomainConflict: didDetectDomainConflict,
             onCreateAccount: { [dependency] in
+                dependency?.router.dismissSheet()
                 dependency?.bridge.sendOutboundEvent(.accountRegistrationRequested)
             }
         )

--- a/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/LoginViaEmailComponent.swift
@@ -93,7 +93,7 @@ class LoginViaEmailComponent: Component<LoginViaEmailComponentDependency> {
             didDetectDomainConflict: didDetectDomainConflict,
             onCreateAccount: { [dependency] in
                 dependency?.router.dismissSheet()
-                dependency?.bridge.sendOutboundEvent(.accountRegistrationRequested)
+                dependency?.bridge.sendOutboundEvent(.accountRegistrationRequested(email: email))
             }
         )
     }

--- a/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
@@ -75,7 +75,9 @@ class RootComponent: BootstrapComponent {
     }
 
     @MainActor private var viewModel: RootViewModel {
-        shared { RootViewModel() }
+        shared {
+            RootViewModel(bridge: bridge)
+        }
     }
 
     @MainActor public var bridge: WireAuthenticationBridge {

--- a/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
@@ -30,7 +30,6 @@ class RootComponent: BootstrapComponent {
     public let preferredAPIVersion: APIVersion?
     public let productionVersions: Set<APIVersion>
     public let minTLSVersion: TLSVersion
-    public let accountsURL: URL
     public let howToChangeEmailURL: URL
     public let howToDeleteAccountURL: URL
     public let passwordValidator: any PasswordValidator
@@ -43,7 +42,6 @@ class RootComponent: BootstrapComponent {
         backendConfig: BackendConfig,
         preferredAPIVersion: APIVersion?,
         minTLSVersion: TLSVersion,
-        accountsURL: URL,
         howToChangeEmailURL: URL,
         howToDeleteAccountURL: URL,
         passwordValidator: any PasswordValidator,
@@ -56,7 +54,6 @@ class RootComponent: BootstrapComponent {
         self.preferredAPIVersion = preferredAPIVersion
         self.productionVersions = APIVersion.productionVersions
         self.minTLSVersion = minTLSVersion
-        self.accountsURL = accountsURL
         self.howToChangeEmailURL = howToChangeEmailURL
         self.howToDeleteAccountURL = howToDeleteAccountURL
         self.passwordValidator = passwordValidator

--- a/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
@@ -192,9 +192,6 @@ private class LoginViaEmailComponentDependency6f812ea9ca4f0322dd27Provider: Logi
     var router: any Router {
         return rootComponent.router
     }
-    var accountsURL: URL {
-        return rootComponent.accountsURL
-    }
     var passwordValidator: any PasswordValidator {
         return rootComponent.passwordValidator
     }
@@ -279,7 +276,6 @@ extension RootComponent: NeedleFoundation.Registration {
         localTable["preferredAPIVersion-APIVersion?"] = { [unowned self] in self.preferredAPIVersion as Any }
         localTable["productionVersions-Set<APIVersion>"] = { [unowned self] in self.productionVersions as Any }
         localTable["minTLSVersion-TLSVersion"] = { [unowned self] in self.minTLSVersion as Any }
-        localTable["accountsURL-URL"] = { [unowned self] in self.accountsURL as Any }
         localTable["howToChangeEmailURL-URL"] = { [unowned self] in self.howToChangeEmailURL as Any }
         localTable["howToDeleteAccountURL-URL"] = { [unowned self] in self.howToDeleteAccountURL as Any }
         localTable["passwordValidator-any PasswordValidator"] = { [unowned self] in self.passwordValidator as Any }
@@ -300,7 +296,6 @@ extension NoHistoryComponent: NeedleFoundation.Registration {
 extension LoginViaEmailComponent: NeedleFoundation.Registration {
     public func registerItems() {
         keyPathToName[\LoginViaEmailComponentDependency.router] = "router-any Router"
-        keyPathToName[\LoginViaEmailComponentDependency.accountsURL] = "accountsURL-URL"
         keyPathToName[\LoginViaEmailComponentDependency.passwordValidator] = "passwordValidator-any PasswordValidator"
         keyPathToName[\LoginViaEmailComponentDependency.networkService] = "networkService-NetworkService"
         keyPathToName[\LoginViaEmailComponentDependency.environmentType] = "environmentType-BackendEnvironmentType"

--- a/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
+++ b/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
@@ -59,7 +59,6 @@ public struct WireAuthenticationAssembly {
             backendConfig: backendConfig,
             preferredAPIVersion: preferredAPIVersion,
             minTLSVersion: minTLSVersion,
-            accountsURL: accountsURL,
             howToChangeEmailURL: howToChangeEmailURL,
             howToDeleteAccountURL: howToDeleteAccountURL,
             passwordValidator: passwordValidator,

--- a/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
+++ b/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
@@ -26,6 +26,7 @@ internal import WireAuthenticationUI
 internal import WireAuthenticationLogic
 
 public typealias WireAuthenticationBridge = WireAuthenticationAPI.WireAuthenticationBridge
+public typealias WireAuthenticationBackendEnvironment = WireAuthenticationAPI.WireAuthenticationBackendEnvironment
 public typealias BackendEnvironmentType = WireAuthenticationAPI.BackendEnvironmentType
 public typealias BackendConfig = WireAuthenticationAPI.BackendConfig
 public typealias Endpoints = WireAuthenticationAPI.Endpoints

--- a/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
@@ -61,6 +61,7 @@ public final class WireAuthenticationBridge {
 
     public enum InboundEvent {
 
+        case didRewindToThisView
         case ssoAuthenticationSuccess(userID: UUID, cookies: [HTTPCookie])
         case ssoAutheticationFailure
 

--- a/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
@@ -52,7 +52,7 @@ public final class WireAuthenticationBridge {
     public enum OutboundEvent {
 
         case userAuthenticated(AuthenticationResult)
-        case accountRegistrationRequested(email: String)
+        case accountRegistrationRequested(email: String, WireAuthenticationBackendEnvironment)
 
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
@@ -52,7 +52,7 @@ public final class WireAuthenticationBridge {
     public enum OutboundEvent {
 
         case userAuthenticated(AuthenticationResult)
-        case accountRegistrationRequested
+        case accountRegistrationRequested(email: String)
 
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Mocks/MockDependencies.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Mocks/MockDependencies.swift
@@ -24,7 +24,7 @@ import WireReusableUIComponents
 final class MockDependencies {
 
     private var rootViewModel: RootViewModel {
-        RootViewModel()
+        RootViewModel(bridge: WireAuthenticationBridge())
     }
 
     var environmentType: BackendEnvironmentType {

--- a/WireAuthentication/Sources/WireAuthenticationUI/Mocks/MockDependencies.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Mocks/MockDependencies.swift
@@ -257,7 +257,6 @@ extension MockDependencies: LoginViaEmailBuilder {
             loginViaEmailUseCase: self,
             backendEnvironment: backendEnvironment,
             email: email,
-            accountsURL: URL(string: "https://example.com")!,
             passwordValidator: MockPasswordValidator(validationCallback: { _ in true }),
             canCreateAccount: canCreateAccount,
             didDetectDomainConflict: false,

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailViewModel.swift
@@ -51,7 +51,6 @@ package final class LoginViaEmailViewModel: ObservableObject {
         loginViaEmailUseCase: any LoginViaEmailUseCaseProtocol,
         backendEnvironment: WireAuthenticationBackendEnvironment,
         email: String,
-        accountsURL: URL,
         passwordValidator: any PasswordValidator,
         canCreateAccount: Bool,
         didDetectDomainConflict: Bool,
@@ -61,7 +60,7 @@ package final class LoginViaEmailViewModel: ObservableObject {
         self.loginViaEmailUseCase = loginViaEmailUseCase
         self.backendEnvironment = backendEnvironment
         self.email = email
-        self.forgotPasswordURL = accountsURL.appendingPathComponent("forgot")
+        self.forgotPasswordURL = backendEnvironment.config.endpoints.accountsURL.appendingPathComponent("forgot")
         self.passwordValidator = passwordValidator
         self.canCreateAccount = canCreateAccount
         self.didDetectDomainConflict = didDetectDomainConflict

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaSSO/LoginViaSSOViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaSSO/LoginViaSSOViewModel.swift
@@ -60,6 +60,8 @@ package final class LoginViaSSOViewModel: ObservableObject {
                 )
             case .ssoAutheticationFailure:
                 router.presentAlert(RootViewModel.Alert.ssoLoginFailed)
+            default:
+                break
             }
         }
     }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/RootViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/RootViewModel.swift
@@ -38,7 +38,7 @@ public final class RootViewModel: ObservableObject, Router {
     private var lastModalDestination: RootView.ModalDestination?
 
     public init(bridge: WireAuthenticationBridge) {
-        cancellable = bridge.inboundEvents.sink { [weak self] event in
+        self.cancellable = bridge.inboundEvents.sink { [weak self] event in
             switch event {
             case .didRewindToThisView:
                 self?.restoreSheet()

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/RootViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/RootViewModel.swift
@@ -34,7 +34,19 @@ public final class RootViewModel: ObservableObject, Router {
     @Published var modalDestination: RootView.ModalDestination? = .authFlow
     @Published var alert: Alert?
 
-    public init() {}
+    private var cancellable: AnyCancellable?
+    private var lastModalDestination: RootView.ModalDestination?
+
+    public init(bridge: WireAuthenticationBridge) {
+        cancellable = bridge.inboundEvents.sink { [weak self] event in
+            switch event {
+            case .didRewindToThisView:
+                self?.restoreSheet()
+            default:
+                break
+            }
+        }
+    }
 
     public func popToRoot() {
         path.removeLast(path.count)
@@ -50,6 +62,18 @@ public final class RootViewModel: ObservableObject, Router {
 
     public func presentAlert(_ alert: RootViewModel.Alert) {
         self.alert = alert
+    }
+
+    public func dismissSheet() {
+        lastModalDestination = modalDestination
+        modalDestination = nil
+    }
+
+    private func restoreSheet() {
+        if let lastModalDestination, modalDestination == nil {
+            modalDestination = lastModalDestination
+            self.lastModalDestination = nil
+        }
     }
 
 }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/Router.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/Router.swift
@@ -29,6 +29,8 @@ public protocol Router {
 
     func presentSheet<ModalDestination: Hashable>(_ modalDestination: ModalDestination)
 
+    func dismissSheet()
+
     func presentAlert(_ alert: RootViewModel.Alert)
 
 }

--- a/WireAuthentication/Tests/WireAuthenticationUITests/LoginViaEmail/LoginViaEmailViewModelTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/LoginViaEmail/LoginViaEmailViewModelTests.swift
@@ -49,7 +49,6 @@ class LoginViaEmailViewModelTests: XCTestCase {
             loginViaEmailUseCase: loginViaEmailUseCase,
             backendEnvironment: Fixture.backendEnvironment,
             email: "mika@example.com",
-            accountsURL: URL(string: "https://www.example.com")!,
             passwordValidator: passwordValidator,
             canCreateAccount: true,
             didDetectDomainConflict: false,

--- a/WireAuthentication/Tests/WireAuthenticationUITests/Mocks/MockRouter.swift
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/Mocks/MockRouter.swift
@@ -23,6 +23,7 @@ final class MockRouter: Router {
     public var navigate_Invocations: [any Hashable] = []
     public var modalPresent_Invocations: [any Hashable] = []
     public var alert_Invocations: [RootViewModel.Alert] = []
+    public var dismissSheet_InvocationCount = 0
 
     func popToRoot() {}
 
@@ -36,6 +37,10 @@ final class MockRouter: Router {
 
     func presentAlert(_ alert: RootViewModel.Alert) {
         alert_Invocations.append(alert)
+    }
+
+    func dismissSheet() {
+        dismissSheet_InvocationCount += 1
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -79,7 +79,9 @@ final class AuthenticationInterfaceBuilder {
                 environmentType: BackendEnvironmentType(environment.environmentType.value),
                 backendConfig: BackendConfig(environment),
                 minTLSVersion: TLSVersion.minVersionFrom(SecurityFlags.minTLSVersion.stringValue),
-                preferredAPIVersion: .v8,
+                preferredAPIVersion: BackendInfo.preferredAPIVersion.flatMap {
+                    WireAPI.APIVersion(rawValue: UInt($0.rawValue))
+                },
                 accountsURL: environment.accountsURL,
                 howToChangeEmailURL: WireURLs.shared.howToChangeEmail,
                 howToDeleteAccountURL: WireURLs.shared.howToDeleteAccount,

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -128,8 +128,16 @@ final class AuthenticationInterfaceBuilder {
         case let .provideCredentials(prefill):
             return makeCredentialsViewController(for: .login(prefill))
 
-        case .createCredentials:
-            return makeCredentialsViewController(for: .registration)
+        case let .createCredentials(user):
+            let prefilledCredentials = AuthenticationPrefilledCredentials(
+                credentials: LoginCredentials(
+                    emailAddress: user.unverifiedEmail,
+                    hasPassword: false,
+                    usesCompanyLogin: false
+                ),
+                isExpired: false
+            )
+            return makeCredentialsViewController(for: .registration(prefilledCredentials))
 
         case .clientManagement:
             let manageClientsInvitation = ClientUnregisterInvitationStepDescription()

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+LandingScreen.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+LandingScreen.swift
@@ -48,6 +48,19 @@ extension AuthenticationCoordinator: LandingViewControllerDelegate {
         stateController.transition(to: .createCredentials(unregisteredUser))
     }
 
+    func wireAuthenticationDidRequestAccountRegistration(email: String) {
+        typealias Alert = L10n.Localizable.Landing.Alert.CreateNewAccount.NotSupported
+
+        guard !shouldShowProxyWarning else {
+            showProxyAlert(title: Alert.title, message: Alert.message)
+            return
+        }
+
+        let unregisteredUser = makeUnregisteredUser()
+        unregisteredUser.unverifiedEmail = email
+        stateController.transition(to: .createCredentials(unregisteredUser))
+    }
+
     func landingViewControllerDidChooseEnterpriseLogin() {
         typealias Alert = L10n.Localizable.Landing.Alert.Sso.NotSupported
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+LandingScreen.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+LandingScreen.swift
@@ -17,7 +17,9 @@
 //
 
 import UIKit
+import WireAuthentication
 import WireCommonComponents
+import WireSyncEngine
 import WireTransport
 
 extension AuthenticationCoordinator: LandingViewControllerDelegate {
@@ -48,13 +50,31 @@ extension AuthenticationCoordinator: LandingViewControllerDelegate {
         stateController.transition(to: .createCredentials(unregisteredUser))
     }
 
-    func wireAuthenticationDidRequestAccountRegistration(email: String) {
+    func wireAuthenticationDidRequestAccountRegistration(
+        email: String,
+        backendEnvironment: WireAuthenticationBackendEnvironment
+    ) {
         typealias Alert = L10n.Localizable.Landing.Alert.CreateNewAccount.NotSupported
 
         guard !shouldShowProxyWarning else {
             showProxyAlert(title: Alert.title, message: Alert.message)
             return
         }
+
+        // Make sure we use the same backend from the WireAuthentication.
+        let backendMetadata = backendEnvironment.metadata
+        let backendEnvironment = BackendEnvironment(
+            type: backendEnvironment.environmentType,
+            backendConfig: backendEnvironment.config
+        )
+
+        BackendEnvironment.shared = backendEnvironment
+        SessionManager.shared?.switchBackendWithoutResolving(to: backendEnvironment)
+
+        // Make sure we persist and backend info gathered from WireAuthentication.
+        BackendInfo.apiVersion = APIVersion(backendMetadata.apiVersion)
+        BackendInfo.domain = backendMetadata.domain
+        BackendInfo.isFederationEnabled = backendMetadata.isFederationEnabled
 
         let unregisteredUser = makeUnregisteredUser()
         unregisteredUser.unverifiedEmail = email

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+Navigation.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/Coordinator+Delegates/AuthenticationCoordinator+Navigation.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import WireAuthentication
 
 extension AuthenticationCoordinator: UINavigationControllerDelegate {
 
@@ -57,6 +58,7 @@ extension AuthenticationCoordinator: UINavigationControllerDelegate {
         }
 
         self.currentViewController = authenticationViewController
+        self.currentViewController?.didRewindToThisView()
         stateController.unwindState()
     }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Delegates/AuthenticationCoordinatedViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Delegates/AuthenticationCoordinatedViewController.swift
@@ -41,4 +41,6 @@ protocol AuthenticationCoordinatedViewController: AnyObject {
     ///
     /// - Parameter error: The error to present to the user.
     func displayError(_ error: Error)
+
+    func didRewindToThisView()
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -37,7 +37,7 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
     /// Types of flow provided by the view controller.
     enum FlowType {
         case login(AuthenticationPrefilledCredentials?)
-        case registration
+        case registration(AuthenticationPrefilledCredentials?)
         case reauthentication(AuthenticationPrefilledCredentials?)
     }
 
@@ -103,9 +103,10 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
             self.init(description: description, contentCenterConstraintActivation: false)
             self.prefilledCredentials = credentials
             self.shouldUseScrollView = true
-        case .registration:
+        case let .registration(credentials):
             let description = PersonalRegistrationStepDescription()
             self.init(description: description, contentCenterConstraintActivation: true)
+            self.prefilledCredentials = credentials
             self.shouldUseScrollView = false
         }
 
@@ -393,7 +394,11 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
 
     private func updatePrefilledCredentials() {
         guard let prefilledCredentials else { return }
-        emailPasswordInputField.prefill(email: prefilledCredentials.credentials.emailAddress)
+        if isRegistering, let email = prefilledCredentials.credentials.emailAddress, !email.isEmpty {
+            emailInputField.text = email
+        } else {
+            emailPasswordInputField.prefill(email: prefilledCredentials.credentials.emailAddress)
+        }
     }
 
     override func clearInputFields() {
@@ -430,6 +435,19 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
 
         valueSubmitted(emailInputField.input)
         return true
+    }
+
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        guard
+            textField == emailInputField,
+            isRegistering,
+            let prefilledCredentials,
+            prefilledCredentials.credentials.emailAddress != nil
+        else {
+            return true
+        }
+
+        return false
     }
 
     // MARK: - Email / Password Input

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
@@ -47,9 +47,9 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
                     ofType: .wireAuthenticationModuleComplete(authenticationResult)
                 )
 
-            case .accountRegistrationRequested:
-                authenticationCoordinator?.landingViewControllerDidChooseCreateAccount()
-                break
+            case let .accountRegistrationRequested(email):
+                // TODO: maybe need to switch backend environment
+                authenticationCoordinator?.wireAuthenticationDidRequestAccountRegistration(email: email)
             }
         }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
@@ -46,10 +46,14 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
                 authenticationCoordinator?.eventResponderChain.handleEvent(
                     ofType: .wireAuthenticationModuleComplete(authenticationResult)
                 )
-
-            case let .accountRegistrationRequested(email):
-                // TODO: maybe need to switch backend environment
-                authenticationCoordinator?.wireAuthenticationDidRequestAccountRegistration(email: email)
+            case let .accountRegistrationRequested(
+                email,
+                backendEnvironment
+            ):
+                authenticationCoordinator?.wireAuthenticationDidRequestAccountRegistration(
+                    email: email,
+                    backendEnvironment: backendEnvironment
+                )
             }
         }
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
@@ -28,6 +28,7 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
     AuthenticationCoordinatedViewController {
 
     var authenticationCoordinator: AuthenticationCoordinator?
+    private let bridge: WireAuthenticationBridge
     private var cancellable: AnyCancellable?
 
     init(
@@ -36,6 +37,7 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
         authenticationCoordinator: AuthenticationCoordinator?
     ) {
         self.authenticationCoordinator = authenticationCoordinator
+        self.bridge = bridge
         super.init(rootView: rootView)
 
         self.cancellable = bridge.outboundEvents.sink { event in
@@ -46,7 +48,7 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
                 )
 
             case .accountRegistrationRequested:
-                // TODO: [WPB-16279] Navigate to the account registration flow
+                authenticationCoordinator?.landingViewControllerDidChooseCreateAccount()
                 break
             }
         }
@@ -72,6 +74,10 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
 
     func displayError(_ error: any Error) {
         // no op
+    }
+
+    func didRewindToThisView() {
+        bridge.sendInboundEvent(.didRewindToThisView)
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationStepController.swift
@@ -424,6 +424,10 @@ extension AuthenticationStepController {
         }
     }
 
+    func didRewindToThisView() {
+        // no-op
+    }
+
     func valueSubmitted(_ value: Any) {
         dismissKeyboard()
         authenticationCoordinator?.handleUserInput(value)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/RemoveClientStepViewController.swift
@@ -123,6 +123,10 @@ final class RemoveClientStepViewController: UIViewController, AuthenticationCoor
     func displayError(_ error: Error) {
         // no-op
     }
+
+    func didRewindToThisView() {
+        // no-op
+    }
 }
 
 // MARK: - ClientListViewControllerDelegate

--- a/wire-ios/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
@@ -565,4 +565,8 @@ final class LandingViewController: AuthenticationStepViewController {
     func displayError(_ error: Error) {
         // no-op
     }
+
+    func didRewindToThisView() {
+        // no-op
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/PreBackendSwitchViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Company Login/PreBackendSwitchViewController.swift
@@ -127,4 +127,8 @@ final class PreBackendSwitchViewController: AuthenticationStepViewController {
     func displayError(_ error: Error) {
         // NO OP
     }
+
+    func didRewindToThisView() {
+        // no-op
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/KeyboardAvoiding/KeyboardAvoidingAuthenticationCoordinatedViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/CustomAppLock/Setup/KeyboardAvoiding/KeyboardAvoidingAuthenticationCoordinatedViewController.swift
@@ -38,6 +38,10 @@ final class KeyboardAvoidingAuthenticationCoordinatedViewController: KeyboardAvo
         childAuthenticationCoordinatedViewController?.displayError(error)
     }
 
+    func didRewindToThisView() {
+        // no-op
+    }
+
     private var childAuthenticationCoordinatedViewController: AuthenticationCoordinatedViewController? {
         viewController as? AuthenticationCoordinatedViewController
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/SuccessfulCertificateEnrollmentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/E2EIdentity/SuccessfulCertificateEnrollmentViewController.swift
@@ -217,6 +217,10 @@ final class SuccessfulCertificateEnrollmentViewController: AuthenticationStepVie
     func executeErrorFeedbackAction(_ feedbackAction: AuthenticationErrorFeedbackAction) {}
 
     func displayError(_ error: Error) {}
+
+    func didRewindToThisView() {
+        // no-op
+    }
 }
 
 // MARK: - Previews


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16279" title="WPB-16279" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16279</a>  [iOS] Path1,2: Integrate account registration into legacy code
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
This PR connects the "create a personal account" button on the new login screen in WireAuthentication with the existing account registration flow. Changes include:

- pass email and backend environment over bridge when account registration is requested
- transition to `createCredentials` step in the legacy authentication flow

### Testing
1. enable `useWireAuthentication` feature flag
2. on "enter email or sso" screen enter in a random email address and tap next
3. on "login via email" screen, tap "create a personal account button
4. continue the registration flow to create an account
5. assert that the account is created as expected, after restart the account is still there, etc.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
