### PR TITLE
feat: track alert confirmation - WPB-15936

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryView.swift
@@ -88,8 +88,10 @@ package struct NoHistoryView: View {
         .onAppear {
             viewModel.onAppear()
         }
-        .onReceive(NotificationCenter.default.publisher(
-            for: UIApplication.willEnterForegroundNotification)
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: UIApplication.willEnterForegroundNotification
+            )
         ) { _ in
             viewModel.onAppear()
         }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryView.swift
@@ -80,10 +80,17 @@ package struct NoHistoryView: View {
                 Button(L10n.Authentication.Error.howToDeleteAccount, action: {
                     viewModel.howToDeleteAccount()
                 })
-                Button(L10n.Authentication.Error.confirm, action: {})
+                Button(L10n.Authentication.Error.confirm, action: {
+                    viewModel.confirmAlert()
+                })
             }
         )
         .onAppear {
+            viewModel.onAppear()
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.willEnterForegroundNotification)
+        ) { _ in
             viewModel.onAppear()
         }
         .padding(.vertical, 32)

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryViewModel.swift
@@ -33,11 +33,11 @@ package final class NoHistoryViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var alert: Alert?
 
+    private let didDetectDomainConflict: Bool
     private let howToChangeEmailURL: URL
     private let howToDeleteAccountURL: URL
     private let onFlowCompletion: () -> Void
-
-    let didDetectDomainConflict: Bool
+    private var didConfirmAlert = false
 
     package init(
         didDetectDomainConflict: Bool,
@@ -61,17 +61,24 @@ package final class NoHistoryViewModel: ObservableObject {
     }
 
     func onAppear() {
-        if didDetectDomainConflict {
+        if didDetectDomainConflict, !didConfirmAlert {
             alert = .cloudAccountAlreadyRegistered
         }
     }
 
     func howToChangeEmail() {
+        didConfirmAlert = false
         UIApplication.shared.open(howToChangeEmailURL)
     }
 
     func howToDeleteAccount() {
+        didConfirmAlert = false
         UIApplication.shared.open(howToDeleteAccountURL)
+    }
+
+    func confirmAlert() {
+        didConfirmAlert = true
+        alert = nil
     }
 
 }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryViewModel.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryViewModel.swift
@@ -37,6 +37,8 @@ package final class NoHistoryViewModel: ObservableObject {
     private let howToChangeEmailURL: URL
     private let howToDeleteAccountURL: URL
     private let onFlowCompletion: () -> Void
+
+    /// Tracks if the user has already acknowledged the alert.
     private var didConfirmAlert = false
 
     package init(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15936" title="WPB-15936" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15936</a>  [iOS] Path 3b: Implement "email already in use" error alert
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
<img width="230" alt="Screenshot 2025-03-26 at 07 50 53" src="https://github.com/user-attachments/assets/90e48809-89df-4734-baba-05d0af78f5b9" />

This alert has 2 buttons that open web links. When the user opens one of them and returns to the app, there is no alert and therefore no option to select the second link.

### Solution

Check if the user has pressed the confirm button and only then stop showing the alert.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
