### PR TITLE
refactor: create simple SwitchBackendConfirmation - WPB-16256

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/SwitchBackendConfirmation.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/SwitchBackendConfirmation.swift
@@ -1,0 +1,258 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WireAuthenticationAPI
+import WireDesign
+
+struct SwitchBackendConfirmation: View {
+
+    private typealias Strings = L10n.SwitchBackendConfirmation
+
+    private struct Item {
+
+        let title: String
+        let value: String
+        let isURL: Bool
+
+    }
+
+    // MARK: - Properties
+
+    @Environment(\.dismiss) var dismiss
+    @State private var showFullDetails: Bool = false
+
+    private let items: [Item]
+    private let onConfirm: (Bool) -> Void
+
+    init(
+        backendConfig: BackendConfig,
+        onConfirm: @escaping (Bool) -> Void
+    ) {
+        var items = [
+            Item(
+                title: Strings.backendName,
+                value: backendConfig.title,
+                isURL: false
+            ),
+            Item(
+                title: Strings.backendUrl,
+                value: backendConfig.endpoints.backendURL.absoluteString,
+                isURL: true
+            ),
+            Item(
+                title: Strings.backendWsurl,
+                value: backendConfig.endpoints.backendWSURL.absoluteString,
+                isURL: true
+            ),
+            Item(
+                title: Strings.blacklistUrl,
+                value: backendConfig.endpoints.blackListURL.absoluteString,
+                isURL: true
+            ),
+            Item(
+                title: Strings.teamsUrl,
+                value: backendConfig.endpoints.teamsURL.absoluteString,
+                isURL: true
+            ),
+            Item(
+                title: Strings.accountsUrl,
+                value: backendConfig.endpoints.accountsURL.absoluteString,
+                isURL: true
+            ),
+            Item(
+                title: Strings.websiteUrl,
+                value: backendConfig.endpoints.websiteURL.absoluteString,
+                isURL: true
+            )
+        ]
+
+        if let countlyURL = backendConfig.endpoints.countlyURL {
+            items.append(
+                Item(
+                    title: Strings.countlyUrl,
+                    value: countlyURL.absoluteString,
+                    isURL: true
+                )
+            )
+        }
+
+        self.items = items
+        self.onConfirm = onConfirm
+    }
+
+    // MARK: - UI
+
+    var body: some View {
+        VStack(spacing: 20) {
+            title
+            backendDetails
+            buttons
+        }
+        .padding()
+        .interactiveDismissDisabled()
+        .background(ColorTheme.Backgrounds.surface.color)
+        .cornerRadius(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(ColorTheme.Backgrounds.surface.color, lineWidth: 1)
+        )
+        .frame(width: 350)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var title: some View {
+        Text(Strings.title)
+            .font(.textStyle(.h2))
+            .foregroundStyle(Color.primaryText)
+            .multilineTextAlignment(.center)
+            .lineLimit(nil)
+            .minimumScaleFactor(0.8)
+    }
+
+    private var backendDetails: some View {
+        Group {
+            if showFullDetails {
+                fullDetails
+                    .transition(.asymmetric(insertion: .opacity, removal: .opacity))
+            } else {
+                shortDetails
+                    .transition(.asymmetric(insertion: .opacity, removal: .opacity))
+            }
+        }
+        .animation(.default, value: showFullDetails)
+    }
+
+    private var contentHeight: CGFloat {
+        UIScreen.main.bounds.height * 0.4
+    }
+
+    private var fullDetails: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Text(Strings.message)
+                    .foregroundStyle(Color.primaryText)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                ForEach(items, id: \.title) { model in
+                    itemView(
+                        title: model.title,
+                        value: model.value,
+                        isURL: model.isURL
+                    )
+                }
+            }
+        }
+        .frame(maxHeight: contentHeight)
+    }
+
+    private var shortDetails: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Text(Strings.message)
+                    .foregroundStyle(Color.primaryText)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                ForEach(items.prefix(2), id: \.title) { model in
+                    itemView(
+                        title: model.title,
+                        value: model.value,
+                        isURL: model.isURL
+                    )
+                }
+                Button {
+                    withAnimation {
+                        showFullDetails.toggle()
+                    }
+                } label: {
+                    Text(Strings.showDetails)
+                        .font(.textStyle(.body1))
+                }
+                .wireButtonStyle(.link)
+            }
+        }
+        .frame(maxHeight: contentHeight)
+    }
+
+    private func itemView(
+        title: String,
+        value: String,
+        isURL: Bool = false
+    ) -> some View {
+        VStack {
+            Text(title)
+                .foregroundStyle(Color.secondaryText)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(value)
+                .foregroundStyle(Color.primaryText)
+                .accessibilityTextContentType(isURL ? .fileSystem : .plain)
+        }
+    }
+
+    private var buttons: some View {
+        VStack(spacing: 6) {
+            cancelButton
+            proceedButton
+        }
+    }
+
+    private var cancelButton: some View {
+        Button {
+            dismiss()
+            onConfirm(false)
+        } label: {
+            Text(Strings.cancel)
+                .font(.textStyle(.buttonBig))
+        }
+        .wireButtonStyle(.secondary)
+    }
+
+    private var proceedButton: some View {
+        Button {
+            dismiss()
+            onConfirm(true)
+        } label: {
+            Text(Strings.proceed)
+                .font(.textStyle(.buttonBig))
+        }
+        .wireButtonStyle(.primary)
+    }
+
+}
+
+// MARK: - Previews
+
+#Preview("Regular fonts") {
+    BackgroundView()
+        .overlay(
+            ZStack {
+                SwitchBackendConfirmation(
+                    backendConfig: MockDependencies()._backendConfig,
+                    onConfirm: { _ in }
+                )
+                .padding()
+            }.frame(
+                maxWidth: .infinity,
+                maxHeight: .infinity
+            )
+        )
+}

--- a/WireAuthentication/Tests/WireAuthenticationUITests/SwitchBackendConfirmationViewTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationUITests/SwitchBackendConfirmationViewTests.swift
@@ -20,11 +20,27 @@ import SwiftUI
 import WireTestingPackage
 import XCTest
 
+@testable import WireAuthenticationAPI
 @testable import WireAuthenticationUI
 
 class SwitchBackendConfirmationViewTests: XCTestCase {
 
     private var snapshotHelper: SnapshotHelper!
+
+    private let backendConfig = BackendConfig(
+        title: "Staging",
+        endpoints: Endpoints(
+            backendURL: URL(string: "www.staging.com")!,
+            backendWSURL: URL(string: "www.staging.com")!,
+            blackListURL: URL(string: "www.staging.com")!,
+            teamsURL: URL(string: "www.staging.com")!,
+            accountsURL: URL(string: "www.staging.com")!,
+            websiteURL: URL(string: "www.staging.com")!,
+            countlyURL: URL(string: "www.staging.com")
+        ),
+        proxySettings: nil,
+        pinnedKeys: nil
+    )
 
     override func setUp() {
         snapshotHelper = .init()
@@ -39,17 +55,13 @@ class SwitchBackendConfirmationViewTests: XCTestCase {
     func testColorSchemeVariants() {
         let screenBounds = UIScreen.main.bounds
 
-        let view = makeSwitchBackendConfirmationViewPreview(
-            backendName: "Staging",
-            backendURL: URL(string: "www.staging.com")!,
-            backendWSURL: URL(string: "www.staging.com")!,
-            blackListURL: URL(string: "www.staging.com")!,
-            teamsURL: URL(string: "www.staging.com")!,
-            accountsURL: URL(string: "www.staging.com")!,
-            websiteURL: URL(string: "www.staging.com")!,
-            countlyURL: URL(string: "www.staging.com")!
+        let view = SwitchBackendConfirmation(
+            backendConfig: backendConfig,
+            onConfirm: { _ in }
+        ).frame(
+            width: screenBounds.width,
+            height: screenBounds.height
         )
-        .frame(width: screenBounds.width, height: screenBounds.height)
 
         snapshotHelper
             .withUserInterfaceStyle(.light)
@@ -63,17 +75,13 @@ class SwitchBackendConfirmationViewTests: XCTestCase {
     func testDynamicTypeVariants() {
         let screenBounds = UIScreen.main.bounds
 
-        let view = makeSwitchBackendConfirmationViewPreview(
-            backendName: "Staging",
-            backendURL: URL(string: "www.staging.com")!,
-            backendWSURL: URL(string: "www.staging.com")!,
-            blackListURL: URL(string: "www.staging.com")!,
-            teamsURL: URL(string: "www.staging.com")!,
-            accountsURL: URL(string: "www.staging.com")!,
-            websiteURL: URL(string: "www.staging.com")!,
-            countlyURL: URL(string: "www.staging.com")!
+        let view = SwitchBackendConfirmation(
+            backendConfig: backendConfig,
+            onConfirm: { _ in }
+        ).frame(
+            width: screenBounds.width,
+            height: screenBounds.height
         )
-        .frame(width: screenBounds.width, height: screenBounds.height)
 
         for dynamicTypeSize in DynamicTypeSize.allCases {
             snapshotHelper


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16256" title="WPB-16256" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16256</a>  [iOS] Login via email - proxy support
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
We want to simplify the dependency graph by removing the `SwitchBackendConfirmationComponent`. To do this, we will remove the view model and component for the confirmation, and instead have a simple confirmation view that will only report the user confirmation boolean back to the caller. The logic that has been taken out will be performed by the caller.

This PR only adds the simplified (i.e no logic) confirmation view.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
