### PR TITLE
feat: Broken error handling on message decryption - WPB-17193

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -325,26 +325,32 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func decryptMessage(_ message: Data, in groupID: MLSGroupID) async throws -> DecryptedMessage {
         try await performNonReentrant(groupID: groupID) {
             try await coreCrypto.perform {
-                let result: DecryptedMessage? = try await $0.transaction { context in
-
-                    do {
-                        return try await context.decryptMessage(conversationId: groupID.data, payload: message)
-                    } catch let CoreCryptoError.Mls(error) {
-                        switch error {
-                        case .BufferedFutureMessage, .Other(coreCryptoCommitForMissingProposalError):
-                            // ignore error so transaction is saved and message is saved too.
-                            return nil
-                        default:
+                var capturedError: Error?
+                do {
+                    let result: DecryptedMessage? = try await $0.transaction { context in
+                        do {
+                            return try await context.decryptMessage(conversationId: groupID.data, payload: message)
+                        } catch let CoreCryptoError.Mls(error) {
+                            switch error {
+                            case .BufferedFutureMessage, .Other(coreCryptoCommitForMissingProposalError):
+                                // ignore error so transaction is saved and message is saved too.
+                                return nil
+                            default:
+                                capturedError = CoreCryptoError.Mls(error)
+                                throw error
+                            }
+                        } catch {
+                            capturedError = error
                             throw error
                         }
-                    } catch {
-                        throw error
                     }
-                }
-                if let result {
-                    return result
-                } else {
-                    throw Failure.bufferedDecryptedMessage
+                    if let result {
+                        return result
+                    } else {
+                        throw Failure.bufferedDecryptedMessage
+                    }
+                } catch {
+                    throw capturedError ?? error
                 }
             }
         }

--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -325,32 +325,26 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func decryptMessage(_ message: Data, in groupID: MLSGroupID) async throws -> DecryptedMessage {
         try await performNonReentrant(groupID: groupID) {
             try await coreCrypto.perform {
-                var capturedError: Error?
-                do {
-                    let result: DecryptedMessage? = try await $0.transaction { context in
-                        do {
-                            return try await context.decryptMessage(conversationId: groupID.data, payload: message)
-                        } catch let CoreCryptoError.Mls(error) {
-                            switch error {
-                            case .BufferedFutureMessage, .Other(coreCryptoCommitForMissingProposalError):
-                                // ignore error so transaction is saved and message is saved too.
-                                return nil
-                            default:
-                                capturedError = CoreCryptoError.Mls(error)
-                                throw error
-                            }
-                        } catch {
-                            capturedError = error
-                            throw error
+                let result: DecryptedMessage? = try await $0.transaction { context in
+
+                    do {
+                        return try await context.decryptMessage(conversationId: groupID.data, payload: message)
+                    } catch let CoreCryptoError.Mls(error) {
+                        switch error {
+                        case .BufferedFutureMessage, .Other(coreCryptoCommitForMissingProposalError):
+                            // ignore error so transaction is saved and message is saved too.
+                            return nil
+                        default:
+                            throw CoreCryptoError.Mls(error)
                         }
+                    } catch {
+                        throw error
                     }
-                    if let result {
-                        return result
-                    } else {
-                        throw Failure.bufferedDecryptedMessage
-                    }
-                } catch {
-                    throw capturedError ?? error
+                }
+                if let result {
+                    return result
+                } else {
+                    throw Failure.bufferedDecryptedMessage
                 }
             }
         }

--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -325,26 +325,32 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func decryptMessage(_ message: Data, in groupID: MLSGroupID) async throws -> DecryptedMessage {
         try await performNonReentrant(groupID: groupID) {
             try await coreCrypto.perform {
-                let result: DecryptedMessage? = try await $0.transaction { context in
-
-                    do {
-                        return try await context.decryptMessage(conversationId: groupID.data, payload: message)
-                    } catch let CoreCryptoError.Mls(error) {
-                        switch error {
-                        case .BufferedFutureMessage, .Other(coreCryptoCommitForMissingProposalError):
-                            // ignore error so transaction is saved and message is saved too.
-                            return nil
-                        default:
-                            throw CoreCryptoError.Mls(error)
+                var capturedError: Error?
+                do {
+                    let result: DecryptedMessage? = try await $0.transaction { context in
+                        do {
+                            return try await context.decryptMessage(conversationId: groupID.data, payload: message)
+                        } catch let CoreCryptoError.Mls(error) {
+                            switch error {
+                            case .BufferedFutureMessage, .Other(coreCryptoCommitForMissingProposalError):
+                                // ignore error so transaction is saved and message is saved too.
+                                return nil
+                            default:
+                                capturedError = CoreCryptoError.Mls(error)
+                                throw CoreCryptoError.Mls(error)
+                            }
+                        } catch {
+                            capturedError = error
+                            throw error
                         }
-                    } catch {
-                        throw error
                     }
-                }
-                if let result {
-                    return result
-                } else {
-                    throw Failure.bufferedDecryptedMessage
+                    if let result {
+                        return result
+                    } else {
+                        throw Failure.bufferedDecryptedMessage
+                    }
+                } catch {
+                    throw capturedError ?? error
                 }
             }
         }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1697,7 +1697,9 @@ public final class MLSService: MLSServiceInterface {
                 subconversationType: subconversationType
             )
         } catch DecryptionError.wrongEpoch {
-            await fetchAndRepairGroupIfPossible(with: groupID)
+            Task.detached { [self] in
+                await fetchAndRepairGroupIfPossible(with: groupID)
+            }
             throw DecryptionError.wrongEpoch
         } catch {
             throw error

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1698,6 +1698,10 @@ public final class MLSService: MLSServiceInterface {
             )
         } catch DecryptionError.wrongEpoch {
             Task.detached { [self] in
+                // ⚠️ Important:
+                // Run in detached Task to avoid deadlock:
+                // `fetchAndRepairGroupIfPossible` internally triggers quick sync via `recoverWithQuickSync()`.
+                // If this is called during an ongoing quick sync, awaiting it directly would deadlock.
                 await fetchAndRepairGroupIfPossible(with: groupID)
             }
             throw DecryptionError.wrongEpoch


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

MLS conversation are not repaired as expected when they go out of sync to the broken state (the epoch is old). User can't receive messages.
We have a way to repair the conversation, but it waits for **DecryptionError.wrongEpoch** during the message decryption.
There’s general issue with error handling when decrypting MLS messages.
```
decryptMessage(message: Message) {
  // The WrongEpoch will fail the transaction and and be re-thrown as a ClientError
  coreCrypto.transaction { context ->
      // Can for example throw WrongEpoch
      context.decryptMessage(message)
  }
}
```
Any error which is not handled inside the transaction will cancel the transaction and new `ClientError` will be thrown instead.
As a result, we don't repair the conversation.

### Solution

The inner error needs to be captured and re-thrown when the transaction fails.

**Note: this solution won't bring back messages that were sent while conversation was broken, and the first message sent will repair the conversation but will be lost!!!**

### Testing

Break the conversation and have an old epoch, try to receive messages.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
