### PR TITLE
feat: set content types for input fields - WPB-16655

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
@@ -90,6 +90,8 @@ package struct DetermineAuthMethodView: View {
                     )
                     .autocapitalization(.none)
                     .autocorrectionDisabled()
+                    .textContentType(.username)
+                    .keyboardType(.emailAddress)
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
                 }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -133,6 +133,8 @@ package struct LoginViaEmailView: View {
             string: .constant(viewModel.email ?? "")
         )
         .autocorrectionDisabled()
+        .textContentType(.username)
+        .keyboardType(.emailAddress)
         .disabled(viewModel.isValidEmail)
     }
 

--- a/WireUI/Sources/WireReusableUIComponents/PasswordField/PasswordField.swift
+++ b/WireUI/Sources/WireReusableUIComponents/PasswordField/PasswordField.swift
@@ -60,12 +60,14 @@ public struct PasswordField: View {
                 if isPasswordVisible {
                     TextField(placeholder, text: $password)
                         .autocorrectionDisabled()
+                        .textContentType(.password)
                         .wireTextStyle(.body1)
                         .frame(height: fieldHeight)
                         .focused($isFocused)
                 } else {
                     SecureField(placeholder, text: $password)
                         .autocorrectionDisabled()
+                        .textContentType(.password)
                         .frame(height: fieldHeight)
                         .focused($isFocused)
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16655" title="WPB-16655" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16655</a>  [iOS] Set content types for input fields
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Can't use password manager for email and login.

### Solution 

Set content types for input fields

### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
