### PR TITLE
fix: event processor is missing some event consumers - WPB-17587

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/EventProcessor.swift
@@ -32,10 +32,18 @@ actor EventProcessor: UpdateEventProcessor {
     private let eventProcessingTracker: EventProcessingTrackerProtocol
     private let earService: EARServiceInterface
     private var processingTask: Task<Void, Error>?
-    private let eventConsumers: [ZMEventConsumer]
-    private let eventAsyncConsumers: [ZMEventAsyncConsumer]
-
+    private let strategyDirectory: any StrategyDirectoryProtocol
     private let processedEventList = ProcessedEventList()
+
+    private var eventConsumers: [ZMEventConsumer] {
+        strategyDirectory.eventConsumers
+    }
+
+    private var eventAsyncConsumers: [ZMEventAsyncConsumer] {
+        strategyDirectory.eventAsyncConsumers + additionEventConsumers
+    }
+
+    private let additionEventConsumers: [any ZMEventAsyncConsumer]
 
     // MARK: Life Cycle
 
@@ -43,9 +51,9 @@ actor EventProcessor: UpdateEventProcessor {
         storeProvider: CoreDataStack,
         eventProcessingTracker: EventProcessingTrackerProtocol,
         earService: EARServiceInterface,
-        eventConsumers: [ZMEventConsumer],
-        eventAsyncConsumers: [ZMEventAsyncConsumer],
-        lastEventIDRepository: LastEventIDRepositoryInterface
+        lastEventIDRepository: LastEventIDRepositoryInterface,
+        strategyDirectory: any StrategyDirectoryProtocol,
+        additionalEventConsumers: [any ZMEventAsyncConsumer]
     ) {
         let eventDecoder = EventDecoder(
             eventMOC: storeProvider.eventContext,
@@ -58,8 +66,8 @@ actor EventProcessor: UpdateEventProcessor {
             eventDecoder: eventDecoder,
             eventProcessingTracker: eventProcessingTracker,
             earService: earService,
-            eventConsumers: eventConsumers,
-            eventAsyncConsumers: eventAsyncConsumers
+            strategyDirectory: strategyDirectory,
+            additionalEventConsumers: additionalEventConsumers
         )
     }
 
@@ -68,8 +76,8 @@ actor EventProcessor: UpdateEventProcessor {
         eventDecoder: any EventDecoderProtocol,
         eventProcessingTracker: EventProcessingTrackerProtocol,
         earService: EARServiceInterface,
-        eventConsumers: [ZMEventConsumer],
-        eventAsyncConsumers: [ZMEventAsyncConsumer]
+        strategyDirectory: any StrategyDirectoryProtocol,
+        additionalEventConsumers: [any ZMEventAsyncConsumer]
     ) {
         self.syncContext = storeProvider.syncContext
         self.eventContext = storeProvider.eventContext
@@ -77,8 +85,8 @@ actor EventProcessor: UpdateEventProcessor {
         self.eventProcessingTracker = eventProcessingTracker
         self.earService = earService
         self.bufferedEvents = []
-        self.eventConsumers = eventConsumers
-        self.eventAsyncConsumers = eventAsyncConsumers
+        self.strategyDirectory = strategyDirectory
+        self.additionEventConsumers = additionalEventConsumers
     }
 
     // MARK: Methods
@@ -247,8 +255,11 @@ actor EventProcessor: UpdateEventProcessor {
                     continue
                 }
 
+                let eventConsumers = await eventConsumers
+                let eventAsyncConsumers = await eventAsyncConsumers
+
                 await syncContext.perform {
-                    for eventConsumer in self.eventConsumers {
+                    for eventConsumer in eventConsumers {
                         eventConsumer.processEvents([event], liveEvents: true, prefetchResult: prefetchResult)
                     }
                 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -770,9 +770,9 @@ public final class ZMUserSession: NSObject {
             storeProvider: coreDataStack,
             eventProcessingTracker: eventProcessingTracker,
             earService: earService,
-            eventConsumers: strategyDirectory?.eventConsumers ?? [],
-            eventAsyncConsumers: (strategyDirectory?.eventAsyncConsumers ?? []) + [conversationEventProcessor],
-            lastEventIDRepository: lastEventIDRepository
+            lastEventIDRepository: lastEventIDRepository,
+            strategyDirectory: strategyDirectory!,
+            additionalEventConsumers: [conversationEventProcessor]
         )
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/EventProcessorTests.swift
@@ -28,6 +28,7 @@ final class EventProcessorTests: MessagingTest {
 
     var sut: EventProcessor!
     var eventProcessingTracker: EventProcessingTracker!
+    var mockStrategyDirectory: MockStrategyDirectory!
     var mockEventsConsumers: [MockEventConsumer]!
     var mockEventAsyncConsumers: [MockEventAsyncConsumer]!
     var earService: MockEARServiceInterface!
@@ -41,6 +42,9 @@ final class EventProcessorTests: MessagingTest {
 
         mockEventsConsumers = [MockEventConsumer(), MockEventConsumer()]
         mockEventAsyncConsumers = [MockEventAsyncConsumer(), MockEventAsyncConsumer()]
+        mockStrategyDirectory = MockStrategyDirectory()
+        mockStrategyDirectory.eventConsumers = mockEventsConsumers
+        mockStrategyDirectory.eventAsyncConsumers = mockEventAsyncConsumers
 
         eventProcessingTracker = EventProcessingTracker()
 
@@ -52,13 +56,14 @@ final class EventProcessorTests: MessagingTest {
             storeProvider: coreDataStack,
             eventProcessingTracker: eventProcessingTracker,
             earService: earService,
-            eventConsumers: mockEventsConsumers,
-            eventAsyncConsumers: mockEventAsyncConsumers,
-            lastEventIDRepository: lastEventIDRepository
+            lastEventIDRepository: lastEventIDRepository,
+            strategyDirectory: mockStrategyDirectory,
+            additionalEventConsumers: []
         )
     }
 
     override func tearDown() {
+        mockStrategyDirectory = nil
         mockEventsConsumers = nil
         mockEventAsyncConsumers = nil
         eventProcessingTracker = nil
@@ -231,8 +236,8 @@ final class EventProcessorTests: MessagingTest {
             eventDecoder: eventDecoder,
             eventProcessingTracker: eventProcessingTracker,
             earService: earService,
-            eventConsumers: mockEventsConsumers,
-            eventAsyncConsumers: mockEventAsyncConsumers
+            strategyDirectory: mockStrategyDirectory,
+            additionalEventConsumers: []
         )
 
         // When


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17587" title="WPB-17587" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17587</a>  [iOS] Missing messages 3.123 to 3.124 - Sync refactor 3.124
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Sometimes the app is not able to receive messages, but is able to send messages. The reason is that we made a change in https://github.com/wireapp/wire-ios/pull/2966  that sets up some request strategies only when there is a registered client, which happens at a later time. The request strategies are also event consumers, so after creating the remaining strategies (i.e consumers) they are added to the strategy directory but the `EventProcessor` has already been created and is not updated. Therefore, it had only a partial list of event consumers. As a result, when some events we received, such as a new message event, there was no consumer available to process it and it looks like the message is missing.

The solution is to ensure the `EventProcessor` always has the full list of event consumers. Due to some limitations of the legacy architecture, I had to resort to non optimal solution of injecting in the strategy directory (which has the updated event consumers) into the event processor. I wanted to delay creation of the event processor, but it's needed early to create the operation loop. Perhaps this is something we can revisit.

### Testing
1. Log in
2. Receive messages
3. Assert that you see them.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
