### PR TITLE
fix: handle sync failures - WPB-17266

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+UserSessionSelfUserClientDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+UserSessionSelfUserClientDelegate.swift
@@ -28,6 +28,11 @@ protocol UserSessionSelfUserClientDelegate: AnyObject {
 
     /// Invoked when the client has completed the initial sync
     func clientCompletedInitialSync(accountId: UUID)
+    
+    func clientDidFailSyncing(
+        error: any Error,
+        retryHandler: @escaping () -> Void
+    )
 }
 
 extension SessionManager: UserSessionSelfUserClientDelegate {
@@ -73,6 +78,18 @@ extension SessionManager: UserSessionSelfUserClientDelegate {
             await MainActor.run {
                 delegate?.sessionManagerDidCompleteInitialSync(for: activeUserSession)
             }
+        }
+    }
+    
+    func clientDidFailSyncing(
+        error: any Error,
+        retryHandler: @escaping () -> Void
+    ) {
+        Task {
+            delegate?.sessionManagerDidFailSyncing(
+                error: error,
+                retryHandler: retryHandler
+            )
         }
     }
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+UserSessionSelfUserClientDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+UserSessionSelfUserClientDelegate.swift
@@ -28,7 +28,7 @@ protocol UserSessionSelfUserClientDelegate: AnyObject {
 
     /// Invoked when the client has completed the initial sync
     func clientCompletedInitialSync(accountId: UUID)
-    
+
     func clientDidFailSyncing(
         error: any Error,
         retryHandler: @escaping () -> Void
@@ -80,7 +80,7 @@ extension SessionManager: UserSessionSelfUserClientDelegate {
             }
         }
     }
-    
+
     func clientDidFailSyncing(
         error: any Error,
         retryHandler: @escaping () -> Void

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+UserSessionSelfUserClientDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+UserSessionSelfUserClientDelegate.swift
@@ -85,11 +85,9 @@ extension SessionManager: UserSessionSelfUserClientDelegate {
         error: any Error,
         retryHandler: @escaping () -> Void
     ) {
-        Task {
-            delegate?.sessionManagerDidFailSyncing(
-                error: error,
-                retryHandler: retryHandler
-            )
-        }
+        delegate?.sessionManagerDidFailSyncing(
+            error: error,
+            retryHandler: retryHandler
+        )
     }
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -68,6 +68,10 @@ public protocol SessionManagerDelegate: AnyObject, SessionActivationObserver {
     func sessionManagerDidPerformAPIMigrations(activeSession: UserSession?)
     func sessionManagerAsksToRetryStart()
     func sessionManagerDidCompleteInitialSync(for activeSession: UserSession?)
+    func sessionManagerDidFailSyncing(
+        error: any Error,
+        retryHandler: @escaping () -> Void
+    )
 
     var isInAuthenticatedAppState: Bool { get }
     var isInUnathenticatedAppState: Bool { get }

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgentDelegate.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgentDelegate.swift
@@ -24,7 +24,7 @@ protocol SyncAgentDelegate: AnyObject {
     func syncAgentDidFinishInitialSync(_ syncAgent: SyncAgent)
     func syncAgentDidStartIncrementalSync(_ syncAgent: SyncAgent)
     func syncAgentDidFinishIncrementalSync(_ syncAgent: SyncAgent)
-    func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: Error)
+    func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: any Error)
 
     func syncAgentDidStartLegacyInitialSync(_ syncAgent: SyncAgent)
     func syncAgentDidFinishLegacyInitialSync(_ syncAgent: SyncAgent)

--- a/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
@@ -88,7 +88,9 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
         WireLogger.userClient.error(
             "error removing self client \(userClient.safeForLoggingDescription): \(failure.localizedDescription)"
         )
-
+WireLogger.userClient.error(
+            "error removing self client: \(failure.localizedDescription)", attributes: [.selfClientId: userClient.safeForLoggingDescription]
+        )
         switch failure {
         case let .invalidRequestError(failureResponse, _):
             switch failureResponse.label {

--- a/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireLogging
 
 // sourcery: AutoMockable
 public protocol RemoveUserClientUseCaseProtocol {
@@ -83,6 +84,11 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
     }
 
     private func handleFailure(_ failure: NetworkError, userClient: UserClient) async throws {
+
+        WireLogger.userClient.error(
+            "error removing self client \(userClient.safeForLoggingDescription): \(failure.localizedDescription)"
+        )
+
         switch failure {
         case let .invalidRequestError(failureResponse, _):
             switch failureResponse.label {

--- a/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/RemoveUserClientUseCase.swift
@@ -84,13 +84,11 @@ class RemoveUserClientUseCase: RemoveUserClientUseCaseProtocol {
     }
 
     private func handleFailure(_ failure: NetworkError, userClient: UserClient) async throws {
-
         WireLogger.userClient.error(
-            "error removing self client \(userClient.safeForLoggingDescription): \(failure.localizedDescription)"
+            "error removing self client: \(failure.localizedDescription)",
+            attributes: [.selfClientId: userClient.safeForLoggingDescription]
         )
-WireLogger.userClient.error(
-            "error removing self client: \(failure.localizedDescription)", attributes: [.selfClientId: userClient.safeForLoggingDescription]
-        )
+
         switch failure {
         case let .invalidRequestError(failureResponse, _):
             switch failureResponse.label {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1084,15 +1084,15 @@ extension ZMUserSession: SyncAgentDelegate {
                 self?.isPerformingSync = true
                 self?.updateNetworkState()
             }
-            
+
             syncAgent.resume()
         }
-        
+
         delegate?.clientDidFailSyncing(
             error: error,
             retryHandler: onRetry
         )
-        
+
         WireLogger.sync.error("failed to perform sync: \(String(describing: error))")
 
         managedObjectContext.performGroupedBlock { [weak self] in

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1078,7 +1078,21 @@ extension ZMUserSession: SyncAgentDelegate {
         didFinishIncrementalSync(isRecovering: isRecovering)
     }
 
-    func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: Error) {
+    func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: any Error) {
+        let onRetry: () -> Void = { [weak self] in
+            self?.managedObjectContext.performGroupedBlock {
+                self?.isPerformingSync = true
+                self?.updateNetworkState()
+            }
+            
+            syncAgent.resume()
+        }
+        
+        delegate?.clientDidFailSyncing(
+            error: error,
+            retryHandler: onRetry
+        )
+        
         WireLogger.sync.error("failed to perform sync: \(String(describing: error))")
 
         managedObjectContext.performGroupedBlock { [weak self] in

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1042,6 +1042,21 @@ public class MockSessionManagerDelegate: SessionManagerDelegate {
         mock(activeSession)
     }
 
+    // MARK: - sessionManagerDidFailSyncing
+
+    public var sessionManagerDidFailSyncingErrorRetryHandler_Invocations: [(error: any Error, retryHandler: () -> Void)] = []
+    public var sessionManagerDidFailSyncingErrorRetryHandler_MockMethod: ((any Error, @escaping () -> Void) -> Void)?
+
+    public func sessionManagerDidFailSyncing(error: any Error, retryHandler: @escaping () -> Void) {
+        sessionManagerDidFailSyncingErrorRetryHandler_Invocations.append((error: error, retryHandler: retryHandler))
+
+        guard let mock = sessionManagerDidFailSyncingErrorRetryHandler_MockMethod else {
+            fatalError("no mock for `sessionManagerDidFailSyncingErrorRetryHandler`")
+        }
+
+        mock(error, retryHandler)
+    }
+
     // MARK: - sessionManagerDidChangeActiveUserSession
 
     public var sessionManagerDidChangeActiveUserSessionUserSession_Invocations: [ZMUserSession] = []

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockUserSessionDelegate.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockUserSessionDelegate.swift
@@ -45,7 +45,7 @@ final class MockUserSessionDelegate: NSObject, UserSessionDelegate {
     }
 
     func authenticationInvalidated(_ error: NSError, accountId: UUID) {}
-    
+
     func clientDidFailSyncing(error: any Error, retryHandler: @escaping () -> Void) {}
-    
+
 }

--- a/wire-ios-sync-engine/Tests/Source/Mocks/MockUserSessionDelegate.swift
+++ b/wire-ios-sync-engine/Tests/Source/Mocks/MockUserSessionDelegate.swift
@@ -45,4 +45,7 @@ final class MockUserSessionDelegate: NSObject, UserSessionDelegate {
     }
 
     func authenticationInvalidated(_ error: NSError, accountId: UUID) {}
+    
+    func clientDidFailSyncing(error: any Error, retryHandler: @escaping () -> Void) {}
+    
 }

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -73,7 +73,7 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .asyncStreamNotifications:
             "Turn on to enable new sync with consumable notifications"
-            
+
         case .showDetailedSyncError:
             "Show detailed sync error"
         }

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -33,7 +33,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case useWireAuthentication
     case wireCellsAttachmentsPreviews
     case asyncStreamNotifications
-    case showDetailedSyncError
+    case showDetailedErrors
 
     public var description: String {
         switch self {
@@ -70,8 +70,8 @@ public enum DeveloperFlag: String, CaseIterable {
         case .asyncStreamNotifications:
             "Turn on to enable new sync with consumable notifications"
 
-        case .showDetailedSyncError:
-            "Show detailed sync error"
+        case .showDetailedErrors:
+            "Show detailed errors"
         }
     }
 

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -34,6 +34,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case useWireAuthentication
     case wireCellsAttachmentsPreviews
     case asyncStreamNotifications
+    case showDetailedSyncError
 
     public var description: String {
         switch self {
@@ -72,6 +73,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .asyncStreamNotifications:
             "Turn on to enable new sync with consumable notifications"
+            
+        case .showDetailedSyncError:
+            "Show detailed sync error"
         }
     }
 

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5919,6 +5919,16 @@ internal enum L10n {
       /// Tap colors to change brush size
       internal static let initialHint = L10n.tr("Localizable", "sketchpad.initial_hint", fallback: "Tap colors to change brush size")
     }
+    internal enum Sync {
+      internal enum Error {
+        /// An error occured while synchronizing your app, please try again
+        internal static let message = L10n.tr("Localizable", "sync.error.message", fallback: "An error occured while synchronizing your app, please try again")
+        /// Retry
+        internal static let retry = L10n.tr("Localizable", "sync.error.retry", fallback: "Retry")
+        /// Synchronization error
+        internal static let title = L10n.tr("Localizable", "sync.error.title", fallback: "Synchronization error")
+      }
+    }
     internal enum SystemStatusBar {
       internal enum NoInternet {
         /// There seems to be a problem with your Internet connection. Please make sure it’s working.

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -105,6 +105,11 @@
 "add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
 "add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more.";
 
+// Synchronization
+"sync.error.title" = "Synchronization error";
+"sync.error.message" = "An error occured while synchronizing your app, please try again";
+"sync.error.retry" = "Retry";
+
 // Channel Creation UI - Navigation
 "conversation.create.channel.title" = "New channel";
 "conversation.create.channel.back" = "Back";

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -260,7 +260,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         onRetry: @escaping () -> Void
     ) {
 
-        let syncErrorMessage = if DeveloperFlag.showDetailedSyncError.isOn {
+        let syncErrorMessage = if DeveloperFlag.showDetailedErrors.isOn {
             // show detailed sync error message
             (error as NSError).description
         } else {

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -250,7 +250,46 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         case let .locked(userSession):
             screenCurtainWindow.userSession = userSession
             showAppLock(userSession: userSession, completion: completion)
+        case .syncFailure(let error, let onRetry):
+            presentSyncErrorAlert(error: error, onRetry: onRetry)
         }
+    }
+    
+    private func presentSyncErrorAlert(
+        error: any Error,
+        onRetry: @escaping () -> Void
+    ) {
+        
+        let syncErrorMessage = if DeveloperFlag.showDetailedSyncError.isOn {
+            // show detailed sync error message
+            (error as NSError).description
+        } else {
+            // show generic sync error message
+            L10n.Localizable.Sync.Error.message
+        }
+        
+        let alert = UIAlertController(
+            title: L10n.Localizable.Sync.Error.title,
+            message: syncErrorMessage,
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(UIAlertAction(
+            title: L10n.Localizable.Sync.Error.retry,
+            style: .default) { [weak self] _ in
+                onRetry()
+                self?.appStateTransitionGroup.leave()
+            }
+        )
+        
+        alert.addAction(UIAlertAction(
+            title: L10n.Localizable.General.cancel,
+            style: .destructive) { [weak self] _ in
+                self?.appStateTransitionGroup.leave()
+            }
+        )
+        
+        rootViewController.present(alert, animated: true)
     }
 
     private func resetAuthenticationCoordinatorIfNeeded(for state: AppState) {

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -250,16 +250,16 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         case let .locked(userSession):
             screenCurtainWindow.userSession = userSession
             showAppLock(userSession: userSession, completion: completion)
-        case .syncFailure(let error, let onRetry):
+        case let .syncFailure(error, onRetry):
             presentSyncErrorAlert(error: error, onRetry: onRetry)
         }
     }
-    
+
     private func presentSyncErrorAlert(
         error: any Error,
         onRetry: @escaping () -> Void
     ) {
-        
+
         let syncErrorMessage = if DeveloperFlag.showDetailedSyncError.isOn {
             // show detailed sync error message
             (error as NSError).description
@@ -267,28 +267,32 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             // show generic sync error message
             L10n.Localizable.Sync.Error.message
         }
-        
+
         let alert = UIAlertController(
             title: L10n.Localizable.Sync.Error.title,
             message: syncErrorMessage,
             preferredStyle: .alert
         )
-        
-        alert.addAction(UIAlertAction(
-            title: L10n.Localizable.Sync.Error.retry,
-            style: .default) { [weak self] _ in
+
+        alert.addAction(
+            UIAlertAction(
+                title: L10n.Localizable.Sync.Error.retry,
+                style: .default
+            ) { [weak self] _ in
                 onRetry()
                 self?.appStateTransitionGroup.leave()
             }
         )
-        
-        alert.addAction(UIAlertAction(
-            title: L10n.Localizable.General.cancel,
-            style: .destructive) { [weak self] _ in
+
+        alert.addAction(
+            UIAlertAction(
+                title: L10n.Localizable.General.cancel,
+                style: .destructive
+            ) { [weak self] _ in
                 self?.appStateTransitionGroup.leave()
             }
         )
-        
+
         rootViewController.present(alert, animated: true)
     }
 

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -32,6 +32,7 @@ enum AppState: Equatable {
     case databaseFailure(reason: Error)
     case migrating
     case loading(account: Account, from: Account?)
+    case syncFailure(error: any Error, onRetry: () -> Void)
 
     static func == (lhs: AppState, rhs: AppState) -> Bool {
         switch (lhs, rhs) {
@@ -89,6 +90,8 @@ extension AppState: CustomDebugStringConvertible {
             "migrating"
         case .loading:
             "loading"
+        case .syncFailure(let error, _):
+            "syncFailure: \(error.localizedDescription)"
         }
     }
 }
@@ -118,6 +121,8 @@ extension AppState: SafeForLoggingStringConvertible {
             "migrating"
         case let .loading(account, from):
             "loading account: \(account.userIdentifier.safeForLoggingDescription), from: \(from?.userIdentifier.safeForLoggingDescription ?? "<nil>")"
+        case .syncFailure(let error, _):
+            "syncFailure \(error.localizedDescription)"
         }
     }
 
@@ -331,6 +336,13 @@ extension AppStateCalculator: SessionManagerDelegate {
         if let activeSession {
             transition(to: .authenticated(activeSession))
         }
+    }
+    
+    func sessionManagerDidFailSyncing(
+        error: any Error,
+        retryHandler: @escaping () -> Void
+    ) {
+        transition(to: .syncFailure(error: error, onRetry: retryHandler))
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -90,7 +90,7 @@ extension AppState: CustomDebugStringConvertible {
             "migrating"
         case .loading:
             "loading"
-        case .syncFailure(let error, _):
+        case let .syncFailure(error, _):
             "syncFailure: \(error.localizedDescription)"
         }
     }
@@ -121,7 +121,7 @@ extension AppState: SafeForLoggingStringConvertible {
             "migrating"
         case let .loading(account, from):
             "loading account: \(account.userIdentifier.safeForLoggingDescription), from: \(from?.userIdentifier.safeForLoggingDescription ?? "<nil>")"
-        case .syncFailure(let error, _):
+        case let .syncFailure(error, _):
             "syncFailure \(error.localizedDescription)"
         }
     }
@@ -337,7 +337,7 @@ extension AppStateCalculator: SessionManagerDelegate {
             transition(to: .authenticated(activeSession))
         }
     }
-    
+
     func sessionManagerDidFailSyncing(
         error: any Error,
         retryHandler: @escaping () -> Void


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17266" title="WPB-17266" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17266</a>  [iOS] Handle sync failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We don't display any error to the user is the sync fails nor the ability to retry.

This PR introduces an alert displayed to the user if one of the sync fails (initial / incremental) with the ability to retry.

For debugging, it adds a flag which, when enabled (disabled by default), show the detailed sync error.

### #1 **Error alert shown to the user** 
![IMG_0062](https://github.com/user-attachments/assets/cba2c58c-e3fd-4ad7-9f3b-2b6615c03677)

### **#2 Error alert for debugging** 
![IMG_0063](https://github.com/user-attachments/assets/56d8bcc0-9c30-40ad-8968-bc3699ae5d1d)

### **Developer flag to enable detailed error** 
![IMG_0060](https://github.com/user-attachments/assets/dc355978-be8c-4a7e-b6bd-59d3eccb719a)


### Testing

Only testable internally - on Xcode added specific debug code:

Use existing debug action (like the incremental sync one) and modify it as follows:
- Add code to update the sync status bar (so it changes to .onlineSynchronizing) in this method
- Call syncAgent.resume()
- in the initial sync / incremental sync methods, force throwing an error after a couple of seconds

To display the alert user will see - screenshot #1:
- trigger the debug action, it will show the alert, tap on retry, it should retry syncing (and will be displayed the alert again since we added a force thrown error)

To display the debug detailed alert - screenshot #2:
- enable the `showDetailedSyncError` flag (flag is disabled by default) in the developers panel, trigger debug action again, same alert will be displayed with a more detailed error

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---