### PR TITLE
fix: pulling labels sync error on Bella - WPB-17309

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/UserPropertiesAPI/UserPropertiesAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UserPropertiesAPI/UserPropertiesAPIV0.swift
@@ -102,10 +102,14 @@ class UserPropertiesAPIV0: UserPropertiesAPI, VersionedAPI {
                 return .areTypingIndicatorsEnabled(false)
             }
         case .labels:
-            return try parseResponse(
-                (response.statusCode, data),
-                forPayloadType: LabelsResponseV0.self
-            )
+            do {
+                return try parseResponse(
+                    (response.statusCode, data),
+                    forPayloadType: LabelsResponseV0.self
+                )
+            } catch UserPropertiesAPIError.propertyNotFound {
+                return .conversationLabels([])
+            }
         }
     }
 

--- a/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/UserPropertiesAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UserPropertiesAPI/UserPropertiesAPITests.swift
@@ -127,11 +127,11 @@ final class UserPropertiesAPITests: XCTestCase {
 
         let sut = UserPropertiesAPIV4(apiService: apiService)
 
+        // When
+        let result = try await sut.getLabels()
+
         // Then
-        await XCTAssertThrowsErrorAsync(UserPropertiesAPIError.propertyNotFound) {
-            // When
-            _ = try await sut.getLabels()
-        }
+        XCTAssertEqual(result, [])
     }
 
     func testGetUserTypingIndicatorModeProperty_FailureResponse_PropertyNotFound_V0() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17309" title="WPB-17309" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17309</a>  [iOS] New sync: error pulling labels
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: in Bella environment, pulling conversations labels fails when performing an initial / incremental sync.

**Solution**: as we did for other user properties, catch the 404 error and return empty conversation labels.

### Testing

Using BELLA, in debug actions menu, trigger incremental sync / initial sync, it should successfully perform sync.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
