### PR TITLE
chore: improve some channels accessibility labels - WPB-16996

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -725,6 +725,16 @@ internal enum L10n {
       internal enum ItemCell {
         /// Double tap to open conversation
         internal static let hint = L10n.tr("Accessibility", "conversationsList.itemCell.hint", fallback: "Double tap to open conversation")
+        internal enum Avatar {
+          internal enum Channel {
+            /// Channel
+            internal static let label = L10n.tr("Accessibility", "conversationsList.itemCell.avatar.channel.label", fallback: "Channel")
+          }
+          internal enum Group {
+            /// Group
+            internal static let label = L10n.tr("Accessibility", "conversationsList.itemCell.avatar.group.label", fallback: "Group")
+          }
+        }
       }
       internal enum JoinButton {
         /// Join

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -277,8 +277,8 @@ internal enum L10n {
     }
     internal enum ContactsList {
       internal enum CancelButton {
-        /// Close contact list
-        internal static let description = L10n.tr("Accessibility", "contactsList.cancelButton.description", fallback: "Close contact list")
+        /// Close new conversation overview
+        internal static let description = L10n.tr("Accessibility", "contactsList.cancelButton.description", fallback: "Close new conversation overview")
       }
       internal enum ExternalIcon {
         /// External
@@ -561,8 +561,8 @@ internal enum L10n {
     }
     internal enum ConversationList {
       internal enum StartConversationButton {
-        /// Create group or search for people
-        internal static let description = L10n.tr("Accessibility", "conversationList.startConversationButton.description", fallback: "Create group or search for people")
+        /// Create a group or channel, or search for people
+        internal static let description = L10n.tr("Accessibility", "conversationList.startConversationButton.description", fallback: "Create a group or channel, or search for people")
       }
     }
     internal enum ConversationSearch {

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
@@ -218,6 +218,8 @@
 "conversationsList.replyStatus.value" = "Reply";
 "conversationsList.badgeView.value" = "New messages: %d";
 "conversationsList.itemCell.hint" = "Double tap to open conversation";
+"conversationsList.itemCell.avatar.group.label" = "Group";
+"conversationsList.itemCell.avatar.channel.label" = "Channel";
 "conversationsList.joinButton.description" = "Join";
 "conversationsList.joinButton.hint" = "Double tap to join the call";
 "conversationsList.connectionRequest.description" = "Pending approval of connection request";

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
@@ -223,7 +223,7 @@
 "conversationsList.connectionRequest.description" = "Pending approval of connection request";
 "conversationsList.connectionRequest.hint" = "Double tap to open profile";
 
-"conversationList.startConversationButton.description" = "Create group or search for people";
+"conversationList.startConversationButton.description" = "Create a group or channel, or search for people";
 "conversationsList.filterButton.description" = "Filter conversations";
 
 "conversationsList.filter_menu_options.allConversations.description" = "Show all conversations";

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Accessibility.strings
@@ -200,7 +200,7 @@
 "contactsList.memberIcon.description" = "Member";
 "contactsList.userCell.hint" = "Double tap to open conversation";
 "contactsList.pendingConnection.hint" = "Double tap to open profile";
-"contactsList.cancelButton.description" = "Close contact list";
+"contactsList.cancelButton.description" = "Close new conversation overview";
 
 "servicesList.serviceCell.hint" = "Double tap to open service details";
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/ConversationGroupAvatarView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/ConversationGroupAvatarView.swift
@@ -48,7 +48,9 @@ final class ConversationGroupAvatarView: UIView {
         iconContainer.addSubview(iconView)
         iconView.fitIn(view: iconContainer)
 
-        accessibilityLabel = "Avatar for \(conversation.displayNameWithFallback)"
+        typealias Avatar = L10n.Accessibility.ConversationsList.ItemCell.Avatar
+        accessibilityLabel = conversation.isChannel ? Avatar.Channel.label : Avatar.Group.label
+        isAccessibilityElement = true
     }
 
     private var qualifiedID: QualifiedID? = .none

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -40,7 +40,7 @@ extension ConversationViewController {
 
         button.accessibilityIdentifier = "videoCallBarButton"
         button.accessibilityTraits.insert(.startsMediaSession)
-        button.accessibilityLabel = CallActions.Label.makeVideoCall
+        button.accessibilityLabel = CallActions.Label.makeAudioCall
 
         let videoCallAction = UIAction { [weak self] _ in
             self?.callItemTapped()
@@ -54,7 +54,7 @@ extension ConversationViewController {
 
         // Enable large content viewer
         button.showsLargeContentViewer = true
-        button.largeContentTitle = CallActions.Label.makeVideoCall
+        button.largeContentTitle = CallActions.Label.makeAudioCall
         button.largeContentImage = UIImage(resource: .videoCall)
 
         button.bounds.size = button.systemLayoutSizeFitting(CGSize(width: .max, height: 32))

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+NavigationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController+NavigationController.swift
@@ -33,8 +33,5 @@ extension StartUIViewController {
         cancelButton.accessibilityLabel = L10n.Accessibility.ContactsList.CancelButton.description
         cancelButton.accessibilityIdentifier = "cancel"
         navigationItem.rightBarButtonItem = cancelButton
-
-        cancelButton.accessibilityLabel = L10n.Accessibility.ContactsList.CancelButton.description
-
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16996" title="WPB-16996" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16996</a>  [iOS] None of the accessibility values have been updated for channel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR improves some of the channels accessibility labels. I struggled setting custom accessibility labels for the back buttons so will discuss and maybe try to stick with Apples defaults for now. Otherwise those will be fixed in a followup PR. The changes include:

- Add `Group` or `Channel` label to the avatars in the conversation list
- Updated the start conversation button
- Updated the close new conversation button
- Updated the start call button from the conversation

### Testing

Use the accessibility inspector / VoiceOver to inspect the new labels

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
