### PR TITLE
chore: bump app version, add release branch to nightly builds - WPB-17172

### DIFF
--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -14,7 +14,7 @@ jobs:
   trigger_tests:
     strategy:
       matrix:
-        branch: [develop, release/cycle-3.120, release/cycle-3.121, release/cycle-3.122]  # List other branches here
+        branch: [develop, release/cycle-3.120, release/cycle-3.121, release/cycle-3.122, release/cycle-3.123]  # List other branches here
       fail-fast: false # avoid to fail one job
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -14,7 +14,7 @@ jobs:
   trigger_tests:
     strategy:
       matrix:
-        branch: [develop, release/cycle-3.120, release/cycle-3.121, release/cycle-3.122, release/cycle-3.123]  # List other branches here
+        branch: [develop, release/cycle-3.120, release/cycle-3.122, release/cycle-3.123]  # List other branches here
       fail-fast: false # avoid to fail one job
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,5 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.123.0
+WIRE_SHORT_VERSION = 3.124.0
 MAJOR_VERSION = 3


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17172" title="WPB-17172" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17172</a>  Manage release iOS 3.123.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Bump app version to 3.124.0
Update nightly builds with branch release/cycle-3.123

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
