### PR TITLE
feat: shared logs via Wire navigates to conversation - WPB-16710

### DIFF
--- a/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/SettingsTableViewControllerSnapshotTests.swift
@@ -95,7 +95,8 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
         let group = settingsCellDescriptorFactory.settingsGroup(
             isPublicDomain: true,
             userSession: userSession,
-            useTypeIntrinsicSizeTableView: true
+            useTypeIntrinsicSizeTableView: true,
+            mainCoordinator: MockMainCoordinator()
         )
         try verify(group: group)
     }
@@ -233,7 +234,10 @@ final class SettingsTableViewControllerSnapshotTests: XCTestCase {
     // MARK: - advanced
 
     func testForAdvancedGroup() throws {
-        let group = settingsCellDescriptorFactory.advancedGroup(userSession: userSession)
+        let group = settingsCellDescriptorFactory.advancedGroup(
+            userSession: userSession,
+            mainCoordinator: MockMainCoordinator()
+        )
         try verify(group: group)
     }
 

--- a/wire-ios/Wire-iOS Tests/ShareViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ShareViewControllerTests.swift
@@ -165,7 +165,9 @@ final class ShareViewControllerTests: XCTestCase {
         sut = ShareViewController<MockShareViewControllerConversation, MockShareableMessage>(
             shareable: message,
             destinations: [groupConversation, oneToOneConversation],
-            showPreview: true, allowsMultipleSelection: allowsMultipleSelection
+            showPreview: true,
+            allowsMultipleSelection: allowsMultipleSelection,
+            mainCoordinator: MockMainCoordinator()
         )
     }
 

--- a/wire-ios/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -156,7 +156,10 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
             shareable.share(to: Array(selectedDestinations))
             if let conversation = selectedDestinations.first as? ZMConversation,
                let mainCoordinator = mainCoordinator as? MainCoordinator {
-                mainCoordinator.showConversation(conversation: conversation, message: nil)
+                Task {
+                    await mainCoordinator.showConversationList(conversationFilter: nil)
+                    mainCoordinator.showConversation(conversation: conversation, message: nil)
+                }
             } else {
                 onDismiss?(self, true)
             }

--- a/wire-ios/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/ShareViewController/ShareViewController.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireMainNavigationUI
 
 protocol ShareDestination: Hashable {
     var displayNameWithFallback: String { get }
@@ -36,8 +37,12 @@ protocol Shareable {
 
 final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Shareable>: UIViewController,
     UITableViewDelegate, UITableViewDataSource {
+
+    typealias MainCoordinator = WireMainNavigationUI.MainCoordinator<MainCoordinatorDependencies>
+
     let destinations: [D]
     let shareable: S
+    private let mainCoordinator: any MainCoordinatorProtocol
     private(set) var selectedDestinations: Set<D> = Set() {
         didSet {
             sendButton.isEnabled = selectedDestinations.count > 0
@@ -72,12 +77,19 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
     var onDismiss: ((ShareViewController, Bool) -> Void)?
     var bottomConstraint: NSLayoutConstraint?
 
-    init(shareable: S, destinations: [D], showPreview: Bool = true, allowsMultipleSelection: Bool = true) {
+    init(
+        shareable: S,
+        destinations: [D],
+        showPreview: Bool = true,
+        allowsMultipleSelection: Bool = true,
+        mainCoordinator: any MainCoordinatorProtocol
+    ) {
         self.destinations = destinations
         self.filteredDestinations = destinations
         self.shareable = shareable
         self.showPreview = showPreview
         self.allowsMultipleSelection = allowsMultipleSelection
+        self.mainCoordinator = mainCoordinator
         super.init(nibName: nil, bundle: nil)
 
         NotificationCenter.default.addObserver(
@@ -142,7 +154,12 @@ final class ShareViewController<D: ShareDestination & NSObjectProtocol, S: Share
     func onSendButtonPressed(sender: AnyObject?) {
         if !selectedDestinations.isEmpty {
             shareable.share(to: Array(selectedDestinations))
-            onDismiss?(self, true)
+            if let conversation = selectedDestinations.first as? ZMConversation,
+               let mainCoordinator = mainCoordinator as? MainCoordinator {
+                mainCoordinator.showConversation(conversation: conversation, message: nil)
+            } else {
+                onDismiss?(self, true)
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Advanced.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireCommonComponents
+import WireMainNavigationUI
 import WireSyncEngine
 
 extension SettingsCellDescriptorFactory {
@@ -26,9 +27,12 @@ extension SettingsCellDescriptorFactory {
 
     // MARK: - Advanced group
 
-    func advancedGroup(userSession: UserSession) -> any SettingsCellDescriptorType {
+    func advancedGroup(
+        userSession: UserSession,
+        mainCoordinator: any MainCoordinatorProtocol
+    ) -> any SettingsCellDescriptorType {
         let items = [
-            troubleshootingSection(userSession: userSession),
+            troubleshootingSection(userSession: userSession, mainCoordinator: mainCoordinator),
             debuggingToolsSection,
             pushSection
         ]
@@ -45,11 +49,14 @@ extension SettingsCellDescriptorFactory {
 
     // MARK: - Sections
 
-    private func troubleshootingSection(userSession: UserSession) -> SettingsSectionDescriptor {
+    private func troubleshootingSection(
+        userSession: UserSession,
+        mainCoordinator: any MainCoordinatorProtocol
+    ) -> SettingsSectionDescriptor {
         let submitDebugButton = SettingsExternalScreenCellDescriptor(
             title: SelfSettingsAdvancedLocale.Troubleshooting.SubmitDebug.title,
             presentationAction: { () -> (UIViewController?) in
-                let router = SettingsDebugReportRouter()
+                let router = SettingsDebugReportRouter(mainCoordinator: mainCoordinator)
                 let shareFile = ShareFileUseCase(contextProvider: userSession.contextProvider)
                 let fetchShareableConversations = FetchShareableConversationsUseCase(
                     contextProvider: userSession

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -19,6 +19,7 @@
 import avs
 import Foundation
 import SafariServices
+import WireMainNavigationUI
 import WireSettingsUI
 import WireSyncEngine
 
@@ -119,7 +120,8 @@ struct SettingsCellDescriptorFactory {
     func settingsGroup(
         isPublicDomain: Bool,
         userSession: UserSession,
-        useTypeIntrinsicSizeTableView: Bool
+        useTypeIntrinsicSizeTableView: Bool,
+        mainCoordinator: some MainCoordinatorProtocol
     ) -> any SettingsControllerGeneratorType & SettingsInternalGroupCellDescriptorType {
         var topLevelElements = [
             accountGroup(
@@ -129,7 +131,7 @@ struct SettingsCellDescriptorFactory {
             ),
             devicesCell(),
             optionsGroup,
-            advancedGroup(userSession: userSession),
+            advancedGroup(userSession: userSession, mainCoordinator: mainCoordinator),
             helpSection(),
             aboutSection()
         ]

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/SettingsDebugReportRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/SettingsDebugReportRouter.swift
@@ -18,6 +18,7 @@
 
 import MessageUI
 import WireDataModel
+import WireMainNavigationUI
 import WireReusableUIComponents
 
 // sourcery: AutoMockable
@@ -51,6 +52,11 @@ final class SettingsDebugReportRouter: NSObject, SettingsDebugReportRouterProtoc
     weak var viewController: UIViewController?
 
     private let mailRecipient = WireEmail.shared.callingSupportEmail
+    private let mainCoordinator: any MainCoordinatorProtocol
+
+    init(mainCoordinator: any MainCoordinatorProtocol) {
+        self.mainCoordinator = mainCoordinator
+    }
 
     private lazy var activityIndicator = {
         let topMostViewController = UIApplication.shared.topmostViewController(onlyFullScreen: false)
@@ -67,7 +73,8 @@ final class SettingsDebugReportRouter: NSObject, SettingsDebugReportRouterProtoc
         let shareViewController = ShareViewController<ZMConversation, ShareableDebugReport>(
             shareable: debugReport,
             destinations: destinations,
-            showPreview: true
+            showPreview: true,
+            mainCoordinator: mainCoordinator
         )
 
         shareViewController.onDismiss = { shareController, _ in

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsViewControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsViewControllerBuilder.swift
@@ -64,7 +64,8 @@ final class SettingsViewControllerBuilder: MainSettingsUIBuilderProtocol, MainSe
         let group = factory.settingsGroup(
             isPublicDomain: isPublicDomain,
             userSession: userSession,
-            useTypeIntrinsicSizeTableView: false
+            useTypeIntrinsicSizeTableView: false,
+            mainCoordinator: mainCoordinator
         )
         return .init(group: group, settingsCoordinator: .init(settingsCoordinator: settingsCoordinator))
     }
@@ -127,7 +128,10 @@ final class SettingsViewControllerBuilder: MainSettingsUIBuilderProtocol, MainSe
         let settingsCoordinator = SettingsCoordinator(mainCoordinator: mainCoordinator)
         let factory =
             settingsCellDescriptorFactory(settingsCoordinator: .init(settingsCoordinator: settingsCoordinator))
-        let group = factory.advancedGroup(userSession: userSession) as! SettingsGroupCellDescriptor
+        let group = factory.advancedGroup(
+            userSession: userSession,
+            mainCoordinator: mainCoordinator
+        ) as! SettingsGroupCellDescriptor
         return SettingsTableViewController(
             group: group,
             settingsCoordinator: .init(settingsCoordinator: settingsCoordinator)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Details/ProfileDetailsContentController.swift
@@ -297,7 +297,7 @@ final class ProfileDetailsContentController: NSObject,
                 style: .default,
                 reuseIdentifier: messageProtocolCellID
             )
-            cell.propertyName = "Message protocol"
+            cell.propertyName = L10n.Localizable.GroupDetails.MessageProtocol.title
             cell.propertyValue = messageProtocol.rawValue
             return cell
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16710" title="WPB-16710" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16710</a>  [iOS] Debug logs shared via Wire unviewable on web
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

1. There is an issue from the customer:  "we should also take this opportunity  change the behaviour to “Send report Via Wire” -> "Select conversation" -> "Click ok" - then we are taken into the conversation rather than going back to Debug report share panel.”
The solution is to use mainCoordinator to navigate to the selected conversation (first, if several were selected).

2. Replace hardcoded string with localised string.

### Testing

Settings -> Advanced -> Debug Report -> Share via Wire


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
