### PR TITLE
fix: raw api error displayed to the user - WPB-17232

### DIFF
--- a/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
@@ -96,12 +96,20 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
             case .invalidCredentials, .missingAuth, .badRequest:
                 throw RemoveUserClientError.invalidCredentials
 
+            case .unknown:
+                switch failureResponse.code {
+                case TooManyRequestsStatusCode:
+                    throw RemoveUserClientError.tooManyRequests
+                default:
+                    throw RemoveUserClientError.generic
+                }
+
             default:
-                throw failure
+                throw RemoveUserClientError.generic
             }
 
         default:
-            throw failure
+            throw RemoveUserClientError.generic
         }
     }
 }
@@ -111,5 +119,10 @@ public enum RemoveUserClientError: Error {
     case clientToDeleteNotFound
     case clientDoesNotExistLocally
     case invalidCredentials
+    case tooManyRequests
+
+    // other error types that are not explicitly handled
+    // this allows showing a readable error message to the user
+    case generic
 
 }

--- a/wire-ios-sync-engine/Tests/Source/Use cases/RemoveUserClientUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/RemoveUserClientUseCaseTests.swift
@@ -100,6 +100,29 @@ final class RemoveUserClientUseCaseTests: XCTestCase {
         }
     }
 
+    func testThatItDoesNotRemoveUserClient_WhenTooManyRequests() async throws {
+        // Given
+        let clientId = "222"
+        try await createSelfClient(clientId: clientId)
+        let tooManyRequestsResponseCode = 429
+        let mockResponseFailure = Payload.ResponseFailure(
+            code: tooManyRequestsResponseCode,
+            label: .unknown,
+            message: "Please try again later.",
+            data: nil
+        )
+
+        userClientAPI.deleteUserClientClientIdPassword_MockError = NetworkError.invalidRequestError(
+            mockResponseFailure,
+            ZMTransportResponse()
+        )
+
+        // When / Then
+        await assertItThrows(error: RemoveUserClientError.tooManyRequests) {
+            try await sut.invoke(clientId: clientId, password: "")
+        }
+    }
+
     private func createSelfClient(clientId: String) async throws {
         let selfUserHandle = "foo"
         let selfUserName = "Ms Foo"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/RemoveClients/RemoveClientsViewController.swift
@@ -220,6 +220,11 @@ final class RemoveClientsViewController: UIViewController,
 
 extension RemoveUserClientError: LocalizedError {
     public var errorDescription: String? {
-        L10n.Localizable.General.failure
+        switch self {
+        case .tooManyRequests:
+            L10n.Localizable.Error.User.tooManyRequests
+        default:
+            L10n.Localizable.General.failure
+        }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17232" title="WPB-17232" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17232</a>  [iOS] Rate limit error on manage devices screen is just the raw error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When removing a user client, a raw api error is displayed to the user, looking at the error it happens when too many requests were made to the server.

**Causes**:  When mapping the error `RemoveUserClientError` some errors are not mapped to `RemoveUserClientError` and propagated as is to to the UIViewController extension helper method `showAlert` where we display the `error.localizedDescription`.

**Solutions**: Ensure all errors, specifically the `TooManyRequests` one are caught and mapped to a `RemoveUserClientError` so we provide a readable message to the user.

![image](https://github.com/user-attachments/assets/79030264-c424-432c-9f8b-597452fa0582)

### Testing

- Use the 2FA Login automated bund test to replicate easily (removing the wait before login). 

Otherwise:
- Have 7 devices on your account
- Before logging in, cause 4 password related requests in a 4-minute window
- Login with the 8th device
- Accept prompt to remove a device and choose one

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
