### PR TITLE
feat: handle 503 for get-domain-registraion - WPB-16991

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIError.swift
+++ b/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIError.swift
@@ -42,6 +42,8 @@ public enum AuthenticationAPIError: Error {
 
     case invalidCredentials
 
+    case serviceUnavailable
+
     /// Thrown by `requestVerificationCode(for:)`.
 
     case invalidEmail

--- a/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
+++ b/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
@@ -45,6 +45,7 @@ final class AuthenticationAPIV8: AuthenticationAPIV7 {
 
         return try ResponseParser()
             .success(code: .ok, type: DomainRegistrationConfigurationV8.self)
+            .failure(code: .serviceUnavailable, error: AuthenticationAPIError.serviceUnavailable)
             .failure(code: .badRequest, label: "invalid-domain", error: AuthenticationAPIError.invalidDomain)
             .failure(code: .badRequest, error: AuthenticationAPIError.invalidRequestBody)
             .parse(code: response.statusCode, data: data)

--- a/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
@@ -75,6 +75,8 @@ package struct DetermineAuthMethodUseCase: DetermineAuthMethodUseCaseProtocol {
             } catch AuthenticationAPIError.configNotFound, AuthenticationAPIError.domainNotFound {
                 return .loginOrRegisterViaEmail(email: email)
             }
+        } catch {
+            return .loginViaEmail(email: email, didDetectDomainConflict: false)
         }
 
         switch configuration.domainRedirect {

--- a/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
@@ -75,7 +75,7 @@ package struct DetermineAuthMethodUseCase: DetermineAuthMethodUseCaseProtocol {
             } catch AuthenticationAPIError.configNotFound, AuthenticationAPIError.domainNotFound {
                 return .loginOrRegisterViaEmail(email: email)
             }
-        } catch {
+        } catch AuthenticationAPIError.serviceUnavailable {
             return .loginViaEmail(email: email, didDetectDomainConflict: false)
         }
 

--- a/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
@@ -148,6 +148,18 @@ final class DetermineAuthMethodUseCaseTests: XCTestCase {
         }
     }
 
+    func testInvoke_withEmail_whenServiceUnavailable() async throws {
+        // given
+        let email = "user@example.com"
+        mockAuthenticationAPI.getDomainRegistrationForEmail_MockError = AuthenticationAPIError.serviceUnavailable
+
+        // when
+        let authMethod = try await sut.invoke(emailOrSSOCode: email)
+
+        // then
+        XCTAssertEqual(authMethod, .loginViaEmail(email: email, didDetectDomainConflict: false))
+    }
+
     func testInvoke_forwardsUnderlyingErrors() async throws {
         // given
         mockAuthenticationAPI.getDomainRegistrationForEmail_MockError = URLError(.notConnectedToInternet)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16991" title="WPB-16991" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16991</a>  [iOS] Handle `get-domain-registraion` 503 `enterprise-service-not-enabled` error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The endpoint `get-domain-registraion` will return 503 `enterprise-service-not-enabled` on custom environments with API v8. Anta/Bella/Chala are correctly configured without this error for our testing. But, most likely,  for the rest (for example Staging) of the environment, it will return 503 and we should handle it as 200 with "no-registration".
In this PR, I added a 503 (serviceUnavailable) error handler without checking a specific label, because:
- we do not have an environment with this error now, so we can not check the label;
- what if there is 503 with a similar label (or the label will change).

### Testing


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
