### PR TITLE
feat: treat 503 error as none state - WPB-17087

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
+++ b/WireAuthentication/Sources/WireAuthenticationLogic/DetermineAuthMethodUseCase.swift
@@ -76,7 +76,7 @@ package struct DetermineAuthMethodUseCase: DetermineAuthMethodUseCaseProtocol {
                 return .loginOrRegisterViaEmail(email: email)
             }
         } catch AuthenticationAPIError.serviceUnavailable {
-            return .loginViaEmail(email: email, didDetectDomainConflict: false)
+            return .loginOrRegisterViaEmail(email: email)
         }
 
         switch configuration.domainRedirect {

--- a/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
+++ b/WireAuthentication/Tests/WireAuthenticationLogicTests/DetermineAuthMethodUseCaseTests.swift
@@ -157,7 +157,7 @@ final class DetermineAuthMethodUseCaseTests: XCTestCase {
         let authMethod = try await sut.invoke(emailOrSSOCode: email)
 
         // then
-        XCTAssertEqual(authMethod, .loginViaEmail(email: email, didDetectDomainConflict: false))
+        XCTAssertEqual(authMethod, .loginOrRegisterViaEmail(email: email))
     }
 
     func testInvoke_forwardsUnderlyingErrors() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17087" title="WPB-17087" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17087</a>  [iOS] If error 503, navigate to the login screen with registration.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR cherry-picks https://github.com/wireapp/wire-ios/pull/2869 from develop to the 3.122.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
