### PR TITLE
fix: Request loop on /v7/search/contacts - WPB-16757

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchRequest.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchRequest.swift
@@ -112,9 +112,14 @@ public struct SearchRequest {
         searchOptions: SearchOptions,
         team: Team? = nil
     ) {
-        let (query, parsedDomain) = Self.parseQuery(query)
-        self.query = query
-        self.searchDomain = searchDomain ?? parsedDomain
+        if let searchDomain {
+            self.query = .fullTextSearch(query)
+            self.searchDomain = searchDomain
+        } else {
+            let (query, parsedDomain) = Self.parseQuery(query)
+            self.query = query
+            self.searchDomain = parsedDomain
+        }
         self.searchOptions = searchOptions
         self.team = team
     }

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchRequestTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchRequestTests.swift
@@ -66,6 +66,20 @@ class SearchRequestTests: MessagingTest {
         try assertHandleAndDomain(from: "@john", handle: "john", domain: nil)
     }
 
+    func testThatItConfiguresRequestIfFederationSearchIsAllowed() throws {
+        // given
+        let query = "john@example.com"
+        let domain = "wire.com"
+
+        // when
+        let request = SearchRequest(query: query, searchDomain: domain, searchOptions: [])
+
+        // then
+        XCTAssertEqual(request.query.string, query)
+        XCTAssertEqual(request.searchDomain, domain)
+    }
+
+
     // MARK: - Helpers
 
     func assertHandleAndDomain(

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchRequestTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchRequestTests.swift
@@ -79,7 +79,6 @@ class SearchRequestTests: MessagingTest {
         XCTAssertEqual(request.searchDomain, domain)
     }
 
-
     // MARK: - Helpers
 
     func assertHandleAndDomain(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -77,6 +77,8 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
         accountImageView.availability = viewModel.selfUserStatus.availability.mapToAccountImageAvailability()
         accountImageView.hideProfileNotificationsBadge = viewModel.hideProfileNotificationsBadge
         accountImageView.isAccessibilityElement = true
+        accountImageView.accessibilityValue = L10n.Localizable.ConversationList.Header.SelfTeam
+            .accessibilityValue(viewModel.userSession.selfUser.name ?? "")
         accountImageView.accessibilityTraits = .button
         accountImageView.accessibilityHint = L10n.Accessibility.ConversationsList.AccountButton.hint
         accountImageView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16757" title="WPB-16757" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16757</a>  [iOS] Request loop on /v7/search/contacts with long domain names
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We have a request loop on `/v7/search/contacts` because the user who is actually searching for a federated user is sending many identical requests, which causes the request loop message.
Why this happens:
- there so me restrictions for searching federated users, described here: https://wearezeta.atlassian.net/browse/WPB-14455.
-  we always replace the domain part for searched federated users.
As a result, the user enters the long part of the domain of the searching user, but in fact sends the same request over and over again.

### Solution

Do not replace the domain part .

### Testing



### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
