### PR TITLE
fix: showing import backup alerts - WPB-16633

### DIFF
--- a/WireDomain/Sources/WireDomain/UseCases/Protocols/ImportBackupError.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/Protocols/ImportBackupError.swift
@@ -21,7 +21,7 @@ public enum ImportBackupError: Error, Equatable, CaseIterable {
     /// The backup file is encrypted and a password is needed for decryption.
     case passwordRequired
     /// E.g. if the file to import was created with a different (incompatible) version of the app.
-    case incompatibleFileFormat
+    case incompatibleFileFormat // there is no mapping to this error (it's never thrown)
     case invalidAccountID
     case compressionError
     case invalidFileExtension

--- a/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
@@ -208,9 +208,10 @@ final class ImportBackupViewModel: ObservableObject {
             false
         }
 
-        let isAlertPresented = if case .success = state {
+        let isAlertPresented = switch state {
+        case .success, .restoreFailed:
             true
-        } else {
+        default:
             false
         }
 

--- a/wire-ios-sync-engine/Source/Use cases/ImportBackupUseCase/ImportBackupUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ImportBackupUseCase/ImportBackupUseCase.swift
@@ -20,6 +20,7 @@ import Foundation
 import WireCrypto
 import WireDataModel
 import WireDomainPkg
+import WireFoundation
 import WireLogging
 import WireSystem
 
@@ -164,12 +165,16 @@ struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
             let outputStream = OutputStream(url: decryptedURL, append: false)
         else { throw ImportBackupError.failedToCreateStreamForDecryption }
 
-        try streamDecryptor.decrypt(
-            input: inputStream,
-            output: outputStream,
-            accountID: accountID,
-            password: password
-        )
+        do {
+            try streamDecryptor.decrypt(
+                input: inputStream,
+                output: outputStream,
+                accountID: accountID,
+                password: password
+            )
+        } catch WireCrypto.ChaCha20Poly1305.StreamEncryption.EncryptionError.mismatchingUUID {
+            throw ImportBackupError.invalidAccountID
+        }
 
         try fileArchiver.unzipFile(at: decryptedURL, to: unzippedURL)
         return unzippedURL

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -30,7 +30,6 @@ final class ConversationViewController: UIViewController {
     let selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol
     private let visibleMessage: ZMConversationMessage?
     private let getParticipantImageSourceUseCase: GetParticipantImageSourceUseCaseProtocol
-
     var actionControllerForSelectedEmoji: ConversationMessageActionController?
 
     typealias keyboardShortcut = L10n.Localizable.Keyboardshortcut


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16633" title="WPB-16633" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16633</a>  [iOS] Errors when importing backups are not shown
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The error when trying to import a backup of another user account is not presented during the import backup flow.
This PR adds a mapping of an underlying error to the one which is expected.

### Testing

Create a backup on one account and try to import it in another one.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
