### PR TITLE
fix: app sends large amount of last read messages - WPB-17439

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SelfConversation.swift
@@ -123,7 +123,13 @@ public extension ZMConversation {
         _ content: MessageCapable,
         in context: NSManagedObjectContext
     ) throws -> ZMClientMessage? {
-        guard let selfConversation = ZMConversation.fetchSelfMLSConversation(in: context) else {
+        let selfClient = ZMUser.selfUser(in: context).selfClient()
+        let hasRegisteredMLSClient = selfClient?.hasRegisteredMLSClient ?? false
+
+        guard
+            hasRegisteredMLSClient,
+            let selfConversation = ZMConversation.fetchSelfMLSConversation(in: context)
+        else {
             return nil
         }
 

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+SelfConversation.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 @testable import WireDataModel
+@testable import WireDataModelSupport
 
 class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
 
@@ -37,6 +38,11 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
         // Given self conversations
         let proteusSelfConversation = try XCTUnwrap(ZMConversation.selfConversation(in: uiMOC))
         let mlsSelfConversation = createMLSSelfConversation()
+
+        // Self client is an mls client
+        let selfClient = ModelHelper().createSelfClient(in: uiMOC)
+        selfClient.mlsPublicKeys = .init(ed25519: "somekey")
+        selfClient.needsToUploadMLSPublicKeys = false
 
         // A conversation with a last read time stamp
         let conversationID = UUID.create()
@@ -84,6 +90,11 @@ class ZMConversationTests_SelfConversation: ZMConversationTestsBase {
         // Given self conversations
         let proteusSelfConversation = try XCTUnwrap(ZMConversation.selfConversation(in: uiMOC))
         let mlsSelfConversation = createMLSSelfConversation()
+
+        // Self client is an mls client
+        let selfClient = ModelHelper().createSelfClient(in: uiMOC)
+        selfClient.mlsPublicKeys = .init(ed25519: "somekey")
+        selfClient.needsToUploadMLSPublicKeys = false
 
         // A conversation with a cleared time stamp
         let conversationID = UUID.create()

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -91,6 +91,16 @@ extension ClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
     typealias Object = ZMClientMessage
 
     func insert(object: ZMClientMessage, completion: @escaping () -> Void) {
+        // Temp fix for avoiding to send a large amount of last read
+        // messages, see: [WPB-17439]
+        if
+            let conversation = object.conversation,
+            conversation.isSelfConversation,
+            conversation.messageProtocol == .mls {
+            completion()
+            return
+        }
+
         let hasRegisteredMLSClient = context.performAndWait {
             let selfClient = ZMUser.selfUser(in: context).selfClient()
             return selfClient?.hasRegisteredMLSClient ?? false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17439" title="WPB-17439" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17439</a>  [iOS] Application sends a lot of MLS messages in a loop
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR was cherry-picked based on the following PR:
https://github.com/wireapp/wire-ios/pull/2959

### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
