### PR TITLE
fix: Register a new personal account - WPB-16919

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationCredentialsViewController.swift
@@ -439,6 +439,7 @@ final class AuthenticationCredentialsViewController: AuthenticationStepControlle
 
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         guard
+            DeveloperFlag.useWireAuthentication.isOn,
             textField == emailInputField,
             isRegistering,
             let prefilledCredentials,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16919" title="WPB-16919" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16919</a>  [iOS] Can't register new account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…ing the registration

<!--do not remove the jira markers to link tickets automatically -->


### Issue

In the new login flow, we pass the email from the Authentication module to the main app and disable the ability to change the email, but we should still be able to enter the email during the registration in the old login flow. To fix the current issue, we should check the feature flag `DeveloperFlag.useWireAuthentication`.

### Testing

Register a personal account.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
