### PR TITLE
fix: disable autocorrect on WireAuthentication input fields - WPB-16585

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
@@ -86,6 +86,7 @@ package struct DetermineAuthMethodView: View {
                         string: $viewModel.emailOrSSOCode
                     )
                     .autocapitalization(.none)
+                    .autocorrectionDisabled()
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
                 }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -101,6 +101,7 @@ package struct LoginViaEmailView: View {
             title: L10n.CloudUserLogin.InputEmail.title,
             string: .constant(viewModel.email)
         )
+        .autocorrectionDisabled()
         .disabled(true)
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmailOnPrem/LoginViaEmailOnPremView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmailOnPrem/LoginViaEmailOnPremView.swift
@@ -119,6 +119,7 @@ package struct LoginViaEmailOnPremView: View {
             title: L10n.CloudUserLogin.InputEmail.title,
             string: .constant(viewModel.email ?? "")
         )
+        .autocorrectionDisabled()
         .disabled(viewModel.isValidEmail)
     }
 

--- a/WireUI/Sources/WireReusableUIComponents/PasswordField/PasswordField.swift
+++ b/WireUI/Sources/WireReusableUIComponents/PasswordField/PasswordField.swift
@@ -59,11 +59,13 @@ public struct PasswordField: View {
             HStack {
                 if isPasswordVisible {
                     TextField(placeholder, text: $password)
+                        .autocorrectionDisabled()
                         .wireTextStyle(.body1)
                         .frame(height: fieldHeight)
                         .focused($isFocused)
                 } else {
                     SecureField(placeholder, text: $password)
+                        .autocorrectionDisabled()
                         .frame(height: fieldHeight)
                         .focused($isFocused)
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16585" title="WPB-16585" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16585</a>  [iOS] Autocorrect is enabled for input fields
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
The input fields in WireAuthentication flow have autocorrect enabled (by default) and it's annoying because we need to enter credentials. This PR disables autocorrect for these input fields.


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
