### PR TITLE
feat: search button for 1:1 conversation - WPB-17294

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationViewControllerSnapshotTests.swift
@@ -26,12 +26,10 @@ final class ConversationViewControllerSnapshotTests: ZMSnapshotTestCase, CoreDat
 
     private var mockMainCoordinator: AnyMainCoordinator!
     private var sut: ConversationViewController!
-    private var mockConversation: ZMConversation!
     private var serviceUser: ZMUser!
     private var userSession: UserSessionMock!
     var coreDataFixture: CoreDataFixture!
     var snapshotHelper: SnapshotHelper!
-    private var imageTransformerMock: MockImageTransformer!
 
     override func setupCoreDataStack() {
         coreDataFixture = CoreDataFixture()
@@ -47,31 +45,161 @@ final class ConversationViewControllerSnapshotTests: ZMSnapshotTestCase, CoreDat
 
     override func setUp() {
         super.setUp()
+
         snapshotHelper = SnapshotHelper()
-        imageTransformerMock = .init()
-        mockConversation = createTeamGroupConversation()
+        serviceUser = coreDataFixture.createServiceUser()
+    }
+
+    override func tearDown() {
+        snapshotHelper = nil
+        sut = nil
+        serviceUser = nil
+        coreDataFixture = nil
+
+        super.tearDown()
+    }
+
+    func testForInitState() {
+        // given
+        let mockConversation = createTeamGroupConversation()
+        createSut(conversation: mockConversation)
+
+        // then
+        snapshotHelper.verify(matching: sut)
+    }
+}
+
+// MARK: - Disable / Enable search in conversations
+
+extension ConversationViewControllerSnapshotTests {
+
+    func testThatTheSearchButtonIsDisabledIfMessagesAreEncryptedInTheDataBase() {
+        // given
+        let mockConversation = createTeamGroupConversation()
+        createSut(conversation: mockConversation)
+
+        // when
+        userSession.encryptMessagesAtRest = true
+
+        // then
+        XCTAssertFalse(sut.shouldShowCollectionsButton)
+    }
+
+    func testThatTheSearchButtonIsEnabledIfMessagesAreNotEncryptedInTheDataBase() {
+        // given
+        let mockConversation = createTeamGroupConversation()
+        createSut(conversation: mockConversation)
+
+        // when
+        userSession.encryptMessagesAtRest = false
+
+        // then
+        XCTAssertTrue(sut.shouldShowCollectionsButton)
+    }
+
+    func testThatTheSearchButtonIsDisabled_IfConversationIsPendingConnection() {
+        // given
+        let mockConversation = createOneOnOneConversation(.pending)
+        createSut(conversation: mockConversation)
+
+        // then
+        XCTAssertFalse(sut.shouldShowCollectionsButton)
+    }
+
+    func testThatTheSearchButtonIsDisabled_IfConversationIsSentConnection() {
+        // given
+        let mockConversation = createOneOnOneConversation(.sent)
+        createSut(conversation: mockConversation)
+
+        // then
+        XCTAssertFalse(sut.shouldShowCollectionsButton)
+    }
+
+    func testThatTheSearchButtonIsEnabled_IfConversationIsOneOnOne() {
+        // given
+        let mockConversation = createOneOnOneConversation(.accepted)
+        createSut(conversation: mockConversation)
+
+        // then
+        XCTAssertTrue(sut.shouldShowCollectionsButton)
+    }
+
+}
+
+// MARK: - Guests bar controller
+
+extension ConversationViewControllerSnapshotTests {
+
+    func testThatGuestsBarControllerIsVisibleIfExternalsArePresent() {
+        // given
+        let mockConversation = createTeamGroupConversation()
+        mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
+        let teamMember = Member.insertNewObject(in: uiMOC)
+        teamMember.user = otherUser
+        teamMember.team = team
+        otherUser.membership?.setTeamRole(.partner)
+        UIColor.setAccentOverride(.green)
+        createSut(conversation: mockConversation)
+
+        // when
+        sut.updateGuestsBarVisibility()
+
+        // then
+        snapshotHelper.verify(matching: sut)
+    }
+
+    func testThatGuestsBarControllerIsVisibleIfServicesArePresent() {
+        // given
+        let mockConversation = createTeamGroupConversation()
+        mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
+        mockConversation.addParticipantAndUpdateConversationState(user: serviceUser)
+
+        UIColor.setAccentOverride(.green)
+        createSut(conversation: mockConversation)
+
+        // when
+        sut.updateGuestsBarVisibility()
+
+        // then
+        snapshotHelper.verify(matching: sut)
+    }
+
+    func testThatGuestsBarControllerIsVisibleIfExternalsAndServicesArePresent() {
+        // given
+        let mockConversation = createTeamGroupConversation()
+        let teamMember = Member.insertNewObject(in: uiMOC)
+        teamMember.user = otherUser
+        teamMember.team = team
+        otherUser.membership?.setTeamRole(.partner)
+
+        mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
+        mockConversation.addParticipantAndUpdateConversationState(user: serviceUser)
+
+        UIColor.setAccentOverride(.green)
+        createSut(conversation: mockConversation)
+
+        // when
+        sut.updateGuestsBarVisibility()
+
+        // then
+        snapshotHelper.verify(matching: sut)
+    }
+
+    // MARK: - Helper Method
+
+    private func createSut(conversation: ZMConversation) {
+        //mockConversation = createTeamGroupConversation()
         userSession = UserSessionMock(mockUser: .createSelfUser(name: "Bob"))
         userSession.coreDataStack = coreDataStack
         userSession.mockConversationList = ConversationList(
-            allConversations: [mockConversation!],
+            allConversations: [conversation],
             filteringPredicate: NSPredicate(value: true),
             managedObjectContext: uiMOC,
             description: "all conversations"
         )
 
-        serviceUser = coreDataFixture.createServiceUser()
-
-        let mockAccount = Account(userName: "mock user", userIdentifier: UUID())
-
-        let zClientViewController = ZClientViewController(
-            account: mockAccount,
-            selfProfileViewsMonitor: SelfProfileViewsMonitorImplementation(),
-            userSession: userSession,
-            trackingManager: nil
-        )
-
         sut = ConversationViewController(
-            conversation: mockConversation,
+            conversation: conversation,
             visibleMessage: nil,
             userSession: userSession,
             mainCoordinator: mockMainCoordinator,
@@ -83,98 +211,24 @@ final class ConversationViewControllerSnapshotTests: ZMSnapshotTestCase, CoreDat
         )
     }
 
-    override func tearDown() {
-        snapshotHelper = nil
-        sut = nil
-        serviceUser = nil
-        coreDataFixture = nil
-        imageTransformerMock = nil
-        mockMainCoordinator = nil
+    private func createOneOnOneConversation(_ connectionStatus: ZMConnectionStatus) -> ZMConversation {
+        let selfUser = ZMUser.selfUser(in: uiMOC)
+        let otherUser = ZMUser.insertNewObject(in: uiMOC)
+        otherUser.remoteIdentifier = UUID()
+        otherUser.name = "Bruno"
 
-        super.tearDown()
-    }
+        let mockConversation = ZMConversation.insertNewObject(in: uiMOC)
+        mockConversation.messageProtocol = .proteus
+        mockConversation.addParticipantAndUpdateConversationState(user: selfUser)
+        mockConversation.conversationType = .oneOnOne
+        mockConversation.remoteIdentifier = UUID.create()
+        mockConversation.oneOnOneUser = otherUser
 
-    func testForInitState() {
-        snapshotHelper.verify(matching: sut)
-    }
-}
+        let connection = ZMConnection.insertNewObject(in: uiMOC)
+        connection.to = otherUser
+        connection.status = connectionStatus
 
-// MARK: - Disable / Enable search in conversations
-
-extension ConversationViewControllerSnapshotTests {
-
-    func testThatTheSearchButtonIsDisabledIfMessagesAreEncryptedInTheDataBase() {
-        // given
-
-        // when
-        userSession.encryptMessagesAtRest = true
-
-        // then
-        XCTAssertFalse(sut.shouldShowCollectionsButton)
-    }
-
-    func testThatTheSearchButtonIsEnabledIfMessagesAreNotEncryptedInTheDataBase() {
-        // given
-
-        // when
-        userSession.encryptMessagesAtRest = false
-
-        // then
-        XCTAssertTrue(sut.shouldShowCollectionsButton)
-    }
-}
-
-// MARK: - Guests bar controller
-
-extension ConversationViewControllerSnapshotTests {
-
-    func testThatGuestsBarControllerIsVisibleIfExternalsArePresent() {
-        // given
-        mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
-        let teamMember = Member.insertNewObject(in: uiMOC)
-        teamMember.user = otherUser
-        teamMember.team = team
-        otherUser.membership?.setTeamRole(.partner)
-        UIColor.setAccentOverride(.green)
-
-        // when
-        sut.updateGuestsBarVisibility()
-
-        // then
-        snapshotHelper.verify(matching: sut)
-    }
-
-    func testThatGuestsBarControllerIsVisibleIfServicesArePresent() {
-        // given
-        mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
-        mockConversation.addParticipantAndUpdateConversationState(user: serviceUser)
-
-        UIColor.setAccentOverride(.green)
-
-        // when
-        sut.updateGuestsBarVisibility()
-
-        // then
-        snapshotHelper.verify(matching: sut)
-    }
-
-    func testThatGuestsBarControllerIsVisibleIfExternalsAndServicesArePresent() {
-        // given
-        let teamMember = Member.insertNewObject(in: uiMOC)
-        teamMember.user = otherUser
-        teamMember.team = team
-        otherUser.membership?.setTeamRole(.partner)
-
-        mockConversation.teamRemoteIdentifier = team?.remoteIdentifier
-        mockConversation.addParticipantAndUpdateConversationState(user: serviceUser)
-
-        UIColor.setAccentOverride(.green)
-
-        // when
-        sut.updateGuestsBarVisibility()
-
-        // then
-        snapshotHelper.verify(matching: sut)
+        return mockConversation
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/ConversationViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationViewControllerSnapshotTests.swift
@@ -188,7 +188,6 @@ extension ConversationViewControllerSnapshotTests {
     // MARK: - Helper Method
 
     private func createSut(conversation: ZMConversation) {
-        //mockConversation = createTeamGroupConversation()
         userSession = UserSessionMock(mockUser: .createSelfUser(name: "Bob"))
         userSession.coreDataStack = coreDataStack
         userSession.mockConversationList = ConversationList(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -147,12 +147,10 @@ extension ConversationViewController {
         switch conversation.conversationType {
         case .group: return true
         case .oneOnOne:
-            if let connection = conversation.oneOnOneUser?.connection,
-               connection.status != .pending, connection.status != .sent {
+            guard let connection = conversation.oneOnOneUser?.connection else {
                 return true
-            } else {
-                return conversation.teamRemoteIdentifier != nil
             }
+            return connection.status != .pending && connection.status != .sent
         default: return false
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17294" title="WPB-17294" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17294</a>  [iOS] Conversation Search missing in 1-1 MLS conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

On 1-1 conversation, the conversation search is not shown.

We check `conversation.teamRemoteIdentifier` but it's nil and so we don't show the search option. I don't know why we have this condition.
On Android there are the following conditions:

```
fun shouldShowSearchButton(): Boolean = (groupState == null
        && connectionState in listOf(
    ConnectionState.ACCEPTED,
    ConnectionState.BLOCKED,
    ConnectionState.MISSING_LEGALHOLD_CONSENT
))
```

In this PR, I removed `conversation.teamRemoteIdentifier` condition and added tests.

### Testing

Open 1:1 conversation -> Search

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
