### PR TITLE
chore: add debug action to enable/disable usage of CallKit for calling operations - WPB-17355

### DIFF
--- a/wire-ios/Wire-iOS UnitTests/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModelTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModelTests.swift
@@ -27,7 +27,7 @@ final class DeveloperDebugActionsViewModelTests: XCTestCase {
 
         // when
         // then
-        XCTAssertEqual(viewModel.buttons.count, 10)
+        XCTAssertEqual(viewModel.debugItems.count, 11)
     }
 
     // MARK: - Helpers

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsDisplayModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsDisplayModel.swift
@@ -16,14 +16,32 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
+import SwiftUI
 
 enum DeveloperDebugActionsDisplayModel {
 
-    struct ButtonItem: Identifiable {
-        var id: String { title }
+    enum DebugItem: Identifiable {
+        case button(ButtonItem)
+        case toggle(ToggleItem)
 
+        var id: String {
+            switch self {
+            case let .button(buttonItem):
+                buttonItem.title
+            case let .toggle(toggleItem):
+                toggleItem.title
+            }
+        }
+    }
+
+    struct ButtonItem {
         let title: String
         let action: () -> Void
+    }
+
+    struct ToggleItem {
+        let title: String
+        let isOn: Binding<Bool>
+        let enabled: Bool
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsView.swift
@@ -24,9 +24,17 @@ struct DeveloperDebugActionsView: View {
     @State var userInput: String = ""
 
     var body: some View {
-        List(viewModel.buttons) { button in
-            Button(action: button.action) {
-                Text(button.title)
+        List(viewModel.debugItems) { debugItem in
+            switch debugItem {
+            case let .button(buttonItem):
+                Button(action: buttonItem.action) {
+                    Text(buttonItem.title)
+                }
+            case let .toggle(toggleItem):
+                Toggle(isOn: toggleItem.isOn) {
+                    Text(toggleItem.title)
+                        .foregroundColor(.accentColor)
+                }.disabled(!toggleItem.enabled)
             }
         }
         .sheet(item: $viewModel.mlsGroupSearchItem, content: mlsGroupSearchView)

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import SwiftUI
 import WireDataModel
 import WireLogging
 import WireSyncEngine
@@ -44,7 +45,7 @@ enum MLSGroupSearchItem: Identifiable {
 
 final class DeveloperDebugActionsViewModel: ObservableObject {
 
-    @Published var buttons: [DeveloperDebugActionsDisplayModel.ButtonItem] = []
+    @Published var debugItems: [DeveloperDebugActionsDisplayModel.DebugItem] = []
     @Published var mlsGroupSearchItem: MLSGroupSearchItem?
 
     private var userSession: ZMUserSession? { ZMUserSession.shared() }
@@ -67,7 +68,7 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
     }
 
     private func setupButtons() {
-        buttons = [
+        let buttonItems: [DeveloperDebugActionsDisplayModel.ButtonItem] = [
             .init(title: "Send debug logs", action: sendDebugLogs),
             .init(title: "Trigger incremental sync", action: triggerIncrementalSync),
             .init(title: "Trigger resources sync", action: triggerResourcesSync),
@@ -79,6 +80,26 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
             .init(title: "Find Conversation with MLS Group", action: showSearchMLSConversations),
             .init(title: "Clear access token & cookie (forces logout)", action: clearAccessTokenAndCookie)
         ]
+
+        let toggleItems: [DeveloperDebugActionsDisplayModel.ToggleItem] = [
+            .init(title: "Use CallKit", isOn: Binding(
+                get: { self.isCallKitEnabled() },
+                set: { self.enableCallKit($0) }
+            ), enabled: !UIDevice.isSimulator)
+        ]
+
+        debugItems = buttonItems.map { .button($0) } + toggleItems.map { .toggle($0) }
+    }
+
+    // MARK: - CallKit
+
+    private func isCallKitEnabled() -> Bool {
+        SessionManager.shared?.callNotificationStyle == .callKit
+    }
+
+    private func enableCallKit(_ enabled: Bool) {
+        SessionManager.shared?.callNotificationStyle = enabled ? .callKit : .pushNotifications
+        onDismiss?()
     }
 
     // MARK: - Clear access token & cookie


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17355" title="WPB-17355" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17355</a>  [iOS] Create debug action to enable/disable usage of CallKit (for debugging purposes)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Add debug action in developers panel to enable/disable use of CallKit for calling.
It was implemented while working on this [calling issue](https://wearezeta.atlassian.net/browse/WPB-16853) to simplify debugging.

**Enabled**: It will use CallKit built-in system
**Disabled**: It will use our native calling controller screen

Debug action disabled when on simulator

### Testing

Open developer panel, disable CallKit, have an incoming call, it should display the calling controller screen.
switching back to CallKit enabled, it will present incoming call with CallKit

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

