### PR TITLE
fix: typing indicator not showing, revisit typing users implementation - WPB-17450

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -22,6 +22,22 @@ import WireDataModel
 
 public final class ClientSessionComponent {
 
+    public struct ProcessorHandlers {
+        let onProcessedCallEvent: (CallEventInfo) -> Void
+        let onSelfClientInvalidated: () async -> Void
+        let onProcessedTypingUsers: ([ConversationTypingUsersInfo]) -> Void
+
+        public init(
+            onProcessedCallEvent: @escaping (CallEventInfo) -> Void,
+            onSelfClientInvalidated: @escaping () async -> Void,
+            onProcessedTypingUsers: @escaping ([ConversationTypingUsersInfo]) -> Void
+        ) {
+            self.onProcessedCallEvent = onProcessedCallEvent
+            self.onSelfClientInvalidated = onSelfClientInvalidated
+            self.onProcessedTypingUsers = onProcessedTypingUsers
+        }
+    }
+
     private let selfUserID: UUID
     private let selfClientID: String
 
@@ -42,8 +58,7 @@ public final class ClientSessionComponent {
     private let mlsDecryptionService: any MLSDecryptionServiceInterface
     private let proteusService: any ProteusServiceInterface
 
-    private let onProcessedCallEvent: (CallEventInfo) -> Void
-    private let onSelfClientInvalidated: () async -> Void
+    private let processorHandlers: ProcessorHandlers
 
     public init(
         selfUserID: UUID,
@@ -61,8 +76,7 @@ public final class ClientSessionComponent {
         mlsService: any MLSServiceInterface,
         mlsDecryptionService: any MLSDecryptionServiceInterface,
         proteusService: any ProteusServiceInterface,
-        onSelfClientInvalidated: @escaping () async -> Void,
-        onProcessedCallEvent: @escaping (CallEventInfo) -> Void
+        processorHandlers: ProcessorHandlers
     ) {
         self.selfUserID = selfUserID
         self.selfClientID = selfClientID
@@ -79,8 +93,7 @@ public final class ClientSessionComponent {
         self.localDomain = localDomain
         self.isFederationEnabled = isFederationEnabled
         self.isMLSEnabled = isMLSEnabled
-        self.onProcessedCallEvent = onProcessedCallEvent
-        self.onSelfClientInvalidated = onSelfClientInvalidated
+        self.processorHandlers = processorHandlers
     }
 
     private lazy var authenticationManager = AuthenticationManager(
@@ -441,7 +454,7 @@ public final class ClientSessionComponent {
         messageLocalStore: messageLocalStore,
         userLocalStore: userLocalStore,
         protobufMessageProcessor: conversationProtobufMessageProcessor,
-        onProcessedCallEvent: onProcessedCallEvent
+        onProcessedCallEvent: processorHandlers.onProcessedCallEvent
     )
 
     private lazy var conversationMLSWelcomeEventProcessor = ConversationMLSWelcomeEventProcessor(
@@ -457,7 +470,7 @@ public final class ClientSessionComponent {
         messageLocalStore: messageLocalStore,
         userLocalStore: userLocalStore,
         protobufMessageProcessor: conversationProtobufMessageProcessor,
-        onProcessedCallEvent: onProcessedCallEvent
+        onProcessedCallEvent: processorHandlers.onProcessedCallEvent
     )
 
     private lazy var conversationProtocolUpdateEventProcessor = ConversationProtocolUpdateEventProcessor(
@@ -478,7 +491,8 @@ public final class ClientSessionComponent {
     private lazy var conversationTypingEventProcessor = ConversationTypingEventProcessor(
         conversationRepository: conversationRepository,
         conversationLocalStore: conversationLocalStore,
-        userRepository: userRepository
+        userRepository: userRepository,
+        onProcessedTypingUsers: processorHandlers.onProcessedTypingUsers
     )
 
     private lazy var featureConfigUpdateEventProcessor = FeatureConfigUpdateEventProcessor(
@@ -503,7 +517,7 @@ public final class ClientSessionComponent {
         pushSupportedProtocolsUseCase: pushSupportedProtocolsUseCase,
         oneOnOneResolver: oneOnOneResolver,
         context: syncContext,
-        onSelfClientInvalidated: onSelfClientInvalidated
+        onSelfClientInvalidated: processorHandlers.onSelfClientInvalidated
     )
 
     private lazy var userConnectionEventProcessor = UserConnectionEventProcessor(

--- a/WireDomain/Sources/WireDomain/Components/UserSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/UserSessionComponent.swift
@@ -123,8 +123,7 @@ public final class UserSessionComponent {
 
     public func clientSessionComponent(
         clientID: String,
-        onSelfClientInvalidated: @escaping () async -> Void,
-        onProcessedCallEvent: @escaping (CallEventInfo) -> Void
+        processorHandlers: ClientSessionComponent.ProcessorHandlers
     ) -> ClientSessionComponent {
         ClientSessionComponent(
             selfUserID: selfUserID,
@@ -142,8 +141,7 @@ public final class UserSessionComponent {
             mlsService: mlsService,
             mlsDecryptionService: mlsDecryptionService,
             proteusService: proteusService,
-            onSelfClientInvalidated: onSelfClientInvalidated,
-            onProcessedCallEvent: onProcessedCallEvent
+            processorHandlers: processorHandlers
         )
     }
 

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationTypingEventProcessor/ConversationTypingEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationTypingEventProcessor/ConversationTypingEventProcessor.swift
@@ -24,6 +24,7 @@ struct ConversationTypingEventProcessor: ConversationTypingEventProcessorProtoco
     let conversationRepository: any ConversationRepositoryProtocol
     let conversationLocalStore: any ConversationLocalStoreProtocol
     let userRepository: any UserRepositoryProtocol
+    let onProcessedTypingUsers: ([ConversationTypingUsersInfo]) -> Void
 
     private let typingUsersTimeout = ConversationTypingUsersTimeout()
 
@@ -41,6 +42,8 @@ struct ConversationTypingEventProcessor: ConversationTypingEventProcessorProtoco
             id: conversationID.uuid,
             domain: conversationID.domain
         )
+
+        typingUsersTimeout.timerFiredCallback = timerDidFire
 
         // Since we'll be manipulating managed object IDs in `ConversationTypingUsersTimeout`
         // we need to make sure we have valid, consistent IDs for the user and conversation.
@@ -88,10 +91,8 @@ struct ConversationTypingEventProcessor: ConversationTypingEventProcessorProtoco
             )
 
             // Updates non timed out typing users
-            await conversationRepository.updateTypingUsers([typingUsersInfo])
+            onProcessedTypingUsers([typingUsersInfo])
         }
-
-        typingUsersTimeout.timerFiredCallback = timerDidFire
 
         typingUsersTimeout.updateExpirationIfNeeded()
     }
@@ -111,7 +112,7 @@ struct ConversationTypingEventProcessor: ConversationTypingEventProcessorProtoco
             return .init(users: userObjectIDs, conversationID: $0)
         }
 
-        await conversationRepository.updateTypingUsers(typingUsersInfo)
+        onProcessedTypingUsers(typingUsersInfo)
 
         typingUsersTimeout.updateExpirationIfNeeded()
     }

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationTypingEventProcessor/ConversationTypingUsersInfo.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationTypingEventProcessor/ConversationTypingUsersInfo.swift
@@ -20,6 +20,6 @@ import CoreData
 
 /// The typing users for a given conversation
 public struct ConversationTypingUsersInfo {
-    let users: Set<NSManagedObjectID>
-    let conversationID: NSManagedObjectID
+    public let users: Set<NSManagedObjectID>
+    public let conversationID: NSManagedObjectID
 }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -351,30 +351,6 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         }
     }
 
-    public func updateTypingUsers(
-        conversationID: NSManagedObjectID,
-        usersID: Set<NSManagedObjectID>
-    ) async {
-        await context.perform { [context] in
-            if let conversation = context.object(with: conversationID) as? ZMConversation {
-
-                let users = usersID.compactMap {
-                    context.object(with: $0) as? ZMUser
-                }
-
-                context.typingUsers?.update(
-                    typingUsers: Set(users),
-                    in: conversation
-                )
-
-                self.notifyTypingUsers(
-                    Set(users),
-                    in: conversation
-                )
-            }
-        }
-    }
-
     public func obtainPermanentIDs(
         user: ZMUser,
         conversation: ZMConversation

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -335,17 +335,6 @@ public protocol ConversationLocalStoreProtocol {
         in conversation: ZMConversation
     ) async
 
-    /// Sends a notification using the main context informing typing users
-    /// have been updated for a given conversation.
-    /// - Parameters:
-    ///     - conversationID: The conversation managed object ID.
-    ///     - usersID: The updated typing users managed object IDs.
-
-    func updateTypingUsers(
-        conversationID: NSManagedObjectID,
-        usersID: Set<NSManagedObjectID>
-    ) async
-
     /// Obtain permanent stored object IDs.
     /// - Parameters:
     ///     - user: The user to get the permanent managed object ID for.

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationRepositoryProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationRepositoryProtocol.swift
@@ -188,14 +188,6 @@ public protocol ConversationRepositoryProtocol {
         date: Date
     ) async
 
-    /// Updates the typing users for a given conversation.
-    /// - Parameters:
-    ///     - typingUsersInfo: A list of typing users for a given conversation.
-
-    func updateTypingUsers(
-        _ typingUsersInfo: [ConversationTypingUsersInfo]
-    ) async
-
     /// Fetches the guest link for a given conversation.
     /// - parameter conversationID: The conversation id.
     /// - returns: The guest link.

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -390,17 +390,6 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
         await deleteMembership(for: removedUserIDs, time: date)
     }
 
-    public func updateTypingUsers(
-        _ typingUsersInfo: [ConversationTypingUsersInfo]
-    ) async {
-        for typingUserInfo in typingUsersInfo {
-            await conversationsLocalStore.updateTypingUsers(
-                conversationID: typingUserInfo.conversationID,
-                usersID: typingUserInfo.users
-            )
-        }
-    }
-
     // MARK: - Private
 
     private func addSystemMessage(

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -1031,21 +1031,6 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
         await mock(clearedMessage, conversation)
     }
 
-    // MARK: - updateTypingUsers
-
-    public var updateTypingUsersConversationIDUsersID_Invocations: [(conversationID: NSManagedObjectID, usersID: Set<NSManagedObjectID>)] = []
-    public var updateTypingUsersConversationIDUsersID_MockMethod: ((NSManagedObjectID, Set<NSManagedObjectID>) async -> Void)?
-
-    public func updateTypingUsers(conversationID: NSManagedObjectID, usersID: Set<NSManagedObjectID>) async {
-        updateTypingUsersConversationIDUsersID_Invocations.append((conversationID: conversationID, usersID: usersID))
-
-        guard let mock = updateTypingUsersConversationIDUsersID_MockMethod else {
-            fatalError("no mock for `updateTypingUsersConversationIDUsersID`")
-        }
-
-        await mock(conversationID, usersID)
-    }
-
     // MARK: - obtainPermanentIDs
 
     public var obtainPermanentIDsUserConversation_Invocations: [(user: ZMUser, conversation: ZMConversation)] = []
@@ -1751,21 +1736,6 @@ public class MockConversationRepositoryProtocol: ConversationRepositoryProtocol 
         }
 
         await mock(newName, conversationID, conversationDomain, senderID, senderDomain, date)
-    }
-
-    // MARK: - updateTypingUsers
-
-    public var updateTypingUsers_Invocations: [[ConversationTypingUsersInfo]] = []
-    public var updateTypingUsers_MockMethod: (([ConversationTypingUsersInfo]) async -> Void)?
-
-    public func updateTypingUsers(_ typingUsersInfo: [ConversationTypingUsersInfo]) async {
-        updateTypingUsers_Invocations.append(typingUsersInfo)
-
-        guard let mock = updateTypingUsers_MockMethod else {
-            fatalError("no mock for `updateTypingUsers`")
-        }
-
-        await mock(typingUsersInfo)
     }
 
     // MARK: - fetchConversationGuestLink

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationTypingEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationTypingEventProcessorTests.swift
@@ -32,6 +32,7 @@ final class ConversationTypingEventProcessorTests: XCTestCase {
     private var coreDataStack: CoreDataStack!
     private var coreDataStackHelper: CoreDataStackHelper!
     private var modelHelper: ModelHelper!
+    private var didProcessTypingUsers = false
 
     private var context: NSManagedObjectContext {
         coreDataStack.syncContext
@@ -48,7 +49,8 @@ final class ConversationTypingEventProcessorTests: XCTestCase {
         sut = ConversationTypingEventProcessor(
             conversationRepository: conversationRepository,
             conversationLocalStore: conversationLocalStore,
-            userRepository: userRepository
+            userRepository: userRepository,
+            onProcessedTypingUsers: { _ in self.didProcessTypingUsers = true }
         )
     }
 
@@ -61,6 +63,7 @@ final class ConversationTypingEventProcessorTests: XCTestCase {
         sut = nil
         try coreDataStackHelper.cleanupDirectory()
         coreDataStackHelper = nil
+        didProcessTypingUsers = false
     }
 
     // MARK: - Tests
@@ -78,7 +81,6 @@ final class ConversationTypingEventProcessorTests: XCTestCase {
 
         userRepository.fetchOrCreateUserIdDomain_MockValue = user
         conversationRepository.fetchOrCreateConversationIdDomain_MockValue = conversation
-        conversationRepository.updateTypingUsers_MockMethod = { _ in }
         conversationLocalStore.obtainPermanentIDsUserConversation_MockMethod = { _, _ in }
 
         // When
@@ -90,7 +92,7 @@ final class ConversationTypingEventProcessorTests: XCTestCase {
         XCTAssertEqual(conversationLocalStore.obtainPermanentIDsUserConversation_Invocations.count, 1)
         XCTAssertEqual(userRepository.fetchOrCreateUserIdDomain_Invocations.count, 1)
         XCTAssertEqual(conversationRepository.fetchOrCreateConversationIdDomain_Invocations.count, 1)
-        XCTAssertEqual(conversationRepository.updateTypingUsers_Invocations.count, 1)
+        XCTAssertEqual(didProcessTypingUsers, true)
     }
 
     private enum Scaffolding {

--- a/WireDomain/Tests/WireDomainTests/LocalStores/ConversationLocalStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/LocalStores/ConversationLocalStoreTests.swift
@@ -430,40 +430,6 @@ final class ConversationLocalStoreTests: XCTestCase {
         }
     }
 
-    func testUpdateTypingUsers_It_Sends_A_Notification_With_Typing_Users() async throws {
-
-        let (userObjectID, conversationObjectID) = try await context.perform { [self] in
-            let user = modelHelper.createUser(in: context)
-            let conversation = modelHelper.createGroupConversation(in: context)
-
-            try context.obtainPermanentIDs(for: [user, conversation])
-
-            return (user.objectID, conversation.objectID)
-
-        }
-
-        let expectation = XCTestExpectation()
-
-        subscription = NotificationCenter.default.publisher(for: .typingNotification)
-            .compactMap { $0.userInfo?["typingUsers"] as? Set<ZMUser> }
-            .sink { typingUsers in
-                // Then
-                XCTAssertEqual(typingUsers.first?.objectID, userObjectID)
-                expectation.fulfill()
-            }
-
-        // When
-
-        await sut.updateTypingUsers(
-            conversationID: conversationObjectID,
-            usersID: Set([userObjectID])
-        )
-
-        // Then
-
-        await fulfillment(of: [expectation], timeout: 5.0)
-    }
-
     func testStoreMLSConversationEstablished_It_Sets_MLS_Status_Ready_And_Updates_MLS_Group_ID() async throws {
 
         // Mock

--- a/WireDomain/Tests/WireDomainTests/Repositories/ConversationRepositoryTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Repositories/ConversationRepositoryTests.swift
@@ -580,26 +580,6 @@ final class ConversationRepositoryTests: XCTestCase {
         }
     }
 
-    func testUpdateTypingUsers_It_Invokes_Local_Store_Method() async throws {
-
-        // Mock
-
-        conversationsLocalStore.updateTypingUsersConversationIDUsersID_MockMethod = { _, _ in }
-
-        let typingUsersInfo = ConversationTypingUsersInfo(
-            users: Set([NSManagedObjectID()]),
-            conversationID: NSManagedObjectID()
-        )
-
-        // When
-
-        await sut.updateTypingUsers([typingUsersInfo])
-
-        // Then
-
-        XCTAssertEqual(conversationsLocalStore.updateTypingUsersConversationIDUsersID_Invocations.count, 1)
-    }
-
     private enum Scaffolding {
 
         static let id = UUID.mockID1

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -559,32 +559,13 @@ public final class ZMUserSession: NSObject {
     }
 
     private func setUpSyncAgent(clientID: String, asyncStreamEnabled: Bool) {
-        let onSelfClientInvalidated: () async -> Void = { [self] in
-            await syncContext.perform { [self] in
-                syncContext.tearDownCryptoStack()
-
-                let clientRegistrationStatus = applicationStatusDirectory.clientRegistrationStatus
-                let clientUpdateStatus = applicationStatusDirectory.clientUpdateStatus
-
-                clientRegistrationStatus.emailCredentials = nil
-                clientRegistrationStatus.cookieProvider.deleteKeychainItems()
-
-                let selfUser = ZMUser.selfUser(in: managedObjectContext)
-                let clientDeletedRemotelyError = NSError.userSessionError(
-                    code: .clientDeletedRemotely,
-                    userInfo: selfUser.loginCredentials.dictionaryRepresentation
-                )
-
-                didDeleteSelfUserClient(error: clientDeletedRemotelyError)
-
-                clientUpdateStatus.needsToVerifySelfClient = false
-            }
-        }
-
         let clientSessionComponent = userSessionComponent.clientSessionComponent(
             clientID: clientID,
-            onSelfClientInvalidated: onSelfClientInvalidated,
-            onProcessedCallEvent: onProcessedCallEvent(callEventInfo:)
+            processorHandlers: .init(
+                onProcessedCallEvent: onProcessedCallEvent(callEventInfo:),
+                onSelfClientInvalidated: onSelfClientInvalidated,
+                onProcessedTypingUsers: onProcessedTypingUsers(typingUsersInfo:)
+            )
         )
 
         let incrementalSyncProvider: IncrementalSyncProvider = if !asyncStreamEnabled {
@@ -607,6 +588,54 @@ public final class ZMUserSession: NSObject {
 
         // TODO: [WPB-17223] remove `resume` call from here
         syncAgent.resume()
+    }
+
+    func onProcessedTypingUsers(
+        typingUsersInfo: [ConversationTypingUsersInfo]
+    ) {
+
+        viewContext.performGroupedBlock { [viewContext] in
+            for typingUserInfo in typingUsersInfo {
+                let conversationID = typingUserInfo.conversationID
+                let usersID = typingUserInfo.users
+
+                if let conversation = viewContext.object(with: conversationID) as? ZMConversation {
+
+                    let users = usersID.compactMap {
+                        viewContext.object(with: $0) as? ZMUser
+                    }
+
+                    viewContext.typingUsers?.update(
+                        typingUsers: Set(users),
+                        in: conversation
+                    )
+
+                    conversation.notifyTyping(typingUsers: Set(users))
+                }
+            }
+        }
+    }
+
+    func onSelfClientInvalidated() async {
+        await syncContext.perform { [self] in
+            syncContext.tearDownCryptoStack()
+
+            let clientRegistrationStatus = applicationStatusDirectory.clientRegistrationStatus
+            let clientUpdateStatus = applicationStatusDirectory.clientUpdateStatus
+
+            clientRegistrationStatus.emailCredentials = nil
+            clientRegistrationStatus.cookieProvider.deleteKeychainItems()
+
+            let selfUser = ZMUser.selfUser(in: managedObjectContext)
+            let clientDeletedRemotelyError = NSError.userSessionError(
+                code: .clientDeletedRemotely,
+                userInfo: selfUser.loginCredentials.dictionaryRepresentation
+            )
+
+            didDeleteSelfUserClient(error: clientDeletedRemotelyError)
+
+            clientUpdateStatus.needsToVerifySelfClient = false
+        }
     }
 
     func onProcessedCallEvent(callEventInfo: CallEventInfo) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17450" title="WPB-17450" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17450</a>  [iOS] Typing indicator doesn't work with new sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: Typing indicator is not showing up when a user is typing in new sync mechanism

**Causes**: in our new code, specifically the local store, we're posting a notification passing the object (self which is the store) then the notification observer is not called because we early exit in `addUnboundedObserver` method from `NotificationInContext` class since the object we use to register the observer and the object we use to post the notification is not the same.

**Solution**: Move the UI update logic part out from the store and repository, create a handler to handle the UI update logic part once the typing users have been processed.

### Testing

UserA on iOS client, userB on another client, send message from userB, check that the typing indicator works properly (shows up and disappears) on userA when userB is typing

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.