### PR TITLE
fix: disable autocapitalization on email fields - WPB-16769

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -126,6 +126,7 @@ package struct LoginViaEmailView: View {
             title: L10n.CloudUserLogin.InputEmail.title,
             string: $viewModel.email
         )
+        .autocapitalization(.none)
         .autocorrectionDisabled()
         .textContentType(.username)
         .keyboardType(.emailAddress)
@@ -223,6 +224,10 @@ package struct LoginViaEmailView: View {
                 title: L10n.ProxyCredentials.InputEmail.title,
                 string: $viewModel.proxyUsername
             )
+            .autocapitalization(.none)
+            .autocorrectionDisabled()
+            .textContentType(.username)
+            .keyboardType(.emailAddress)
 
             PasswordField(
                 password: $viewModel.proxyPassword,

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -233,7 +233,7 @@ package struct LoginViaEmailView: View {
                 password: $viewModel.proxyPassword,
                 placeholder: L10n.CloudUserLogin.InputPassword.placeholder,
                 title: L10n.CloudUserLogin.InputPassword.title,
-                passwordRules: "viewModel.localizedPasswordRules",
+                passwordRules: "",
                 isValidPassword: viewModel.isPasswordValid
             )
             Spacer()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16769" title="WPB-16769" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16769</a>  [iOS] Email fields have autocapitalization
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
This PR removes the autocapitalization on both the account email and proxy username fields in the login screen.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
