### PR TITLE
fix: unable to decode conversation member leave event - WPB-17156

### DIFF
--- a/WireAPI/Sources/WireAPI/Models/Conversation/ConversationMemberLeaveReason.swift
+++ b/WireAPI/Sources/WireAPI/Models/Conversation/ConversationMemberLeaveReason.swift
@@ -29,10 +29,10 @@ public enum ConversationMemberLeaveReason: String, Codable, Sendable {
 
     /// The user left the conversation by themselves.
 
-    case userLeft
+    case userLeft = "left"
 
     /// The user was removed from the conversation by an admin.
 
-    case userRemoved
+    case userRemoved = "removed"
 
 }

--- a/WireAPI/Tests/WireAPITests/UpdateEvent/ConversationEventDecodingTests.swift
+++ b/WireAPI/Tests/WireAPITests/UpdateEvent/ConversationEventDecodingTests.swift
@@ -118,7 +118,24 @@ final class ConversationEventDecodingTests: XCTestCase {
         )
     }
 
-    func testDecodingConversationMemberLeaveEvent() throws {
+    func testDecodingConversationMemberLeaveEvent_Deleted() throws {
+        // Given
+        let mockEventData = try MockJSONPayloadResource(name: "ConversationMemberDelete")
+
+        // When
+        let decodedEvent = try decoder.decode(
+            UpdateEventDecodingProxy.self,
+            from: mockEventData.jsonData
+        ).updateEvent
+
+        // Then
+        XCTAssertEqual(
+            decodedEvent,
+            .conversation(.memberLeave(Scaffolding.memberDeletedEvent))
+        )
+    }
+
+    func testDecodingConversationMemberLeaveEvent_Left() throws {
         // Given
         let mockEventData = try MockJSONPayloadResource(name: "ConversationMemberLeave")
 
@@ -131,7 +148,24 @@ final class ConversationEventDecodingTests: XCTestCase {
         // Then
         XCTAssertEqual(
             decodedEvent,
-            .conversation(.memberLeave(Scaffolding.memberLeaveEvent))
+            .conversation(.memberLeave(Scaffolding.memberLeftEvent))
+        )
+    }
+
+    func testDecodingConversationMemberLeaveEvent_Removed() throws {
+        // Given
+        let mockEventData = try MockJSONPayloadResource(name: "ConversationMemberRemove")
+
+        // When
+        let decodedEvent = try decoder.decode(
+            UpdateEventDecodingProxy.self,
+            from: mockEventData.jsonData
+        ).updateEvent
+
+        // Then
+        XCTAssertEqual(
+            decodedEvent,
+            .conversation(.memberLeave(Scaffolding.memberRemovedEvent))
         )
     }
 
@@ -425,12 +459,28 @@ final class ConversationEventDecodingTests: XCTestCase {
             ]
         )
 
-        static let memberLeaveEvent = ConversationMemberLeaveEvent(
+        static let memberDeletedEvent = ConversationMemberLeaveEvent(
             conversationID: conversationID,
             senderID: senderID,
             timestamp: timestamp,
             removedUserIDs: [senderID],
             reason: .userDeleted
+        )
+
+        static let memberLeftEvent = ConversationMemberLeaveEvent(
+            conversationID: conversationID,
+            senderID: senderID,
+            timestamp: timestamp,
+            removedUserIDs: [senderID],
+            reason: .userLeft
+        )
+
+        static let memberRemovedEvent = ConversationMemberLeaveEvent(
+            conversationID: conversationID,
+            senderID: senderID,
+            timestamp: timestamp,
+            removedUserIDs: [senderID],
+            reason: .userRemoved
         )
 
         static let memberUpdateEvent = ConversationMemberUpdateEvent(

--- a/WireAPI/Tests/WireAPITests/UpdateEvent/Resources/ConversationMemberDelete.json
+++ b/WireAPI/Tests/WireAPITests/UpdateEvent/Resources/ConversationMemberDelete.json
@@ -16,6 +16,6 @@
                 "domain": "example.com"
             }
         ],
-        "reason": "left"
+        "reason": "user-deleted"
     }
 }

--- a/WireAPI/Tests/WireAPITests/UpdateEvent/Resources/ConversationMemberRemove.json
+++ b/WireAPI/Tests/WireAPITests/UpdateEvent/Resources/ConversationMemberRemove.json
@@ -16,6 +16,6 @@
                 "domain": "example.com"
             }
         ],
-        "reason": "left"
+        "reason": "removed"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17156" title="WPB-17156" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17156</a>  [iOS] Failed to decode conversation member leave event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
The new sync is unable to decode conversation member leave events if the reason if "left" or "removed". The solution is to adjust the raw strings for the enum that models the reason.

### Testing
1. enable the new sync
2. be in a group conversation 
3. on another device, remove a user, or as a another user leave the conversation
4. assert the app is able to process the event.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
