### PR TITLE
fix: time divider / unread indicator snapshot tests - WPB-16017

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationCell/ConversationCellBurstTimestampViewSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/ConversationCellBurstTimestampViewSnapshotTests.swift
@@ -81,9 +81,15 @@ final class ConversationCellBurstTimestampViewSnapshotTests: XCTestCase {
     }
 
     func testYesterdayNoUnread() {
+        // GIVEN
+        let mockedNow = ISO8601DateFormatter().date(from: "2025-03-20T09:44:10+01:00")!
+        let currentDateProvider = MockCurrentDateProviding()
+        currentDateProvider.now = mockedNow
+        sut.currentDateProvider = currentDateProvider
+
         // WHEN
         sut.configure(
-            timestamp: .now.addingTimeInterval(-24 * 3600), // 24h ago
+            timestamp: mockedNow.addingTimeInterval(-24 * 3600), // 24h ago
             isFirstMessageOfTheDay: false,
             showUnreadDot: false,
             accentColor: userSession.selfUser.accentColor
@@ -107,9 +113,15 @@ final class ConversationCellBurstTimestampViewSnapshotTests: XCTestCase {
     }
 
     func testYesterdayWithUnreadAndFirstMessageOfToday() {
+        // GIVEN
+        let mockedNow = ISO8601DateFormatter().date(from: "2025-03-20T09:44:10+01:00")!
+        let currentDateProvider = MockCurrentDateProviding()
+        currentDateProvider.now = mockedNow
+        sut.currentDateProvider = currentDateProvider
+
         // WHEN
         sut.configure(
-            timestamp: .now.addingTimeInterval(-24 * 3600), // 24h ago
+            timestamp: mockedNow.addingTimeInterval(-24 * 3600), // 24h ago
             isFirstMessageOfTheDay: true,
             showUnreadDot: true,
             accentColor: userSession.selfUser.accentColor


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16017" title="WPB-16017" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-16017</a>  [iOS] Grouping of messages by time 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes two snapshot tests which only worked on the day they were developed.

### Testing

Automatic tests should succeed.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
