### PR TITLE
fix: crash when selecting "Leave group" context menu item - WPB-16134

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/AlertResultConfiguration.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/AlertResultConfiguration.swift
@@ -35,7 +35,12 @@ extension AlertResultConfiguration {
 extension ConversationActionController {
 
     func request<T: AlertResultConfiguration>(_ result: T.Type, handler: @escaping (T) -> Void) {
-        present(result.controller(handler))
+        let alertController = result.controller(handler)
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            popoverPresentationController.sourceView = sourceView?.superview
+            popoverPresentationController.sourceRect = sourceView?.frame ?? .zero
+        }
+        present(alertController)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16134" title="WPB-16134" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16134</a>  [iOS] Crash on iPad when opening the "Leave Group" submenu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes a crash when long pressing on a conversation from the conversation list and selecting "Leave Group" on iPad.
The alert controller needs a `popoverPresentationController` set.

### Testing

- Create a group.
- Long press and select leave.
- The alert controller should be presented as popover.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
