### PR TITLE
fix: don't update last event id for transient live events - WPB-17602

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -119,7 +119,13 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                     }
 
                     // Bump the last event id so we don't refech it.
-                    store.storeLastEventID(id: envelope.id)
+                    if !envelope.isTransient {
+                        logger.debug(
+                            "updating last event id",
+                            attributes: [.eventEnvelopeID: envelope.id]
+                        )
+                        store.storeLastEventID(id: envelope.id)
+                    }
 
                     // Process.
                     for event in envelope.events {

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -156,10 +156,10 @@ final class IncrementalSyncTests: XCTestCase {
         XCTAssertEqual(storeInvocations[1].eventEnvelope, Scaffolding.event5)
         XCTAssertEqual(storeInvocations[1].index, 12)
 
-        // Then last event id was updated, onece for each live event.
-        try XCTAssertCount(store.storeLastEventIDId_Invocations, count: 2)
-        XCTAssertEqual(store.storeLastEventIDId_Invocations[0], Scaffolding.event4.id)
-        XCTAssertEqual(store.storeLastEventIDId_Invocations[1], Scaffolding.event5.id)
+        // Then last event id was updated once (for the non-transient live
+        // event)
+        try XCTAssertCount(store.storeLastEventIDId_Invocations, count: 1)
+        XCTAssertEqual(store.storeLastEventIDId_Invocations[0], Scaffolding.event5.id)
 
         // Then all events were processed once (duplicates skipped).
         XCTAssertEqual(
@@ -211,7 +211,8 @@ private enum Scaffolding {
 
     static let event4 = createEvent(
         message: "hallo",
-        timeIntervalSinceNow: -7
+        timeIntervalSinceNow: -7,
+        isTransient: true
     )
 
     static let event5 = createEvent(
@@ -221,7 +222,8 @@ private enum Scaffolding {
 
     static func createEvent(
         message: String,
-        timeIntervalSinceNow: TimeInterval
+        timeIntervalSinceNow: TimeInterval,
+        isTransient: Bool = false
     ) -> UpdateEventEnvelope {
         let event = ConversationProteusMessageAddEvent(
             conversationID: ConversationID(
@@ -244,7 +246,7 @@ private enum Scaffolding {
         return UpdateEventEnvelope(
             id: UUID(),
             events: [.conversation(.proteusMessageAdd(event))],
-            isTransient: false
+            isTransient: isTransient
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17602" title="WPB-17602" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17602</a>  [iOS] Events received through push channel are refetched in incremental sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
This PR is a follow up to https://github.com/wireapp/wire-ios/pull/2987 in which I forgot that we shouldn't keep track of the ids of transient events.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
