### PR TITLE
fix: events received via push channel are refetched - WPB-17602

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
@@ -88,7 +88,7 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
                     decryptedEvents.append(.conversation(.proteusMessageAdd(decryptedEventData)))
                 } catch let error as ProteusService.DecryptionError {
                     WireLogger.updateEvent.error(
-                        "failed to decrypt proteus event payload, dropping: \(error.localizedDescription)",
+                        "failed to decrypt proteus event payload, dropping: \(String(describing: error))",
                         attributes: logAttributes
                     )
 

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -118,6 +118,9 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                         continue
                     }
 
+                    // Bump the last event id so we don't refech it.
+                    store.storeLastEventID(id: envelope.id)
+
                     // Process.
                     for event in envelope.events {
                         do {

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
@@ -42,12 +42,12 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
 
     @discardableResult
     public func pull() async throws -> AsyncStream<[UpdateEvent]> {
-        WireLogger.sync.debug("pulling pending events")
-
         // We want all events since this event.
         guard let lastEventID = store.lastEventID() else {
             throw PullPendingUpdateEventsSyncError.noLastEventID
         }
+
+        WireLogger.sync.debug("pulling pending events since: \(lastEventID)")
 
         // We'll insert new events from this index.
         var currentIndex = try await store.indexOfLastEventEnvelope() + 1

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -112,6 +112,9 @@ final class IncrementalSyncTests: XCTestCase {
         // Live events are decrypted.
         decryptor.decryptEventsIn_MockMethod = { $0.events }
 
+        // Last event is being updated.
+        store.storeLastEventIDId_MockMethod = { _ in }
+
         // Events are processed.
         processor.processEvent_MockMethod = { _ in }
 
@@ -146,13 +149,17 @@ final class IncrementalSyncTests: XCTestCase {
         // Then live events were stored (duplicates skipped).
         XCTAssertEqual(store.indexOfLastEventEnvelope_Invocations.count, 2)
 
-        // Then live events were stored (duplicates skipped).
         let storeInvocations = store.persistEventEnvelopeIndex_Invocations
         try XCTAssertCount(storeInvocations, count: 2)
         XCTAssertEqual(storeInvocations[0].eventEnvelope, Scaffolding.event4)
         XCTAssertEqual(storeInvocations[0].index, 11)
         XCTAssertEqual(storeInvocations[1].eventEnvelope, Scaffolding.event5)
         XCTAssertEqual(storeInvocations[1].index, 12)
+
+        // Then last event id was updated, onece for each live event.
+        try XCTAssertCount(store.storeLastEventIDId_Invocations, count: 2)
+        XCTAssertEqual(store.storeLastEventIDId_Invocations[0], Scaffolding.event4.id)
+        XCTAssertEqual(store.storeLastEventIDId_Invocations[1], Scaffolding.event5.id)
 
         // Then all events were processed once (duplicates skipped).
         XCTAssertEqual(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17602" title="WPB-17602" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17602</a>  [iOS] Events received through push channel are refetched in incremental sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Events that are received via the push channel are refetched in the next incremental sync because we don't update the last event id for live events. This means that during the next incremental sync it will fetch all events sync the end of the last incremental sync, including all live events already received.

The solution is to update the last event id also for live events.

### Testing
1. Log in, receive messages.
2. Put the app in the background, put it back in the foreground
3. Look up the Datadog logs for this user, assert you don't see "Duplicate Message" errors.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
