### PR TITLE
fix: pulling read receipt mode when disabled - WPB-16352

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
@@ -48,8 +48,8 @@ class TeamsAPIV0: TeamsAPI, VersionedAPI {
 
         return try ResponseParser()
             .success(code: .ok, type: TeamResponseV0.self)
-            .failure(code: .notFound, error: TeamsAPIError.invalidTeamID)
             .failure(code: .notFound, label: "no-team", error: TeamsAPIError.teamNotFound)
+            .failure(code: .notFound, error: TeamsAPIError.invalidTeamID)
             .parse(code: response.statusCode, data: data)
     }
 
@@ -119,8 +119,8 @@ class TeamsAPIV0: TeamsAPI, VersionedAPI {
 
         return try ResponseParser()
             .success(code: .ok, type: TeamMemberLegalholdResponseV0.self)
-            .failure(code: .notFound, error: TeamsAPIError.invalidRequest)
             .failure(code: .notFound, label: "no-team-member", error: TeamsAPIError.teamMemberNotFound)
+            .failure(code: .notFound, error: TeamsAPIError.invalidRequest)
             .parse(code: response.statusCode, data: data)
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/TeamsAPI/TeamsAPIV0.swift
@@ -48,8 +48,8 @@ class TeamsAPIV0: TeamsAPI, VersionedAPI {
 
         return try ResponseParser()
             .success(code: .ok, type: TeamResponseV0.self)
-            .failure(code: .notFound, label: "no-team", error: TeamsAPIError.teamNotFound)
             .failure(code: .notFound, error: TeamsAPIError.invalidTeamID)
+            .failure(code: .notFound, label: "no-team", error: TeamsAPIError.teamNotFound)
             .parse(code: response.statusCode, data: data)
     }
 
@@ -119,8 +119,8 @@ class TeamsAPIV0: TeamsAPI, VersionedAPI {
 
         return try ResponseParser()
             .success(code: .ok, type: TeamMemberLegalholdResponseV0.self)
-            .failure(code: .notFound, label: "no-team-member", error: TeamsAPIError.teamMemberNotFound)
             .failure(code: .notFound, error: TeamsAPIError.invalidRequest)
+            .failure(code: .notFound, label: "no-team-member", error: TeamsAPIError.teamMemberNotFound)
             .parse(code: response.statusCode, data: data)
     }
 

--- a/WireAPI/Sources/WireAPI/APIs/UserPropertiesAPI/UserPropertiesAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UserPropertiesAPI/UserPropertiesAPIV0.swift
@@ -84,15 +84,23 @@ class UserPropertiesAPIV0: UserPropertiesAPI, VersionedAPI {
 
         switch key {
         case .wireReceiptMode:
-            return try parseResponse(
-                (response.statusCode, data),
-                forPayloadType: ReceiptModeResponseV0.self
-            )
+            do {
+                return try parseResponse(
+                    (response.statusCode, data),
+                    forPayloadType: ReceiptModeResponseV0.self
+                )
+            } catch UserPropertiesAPIError.propertyNotFound {
+                return .areReadReceiptsEnabled(false)
+            }
         case .wireTypingIndicatorMode:
-            return try parseResponse(
-                (response.statusCode, data),
-                forPayloadType: TypeIndicatorModeResponseV0.self
-            )
+            do {
+                return try parseResponse(
+                    (response.statusCode, data),
+                    forPayloadType: TypeIndicatorModeResponseV0.self
+                )
+            } catch UserPropertiesAPIError.propertyNotFound {
+                return .areTypingIndicatorsEnabled(false)
+            }
         case .labels:
             return try parseResponse(
                 (response.statusCode, data),

--- a/WireAPI/Sources/WireAPI/Components/ResponseParser.swift
+++ b/WireAPI/Sources/WireAPI/Components/ResponseParser.swift
@@ -73,17 +73,28 @@ struct ResponseParser<Success> {
         return copy
     }
 
+    /// Matches a failure response with the given `code` and optional `label`.
+    ///
+    /// If `label` is given, this method will attempt to parse a `FailureResponse` from the response data, and if this
+    /// fails or the label does not match the `FailureResponse`, the match will fail.
+
     func failure(
         code: HTTPStatusCode,
-        label: String = "",
+        label: String? = nil,
         error: some Error
     ) -> ResponseParser<Success> {
         var copy = self
         copy.parseBlocks.append { httpCode, data in
-            guard let data, httpCode == code.rawValue else { return nil }
-            let failure = try decoder.decode(FailureResponse.self, from: data)
-            guard failure.code == code.rawValue, failure.label == label else { return nil }
-            throw error
+            guard httpCode == code.rawValue else { return nil }
+
+            if let label {
+                guard let data, let failure = try? decoder.decode(FailureResponse.self, from: data),
+                      failure.label == label else { return nil }
+
+                throw error
+            } else {
+                throw error
+            }
         }
         return copy
     }

--- a/WireAPI/Sources/WireAPI/Components/ResponseParser.swift
+++ b/WireAPI/Sources/WireAPI/Components/ResponseParser.swift
@@ -30,14 +30,14 @@ struct ResponseParser<Success> {
         case noParseResult
     }
 
-    private typealias ParseBlock = (Int, Data?) throws -> Success?
+    private typealias ParseBlock = (Data?) throws -> Success?
 
     private let decoder: JSONDecoder
-    private var parseBlocks: [ParseBlock]
+    private var parseBlocks: [Int: [ParseBlock]]
 
     init(decoder: JSONDecoder = .init()) {
         self.decoder = decoder
-        self.parseBlocks = []
+        self.parseBlocks = [:]
     }
 
     /// Success with output data
@@ -48,13 +48,11 @@ struct ResponseParser<Success> {
     ) -> ResponseParser<Success> where Payload.APIModel == Success {
         precondition(200 ..< 300 ~= code.rawValue, "Requires a valid success code: 2xx")
 
-        var copy = self
-        copy.parseBlocks.append { actualCode, data in
-            guard actualCode == code.rawValue, let data else { return nil }
+        return addParseBlock(code: code) { data in
+            guard let data else { return nil }
             let payload = try decoder.decode(Payload.self, from: data)
             return payload.toAPIModel()
         }
-        return copy
     }
 
     /// Success with no output
@@ -62,31 +60,25 @@ struct ResponseParser<Success> {
     func success(code: HTTPStatusCode) -> ResponseParser<Success> where Success == Void {
         precondition(200 ..< 300 ~= code.rawValue, "Requires a valid success code: 2xx")
 
-        var copy = self
-        copy.parseBlocks.append { actualCode, data in
-            guard
-                actualCode == code.rawValue,
-                data == nil || data?.isEmpty == true
+        return addParseBlock(code: code) { data in
+            guard data == nil || data?.isEmpty == true
             else { return nil }
             return ()
         }
-        return copy
     }
 
     /// Matches a failure response with the given `code` and optional `label`.
     ///
     /// If `label` is given, this method will attempt to parse a `FailureResponse` from the response data, and if this
-    /// fails or the label does not match the `FailureResponse`, the match will fail.
+    /// fails or the label does not match the `FailureResponse`, the match will fail. If this method is called multiple
+    /// times with the same `code`, calls with the `label` set will be prioritized.
 
     func failure(
         code: HTTPStatusCode,
         label: String? = nil,
         error: some Error
     ) -> ResponseParser<Success> {
-        var copy = self
-        copy.parseBlocks.append { httpCode, data in
-            guard httpCode == code.rawValue else { return nil }
-
+        addParseBlock(code: code, prioritize: label != nil) { data in
             if let label {
                 guard let data, let failure = try? decoder.decode(FailureResponse.self, from: data),
                       failure.label == label else { return nil }
@@ -96,20 +88,17 @@ struct ResponseParser<Success> {
                 throw error
             }
         }
-        return copy
     }
 
     func failure<DecodableError: Decodable & Error>(
         code: HTTPStatusCode,
         decodableError: DecodableError.Type
     ) -> ResponseParser<Success> {
-        var copy = self
-        copy.parseBlocks.append { httpCode, data in
-            guard let data, httpCode == code.rawValue else { return nil }
+        addParseBlock(code: code) { data in
+            guard let data else { return nil }
             let failure = try decoder.decode(DecodableError.self, from: data)
             throw failure
         }
-        return copy
     }
 
     func parse(_ response: HTTPResponse) throws -> Success {
@@ -127,8 +116,10 @@ struct ResponseParser<Success> {
     }
 
     func parse(code: Int, data: Data?) throws -> Success {
+        let parseBlocks = parseBlocks[code] ?? []
+
         for matcher in parseBlocks {
-            if let success = try matcher(code, data) {
+            if let success = try matcher(data) {
                 return success
             }
         }
@@ -139,6 +130,26 @@ struct ResponseParser<Success> {
         } else {
             throw ParsingError.noParseResult
         }
+    }
+
+    // MARK: Private helps
+
+    private func addParseBlock(
+        code: HTTPStatusCode,
+        prioritize: Bool = false,
+        block: @escaping ParseBlock
+    ) -> ResponseParser<Success> {
+        var blocks = parseBlocks[code.rawValue] ?? []
+
+        if prioritize {
+            blocks.insert(block, at: 0)
+        } else {
+            blocks.append(block)
+        }
+
+        var copy = self
+        copy.parseBlocks[code.rawValue] = blocks
+        return copy
     }
 
 }

--- a/WireAPI/Tests/WireAPITests/APIs/ConversationsAPI/ConversationsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/ConversationsAPI/ConversationsAPITests.swift
@@ -285,8 +285,7 @@ final class ConversationsAPITests: XCTestCase {
     func testGetConversations_givenV0AndSuccessResponse400() async throws {
         // given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .badRequest,
-            label: "invalid body"
+            statusCode: .badRequest
         )
 
         let api = ConversationsAPIV0(apiService: apiService)
@@ -295,11 +294,10 @@ final class ConversationsAPITests: XCTestCase {
         // then
         do {
             _ = try await api.getConversations(for: [])
-        } catch let error as FailureResponse {
-            XCTAssertEqual(error.code, 400)
-            XCTAssertEqual(error.label, "invalid body")
+        } catch ConversationsAPIError.invalidBody {
+            XCTAssertTrue(true)
         } catch {
-            XCTFail("expected error 'FailureResponse'")
+            XCTFail("expected error 'ConversationsAPIError.invalidBody'")
         }
     }
 
@@ -344,8 +342,7 @@ final class ConversationsAPITests: XCTestCase {
     func testGetConversations_givenV2AndSuccessResponse400() async throws {
         // given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .badRequest,
-            label: "invalid body"
+            statusCode: .badRequest
         )
 
         let api = ConversationsAPIV2(apiService: apiService)
@@ -354,11 +351,10 @@ final class ConversationsAPITests: XCTestCase {
         // then
         do {
             _ = try await api.getConversations(for: [])
-        } catch let error as FailureResponse {
-            XCTAssertEqual(error.code, 400)
-            XCTAssertEqual(error.label, "invalid body")
+        } catch ConversationsAPIError.invalidBody {
+            XCTAssertTrue(true)
         } catch {
-            XCTFail("expected error 'FailureResponse'")
+            XCTFail("expected error 'ConversationsAPIError.invalidBody'")
         }
     }
 
@@ -408,8 +404,7 @@ final class ConversationsAPITests: XCTestCase {
     func testGetConversations_givenV3AndSuccessResponse400() async throws {
         // given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .badRequest,
-            label: "invalid body"
+            statusCode: .badRequest
         )
 
         let api = ConversationsAPIV3(apiService: apiService)
@@ -418,11 +413,10 @@ final class ConversationsAPITests: XCTestCase {
         // then
         do {
             _ = try await api.getConversations(for: [])
-        } catch let error as FailureResponse {
-            XCTAssertEqual(error.code, 400)
-            XCTAssertEqual(error.label, "invalid body")
+        } catch ConversationsAPIError.invalidBody {
+            XCTAssertTrue(true)
         } catch {
-            XCTFail("expected error 'FailureResponse'")
+            XCTFail("expected error 'ConversationsAPIError.invalidBody'")
         }
     }
 

--- a/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/UserPropertiesAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/UserPropertiesAPITests.swift
@@ -91,7 +91,7 @@ final class UserPropertiesAPITests: XCTestCase {
         // Then
         try await apiSnapshotHelper.verifyRequest(for: [.v0], apiService: apiService) { sut in
             // When
-            let result = try await sut.areReadReceiptsEnabled
+            let result = try await sut.areTypingIndicatorsEnabled
 
             // Then
             XCTAssertEqual(
@@ -122,8 +122,7 @@ final class UserPropertiesAPITests: XCTestCase {
     func testGetLabels_FailureResponse_PropertyNotFound_V0() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .notFound,
-            label: ""
+            statusCode: .notFound
         )
 
         let sut = UserPropertiesAPIV4(apiService: apiService)
@@ -138,33 +137,31 @@ final class UserPropertiesAPITests: XCTestCase {
     func testGetUserTypingIndicatorModeProperty_FailureResponse_PropertyNotFound_V0() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .notFound,
-            label: ""
+            statusCode: .notFound
         )
 
         let sut = UserPropertiesAPIV4(apiService: apiService)
 
+        // When
+        let result = try await sut.areTypingIndicatorsEnabled
+
         // Then
-        await XCTAssertThrowsErrorAsync(UserPropertiesAPIError.propertyNotFound) {
-            // When
-            _ = try await sut.areTypingIndicatorsEnabled
-        }
+        XCTAssertFalse(result)
     }
 
     func testGetUserReceiptModeProperty_FailureResponse_PropertyNotFound_V0() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .notFound,
-            label: ""
+            statusCode: .notFound
         )
 
         let sut = UserPropertiesAPIV4(apiService: apiService)
 
+        // When
+        let result = try await sut.areReadReceiptsEnabled
+
         // Then
-        await XCTAssertThrowsErrorAsync(UserPropertiesAPIError.propertyNotFound) {
-            // When
-            _ = try await sut.areReadReceiptsEnabled
-        }
+        XCTAssertFalse(result)
     }
 
     // MARK: - V4
@@ -172,8 +169,7 @@ final class UserPropertiesAPITests: XCTestCase {
     func testGetUserProperties_FailureResponse_InvalidKey_V4() async throws {
         // Given
         let apiService = MockAPIServiceProtocol.withError(
-            statusCode: .badRequest,
-            label: ""
+            statusCode: .badRequest
         )
 
         let sut = UserPropertiesAPIV4(apiService: apiService)

--- a/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/__Snapshots__/UserPropertiesAPITests/testGetUserTypingIndicatorModeProperty_SuccessResponse_200_V0_Then_Verify_Request.request-0-v0.txt
+++ b/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/__Snapshots__/UserPropertiesAPITests/testGetUserTypingIndicatorModeProperty_SuccessResponse_200_V0_Then_Verify_Request.request-0-v0.txt
@@ -1,2 +1,2 @@
 curl \
-	"/properties/WIRE_RECEIPT_MODE"
+	"/properties/WIRE_TYPING_INDICATOR_MODE"

--- a/WireAPI/Tests/WireAPITests/Components/ResponseParserTests.swift
+++ b/WireAPI/Tests/WireAPITests/Components/ResponseParserTests.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+
+@testable import WireAPI
+
+final class ResponseParserTests: XCTestCase {
+
+    private var sut: ResponseParser<String>!
+
+    override func setUp() {
+        sut = ResponseParser()
+    }
+
+    override func tearDown() {
+        sut = nil
+    }
+
+    func testFailure_prioritizesLabeledFailure() throws {
+        enum Failure: Error, Equatable {
+            case a
+            case b
+            case c
+        }
+
+        // given
+        let code = HTTPStatusCode.badRequest
+        let data = try JSONEncoder().encode(FailureResponse(code: code.rawValue, label: "b", message: "message"))
+
+        // when
+        XCTAssertThrowsError(
+            try sut
+                .failure(code: code, error: Failure.a)
+                .failure(code: code, label: "b", error: Failure.b)
+                .failure(code: code, error: Failure.c)
+                .parse(code: code.rawValue, data: data)
+        ) { error in
+            // then
+            XCTAssertEqual(error as? Failure, Failure.b)
+        }
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16352" title="WPB-16352" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-16352</a>  [iOS] Failed to pull self user settings
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

New sync currently can fails to pull self user settings when the send read receipts option is disabled. This is because in this case the service returns a 404 rather than a `0` (e.g. false) response.

This PR updates `UserPropertiesAPIV0.getProperty(forKey:)` to catch `UserPropertiesAPIError.propertyNotFound`  errors and return `false` for both fetching `UserPropertiesAPIV0.areTypingIndicatorsEnabled` & `UserPropertiesAPIV0.areReadReceiptsEnabled`.

To do this this PR also updates the behavior of `ResponseParser.failure(code:label:error:)` which was throwing a JSON decoding error due to unexpected body in the 404 case instead of the expected `UserPropertiesAPIError.propertyNotFound` error. The new behavior:

- if no label is given it only cares about matching the status code
- if a label is given it requires that both the status code and label match. If this doesn't happen it doesn't match but also does not throw.

### Testing

_Describe how to test._

1. Fresh install build with new initial sync enabled
2. On web, ensure your account has "Read receipts" setting off
3. Log in
4. Log in should complete
5. Repeat with "Typing indicator" off 

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
