### PR TITLE
chore: use new AutoMockable stencil in WireFoundation - WPB-9200

### DIFF
--- a/WireAPI/Tests/WireAPITests/APIs/BackendMetadataAPI/BackendMetadataAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/BackendMetadataAPI/BackendMetadataAPITests.swift
@@ -24,10 +24,10 @@ import XCTest
 
 final class BackendMetadataAPITests: XCTestCase {
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
 
     override func setUp() async throws {
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T12:34:56Z")
     }
 

--- a/WireAPI/Tests/WireAPITests/Authentication/AuthenticationManagerTests.swift
+++ b/WireAPI/Tests/WireAPITests/Authentication/AuthenticationManagerTests.swift
@@ -28,10 +28,10 @@ final class AuthenticationManagerTests: XCTestCase {
     var backendURL: URL!
     var cookieStorage: MockCookieStorageProtocol!
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
 
     override func setUpWithError() throws {
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T12:34:56Z")
         cookieStorage = MockCookieStorageProtocol()
         backendURL = try XCTUnwrap(URL(string: "https://www.example.com"))

--- a/WireAPI/Tests/WireAPITests/Authentication/CookieStorageTests.swift
+++ b/WireAPI/Tests/WireAPITests/Authentication/CookieStorageTests.swift
@@ -28,11 +28,11 @@ final class CookieStorageTests: XCTestCase {
 
     var sut: CookieStorage!
     var cookieEncryptionKey: Data!
-    var keychain: MockKeychainProtocol!
+    var keychain: KeychainProtocolMock!
 
     override func setUpWithError() throws {
         cookieEncryptionKey = try Scaffolding.cookieEncryptionKey()
-        keychain = MockKeychainProtocol()
+        keychain = KeychainProtocolMock()
         sut = CookieStorage(
             userID: Scaffolding.userID,
             cookieEncryptionKey: cookieEncryptionKey,

--- a/WireAPI/Tests/WireAPITests/Backend/ServerTrustValidatorTests.swift
+++ b/WireAPI/Tests/WireAPITests/Backend/ServerTrustValidatorTests.swift
@@ -24,10 +24,10 @@ import XCTest
 
 final class ServerTrustValidatorTests: XCTestCase {
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
 
     override func setUp() async throws {
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T12:34:56Z")
     }
 

--- a/WireAPI/Tests/WireAPITests/Network/APIService/APIServiceTests.swift
+++ b/WireAPI/Tests/WireAPITests/Network/APIService/APIServiceTests.swift
@@ -29,10 +29,10 @@ final class APIServiceTests: XCTestCase {
     var backendURL: URL!
     var authenticationManager: MockAuthenticationManagerProtocol!
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
 
     override func setUp() async throws {
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T12:34:56Z")
         backendURL = try XCTUnwrap(URL(string: "https://www.example.com"))
         authenticationManager = MockAuthenticationManagerProtocol()

--- a/WireAPI/Tests/WireAPITests/Network/NetworkService/NetworkServiceTests.swift
+++ b/WireAPI/Tests/WireAPITests/Network/NetworkService/NetworkServiceTests.swift
@@ -29,11 +29,11 @@ final class NetworkServiceTests: XCTestCase {
     var sut: NetworkService!
     var backendURL: URL!
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
 
     override func setUp() async throws {
         // certificate expires on 2025-04-10 GMT
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T23:59:59Z")
 
         session = .mockURLSession()

--- a/WireFoundation/Sources/WireFoundation/Utilities/CurrentDateProviding/CurrentDateProviding.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/CurrentDateProviding/CurrentDateProviding.swift
@@ -18,6 +18,7 @@
 
 public import Foundation
 
+// sourcery: AutoMockable
 /// Abstracts accessing the current system date in order to be mockable in unit tests.
 public protocol CurrentDateProviding: Sendable {
     var now: Date { get }

--- a/WireFoundation/Sources/WireFoundationSupport/Sourcery/AutoMockable.manual.swift
+++ b/WireFoundation/Sources/WireFoundationSupport/Sourcery/AutoMockable.manual.swift
@@ -17,26 +17,8 @@
 //
 
 public import WireFoundation
-public import Foundation
 
-public class MockCurrentDateProviding: CurrentDateProviding, @unchecked Sendable {
-
-    // MARK: - Life cycle
-
-    public init() {}
-
-    // MARK: - now
-
-    public var now: Date {
-        get { return underlyingNow }
-        set(value) { underlyingNow = value }
-    }
-
-    public var underlyingNow: Date!
-
-}
-
-public actor MockKeychainProtocol: KeychainProtocol {
+public actor KeychainProtocolMock: KeychainProtocol {
 
     // MARK: - addItem
 

--- a/WireFoundation/Sources/WireFoundationSupport/Sourcery/AutoMockable.stencil
+++ b/WireFoundation/Sources/WireFoundationSupport/Sourcery/AutoMockable.stencil
@@ -1,1 +1,1 @@
-../../../../WirePlugins/Plugins/SourceryPlugin/Stencils/LegacyAutoMockable.stencil
+../../../../WirePlugins/Plugins/SourceryPlugin/Stencils/AutoMockable.stencil

--- a/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/RecurringActionServiceTests.swift
@@ -26,7 +26,7 @@ import XCTest
 final class RecurringActionServiceTests: XCTestCase {
 
     var userDefaults: UserDefaults!
-    var dateProvider: MockCurrentDateProviding!
+    var dateProvider: CurrentDateProvidingMock!
     var sut: RecurringActionService!
 
     override func setUp() {

--- a/wire-ios-transport/Tests/Source/URLSession/BackendEnvironmentTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/BackendEnvironmentTests.swift
@@ -27,11 +27,11 @@ class BackendEnvironmentTests: XCTestCase {
     var backendBundle: Bundle!
     var defaultsProd: UserDefaults!
     var defaultsCustom: UserDefaults!
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
 
     override func setUpWithError() throws {
 
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T12:34:56Z")
 
         continueAfterFailure = false

--- a/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
@@ -70,12 +70,12 @@ final class BackendTrustProviderTests: XCTestCase {
     var pinnedHosts: [String]!
     var certificates: CertificateData!
     var pinnedKeys: PinnedKeysData!
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
     var sut: ServerCertificateTrust!
 
     override func setUpWithError() throws {
 
-        mockDateProvider = MockCurrentDateProviding()
+        mockDateProvider = CurrentDateProvidingMock()
         mockDateProvider.now = try Date.ISO8601FormatStyle().parse("2025-04-09T12:34:56Z")
 
         // Do not run tests if setup fails

--- a/wire-ios/Wire-iOS Tests/Calling/Analytics/CallEndedAnalyticsControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/Calling/Analytics/CallEndedAnalyticsControllerTests.swift
@@ -34,7 +34,7 @@ final class CallEndedAnalyticsControllerTests: XCTestCase {
     private var secondUser: ZMUser!
     private var thirdUser: ZMUser!
     private var mockAnalyticsEventTracker: MockAnalyticsEventTracker!
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
     private var sut: CallEndedAnalyticsController<WireCallCenterV3>!
 
     var syncContext: NSManagedObjectContext { coreDataStack.syncContext }

--- a/wire-ios/Wire-iOS Tests/ConversationCell/BurstTimestampSenderMessageCellDescriptionTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/BurstTimestampSenderMessageCellDescriptionTests.swift
@@ -207,7 +207,7 @@ final class BurstTimestampSenderMessageCellDescriptionTests: XCTestCase {
         showUnreadDot: Bool
     ) -> SUT {
 
-        let currentDateProvider = MockCurrentDateProviding()
+        let currentDateProvider = CurrentDateProvidingMock()
         currentDateProvider.now = now
 
         return BurstTimestampSenderMessageCellDescription(

--- a/wire-ios/Wire-iOS UnitTests/UserInterface/PermissionDeniedHint/NotificationAuthorizationStatusDeniedUseCases/DidPresentNotificationPermissionHintUseCaseTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/UserInterface/PermissionDeniedHint/NotificationAuthorizationStatusDeniedUseCases/DidPresentNotificationPermissionHintUseCaseTests.swift
@@ -24,9 +24,9 @@ import XCTest
 
 final class DidPresentNotificationPermissionHintUseCaseTests: XCTestCase {
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
     private var userDefaults: UserDefaults!
-    private var sut: DidPresentNotificationPermissionHintUseCase<MockCurrentDateProviding>!
+    private var sut: DidPresentNotificationPermissionHintUseCase<CurrentDateProvidingMock>!
 
     override func setUp() {
         mockDateProvider = .init()

--- a/wire-ios/Wire-iOS UnitTests/UserInterface/PermissionDeniedHint/NotificationAuthorizationStatusDeniedUseCases/ShouldPresentNotificationPermissionHintUseCaseTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/UserInterface/PermissionDeniedHint/NotificationAuthorizationStatusDeniedUseCases/ShouldPresentNotificationPermissionHintUseCaseTests.swift
@@ -25,10 +25,10 @@ import XCTest
 
 final class ShouldPresentNotificationPermissionHintUseCaseTests: XCTestCase {
 
-    private var mockDateProvider: MockCurrentDateProviding!
+    private var mockDateProvider: CurrentDateProvidingMock!
     private var userDefaults: UserDefaults!
     private var userNotificationCenterMock: MockUserNotificationCenterAbstraction!
-    private var sut: ShouldPresentNotificationPermissionHintUseCase<MockCurrentDateProviding>!
+    private var sut: ShouldPresentNotificationPermissionHintUseCase<CurrentDateProvidingMock>!
 
     override func setUp() {
         mockDateProvider = .init()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-9200" title="WPB-9200" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-9200</a>  Upgrade Sourcery when it supports existential any and auto-mock UserNotificationCenterAbstraction
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Updates WireFoundation to use the new stencil of Sourcery.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
