### PR TITLE
fix: slow OneOnOne resolving - WPB-16735

### DIFF
--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -155,10 +155,14 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
             // Note on proteus, it's possible to have duplicate 1-1 conversations, so we need to fetch all relevant
             // 1-1 conversations here.
             let source = OneOnOneSource(context: context)
-            let proteusConversations = try source.fetchOneOnOnes(
-                user: otherUser,
-                types: [.fake, .proteus, .proteusPending]
-            )
+            var proteusConversations: [ZMConversation] = []
+            // NOTE: querying for all types at once triggers a table scan which is very expensive
+            for type in [OneOnOneType.fake, OneOnOneType.proteus, OneOnOneType.proteusPending] {
+                proteusConversations.append(contentsOf: try source.fetchOneOnOnes(
+                                user: otherUser,
+                                types: [type]
+                            ))
+            }
 
             // Move local messages from all proteus conversations
             for proteusConversation in proteusConversations {

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -159,9 +159,9 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
             // NOTE: querying for all types at once triggers a table scan which is very expensive
             for type in [OneOnOneType.fake, OneOnOneType.proteus, OneOnOneType.proteusPending] {
                 proteusConversations.append(contentsOf: try source.fetchOneOnOnes(
-                                user: otherUser,
-                                types: [type]
-                            ))
+                    user: otherUser,
+                    types: [type]
+                ))
             }
 
             // Move local messages from all proteus conversations

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -158,10 +158,11 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
             var proteusConversations: [ZMConversation] = []
             // NOTE: querying for all types at once triggers a table scan which is very expensive
             for type in [OneOnOneType.fake, OneOnOneType.proteus, OneOnOneType.proteusPending] {
-                proteusConversations.append(contentsOf: try source.fetchOneOnOnes(
+                let conversations = try source.fetchOneOnOnes(
                     user: otherUser,
                     types: [type]
-                ))
+                )
+                proteusConversations.append(contentsOf: conversations)
             }
 
             // Move local messages from all proteus conversations


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16735" title="WPB-16735" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16735</a>  [iOS] MLS Bug - Infinite sync and slowness after enabling MLS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When resolving one on one conversations, the query takes up to 80 sec to execute. This blocks the syncContext from running and the end user ends up with infinite sync.

Solution:

Breaking the query into 3 separate queries, resolve the issue.

### Testing

Tested on Jacob's device