### PR TITLE
feat: 1:1 proteus is not migrated to MLS - WPB-17393

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -227,7 +227,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         userID: WireDataModel.QualifiedID
     ) async {
         await context.perform {
-            guard !mlsConversation.migratedToMLS else {
+            guard !(mlsConversation.migratedToMLS && user.oneOnOneConversation == mlsConversation) else {
                 return
             }
 

--- a/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
@@ -68,10 +68,18 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
                         try await self.resolveOneOnOneConversation(with: userID, in: context)
                     } catch {
                         // skip conversation migration for this user
-                        WireLogger.conversation.error(
-                            "resolve 1-1 conversation failed: \(error)",
-                            attributes: [.senderUserId: userID.safeForLoggingDescription]
-                        )
+                        switch error {
+                        case MigrateMLSOneOnOneConversationError.alreadyMigrated:
+                            WireLogger.conversation.warn(
+                                "Skipping conversation migration: the 1-1 conversation for this user is already migrated.",
+                                attributes: [.senderUserId: userID.safeForLoggingDescription]
+                            )
+                        default:
+                            WireLogger.conversation.error(
+                                "resolve 1-1 conversation failed: \(error)",
+                                attributes: [.senderUserId: userID.safeForLoggingDescription]
+                            )
+                        }
                     }
                 }
             }

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import WireLogging
 
 // sourcery: AutoMockable
 public protocol OneOnOneMigratorInterface {
@@ -147,13 +148,19 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
             ) else {
                 throw MigrateMLSOneOnOneConversationError.failedToActivateConversation
             }
-            guard !mlsConversation.migratedToMLS else {
-                throw MigrateMLSOneOnOneConversationError.alreadyMigrated
-            }
+
             guard let otherUser = ZMUser.fetch(with: userID, in: context) else {
                 throw MigrateMLSOneOnOneConversationError.failedToActivateConversation
             }
 
+            guard !(mlsConversation.migratedToMLS && otherUser.oneOnOneConversation == mlsConversation) else {
+                throw MigrateMLSOneOnOneConversationError.alreadyMigrated
+            }
+
+            WireLogger.conversation
+                .info(
+                    "Migrating messages and link the MLS conversation if needed. Conversation is migrated to MLS: \(mlsConversation.migratedToMLS), is oneOnOneConversation MLS: \(otherUser.oneOnOneConversation == mlsConversation)"
+                )
             // Note on proteus, it's possible to have duplicate 1-1 conversations, so we need to fetch all relevant
             // 1-1 conversations here.
             let source = OneOnOneSource(context: context)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17393" title="WPB-17393" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17393</a>  [iOS] Should-be MLS Conversation created as Proteus and not migrated to MLS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We have an issue with one user that his 1:1 with a user from another team is still proteus on iOS, however it's MLS on Web. The result is a conversation on Web (and Android for another user) with a history, but an empty proteus conversation on iOS.

The logs from DD say that tis conversation` resolve 1-1 conversation failed: alreadyMigrated`. From all the logs and the fact that MLS conversation  exists, but for some reason doesn't show up in the conversation list, we suspect that 1:1 MLS conversation is marked as `migratedToMLS`, but `otherUser.oneOnOneConversation` is still Proteus. 
Why or how this happened is unknown. Most likely the conversation was migrated, but something overrode `otherUser.oneOnOneConversation` and set it back to the proteus conversation.
In this PR I added one more condition to trigger messages migration and MLS conversation linking:
if `mlsConversation.migratedToMLS` is **false** and `otherUser.oneOnOneConversation` is **not** `mlsConversation`,
we should attempt to migrate.
Also, since we have an insane amount of error logs like **resolve 1-1 conversation failed: alreadyMigrated** which are not an error but rather info, I changed their logging a bit.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
