### PR TITLE
feat: Update deep link format for QR code - WPB-10531

### DIFF
--- a/wire-ios-sync-engine/Source/DeepLink/UserType+DeepLink.swift
+++ b/wire-ios-sync-engine/Source/DeepLink/UserType+DeepLink.swift
@@ -18,6 +18,6 @@
 
 public extension UserType {
     var profileDeepLink: String? {
-        "wire://\(URL.DeepLink.user)/\(remoteIdentifier.uuidString)"
+        "wire://\(URL.DeepLink.user)/\(domain ?? "wire.com")/\(remoteIdentifier.uuidString)"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-10531" title="WPB-10531" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-10531</a>  [iOS] QR code Profile link - Federation - update domain
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We should change the link for the QR code to
wire://user/<userDomain>/<userId>
i.e.
wire://user/wire.com/0f0f076f-747b-41c2-8291-accdaf99b74e

This has to be hardcoded because we don't want to go to the account page after scanning the QR code, but if the user uses the profile link through the browser, it goes to the account page first.

### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
