### PR TITLE
chore: fix failing test on `develop` - WPB-17624

### DIFF
--- a/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
@@ -126,9 +126,8 @@ final class BackendTrustProviderTests: XCTestCase {
 
     func testThatItVerifiesWithNoPinnedKeys() {
         // given
-        mockDateProvider.now = Date()
         let trustExpectation = expectation(description: "It should verify server trust")
-        let trustProvider = ServerCertificateTrust(trustData: [], currentDateProvider: mockDateProvider)
+        let trustProvider = ServerCertificateTrust(trustData: [], currentDateProvider: .system)
         let trustVerificator = TestTrustVerificator(trustProvider: trustProvider) { trusted in
             if trusted {
                 trustExpectation.fulfill()

--- a/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
@@ -127,6 +127,7 @@ final class BackendTrustProviderTests: XCTestCase {
     func testThatItVerifiesWithNoPinnedKeys() {
         // given
         let trustExpectation = expectation(description: "It should verify server trust")
+        // We use a real date provider as this tests downloads a real live certificate
         let trustProvider = ServerCertificateTrust(trustData: [], currentDateProvider: .system)
         let trustVerificator = TestTrustVerificator(trustProvider: trustProvider) { trusted in
             if trusted {

--- a/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
+++ b/wire-ios-transport/Tests/Source/URLSession/ServerCertificateTrustTests.swift
@@ -126,6 +126,7 @@ final class BackendTrustProviderTests: XCTestCase {
 
     func testThatItVerifiesWithNoPinnedKeys() {
         // given
+        mockDateProvider.now = Date()
         let trustExpectation = expectation(description: "It should verify server trust")
         let trustProvider = ServerCertificateTrust(trustData: [], currentDateProvider: mockDateProvider)
         let trustVerificator = TestTrustVerificator(trustProvider: trustProvider) { trusted in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17624" title="WPB-17624" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17624</a>  [iOS] Fix failing tests on `develop`.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes `BackendTrustProviderTests.testThatItVerifiesWithNoPinnedKeys()`. This test is broken because we pass a mock date to the `ServerCertificateTrust` but for this test we need the real current date because we are fetching a real live certificate.

### Testing

Run automated tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
