### PR TITLE
fix: app sends large amount of last read messages - WPB-17439

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
@@ -123,7 +123,13 @@ public extension ZMConversation {
         _ content: MessageCapable,
         in context: NSManagedObjectContext
     ) throws -> ZMClientMessage? {
-        guard let selfConversation = ZMConversation.fetchSelfMLSConversation(in: context) else {
+        let selfClient = ZMUser.selfUser(in: context).selfClient()
+        let hasRegisteredMLSClient = selfClient?.hasRegisteredMLSClient ?? false
+
+        guard
+            hasRegisteredMLSClient,
+            let selfConversation = ZMConversation.fetchSelfMLSConversation(in: context)
+        else {
             return nil
         }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 @testable import WireDataModel
+@testable import WireDataModelSupport
 
 class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
 
@@ -37,6 +38,11 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
         // Given self conversations
         let proteusSelfConversation = try XCTUnwrap(ZMConversation.selfConversation(in: uiMOC))
         let mlsSelfConversation = createMLSSelfConversation()
+
+        // Self client is an mls client
+        let selfClient = ModelHelper().createSelfClient(in: uiMOC)
+        selfClient.mlsPublicKeys = .init(ed25519: "somekey")
+        selfClient.needsToUploadMLSPublicKeys = false
 
         // A conversation with a last read time stamp
         let conversationID = UUID.create()
@@ -84,6 +90,12 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
         // Given self conversations
         let proteusSelfConversation = try XCTUnwrap(ZMConversation.selfConversation(in: uiMOC))
         let mlsSelfConversation = createMLSSelfConversation()
+
+        // Self client is an mls client
+        let selfClient = ModelHelper().createSelfClient(in: uiMOC)
+        selfClient.mlsPublicKeys = .init(ed25519: "somekey")
+        selfClient.needsToUploadMLSPublicKeys = false
+
 
         // A conversation with a cleared time stamp
         let conversationID = UUID.create()

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
@@ -96,7 +96,6 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
         selfClient.mlsPublicKeys = .init(ed25519: "somekey")
         selfClient.needsToUploadMLSPublicKeys = false
 
-
         // A conversation with a cleared time stamp
         let conversationID = UUID.create()
         let clearedTimestamp = Date(timeIntervalSince1970: 0)

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -91,6 +91,17 @@ extension ClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
     typealias Object = ZMClientMessage
 
     func insert(object: ZMClientMessage, completion: @escaping () -> Void) {
+        // Temp fix for avoiding to send a large amount of last read
+        // messages, see: [WPB-17439]
+        if
+            let conversation = object.conversation,
+            conversation.isSelfConversation,
+            conversation.messageProtocol == .mls
+        {
+            completion()
+            return
+        }
+
         let hasRegisteredMLSClient = context.performAndWait {
             let selfClient = ZMUser.selfUser(in: context).selfClient()
             return selfClient?.hasRegisteredMLSClient ?? false

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -96,8 +96,7 @@ extension ClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
         if
             let conversation = object.conversation,
             conversation.isSelfConversation,
-            conversation.messageProtocol == .mls
-        {
+            conversation.messageProtocol == .mls {
             completion()
             return
         }

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,5 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.122.1
+WIRE_SHORT_VERSION = 3.122.2
 MAJOR_VERSION = 3


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17439" title="WPB-17439" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17439</a>  [iOS] Application sends a lot of MLS messages in a loop
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
After enabling mls client registration on cloud, we observed some clients getting stuck sending a large amount of messages. We believe that the messages are all originating from the MLS self conversation, and are all likely to be "last read" messages (these tell your other clients about updated last read markers for various conversations).

We found that even without an mls client registered, the app would append a last read message to **both the proteus and mls self conversations.**. Without an mls client registered, these messages added to the mls self conversation would fail to send, and should have been expired and not retried. However, these unsent messages still exist in the database, and their number would accumulate. We observed in one case over 135,000 unsent messages. 😱

Each time the app is launched, it would have fetched all unsent messages needing to be sent (this excludes expired messages, which should be the case here but it could be that these last read messages weren't expired or became unexpired... not sure) and then try to send them. Once an mls client was registered, these could all proceed to be encrypted and sent to the backend, which is causing an immense load on the app and would take a long time to complete.

This immense load most likely degraded the performance of the app so much that it became unusable, and certainly would have blocked any new messages that the new user tried to send. However, given enough time, the message queue would eventually be cleared and the app could return to its normal state.

### Fix
The immediate remedy is to simply not send anything over the mls self conversation. This is fine because we still send successfully over the proteus self conversation. Additionally, we won't try use the mls self conversation if we don't have an mls client.

The longer term fix may be more complex which we need more time to understand, such as trying to know why the expired messages were retried automatically.

### Testing
Can only be verified artificially by inserting a large number of last read messages on the mls self conversation with no registered mls client, then register an mls client.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
