### PR TITLE
feat: don't ask for password to delete sso clients - WPB-17020

### DIFF
--- a/wire-ios-request-strategy/Sources/APIs/UserClientAPI.swift
+++ b/wire-ios-request-strategy/Sources/APIs/UserClientAPI.swift
@@ -21,7 +21,7 @@ import Foundation
 // sourcery: AutoMockable
 public protocol UserClientAPI {
 
-    func deleteUserClient(clientId: String, password: String) async throws
+    func deleteUserClient(clientId: String, password: String?) async throws
 
 }
 
@@ -36,7 +36,7 @@ class UserClientAPIV0: UserClientAPI {
         .v0
     }
 
-    func deleteUserClient(clientId: String, password: String) async throws {
+    func deleteUserClient(clientId: String, password: String?) async throws {
         let requestsFactory = UserClientRequestFactory()
 
         let request = requestsFactory.deleteClientRequest(

--- a/wire-ios-request-strategy/Sources/User Client/UserClientRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/User Client/UserClientRequestFactory.swift
@@ -24,12 +24,14 @@ public class UserClientRequestFactory {
 
     func deleteClientRequest(
         clientId: String,
-        password: String,
+        password: String?,
         apiVersion: APIVersion
     ) -> ZMTransportRequest {
-        let payload: [AnyHashable: Any] = [
-            "password": password
-        ]
+        let payload: [String: Any] = if let password, !password.isEmpty {
+            ["password": password]
+        } else {
+            [:]
+        }
 
         return ZMTransportRequest(
             path: "/clients/\(clientId)",

--- a/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1336,11 +1336,11 @@ public class MockUserClientAPI: UserClientAPI {
 
     // MARK: - deleteUserClient
 
-    public var deleteUserClientClientIdPassword_Invocations: [(clientId: String, password: String)] = []
+    public var deleteUserClientClientIdPassword_Invocations: [(clientId: String, password: String?)] = []
     public var deleteUserClientClientIdPassword_MockError: Error?
-    public var deleteUserClientClientIdPassword_MockMethod: ((String, String) async throws -> Void)?
+    public var deleteUserClientClientIdPassword_MockMethod: ((String, String?) async throws -> Void)?
 
-    public func deleteUserClient(clientId: String, password: String) async throws {
+    public func deleteUserClient(clientId: String, password: String?) async throws {
         deleteUserClientClientIdPassword_Invocations.append((clientId: clientId, password: password))
 
         if let error = deleteUserClientClientIdPassword_MockError {

--- a/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
@@ -21,7 +21,7 @@ import Foundation
 // sourcery: AutoMockable
 public protocol RemoveUserClientUseCaseProtocol {
 
-    func invoke(clientId: String, password: String) async throws
+    func invoke(clientId: String, password: String?) async throws
 
 }
 
@@ -44,7 +44,7 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
 
     // MARK: - Public interface
 
-    func invoke(clientId: String, password: String) async throws {
+    func invoke(clientId: String, password: String?) async throws {
         let userClient = await syncContext.perform {
             UserClient.fetchExistingUserClient(with: clientId, in: self.syncContext)
         }

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -662,11 +662,11 @@ public class MockRemoveUserClientUseCaseProtocol: RemoveUserClientUseCaseProtoco
 
     // MARK: - invoke
 
-    public var invokeClientIdPassword_Invocations: [(clientId: String, password: String)] = []
+    public var invokeClientIdPassword_Invocations: [(clientId: String, password: String?)] = []
     public var invokeClientIdPassword_MockError: Error?
-    public var invokeClientIdPassword_MockMethod: ((String, String) async throws -> Void)?
+    public var invokeClientIdPassword_MockMethod: ((String, String?) async throws -> Void)?
 
-    public func invoke(clientId: String, password: String) async throws {
+    public func invoke(clientId: String, password: String?) async throws {
         invokeClientIdPassword_Invocations.append((clientId: clientId, password: password))
 
         if let error = invokeClientIdPassword_MockError {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewController.swift
@@ -112,8 +112,12 @@ final class RemoveClientsViewController: UIViewController,
     }
 
     func removeUserClient(_ userClient: UserClient) async {
-        if let password = await presentRequestPasswordController() {
-            await removeUserClient(userClient, password: password)
+        if let user = userClient.user, user.usesCompanyLogin {
+            await removeUserClient(userClient, password: nil)
+        } else {
+            if let password = await presentRequestPasswordController() {
+                await removeUserClient(userClient, password: password)
+            }
         }
     }
 
@@ -136,7 +140,7 @@ final class RemoveClientsViewController: UIViewController,
         }
     }
 
-    private func removeUserClient(_ userClient: UserClient, password: String) async {
+    private func removeUserClient(_ userClient: UserClient, password: String?) async {
         activityIndicator.start()
         do {
             try await viewModel.removeUserClient(userClient, password: password)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewModel.swift
@@ -45,7 +45,7 @@ extension RemoveClientsViewController {
                 })
         }
 
-        func removeUserClient(_ userClient: UserClient, password: String) async throws {
+        func removeUserClient(_ userClient: UserClient, password: String?) async throws {
             let clientId = await userClient.managedObjectContext?.perform {
                 userClient.remoteIdentifier
             }


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue
If an sso user tries to log into an account with multiple devices and is prompted to remove one of the devices, an error is displayed after submitting the request with a password:

  ```
      - code : 403
      - label : WireRequestStrategy.Payload.ResponseFailure.Label.invalidCredentials
      - message : "Authentication failed"
      - data : nil
```

### Solution

In fact, we shouldn't be asking sso users for password, and this bug has probably been around for a long time. 
For example, we don't ask sso user for a password from the Devices list. I also confirmed this with other platforms.

There is also an old [Jira ticket ](https://wearezeta.atlassian.net/browse/WPB-13484)that is about omitting password for sso users. This ticket is not specific to this case, but it does prove the theory that we shouldn't even ask SSO users for their password.

### Testing

Details it the ticket

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
