### PR TITLE
chore: enable WireAuthentication by default - WPB-16452

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -82,10 +82,15 @@ public enum DeveloperFlag: String, CaseIterable {
     }
 
     private var defaultValue: Bool {
-        guard let bundleKey else {
-            return false
+        switch self {
+        case .useWireAuthentication:
+            return true
+        default:
+            guard let bundleKey else {
+                return false
+            }
+            return DeveloperFlagsDefault.isEnabled(for: bundleKey)
         }
-        return DeveloperFlagsDefault.isEnabled(for: bundleKey)
     }
 
     public static func clearAllFlags() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16452" title="WPB-16452" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16452</a>  [iOS] Remove `UseWireAuthentication` feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Enable `useWireAuthentication` feature flag by default to have more testing in beta.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
