### PR TITLE
chore: enable `3.120.x` nightly builds - WPB-16963

### DIFF
--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -14,7 +14,7 @@ jobs:
   trigger_tests:
     strategy:
       matrix:
-        branch: [develop, release/cycle-3.121, release/cycle-3.122]  # List other branches here
+        branch: [develop, release/cycle-3.120, release/cycle-3.121, release/cycle-3.122]  # List other branches here
       fail-fast: false # avoid to fail one job
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16963" title="WPB-16963" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16963</a>  Manage release iOS 3.122.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Enable nightly builds on `3.120.x`

### Testing

Nothing

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
