### PR TITLE
refactor: pull self user clients during initial sync - WPB-15974

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -275,6 +275,11 @@ public final class ClientSessionComponent {
         store: userLocalStore
     )
 
+    private lazy var pullSelfUserClientsSync = PullSelfUserClientsSync(
+        api: userClientsAPI,
+        store: userClientsLocalStore
+    )
+
     private lazy var pullUserConnectionsSync = PullUserConnectionsSync(
         api: userConnectionsAPI,
         store: userConnectionsStore
@@ -292,6 +297,7 @@ public final class ClientSessionComponent {
     public lazy var initialSync = {
         let pullResourcesSync = PullResourcesSync(
             pullSelfUserSync: pullSelfUserSync,
+            pullSelfUserClientsSync: pullSelfUserClientsSync,
             pullSelfUserSettingsSync: pullSelfUserSettingsSync,
             pullSelfTeamSync: pullSelfTeamSync,
             pullSelfTeamRolesSync: pullSelfTeamRolesSync,

--- a/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullSelfUserClientsSyncProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullSelfUserClientsSyncProtocol.swift
@@ -17,7 +17,9 @@
 //
 
 // sourcery: AutoMockable
-public protocol PullSelfUserClientsProtocol {
+/// An object to keep the local self user clients up to date
+/// with the remote self user clients.
+public protocol PullSelfUserClientsSyncProtocol {
 
-    func pullSelfClients() async throws
+    func pull() async throws
 }

--- a/WireDomain/Sources/WireDomain/Synchronization/PullResourcesSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullResourcesSync.swift
@@ -22,6 +22,7 @@ import WireLogging
 struct PullResourcesSync: PullResourcesSyncProtocol {
 
     private let pullSelfUserSync: any PullSelfUserSyncProtocol
+    private let pullSelfUserClientsSync: any PullSelfUserClientsSyncProtocol
     private let pullSelfUserSettingsSync: any PullSelfUserSettingsSyncProtocol
     private let pullSelfTeamSync: any PullSelfTeamSyncProtocol
     private let pullSelfTeamRolesSync: any PullSelfTeamRolesSyncProtocol
@@ -38,6 +39,7 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
 
     init(
         pullSelfUserSync: any PullSelfUserSyncProtocol,
+        pullSelfUserClientsSync: any PullSelfUserClientsSyncProtocol,
         pullSelfUserSettingsSync: any PullSelfUserSettingsSyncProtocol,
         pullSelfTeamSync: any PullSelfTeamSyncProtocol,
         pullSelfTeamRolesSync: any PullSelfTeamRolesSyncProtocol,
@@ -51,6 +53,7 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
         pullMLSStatusSync: any PullMLSStatusSyncProtocol
     ) {
         self.pullSelfUserSync = pullSelfUserSync
+        self.pullSelfUserClientsSync = pullSelfUserClientsSync
         self.pullSelfUserSettingsSync = pullSelfUserSettingsSync
         self.pullSelfTeamSync = pullSelfTeamSync
         self.pullSelfTeamRolesSync = pullSelfTeamRolesSync
@@ -67,6 +70,7 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
     func pull() async throws {
         try await logger.measureTime(label: "pull resources") {
             let teamID = try await pullSelfUser()
+            try await pullSelfUserClients()
             try await pullSelfUserSettings()
 
             if let teamID {
@@ -95,6 +99,15 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
             return try await pullSelfUserSync.pull().teamID
         } catch {
             throw Failure(resourceName: "pull self user", reason: error)
+        }
+    }
+
+    private func pullSelfUserClients() async throws {
+        do {
+            logger.debug("pulling self user clients")
+            return try await pullSelfUserClientsSync.pull()
+        } catch {
+            throw Failure(resourceName: "pull self user clients", reason: error)
         }
     }
 

--- a/WireDomain/Sources/WireDomain/Synchronization/PullSelfUserClientsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullSelfUserClientsSync.swift
@@ -19,21 +19,24 @@
 import CoreData
 import WireAPI
 
-/// Pull self clients from backend and update local state
-public struct PullSelfUserClients: PullSelfUserClientsProtocol {
-    private let userClientsAPI: any UserClientsAPI
-    private let userClientsLocalStore: any UserClientsLocalStoreProtocol
+public struct PullSelfUserClientsSync: PullSelfUserClientsSyncProtocol {
 
-    init(userClientsAPI: any UserClientsAPI, userClientsLocalStore: any UserClientsLocalStoreProtocol) {
-        self.userClientsAPI = userClientsAPI
-        self.userClientsLocalStore = userClientsLocalStore
+    private let api: any UserClientsAPI
+    private let store: any UserClientsLocalStoreProtocol
+
+    init(
+        api: any UserClientsAPI,
+        store: any UserClientsLocalStoreProtocol
+    ) {
+        self.api = api
+        self.store = store
     }
 
-    public func pullSelfClients() async throws {
-        let remoteSelfClients = try await userClientsAPI.getSelfClients()
+    public func pull() async throws {
+        let remoteSelfClients = try await api.getSelfClients()
 
         for remoteSelfClient in remoteSelfClients {
-            let localUserClient = await userClientsLocalStore.fetchOrCreateClient(
+            let localUserClient = await store.fetchOrCreateClient(
                 id: remoteSelfClient.id
             )
 
@@ -44,12 +47,12 @@ public struct PullSelfUserClients: PullSelfUserClientsProtocol {
             )
         }
 
-        let deletedSelfClientsIDs = await userClientsLocalStore.deletedSelfClients(
+        let deletedSelfClientsIDs = await store.deletedSelfClients(
             newClients: remoteSelfClients.map(\.id)
         )
 
         for deletedSelfClientID in deletedSelfClientsIDs {
-            await userClientsLocalStore.deleteClient(id: deletedSelfClientID)
+            await store.deleteClient(id: deletedSelfClientID)
         }
     }
 
@@ -58,7 +61,7 @@ public struct PullSelfUserClients: PullSelfUserClientsProtocol {
         from remoteClient: WireAPI.SelfUserClient,
         isNewClient: Bool
     ) async throws {
-        await userClientsLocalStore.updateClient(
+        await store.updateClient(
             id: id,
             isNewClient: isNewClient,
             userClientInfo: remoteClient.toDomainModel()
@@ -67,18 +70,18 @@ public struct PullSelfUserClients: PullSelfUserClientsProtocol {
 
 }
 
-public extension PullSelfUserClients {
+public extension PullSelfUserClientsSync {
 
     static func make(
         apiService: any APIServiceProtocol,
         apiVersion: WireAPI.APIVersion,
         context: NSManagedObjectContext
-    ) -> PullSelfUserClientsProtocol {
+    ) -> PullSelfUserClientsSyncProtocol {
         let userClientsAPI = UserClientsAPIBuilder(apiService: apiService).makeAPI(for: apiVersion)
 
         let userLocalStore = UserLocalStore(context: context)
         let userClientsLocalStore = UserClientsLocalStore(context: context, userLocalStore: userLocalStore)
 
-        return PullSelfUserClients(userClientsAPI: userClientsAPI, userClientsLocalStore: userClientsLocalStore)
+        return PullSelfUserClientsSync(api: userClientsAPI, store: userClientsLocalStore)
     }
 }

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2092,28 +2092,28 @@ class MockPullSelfTeamSyncProtocol: PullSelfTeamSyncProtocol {
 
 }
 
-public class MockPullSelfUserClientsProtocol: PullSelfUserClientsProtocol {
+public class MockPullSelfUserClientsSyncProtocol: PullSelfUserClientsSyncProtocol {
 
     // MARK: - Life cycle
 
     public init() {}
 
 
-    // MARK: - pullSelfClients
+    // MARK: - pull
 
-    public var pullSelfClients_Invocations: [Void] = []
-    public var pullSelfClients_MockError: Error?
-    public var pullSelfClients_MockMethod: (() async throws -> Void)?
+    public var pull_Invocations: [Void] = []
+    public var pull_MockError: Error?
+    public var pull_MockMethod: (() async throws -> Void)?
 
-    public func pullSelfClients() async throws {
-        pullSelfClients_Invocations.append(())
+    public func pull() async throws {
+        pull_Invocations.append(())
 
-        if let error = pullSelfClients_MockError {
+        if let error = pull_MockError {
             throw error
         }
 
-        guard let mock = pullSelfClients_MockMethod else {
-            fatalError("no mock for `pullSelfClients`")
+        guard let mock = pull_MockMethod else {
+            fatalError("no mock for `pull`")
         }
 
         try await mock()

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullResourcesSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullResourcesSyncTests.swift
@@ -25,6 +25,7 @@ final class PullResourcesSyncTests: XCTestCase {
     private var sut: PullResourcesSync!
 
     private var pullSelfUserSync: MockPullSelfUserSyncProtocol!
+    private var pullSelfUserClientsSync: MockPullSelfUserClientsSyncProtocol!
     private var pullSelfUserSettingsSync: MockPullSelfUserSettingsSyncProtocol!
     private var pullSelfTeamSync: MockPullSelfTeamSyncProtocol!
     private var pullSelfTeamRolesSync: MockPullSelfTeamRolesSyncProtocol!
@@ -39,6 +40,7 @@ final class PullResourcesSyncTests: XCTestCase {
 
     override func setUp() async throws {
         pullSelfUserSync = MockPullSelfUserSyncProtocol()
+        pullSelfUserClientsSync = MockPullSelfUserClientsSyncProtocol()
         pullSelfUserSettingsSync = MockPullSelfUserSettingsSyncProtocol()
         pullSelfTeamSync = MockPullSelfTeamSyncProtocol()
         pullSelfTeamRolesSync = MockPullSelfTeamRolesSyncProtocol()
@@ -53,6 +55,7 @@ final class PullResourcesSyncTests: XCTestCase {
 
         sut = PullResourcesSync(
             pullSelfUserSync: pullSelfUserSync,
+            pullSelfUserClientsSync: pullSelfUserClientsSync,
             pullSelfUserSettingsSync: pullSelfUserSettingsSync,
             pullSelfTeamSync: pullSelfTeamSync,
             pullSelfTeamRolesSync: pullSelfTeamRolesSync,
@@ -69,6 +72,7 @@ final class PullResourcesSyncTests: XCTestCase {
 
     override func tearDown() async throws {
         pullSelfUserSync = nil
+        pullSelfTeamSync = nil
         pullSelfUserSettingsSync = nil
         pullSelfTeamSync = nil
         pullSelfTeamRolesSync = nil
@@ -90,6 +94,7 @@ final class PullResourcesSyncTests: XCTestCase {
             domain: Scaffolding.domain,
             teamID: Scaffolding.teamID
         )
+        pullSelfUserClientsSync.pull_MockMethod = {}
         pullSelfUserSettingsSync.pull_MockMethod = {}
         pullSelfTeamSync.pullSelfTeamID_MockMethod = { _ in }
         pullSelfTeamRolesSync.pullSelfTeamID_MockMethod = { _ in }
@@ -107,6 +112,7 @@ final class PullResourcesSyncTests: XCTestCase {
 
         // Then
         XCTAssertEqual(pullSelfUserSync.pull_Invocations.count, 1)
+        XCTAssertEqual(pullSelfUserClientsSync.pull_Invocations.count, 1)
         XCTAssertEqual(pullSelfUserSettingsSync.pull_Invocations.count, 1)
         XCTAssertEqual(pullSelfTeamSync.pullSelfTeamID_Invocations, [Scaffolding.teamID])
         XCTAssertEqual(pullSelfTeamRolesSync.pullSelfTeamID_Invocations, [Scaffolding.teamID])

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserClientsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullSelfUserClientsSyncTests.swift
@@ -25,9 +25,9 @@ import XCTest
 @testable import WireAPI
 @testable import WireDomain
 
-final class PullSelfUserClientsTests: XCTestCase {
+final class PullSelfUserClientsSyncTests: XCTestCase {
 
-    private var sut: PullSelfUserClients!
+    private var sut: PullSelfUserClientsSync!
     private var userClientsAPI: MockUserClientsAPI!
     private var userClientsLocalStore: MockUserClientsLocalStoreProtocol!
     private var stack: CoreDataStack!
@@ -45,9 +45,9 @@ final class PullSelfUserClientsTests: XCTestCase {
         userClientsAPI = MockUserClientsAPI()
         userClientsLocalStore = MockUserClientsLocalStoreProtocol()
 
-        sut = PullSelfUserClients(
-            userClientsAPI: userClientsAPI,
-            userClientsLocalStore: userClientsLocalStore
+        sut = PullSelfUserClientsSync(
+            api: userClientsAPI,
+            store: userClientsLocalStore
         )
     }
 
@@ -83,7 +83,7 @@ final class PullSelfUserClientsTests: XCTestCase {
 
         // When
 
-        try await sut.pullSelfClients()
+        try await sut.pull()
 
         // Then
 

--- a/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
@@ -27,7 +27,7 @@ public protocol ResolveOneOnOneConversationsUseCaseProtocol {
 
 }
 
-typealias PullSelfUserClientsFactory = (NSManagedObjectContext) -> PullSelfUserClientsProtocol
+typealias PullSelfUserClientsFactory = (NSManagedObjectContext) -> PullSelfUserClientsSyncProtocol
 
 struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseProtocol {
 
@@ -62,7 +62,7 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
         // we need the self clients to be up to date before calculating supported protocols
         let pullSelfUserClients = pullSelfUserClientsFactory(context)
         do {
-            try await pullSelfUserClients.pullSelfClients()
+            try await pullSelfUserClients.pull()
         } catch {
             WireLogger.userClient.error("error syncing selfclients: \(error.localizedDescription)")
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1162,7 +1162,7 @@ extension ZMUserSession: SyncAgentDelegate {
         )
     }
 
-    private func pullSelfUserClientsFactory(context: NSManagedObjectContext) -> PullSelfUserClientsProtocol {
+    private func pullSelfUserClientsFactory(context: NSManagedObjectContext) -> PullSelfUserClientsSyncProtocol {
         guard let apiService = managedObjectContext.performAndWait({ self.apiService }) else {
             fatal("cannot initialize ResolveOneOnOneConversationsUseCase")
         }
@@ -1174,7 +1174,7 @@ extension ZMUserSession: SyncAgentDelegate {
 
         }
 
-        return PullSelfUserClients.make(
+        return PullSelfUserClientsSync.make(
             apiService: apiService,
             apiVersion: wireAPIVersion,
             context: context

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
@@ -46,7 +46,7 @@ final class ResolveOneOnOneConversationsUseCaseTests: XCTestCase {
         mockSupportedProtocolService = MockSupportedProtocolsServiceInterface()
         mockOneOnOneResolver = MockOneOnOneResolverInterface()
         mockPullSelfUserClients = MockPullSelfUserClientsSyncProtocol()
-        mockPullSelfUserClients.pullSelfClients_MockMethod = {}
+        mockPullSelfUserClients.pull_MockMethod = {}
 
         sut = ResolveOneOnOneConversationsUseCase(
             context: syncContext,
@@ -85,7 +85,7 @@ final class ResolveOneOnOneConversationsUseCaseTests: XCTestCase {
         try await sut.invoke()
 
         // THEN
-        XCTAssertEqual(mockPullSelfUserClients.pullSelfClients_Invocations.count, 1)
+        XCTAssertEqual(mockPullSelfUserClients.pull_Invocations.count, 1)
         XCTAssertEqual(mockOneOnOneResolver.resolveAllOneOnOneConversationsIn_Invocations.count, 1)
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
@@ -30,7 +30,7 @@ final class ResolveOneOnOneConversationsUseCaseTests: XCTestCase {
     private var sut: ResolveOneOnOneConversationsUseCase!
     private var mockSupportedProtocolService: MockSupportedProtocolsServiceInterface!
     private var mockOneOnOneResolver: MockOneOnOneResolverInterface!
-    private var mockPullSelfUserClients: MockPullSelfUserClientsProtocol!
+    private var mockPullSelfUserClients: MockPullSelfUserClientsSyncProtocol!
     private var stack: CoreDataStack!
     private let coreDataStackHelper = CoreDataStackHelper()
 
@@ -45,7 +45,7 @@ final class ResolveOneOnOneConversationsUseCaseTests: XCTestCase {
         stack = try await coreDataStackHelper.createStack()
         mockSupportedProtocolService = MockSupportedProtocolsServiceInterface()
         mockOneOnOneResolver = MockOneOnOneResolverInterface()
-        mockPullSelfUserClients = MockPullSelfUserClientsProtocol()
+        mockPullSelfUserClients = MockPullSelfUserClientsSyncProtocol()
         mockPullSelfUserClients.pullSelfClients_MockMethod = {}
 
         sut = ResolveOneOnOneConversationsUseCase(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15974" title="WPB-15974" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-15974</a>  [iOS] Add migration of legacy events to new sync mechanism
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
To minimize the amount of legacy update events that need to be migrated to new update events, we will trigger an initial sync in the migration process. By pulling the self user clients during the initial sync, we don't need to migrate user client events (add and remove).

### Testing
1. Run initial sync
2. Assert that all clients have been fetched

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
