### PR TITLE
fix: add the label to the 503 error parser - WPB-16991

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
+++ b/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
@@ -45,7 +45,7 @@ final class AuthenticationAPIV8: AuthenticationAPIV7 {
 
         return try ResponseParser()
             .success(code: .ok, type: DomainRegistrationConfigurationV8.self)
-            .failure(code: .serviceUnavailable, error: AuthenticationAPIError.serviceUnavailable)
+            .failure(code: .serviceUnavailable, label: "enterprise-service-not-enabled", error: AuthenticationAPIError.serviceUnavailable)
             .failure(code: .badRequest, label: "invalid-domain", error: AuthenticationAPIError.invalidDomain)
             .failure(code: .badRequest, error: AuthenticationAPIError.invalidRequestBody)
             .parse(code: response.statusCode, data: data)

--- a/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
+++ b/WireAPI/Sources/WireAPI/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
@@ -45,7 +45,11 @@ final class AuthenticationAPIV8: AuthenticationAPIV7 {
 
         return try ResponseParser()
             .success(code: .ok, type: DomainRegistrationConfigurationV8.self)
-            .failure(code: .serviceUnavailable, label: "enterprise-service-not-enabled", error: AuthenticationAPIError.serviceUnavailable)
+            .failure(
+                code: .serviceUnavailable,
+                label: "enterprise-service-not-enabled",
+                error: AuthenticationAPIError.serviceUnavailable
+            )
             .failure(code: .badRequest, label: "invalid-domain", error: AuthenticationAPIError.invalidDomain)
             .failure(code: .badRequest, error: AuthenticationAPIError.invalidRequestBody)
             .parse(code: response.statusCode, data: data)

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/AuthenticationAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/AuthenticationAPITests.swift
@@ -169,6 +169,21 @@ final class AuthenticationAPITests: XCTestCase {
         }
     }
 
+    func testGetDomainRegistration_Response_Handling_V8_Service_Unavailable() async throws {
+        // Given
+        let networkService = MockNetworkServiceProtocol.withResponses([
+            (.serviceUnavailable, "GetDomainRegistrationErrorResponse_ServiceUnavailableV8")
+        ])
+
+        let sut = AuthenticationAPIV8(networkService: networkService)
+
+        // Then
+        await XCTAssertThrowsErrorAsync(AuthenticationAPIError.serviceUnavailable) {
+            // When
+            try await sut.getDomainRegistration(forEmail: "email@example.com")
+        }
+    }
+
     func testGetOnPremConfigURL_Response_Handling_Success() async throws {
         // Given
         let networkService = MockNetworkServiceProtocol.withResponses([

--- a/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/Resources/GetDomainRegistrationErrorResponse_ServiceUnavailableV8.json
+++ b/WireAPI/Tests/WireAPITests/APIs/AuthenticationAPI/Resources/GetDomainRegistrationErrorResponse_ServiceUnavailableV8.json
@@ -1,0 +1,5 @@
+{
+  "code": 503,
+  "label": "enterprise-service-not-enabled",
+  "message": "Enterprise service not enabled"
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16991" title="WPB-16991" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16991</a>  [iOS] Handle `get-domain-registraion` 503 `enterprise-service-not-enabled` error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If the user login on Chala, there is an error:
`FailureResponse(code: 503, label: "enterprise-service-not-enabled", message: "Enterprise service not enabled")`

To parse this error, we need provide not only the error code, but also its label.

### Testing

Login on Chala

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
