### PR TITLE
fix: channel fixes - WPB-16978

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+Permissions.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+Permissions.swift
@@ -27,7 +27,7 @@ enum ConversationAction {
     case modifyConversationAccess
     case modifyOtherConversationMember
     case leaveConversation
-    case deleteConvesation
+    case deleteConversation
 
     var name: String {
         switch self {
@@ -39,7 +39,7 @@ enum ConversationAction {
         case .modifyConversationAccess: "modify_conversation_access"
         case .modifyOtherConversationMember: "modify_other_conversation_member"
         case .leaveConversation: "leave_conversation"
-        case .deleteConvesation: "delete_conversation"
+        case .deleteConversation: "delete_conversation"
         }
     }
 }
@@ -96,7 +96,7 @@ public extension ZMUser {
         let selfUser = ZMUser.selfUser(in: managedObjectContext!)
 
         return hasRoleWithAction(
-            actionName: ConversationAction.deleteConvesation.name,
+            actionName: ConversationAction.deleteConversation.name,
             conversation: conversation
         ) && conversation.creator == self
             && selfUser.hasTeam && selfUser.teamIdentifier == teamIdentifier

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Permissions.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMUserTests+Permissions.swift
@@ -446,7 +446,7 @@ extension ZMUserTests_Permissions {
         XCTAssertFalse(selfUser.canModifyOtherMember(in: conversation))
     }
 
-    func testThatConvesationCreatorWithAdminRoleCanDeleteConvesation() {
+    func testThatConvesationCreatorWithAdminRoleCanDeleteConversation() {
         // given
         makeSelfUserTeamMember(withPermissions: .addRemoveConversationMember)
         conversation.conversationType = .group
@@ -457,7 +457,7 @@ extension ZMUserTests_Permissions {
         XCTAssertTrue(selfUser.canDeleteConversation(conversation))
     }
 
-    func testThatNoConvesationCreatorWithAdminRoleCantDeleteConvesation() {
+    func testThatNoConvesationCreatorWithAdminRoleCantDeleteConversation() {
         // given
         makeSelfUserTeamMember(withPermissions: .addRemoveConversationMember)
         conversation.conversationType = .group
@@ -467,7 +467,7 @@ extension ZMUserTests_Permissions {
         XCTAssertFalse(selfUser.canDeleteConversation(conversation))
     }
 
-    func testThatGroupParticipantCantDeleteConvesation() {
+    func testThatGroupParticipantCantDeleteConversation() {
         // given
         makeSelfUserTeamMember(withPermissions: .addRemoveConversationMember)
         conversation.conversationType = .group

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
@@ -72,4 +72,36 @@ final class ConversationDetailsTests: XCTestCase {
 
         XCTAssertTrue(sut.accessible(in: conversation, by: user))
     }
+
+    func testAddParticipants_NotShown_ForGroups_EvenUserIsTeamOwnerAndChannelPermissionEveryone() {
+        conversation.isChannel = false
+        user.canManageTeam = true
+        conversation.privateChannelPermission = .everyone
+        let sut = GroupDetailsFooterView()
+        sut.update(for: conversation, user: user)
+        XCTAssertTrue(sut.leftButton.isHidden)
+    }
+
+    func testAddParticipants_Shown_ForGroup_UserGroupAdmin() {
+        user.isGroupAdminInConversation = true
+        user.canManageTeam = false
+        conversation.isChannel = false
+        let sut = GroupDetailsFooterView()
+        sut.update(for: conversation, user: user)
+        XCTAssertFalse(sut.leftButton.isHidden)
+    }
+
+    func testAddParticipants_Shown_ForChannel_UserIsRegularMember_PermissionEveryone() {
+        conversation.privateChannelPermission = .everyone
+        let sut = GroupDetailsFooterView()
+        sut.update(for: conversation, user: user)
+        XCTAssertFalse(sut.leftButton.isHidden)
+    }
+
+    func testAddParticipants_Shown_ForChannel_UserIsTeamAdmin() {
+        user.canManageTeam = true
+        let sut = GroupDetailsFooterView()
+        sut.update(for: conversation, user: user)
+        XCTAssertFalse(sut.leftButton.isHidden)
+    }
 }

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
@@ -84,7 +84,7 @@ final class ConversationDetailsTests: XCTestCase {
     }
 
     func testAddParticipants_Shown_ForGroup_UserGroupAdmin() {
-        user.isGroupAdminInConversation = true
+        user.canAddUserToConversation = true
         user.canManageTeam = false
         conversation.isChannel = false
         let sut = GroupDetailsFooterView()

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
@@ -17,56 +17,59 @@
 //
 
 import Foundation
-import XCTest
 import WireTestingPackage
+import XCTest
 @testable import Wire
 
 final class ConversationDetailsTests: XCTestCase {
-    
+
     lazy var conversation = {
         let conversation = MockGroupDetailsConversation()
         conversation.isChannel = true
         return conversation
     }()
-    
+
     let user = {
         let user = MockUserType()
         user.canManageTeam = false
         user.isGroupAdminInConversation = false
         return user
     }()
-    
+
+    let sut = GroupOptionsSectionController.Option.channelAccess
+
     func testAccessOptionNotAllowedForGroup() {
         user.canManageTeam = true
         conversation.isChannel = false
-    
-        XCTAssertFalse(GroupOptionsSectionController.Option.channelAccess
-            .accessible(in: conversation, by: user))
+
+        XCTAssertFalse(
+            sut.accessible(in: conversation, by: user)
+        )
     }
-    
+
     func testAccessOptionAllowed_ForChannel_andTeamAdmin() {
         user.canManageTeam = true
-        
-        XCTAssertTrue(GroupOptionsSectionController.Option.channelAccess
-            .accessible(in: conversation, by: user))
+
+        XCTAssertTrue(
+            sut.accessible(in: conversation, by: user)
+        )
     }
-    
+
     func testAccessOptionNotAllowed_ForChannel_Member() {
-        XCTAssertFalse(GroupOptionsSectionController.Option.channelAccess
-            .accessible(in: conversation, by: user))
+        XCTAssertFalse(
+            sut.accessible(in: conversation, by: user)
+        )
     }
-    
+
     func testAccessOptionAllowed_ForChannel_MemberButTeamOwner() {
         user.canManageTeam = true
-        
-        XCTAssertTrue(GroupOptionsSectionController.Option.channelAccess
-            .accessible(in: conversation, by: user))
+
+        XCTAssertTrue(sut.accessible(in: conversation, by: user))
     }
-    
+
     func testAccessOptionAllowed_ForChannel_ChannelOwner() {
         user.isGroupAdminInConversation = true
-        
-        XCTAssertTrue(GroupOptionsSectionController.Option.channelAccess
-            .accessible(in: conversation, by: user))
+
+        XCTAssertTrue(sut.accessible(in: conversation, by: user))
     }
 }

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
@@ -1,0 +1,72 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+import WireTestingPackage
+@testable import Wire
+
+final class ConversationDetailsTests: XCTestCase {
+    
+    lazy var conversation = {
+        let conversation = MockGroupDetailsConversation()
+        conversation.isChannel = true
+        return conversation
+    }()
+    
+    let user = {
+        let user = MockUserType()
+        user.canManageTeam = false
+        user.isGroupAdminInConversation = false
+        return user
+    }()
+    
+    func testAccessOptionNotAllowedForGroup() {
+        user.canManageTeam = true
+        conversation.isChannel = false
+    
+        XCTAssertFalse(GroupOptionsSectionController.Option.channelAccess
+            .accessible(in: conversation, by: user))
+    }
+    
+    func testAccessOptionAllowed_ForChannel_andTeamAdmin() {
+        user.canManageTeam = true
+        
+        XCTAssertTrue(GroupOptionsSectionController.Option.channelAccess
+            .accessible(in: conversation, by: user))
+    }
+    
+    func testAccessOptionNotAllowed_ForChannel_Member() {
+        XCTAssertFalse(GroupOptionsSectionController.Option.channelAccess
+            .accessible(in: conversation, by: user))
+    }
+    
+    func testAccessOptionAllowed_ForChannel_MemberButTeamOwner() {
+        user.canManageTeam = true
+        
+        XCTAssertTrue(GroupOptionsSectionController.Option.channelAccess
+            .accessible(in: conversation, by: user))
+    }
+    
+    func testAccessOptionAllowed_ForChannel_ChannelOwner() {
+        user.isGroupAdminInConversation = true
+        
+        XCTAssertTrue(GroupOptionsSectionController.Option.channelAccess
+            .accessible(in: conversation, by: user))
+    }
+}

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/ConversationDetailsTests.swift
@@ -32,6 +32,7 @@ final class ConversationDetailsTests: XCTestCase {
     let user = {
         let user = MockUserType()
         user.canManageTeam = false
+        user.canAddUserToConversation = false
         user.isGroupAdminInConversation = false
         return user
     }()

--- a/wire-ios/Wire-iOS Tests/UserInterface/GroupDetails/GroupDetailsViewControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserInterface/GroupDetails/GroupDetailsViewControllerTests.swift
@@ -50,7 +50,7 @@ final class GroupDetailsFooterViewTests: XCTestCase, CoreDataFixtureTestHelper {
             groupConversation.teamRemoteIdentifier = team?.remoteIdentifier
             selfUser.membership?.setTeamRole(.partner)
             sut = GroupDetailsFooterView()
-            sut.update(for: groupConversation)
+            sut.update(for: groupConversation, user: selfUser)
 
             verifyInAllPhoneWidths(matching: sut)
         }

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 				ConversationCell/UnknownMessageCellTests.swift,
 				ConversationContentViewControllerTests.swift,
 				ConversationCreationControllerSnapshotTests.swift,
+				ConversationDetail/ConversationDetailsTests.swift,
 				ConversationDetail/GroupDetailsReceiptOptionsCellTests.swift,
 				ConversationDetail/GroupDetailsTimeoutOptionsCellTests.swift,
 				ConversationDetail/GroupDetailsViewControllerSnapshotTests.swift,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsFooterView.swift
@@ -32,13 +32,13 @@ final class GroupDetailsFooterView: ConversationDetailFooterView {
         case invite
     }
 
-    func update(for conversation: GroupDetailsConversationType) {
-        guard let user = SelfUser.provider?.providedSelfUser else {
-            assertionFailure("expected available 'user'!")
-            return
-        }
-
-        leftButton.isHidden = !user.canAddUser(to: conversation)
+    func update(
+        for conversation: GroupDetailsConversationType,
+        user: any UserType
+    ) {
+        let shouldShow = user.canAddUser(to: conversation) ||
+            ((user.canManageTeam || conversation.privateChannelPermission == .everyone) && conversation.isChannel)
+        leftButton.isHidden = !shouldShow
         leftButton.isEnabled = conversation.freeParticipantSlots > 0
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -118,12 +118,12 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
 
         collectionViewController.collectionView = collectionView
         footerView.delegate = self
-        footerView.update(for: conversation)
+        footerView.update(for: conversation, user: userSession.selfUser)
 
         collectionViewController.sections = computeVisibleSections()
     }
 
-    private func setupNavigatiomItem() {
+    private func setupNavigationItem() {
         navigationController?.navigationBar.backgroundColor = SemanticColors.View.backgroundDefault
 
         let titleView = TwoLineTitleView(
@@ -151,7 +151,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         super.viewWillAppear(animated)
 
         updateLegalHoldIndicator()
-        setupNavigatiomItem()
+        setupNavigationItem()
         collectionViewController.collectionView?.reloadData()
     }
 
@@ -164,7 +164,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        setupNavigatiomItem()
+        setupNavigationItem()
     }
 
     func updateLegalHoldIndicator() {
@@ -198,7 +198,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             let maxNumberWithoutTruncation = Int.ConversationParticipants.maxNumberWithoutTruncation
 
             if admins.count <= maxNumberWithoutTruncation || admins.isEmpty {
-                // Dispay the ShowAll button after the first section.
+                // Display the ShowAll button after the first section.
                 if admins.count >= maxNumberOfDisplayed, participants.count > maxNumberWithoutTruncation {
                     let adminSection = ParticipantsSectionController(
                         participants: admins,
@@ -333,7 +333,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
 
         updateLegalHoldIndicator()
         collectionViewController.sections = computeVisibleSections()
-        footerView.update(for: conversation)
+        footerView.update(for: conversation, user: userSession.selfUser)
 
         if changeInfo.participantsChanged, !conversation.isSelfAnActiveMember {
             navigationController?.popToRootViewController(animated: true)
@@ -342,7 +342,7 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         }
 
         if changeInfo.mlsVerificationStatusChanged {
-            setupNavigatiomItem()
+            setupNavigationItem()
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -29,7 +29,7 @@ protocol GroupOptionsSectionControllerDelegate: AnyObject {
 
 final class GroupOptionsSectionController: GroupDetailsSectionController {
 
-    private enum Option: Int, CaseIterable {
+    enum Option: Int, CaseIterable {
 
         case channelAccess = 0
         case notifications
@@ -42,7 +42,7 @@ final class GroupOptionsSectionController: GroupDetailsSectionController {
             by user: UserType
         ) -> Bool {
             switch self {
-            case .channelAccess: user.canManageTeam && conversation.isChannel
+            case .channelAccess: conversation.isChannel && (user.isGroupAdmin(in: conversation) || user.canManageTeam)
             case .notifications: user.canModifyNotificationSettings(in: conversation)
             case .guests:        user.canModifyAccessControlSettings(in: conversation)
             case .services:      user.canModifyAccessControlSettings(in: conversation) && conversation.botCanBeAdded


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16978" title="WPB-16978" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16978</a>  [iOS] Channels - only channel creator can add members
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

PR with 2 fixes ported to release branch

1. Fix to show add participants button based on next logic:

- show if user is channel admin
- show if user is team admin or team owner
- show if conversation access option is Add participants by "Admins and members"

2. Fix Access option availability:
- should be visible for channel admins and team admins or owners

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
