### PR TITLE
chore: mark API v8 as production version - WPB-16923

### DIFF
--- a/WireAPI/Sources/WireAPI/Models/API/APIVersion.swift
+++ b/WireAPI/Sources/WireAPI/Models/API/APIVersion.swift
@@ -44,7 +44,7 @@ public enum APIVersion: UInt, CaseIterable, Comparable, Sendable {
     /// Only if these critera are met should we explicitly mark the version
     /// as production ready.
 
-    public static let productionVersions: Set<Self> = [.v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7]
+    public static let productionVersions: Set<Self> = [.v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8]
 
     /// API versions currently under development and not suitable for production
     /// environments.

--- a/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
@@ -185,7 +185,7 @@ public extension APIVersion {
     /// Only if these critera are met should we explicitly mark the version
     /// as production ready.
 
-    static let productionVersions: Set<Self> = [.v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7]
+    static let productionVersions: Set<Self> = [.v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8]
 
     /// API versions currently under development and not suitable for production
     /// environments.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16923" title="WPB-16923" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16923</a>  [iOS] Finalize v8
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds the `.v8` version to the list of production API versions.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
