### PR TITLE
fix: restrict sync error alert to debug mode - WPB-17266

### DIFF
--- a/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-request-strategy/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.4 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 //
 // Wire

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -33,7 +33,6 @@ public enum DeveloperFlag: String, CaseIterable {
     case useWireAuthentication
     case wireCellsAttachmentsPreviews
     case asyncStreamNotifications
-    case showDetailedErrors
 
     public var description: String {
         switch self {
@@ -69,9 +68,6 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .asyncStreamNotifications:
             "Turn on to enable new sync with consumable notifications"
-
-        case .showDetailedErrors:
-            "Show detailed errors"
         }
     }
 

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5919,16 +5919,6 @@ internal enum L10n {
       /// Tap colors to change brush size
       internal static let initialHint = L10n.tr("Localizable", "sketchpad.initial_hint", fallback: "Tap colors to change brush size")
     }
-    internal enum Sync {
-      internal enum Error {
-        /// An error occured while synchronizing your app, please try again
-        internal static let message = L10n.tr("Localizable", "sync.error.message", fallback: "An error occured while synchronizing your app, please try again")
-        /// Retry
-        internal static let retry = L10n.tr("Localizable", "sync.error.retry", fallback: "Retry")
-        /// Synchronization error
-        internal static let title = L10n.tr("Localizable", "sync.error.title", fallback: "Synchronization error")
-      }
-    }
     internal enum SystemStatusBar {
       internal enum NoInternet {
         /// There seems to be a problem with your Internet connection. Please make sure it’s working.

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -105,11 +105,6 @@
 "add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
 "add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more.";
 
-// Synchronization
-"sync.error.title" = "Synchronization error";
-"sync.error.message" = "An error occured while synchronizing your app, please try again";
-"sync.error.retry" = "Retry";
-
 // Channel Creation UI - Navigation
 "conversation.create.channel.title" = "New channel";
 "conversation.create.channel.back" = "Back";

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -259,24 +259,20 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         error: any Error,
         onRetry: @escaping () -> Void
     ) {
-
-        let syncErrorMessage = if DeveloperFlag.showDetailedErrors.isOn {
-            // show detailed sync error message
-            (error as NSError).description
-        } else {
-            // show generic sync error message
-            L10n.Localizable.Sync.Error.message
+        // Only show sync error alert for debugging
+        guard Bundle.developerModeEnabled else {
+            return
         }
 
         let alert = UIAlertController(
-            title: L10n.Localizable.Sync.Error.title,
-            message: syncErrorMessage,
+            title: L10n.Localizable.General.failure,
+            message: (error as NSError).description,
             preferredStyle: .alert
         )
 
         alert.addAction(
             UIAlertAction(
-                title: L10n.Localizable.Sync.Error.retry,
+                title: L10n.Localizable.Content.System.FailedtosendMessage.retry, // reusing retry string
                 style: .default
             ) { [weak self] _ in
                 onRetry()

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -261,7 +261,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
     ) {
         // Only show sync error alert for debugging
         guard Bundle.developerModeEnabled else {
-            return
+            return appStateTransitionGroup.leave()
         }
 
         let alert = UIAlertController(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17266" title="WPB-17266" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17266</a>  [iOS] Handle sync failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Only show sync detailed error alert for debugging
alert will not be shown to the user

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
