### PR TITLE
fix: sync status bar never goes away on error - WPB-17151

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -70,7 +70,10 @@ final class SyncAgent: NSObject {
             do {
                 try await performSync()
             } catch {
-                WireLogger.sync.error("failed to perform sync: \(String(describing: error))")
+                delegate?.syncAgentDidFailSyncing(
+                    self,
+                    error: error
+                )
             }
         }
     }
@@ -112,10 +115,9 @@ final class SyncAgent: NSObject {
                 WireLogger.sync.error("failed to perform new initial sync: \(String(describing: error))")
                 throw error
             }
-
+            // Incremental sync automatically follows the slow sync.
             try await performIncrementalSync()
         } else {
-            // Incremental sync automatically follows the slow sync.
             legacySyncStatus.forceSlowSync()
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -115,9 +115,10 @@ final class SyncAgent: NSObject {
                 WireLogger.sync.error("failed to perform new initial sync: \(String(describing: error))")
                 throw error
             }
-            // Incremental sync automatically follows the slow sync.
+
             try await performIncrementalSync()
         } else {
+            // Incremental sync automatically follows the slow sync.
             legacySyncStatus.forceSlowSync()
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgentDelegate.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgentDelegate.swift
@@ -24,6 +24,7 @@ protocol SyncAgentDelegate: AnyObject {
     func syncAgentDidFinishInitialSync(_ syncAgent: SyncAgent)
     func syncAgentDidStartIncrementalSync(_ syncAgent: SyncAgent)
     func syncAgentDidFinishIncrementalSync(_ syncAgent: SyncAgent)
+    func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: Error)
 
     func syncAgentDidStartLegacyInitialSync(_ syncAgent: SyncAgent)
     func syncAgentDidFinishLegacyInitialSync(_ syncAgent: SyncAgent)

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -883,6 +883,7 @@ public final class ZMUserSession: NSObject {
         }
     }
 
+    // Only used for testing
     public func triggerIncrementalSync() {
         Task {
             do {
@@ -1075,6 +1076,15 @@ extension ZMUserSession: SyncAgentDelegate {
 
     func syncAgentDidFinishLegacyIncrementalSync(_ syncAgent: SyncAgent, isRecovering: Bool) {
         didFinishIncrementalSync(isRecovering: isRecovering)
+    }
+
+    func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: Error) {
+        WireLogger.sync.error("failed to perform sync: \(String(describing: error))")
+
+        managedObjectContext.performGroupedBlock { [weak self] in
+            self?.isPerformingSync = false
+            self?.updateNetworkState()
+        }
     }
 
     func didStartInitialSync() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17151" title="WPB-17151" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17151</a>  [iOS] if sync fails the sync bar never goes away
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When sync fails, sync status bar never goes away.

**Causes**: We don't do anything when either the initial or the incremental sync fails, just logging the error.

**Solution**:  Trigger an update of the sync status bar state when the sync fails.

### Testing

Only testable internally - on Xcode added specific debug code:

- Use existing debug action (like the incremental sync one)
- Add code to update the sync status bar (so it changes to .onlineSynchronizing) in this method
- In the same method, call syncAgent.resume()
- in one of the initial sync / incremental sync methods, force throwing an error after a couple of seconds (so we have time to see the sync status bar showing up)

After triggering the debug action, sync status bar should go away when sync fails

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.