### PR TITLE
fix: can't exit authentication flow - WPB-16562

### DIFF
--- a/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodComponent.swift
@@ -34,6 +34,7 @@ protocol DetermineAuthMethodComponentDependency: Dependency {
     var ssoCallbackURLScheme: String { get }
     var userDefaults: UserDefaults { get }
     var appStoreURL: URL { get }
+    var existsAnotherAccount: Bool { get }
 
 }
 
@@ -43,10 +44,11 @@ class DetermineAuthMethodComponent: Component<DetermineAuthMethodComponentDepend
         DetermineAuthMethodViewModel(
             router: dependency.router,
             factory: self,
+            bridge: dependency.bridge,
             environmentType: dependency.environmentType,
             backendConfig: dependency.backendConfig,
             backendMetadata: nil,
-            bridge: dependency.bridge
+            canExitFlow: dependency.existsAnotherAccount
         )
     }
 

--- a/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodOnPremComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/DetermineAuthMethodOnPremComponent.swift
@@ -32,6 +32,7 @@ protocol DetermineAuthMethodOnPremComponentDependency: Dependency {
     var ssoCallbackURLScheme: String { get }
     var userDefaults: UserDefaults { get }
     var appStoreURL: URL { get }
+    var existsAnotherAccount: Bool { get }
 
 }
 
@@ -63,10 +64,11 @@ class DetermineAuthMethodOnPremComponent: Component<DetermineAuthMethodOnPremCom
         DetermineAuthMethodViewModel(
             router: dependency.router,
             factory: self,
+            bridge: dependency.bridge,
             environmentType: environmentType,
             backendConfig: backendConfig,
             backendMetadata: backendMetadata,
-            bridge: dependency.bridge
+            canExitFlow: dependency.existsAnotherAccount
         )
     }
 

--- a/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Components/RootComponent.swift
@@ -38,6 +38,7 @@ class RootComponent: BootstrapComponent {
     public let ssoCallbackURLScheme: String
     public let userDefaults: UserDefaults
     public let appStoreURL: URL
+    public let existsAnotherAccount: Bool
 
     init(
         environmentType: BackendEnvironmentType,
@@ -50,7 +51,8 @@ class RootComponent: BootstrapComponent {
         passwordValidator: any PasswordValidator,
         ssoCallbackURLScheme: String,
         userDefaults: UserDefaults,
-        appStoreURL: URL
+        appStoreURL: URL,
+        existsAnotherAccount: Bool
     ) {
         self.environmentType = environmentType
         self.backendConfig = backendConfig
@@ -64,6 +66,7 @@ class RootComponent: BootstrapComponent {
         self.ssoCallbackURLScheme = ssoCallbackURLScheme
         self.userDefaults = userDefaults
         self.appStoreURL = appStoreURL
+        self.existsAnotherAccount = existsAnotherAccount
     }
 
     // MARK: - View

--- a/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
+++ b/WireAuthentication/Sources/WireAuthentication/Needle.generated.swift
@@ -108,6 +108,9 @@ private class DetermineAuthMethodComponentDependency527e70b5dbcfcb8f2023Provider
     var appStoreURL: URL {
         return rootComponent.appStoreURL
     }
+    var existsAnotherAccount: Bool {
+        return rootComponent.existsAnotherAccount
+    }
     private let rootComponent: RootComponent
     init(rootComponent: RootComponent) {
         self.rootComponent = rootComponent
@@ -212,6 +215,9 @@ private class DetermineAuthMethodOnPremComponentDependencyb4a02ddb77e5a66140fbPr
     }
     var appStoreURL: URL {
         return rootComponent.appStoreURL
+    }
+    var existsAnotherAccount: Bool {
+        return rootComponent.existsAnotherAccount
     }
     private let rootComponent: RootComponent
     init(rootComponent: RootComponent) {
@@ -324,6 +330,7 @@ extension DetermineAuthMethodComponent: NeedleFoundation.Registration {
         keyPathToName[\DetermineAuthMethodComponentDependency.ssoCallbackURLScheme] = "ssoCallbackURLScheme-String"
         keyPathToName[\DetermineAuthMethodComponentDependency.userDefaults] = "userDefaults-UserDefaults"
         keyPathToName[\DetermineAuthMethodComponentDependency.appStoreURL] = "appStoreURL-URL"
+        keyPathToName[\DetermineAuthMethodComponentDependency.existsAnotherAccount] = "existsAnotherAccount-Bool"
         localTable["networkService-NetworkService"] = { [unowned self] in self.networkService as Any }
     }
 }
@@ -360,6 +367,7 @@ extension RootComponent: NeedleFoundation.Registration {
         localTable["ssoCallbackURLScheme-String"] = { [unowned self] in self.ssoCallbackURLScheme as Any }
         localTable["userDefaults-UserDefaults"] = { [unowned self] in self.userDefaults as Any }
         localTable["appStoreURL-URL"] = { [unowned self] in self.appStoreURL as Any }
+        localTable["existsAnotherAccount-Bool"] = { [unowned self] in self.existsAnotherAccount as Any }
         localTable["bridge-WireAuthenticationBridge"] = { [unowned self] in self.bridge as Any }
         localTable["router-any Router"] = { [unowned self] in self.router as Any }
     }
@@ -380,6 +388,7 @@ extension DetermineAuthMethodOnPremComponent: NeedleFoundation.Registration {
         keyPathToName[\DetermineAuthMethodOnPremComponentDependency.ssoCallbackURLScheme] = "ssoCallbackURLScheme-String"
         keyPathToName[\DetermineAuthMethodOnPremComponentDependency.userDefaults] = "userDefaults-UserDefaults"
         keyPathToName[\DetermineAuthMethodOnPremComponentDependency.appStoreURL] = "appStoreURL-URL"
+        keyPathToName[\DetermineAuthMethodOnPremComponentDependency.existsAnotherAccount] = "existsAnotherAccount-Bool"
         localTable["networkService-NetworkService"] = { [unowned self] in self.networkService as Any }
     }
 }

--- a/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
+++ b/WireAuthentication/Sources/WireAuthentication/WireAuthenticationAssembly.swift
@@ -51,7 +51,8 @@ public struct WireAuthenticationAssembly {
         passwordValidator: any PasswordValidator,
         ssoCallbackURLScheme: String,
         userDefaults: UserDefaults,
-        appStoreURL: URL
+        appStoreURL: URL,
+        existsAnotherAccount: Bool
     ) -> (view: some View, bridge: WireAuthenticationBridge) {
         let rootComponent = RootComponent(
             environmentType: environmentType,
@@ -64,7 +65,8 @@ public struct WireAuthenticationAssembly {
             passwordValidator: passwordValidator,
             ssoCallbackURLScheme: ssoCallbackURLScheme,
             userDefaults: userDefaults,
-            appStoreURL: appStoreURL
+            appStoreURL: appStoreURL,
+            existsAnotherAccount: existsAnotherAccount
         )
 
         return (view: rootComponent.view, bridge: rootComponent.bridge)

--- a/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
+++ b/WireAuthentication/Sources/WireAuthenticationAPI/WireAuthenticationBridge.swift
@@ -53,6 +53,7 @@ public final class WireAuthenticationBridge {
 
         case userAuthenticated(AuthenticationResult)
         case accountRegistrationRequested
+        case exitFlowRequested
 
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Mocks/MockDependencies.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Mocks/MockDependencies.swift
@@ -75,18 +75,20 @@ final class MockDependencies {
 
     func makeDetermineAuthMethodView(
         emailOrSSOCode: String,
+        canExitFlow: Bool,
         isLoading: Bool,
         alert: Alert?
     ) -> DetermineAuthMethodView {
         let viewModel = DetermineAuthMethodViewModel(
             router: rootViewModel,
             factory: self,
+            bridge: WireAuthenticationBridge(),
             environmentType: environmentType,
             backendConfig: backendConfig,
             backendMetadata: nil,
             emailOrSSOCode: emailOrSSOCode,
-            isLoading: isLoading,
-            bridge: WireAuthenticationBridge()
+            canExitFlow: canExitFlow,
+            isLoading: isLoading
         )
         viewModel.alert = alert
 
@@ -158,10 +160,11 @@ extension MockDependencies: DetermineAuthMethodBuilder {
         DetermineAuthMethodViewModel(
             router: rootViewModel,
             factory: self,
+            bridge: WireAuthenticationBridge(),
             environmentType: environmentType,
             backendConfig: backendConfig,
             backendMetadata: nil,
-            bridge: WireAuthenticationBridge()
+            canExitFlow: false
         )
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
@@ -108,6 +108,17 @@ package struct DetermineAuthMethodView: View {
                 .disabled(viewModel.isNextButtonEnabled || viewModel.isLoading)
             }.padding()
         }
+        .toolbar {
+            if viewModel.canExitFlow {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewModel.exitFlow()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+        }
         .alert(
             item: $viewModel.alert,
             title: { Text($0.title) },
@@ -225,24 +236,43 @@ extension Alert {
 @MainActor
 func makeDetermineAuthMethodViewPreview(
     emailOrSSOCode: String = "",
+    canExitFlow: Bool = false,
     isLoading: Bool = false,
     alert: Alert? = nil
 ) -> some View {
     MockDependencies().makeDetermineAuthMethodView(
         emailOrSSOCode: emailOrSSOCode,
+        canExitFlow: canExitFlow,
         isLoading: isLoading,
         alert: alert
     )
 }
 
-#Preview {
+#Preview("can't exit flow") {
     BackgroundView()
         .sheet(isPresented: .constant(true)) {
-            makeDetermineAuthMethodViewPreview(
-                emailOrSSOCode: "user@wire.com",
-                isLoading: false,
-                alert: .unknownError
-            )
+            NavigationStack {
+                makeDetermineAuthMethodViewPreview(
+                    emailOrSSOCode: "user@wire.com",
+                    canExitFlow: false,
+                    isLoading: false,
+                    alert: nil
+                )
+            }
+        }
+}
+
+#Preview("can exit flow") {
+    BackgroundView()
+        .sheet(isPresented: .constant(true)) {
+            NavigationStack {
+                makeDetermineAuthMethodViewPreview(
+                    emailOrSSOCode: "user@wire.com",
+                    canExitFlow: true,
+                    isLoading: false,
+                    alert: nil
+                )
+            }
         }
 }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodViewModel.swift
@@ -42,6 +42,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
 
     private let router: any Router
     private let factory: any Factory
+    private let bridge: WireAuthenticationBridge
     private var ssoLinkGenerator: (any SSOLinkGeneratorProtocol)?
     private let environmentType: BackendEnvironmentType
     private let backendMetadata: BackendMetadata?
@@ -52,6 +53,7 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
     @Published private(set) var isLoading = false
     @Published var alert: Alert?
     @Published var modalDestination: ModalDestination?
+    @Published var canExitFlow: Bool
 
     var isNextButtonEnabled: Bool {
         !isValidEmailOrSSOCode()
@@ -64,19 +66,22 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
     package init(
         router: any Router,
         factory: any Factory,
+        bridge: WireAuthenticationBridge,
         environmentType: BackendEnvironmentType,
         backendConfig: BackendConfig,
         backendMetadata: BackendMetadata?,
         emailOrSSOCode: String = "",
-        isLoading: Bool = false,
-        bridge: WireAuthenticationBridge
+        canExitFlow: Bool,
+        isLoading: Bool = false
     ) {
         self.router = router
         self.factory = factory
+        self.bridge = bridge
         self.environmentType = environmentType
         self.backendMetadata = backendMetadata
         self.backendConfig = backendConfig
         self.emailOrSSOCode = emailOrSSOCode
+        self.canExitFlow = canExitFlow
         self.isLoading = isLoading
 
         self.cancellable = bridge.inboundEvents.sink { event in
@@ -146,6 +151,10 @@ package final class DetermineAuthMethodViewModel: ObservableObject {
     func goToAppStore() {
         factory.openAppStoreUseCase().invoke()
         alert = nil
+    }
+
+    func exitFlow() {
+        bridge.sendOutboundEvent(.exitFlowRequested)
     }
 
     // MARK: - Private

--- a/WireAuthentication/Tests/WireAuthenticationUITests/DetermineAuthMethodViewTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/DetermineAuthMethodViewTests.swift
@@ -75,4 +75,18 @@ class DetermineAuthMethodViewTests: XCTestCase {
                 )
         }
     }
+
+    @MainActor
+    func testCanExitFlow() {
+        let screenBounds = UIScreen.main.bounds
+
+        let view = NavigationStack {
+            makeDetermineAuthMethodViewPreview(canExitFlow: true)
+        }
+        .frame(width: screenBounds.width, height: screenBounds.height)
+        .environment(\.wireTextStyleMapping, WireTextStyleMapping())
+        .tint(.primary)
+
+        snapshotHelper.verify(matching: view)
+    }
 }

--- a/WireAuthentication/Tests/WireAuthenticationUITests/Resources/ReferenceImages/DetermineAuthMethodViewTests/testCanExitFlow.1.png
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/Resources/ReferenceImages/DetermineAuthMethodViewTests/testCanExitFlow.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d07f20957898a8da3bf24432081f4fb7927ae62c4ef04e20c16f23ed049b0ad
+size 100676

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -21,6 +21,7 @@ import WireAPI
 import WireAuthentication
 import WireCommonComponents
 import WireDataModel
+import WireSyncEngine
 
 /// A type of view controller that can be managed by an authentication coordinator.
 
@@ -75,6 +76,7 @@ final class AuthenticationInterfaceBuilder {
         switch step {
         case .wireAuthenticationModule:
             let assembly = WireAuthenticationAssembly()
+            let numberOfAccounts = SessionManager.shared?.accountManager.accounts.count ?? 0
             let (rootView, bridge) = assembly.assemble(
                 environmentType: BackendEnvironmentType(environment.environmentType.value),
                 backendConfig: BackendConfig(environment),
@@ -86,7 +88,8 @@ final class AuthenticationInterfaceBuilder {
                 passwordValidator: AuthenticationPasswordValidator(),
                 ssoCallbackURLScheme: Bundle.ssoURLScheme ?? "wire-sso",
                 userDefaults: .shared(),
-                appStoreURL: WireURLs.shared.appOnItunes
+                appStoreURL: WireURLs.shared.appOnItunes,
+                existsAnotherAccount: numberOfAccounts > 0
             )
             return AuthenticationHostingController(
                 rootView: rootView,

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import SwiftUI
 import WireAuthentication
+import WireLogging
 import WireSyncEngine
 
 // A temporary bridging object to allow the new WireAuthentication flow inside
@@ -48,6 +49,17 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
             case .accountRegistrationRequested:
                 // TODO: [WPB-16279] Navigate to the account registration flow
                 break
+
+            case .exitFlowRequested:
+                guard
+                    let sessionManager = SessionManager.shared,
+                    let account = sessionManager.firstAuthenticatedAccount
+                else {
+                    WireLogger.authentication.error("WireAuthentication requested exit but no account to go back to")
+                    return
+                }
+
+                sessionManager.select(account)
             }
         }
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue
This PR fixes a bug where the user could not exit the authentication flow in the case they are adding a second account. Changes include:
- inject whether there exists another account
- use this flag to show a close button on the "enter email or sso" screen (only if there is another account)
- when the close button is tapped, send an outbound event `exitFlowRequested`
- handled the event just like in the legacy authentication flow: use select the other account via the `SessionManager`.


https://github.com/user-attachments/assets/e709286b-9504-4f7a-bfa6-081a85be4f02



### Testing
1. Enable `useWireAuthentication` feature flag
2. Log in with an account
3. Add a second account
4. Assert there is a close button, and tapping it will take you back to your logged in account.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
