### PR TITLE
fix: include missing SecurityTest - WPB-16986

### DIFF
--- a/wire-ios-data-model/Tests/TestPlans/SecurityTests.xctestplan
+++ b/wire-ios-data-model/Tests/TestPlans/SecurityTests.xctestplan
@@ -52,6 +52,7 @@
         "EncryptionKeysTests\/testThatAsymmetricKeysWorksWithExpectedAlgorithm()",
         "EncryptionKeysTests\/testThatEncryptionKeysAreSuccessfullyCreated()",
         "EncryptionKeysTests\/testThatEncryptionKeysAreSuccessfullyDeleted()",
+        "FileAssetCacheTests\/testThatItDoesDecryptAFileWithTheRightSHA256()",
         "FileAssetCacheTests\/testThatItDoesDecryptAndDeletesAFileWithTheRightSHA256()",
         "FileAssetCacheTests\/testThatItDoesNotDecryptAndDeletesAFileWithWrongSHA256()",
         "NSManagedObjectContextTests_EncryptionAtRest\/testItThrowsAnError_WhenDatabaseKeyIsMissing_WhenEarIsEnabled()",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16986" title="WPB-16986" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16986</a>  Manage Bund release IOS 3.120.3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
There is a single test missing from WireDataModel's SecurityTest plan, this PR adds it.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
