### PR TITLE
fix: Conversation header call buttons not re-set - WPB-15074

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.swift
@@ -26,7 +26,7 @@ public extension ZMConversation {
 
     @NSManaged var isDeletedRemotely: Bool
 
-    /// Whether the converstion is marked as read only
+    /// Whether the conversation is marked as read only
 
     @NSManaged var isForcedReadOnly: Bool
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -181,7 +181,9 @@ extension ConversationViewController {
     }
 
     func updateRightNavigationItemsButtons() {
-        navigationItem.rightBarButtonItems = rightNavigationItems(forConversation: conversation)
+        let items = rightNavigationItems(forConversation: conversation)
+        navigationItem.rightBarButtonItems = items
+        parent?.navigationItem.rightBarButtonItems = items
     }
 
     /// Update left navigation bar items


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-15074" title="WPB-15074" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-15074</a>  [iOS] Conversation header (1:1, groups, and channels) not refreshed/redrawn appropriately
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

It's hard to reproduce for me, seems like unstable behaviour. But I think I found the issue, where in some cases we set bar items to root VC and for some cases just to child VC. Added call to set bar items to parent VC that is in navigation stack

### Testing

1. Start a call in a group
2. Answer on device
3. Leave the call
4. Check join button
5. All other participants leave call
6. Check no join call, but start call button

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
