### PR TITLE
chore: remove `wireChannels` developer flag - WPB-17037

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -32,7 +32,6 @@ public enum DeveloperFlag: String, CaseIterable {
     case newInitialSync
     case useWireAuthentication
     case wireCellsAttachmentsPreviews
-    case wireChannels
 
     public var description: String {
         switch self {
@@ -65,9 +64,6 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .wireCellsAttachmentsPreviews:
             "Use the new WireCells previews for conversations attachments"
-
-        case .wireChannels:
-            "Use the new WireChannels features"
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -313,9 +313,6 @@ final class StartUIViewController: UIViewController {
     /// https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1712979983/Channels
 
     private var canCreateChannel: Bool {
-        guard DeveloperFlag.wireChannels.isOn else {
-            return false
-        }
         guard let backendInfoApiVersion = BackendInfo.apiVersion else {
             return false
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17037" title="WPB-17037" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17037</a>  [iOS] Remove channels feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR removes the `wireChannels` developer flag. This is safe to do as the app also depends on a remove channels feature flag.

### Testing

- Shake the app. There should be no channels feature flag. The channels feature should be useable on Anta V8 with a team with channels enabled.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
