### PR TITLE
fix: channel icon issue - WPB-17589

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Event decoding/Conversation/ConversationCreateEventDecoder.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Event decoding/Conversation/ConversationCreateEventDecoder.swift
@@ -66,7 +66,8 @@ struct ConversationCreateEventDecoder {
                 accessRoles: payload.accessRoles,
                 legacyAccessRole: payload.legacyAccessRole,
                 lastEvent: payload.lastEvent,
-                lastEventTime: payload.lastEventTime?.date
+                lastEventTime: payload.lastEventTime?.date,
+                groupType: payload.groupType
             )
         )
     }
@@ -92,6 +93,7 @@ struct ConversationCreateEventDecoder {
         let legacyAccessRole: ConversationAccessRoleLegacy?
         let lastEvent: String?
         let lastEventTime: UTCTime?
+        let groupType: ConversationGroupType?
 
         enum CodingKeys: String, CodingKey {
 
@@ -114,6 +116,7 @@ struct ConversationCreateEventDecoder {
             case legacyAccessRole = "access_role"
             case lastEvent = "last_event"
             case lastEventTime = "last_event_time"
+            case groupType = "group_conv_type"
 
         }
 

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationCreateEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationCreateEventProcessor.swift
@@ -25,7 +25,6 @@ struct ConversationCreateEventProcessor: ConversationCreateEventProcessorProtoco
     let repository: any ConversationRepositoryProtocol
 
     func processEvent(_ event: ConversationCreateEvent) async {
-        let conversationID = event.conversationID
         let conversation = event.conversation
         let timestamp = event.timestamp
 

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.4 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 //
 // Wire


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17589" title="WPB-17589" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17589</a>  [iOS] Self-created channel icon shows as group on client it is created by
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: After creating a channel, the conversation shows up in the list like it is a group conversation instead of a channel (it is noticeable looking at the icon). When performing an initial sync (or triggering resources sync in debug action) the conversations shows up normally, as a channel. 

**Causes**: Upon creation of the channel by the user, it is stored locally in the db (as a channel) then immediately followed by a `conversation.create` event that we're decoding **without** decoding the groupType property (which is an omission) so the groupType is wrongly mapped and the conversation updated locally as not being a channel anymore.

**Solution**: Decode the missing groupType property in the conversation create event decoder.

### Testing

channels should all properly show up as channels (with the right icon + the lock icon (since we only have private channels currently)

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
