### PR TITLE
fix: update event migration missed member removed events - WPB-17588

### DIFF
--- a/wire-ios-request-strategy/Sources/Payloads/Conversation/Events/Payload+UpdateConversationMemberLeave.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Conversation/Events/Payload+UpdateConversationMemberLeave.swift
@@ -19,8 +19,8 @@
 import Foundation
 import WireTransport
 
-extension Payload {
-    public struct UpdateConversationMemberLeave: CodableEventData {
+public extension Payload {
+    struct UpdateConversationMemberLeave: CodableEventData {
 
         public static var eventType: ZMUpdateEventType { .conversationMemberLeave }
 

--- a/wire-ios-request-strategy/Sources/Payloads/Conversation/Events/Payload+UpdateConversationMemberLeave.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Conversation/Events/Payload+UpdateConversationMemberLeave.swift
@@ -20,22 +20,22 @@ import Foundation
 import WireTransport
 
 extension Payload {
-    struct UpdateConversationMemberLeave: CodableEventData {
+    public struct UpdateConversationMemberLeave: CodableEventData {
 
-        static var eventType: ZMUpdateEventType { .conversationMemberLeave }
+        public static var eventType: ZMUpdateEventType { .conversationMemberLeave }
 
-        let userIDs: [UUID]?
-        let qualifiedUserIDs: [QualifiedID]?
-        let reason: Reason?
+        public let userIDs: [UUID]?
+        public let qualifiedUserIDs: [QualifiedID]?
+        public let reason: Reason?
 
-        enum Reason: String, Codable {
+        public enum Reason: String, Codable {
             /// The user has been removed from the team and therefore removed from all conversations.
             case userDeleted = "user-deleted"
             case left
             case removed
         }
 
-        enum CodingKeys: String, CodingKey {
+        public enum CodingKeys: String, CodingKey {
             case userIDs = "user_ids"
             case qualifiedUserIDs = "qualified_user_ids"
             case reason

--- a/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
@@ -71,7 +71,12 @@ struct UpdateEventMigrator {
                         localDomain: localDomain
                     )
                 } catch {
-                    WireLogger.sync.error("failed to map legacy event, skipping... reason: \(String(describing: error))")
+                    WireLogger.sync.error(
+                        """
+                        failed to map legacy event, skipping... \
+                        reason: \(String(describing: error))
+                        """
+                    )
                     continue
                 }
 

--- a/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
@@ -64,10 +64,18 @@ struct UpdateEventMigrator {
 
             for legacyEvent in legacyEvents {
                 // Map it to the new event model.
-                guard let newUpdateEvent = UpdateEvent(
-                    legacyEvent: legacyEvent,
-                    localDomain: localDomain
-                ) else {
+                let newUpdateEvent: UpdateEvent?
+                do {
+                    newUpdateEvent = try UpdateEvent(
+                        legacyEvent: legacyEvent,
+                        localDomain: localDomain
+                    )
+                } catch {
+                    WireLogger.sync.error("failed to map legacy event, skipping... reason: \(String(describing: error))")
+                    continue
+                }
+
+                guard let newUpdateEvent else {
                     WireLogger.sync.warn("legacy event does not need mapping, skipping...")
                     continue
                 }
@@ -113,76 +121,69 @@ struct UpdateEventMigrator {
 
 private extension UpdateEvent {
 
+    enum Failure: Error {
+
+        case failedToDecodeLegacyEvent(any Error)
+        case missingRequiredField
+
+    }
+
     init?(
         legacyEvent: ZMUpdateEvent,
         localDomain: String
-    ) {
+    ) throws {
         switch legacyEvent.type {
         case .conversationDelete:
-            guard let event = Self.conversationDeleteEvent(
+            let event = try Self.conversationDeleteEvent(
                 from: legacyEvent,
                 localDomain: localDomain
-            ) else {
-                return nil
-            }
+            )
 
             self = .conversation(.delete(event))
 
         case .conversationMemberLeave:
-            guard let event = Self.conversationMemberLeaveEvent(
+            let event = try Self.conversationMemberLeaveEvent(
                 from: legacyEvent,
                 localDomain: localDomain
-            ) else {
-                return nil
-            }
+            )
 
             self = .conversation(.memberLeave(event))
 
         case .conversationMLSMessageAdd:
-            guard let event = Self.conversationMLSMessageAddEvent(
+            let event = try Self.conversationMLSMessageAddEvent(
                 from: legacyEvent,
                 localDomain: localDomain
-            ) else {
-                return nil
-            }
+            )
 
             self = .conversation(.mlsMessageAdd(event))
 
         case .conversationMLSWelcome:
-            guard let event = Self.conversationMLSWelcomeEvent(
+            let event = try Self.conversationMLSWelcomeEvent(
                 from: legacyEvent,
                 localDomain: localDomain
-            ) else {
-                return nil
-            }
+            )
 
             self = .conversation(.mlsWelcome(event))
 
         case .conversationOtrMessageAdd:
-            guard let event = Self.conversationProteusMessageAddEvent(
+            let event = try Self.conversationProteusMessageAddEvent(
                 from: legacyEvent,
                 localDomain: localDomain
-            ) else {
-                return nil
-            }
+            )
 
             self = .conversation(.proteusMessageAdd(event))
 
         case .federationConnectionRemoved:
-            guard let event = Self.federationConnectionRemovedEvent(
+            let event = try Self.federationConnectionRemovedEvent(
                 from: legacyEvent
-            ) else {
-                return nil
-            }
+            )
 
             self = .federation(.connectionRemoved(event))
 
         case .federationDelete:
-            guard let event = Self.federationDeleteEvent(
+            let event = try Self.federationDeleteEvent(
                 from: legacyEvent
-            ) else {
-                return nil
-            }
+            )
 
             self = .federation(.delete(event))
 
@@ -199,18 +200,23 @@ private extension UpdateEvent {
     private static func conversationDeleteEvent(
         from event: ZMUpdateEvent,
         localDomain: String
-    ) -> ConversationDeleteEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.ConversationEvent<Payload.UpdateConversationDeleted>.self,
+    ) throws -> ConversationDeleteEvent {
+        let payload: Payload.ConversationEvent<Payload.UpdateConversationDeleted>
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
-            ),
+            )
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
+        }
+
+        guard
             let conversationID = payload.conversationID(localDomain: localDomain),
             let senderID = payload.senderID(localDomain: localDomain),
             let timestamp = payload.timestamp
         else {
-            return nil
+            throw Failure.missingRequiredField
         }
 
         return ConversationDeleteEvent(
@@ -223,19 +229,24 @@ private extension UpdateEvent {
     private static func conversationMemberLeaveEvent(
         from event: ZMUpdateEvent,
         localDomain: String
-    ) -> ConversationMemberLeaveEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.ConversationEvent<Payload.UpdateConversationMemberLeave>.self,
+    ) throws -> ConversationMemberLeaveEvent {
+        let payload: Payload.ConversationEvent<Payload.UpdateConversationMemberLeave>
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
-            ),
+            )
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
+        }
+
+        guard
             let conversationID = payload.conversationID(localDomain: localDomain),
             let senderID = payload.senderID(localDomain: localDomain),
             let timestamp = payload.timestamp,
             let leaveReason = payload.data.reason
         else {
-            return nil
+            throw Failure.missingRequiredField
         }
 
         var removedUserIDs = Set<UserID>()
@@ -279,18 +290,23 @@ private extension UpdateEvent {
     private static func conversationMLSMessageAddEvent(
         from event: ZMUpdateEvent,
         localDomain: String
-    ) -> ConversationMLSMessageAddEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.ConversationEvent<DecryptedMLSMessageAddEvent>.self,
+    ) throws -> ConversationMLSMessageAddEvent {
+        let payload: Payload.ConversationEvent<DecryptedMLSMessageAddEvent>
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
-            ),
+            )
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
+        }
+
+        guard
             let conversationID = payload.conversationID(localDomain: localDomain),
             let senderID = payload.senderID(localDomain: localDomain),
             let timestamp = payload.timestamp
         else {
-            return nil
+            throw Failure.missingRequiredField
         }
 
         // Each mls message can actually produce multiple messages
@@ -320,17 +336,22 @@ private extension UpdateEvent {
     private static func conversationMLSWelcomeEvent(
         from event: ZMUpdateEvent,
         localDomain: String
-    ) -> ConversationMLSWelcomeEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.ConversationEvent<MLSWelcomeEvent>.self,
+    ) throws -> ConversationMLSWelcomeEvent {
+        let payload: Payload.ConversationEvent<MLSWelcomeEvent>
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
-            ),
+            )
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
+        }
+
+        guard
             let conversationID = payload.conversationID(localDomain: localDomain),
             let senderID = payload.senderID(localDomain: localDomain)
         else {
-            return nil
+            throw Failure.missingRequiredField
         }
 
         return ConversationMLSWelcomeEvent(
@@ -343,18 +364,23 @@ private extension UpdateEvent {
     private static func conversationProteusMessageAddEvent(
         from event: ZMUpdateEvent,
         localDomain: String
-    ) -> ConversationProteusMessageAddEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.ConversationEvent<DecryptedProteusMessageEvent>.self,
+    ) throws -> ConversationProteusMessageAddEvent {
+        let payload: Payload.ConversationEvent<DecryptedProteusMessageEvent>
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
-            ),
+            )
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
+        }
+
+        guard
             let conversationID = payload.conversationID(localDomain: localDomain),
             let senderID = payload.senderID(localDomain: localDomain),
             let timestamp = payload.timestamp
         else {
-            return nil
+            throw Failure.missingRequiredField
         }
 
         // We no longer have the encrypted message, but it
@@ -386,30 +412,33 @@ private extension UpdateEvent {
 
     // MARK: - Federation events
 
-    private static func federationConnectionRemovedEvent(from event: ZMUpdateEvent)
-        -> FederationConnectionRemovedEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.ConnectionRemoved.self,
+    private static func federationConnectionRemovedEvent(
+        from event: ZMUpdateEvent
+    ) throws -> FederationConnectionRemovedEvent {
+        let payload: Payload.ConnectionRemoved
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
             )
-        else {
-            return nil
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
         }
 
         return FederationConnectionRemovedEvent(domains: Set(payload.domains))
     }
 
-    private static func federationDeleteEvent(from event: ZMUpdateEvent) -> FederationDeleteEvent? {
-        let decoder = EventPayloadDecoder()
-        guard
-            let payload = try? decoder.decode(
-                Payload.FederationDelete.self,
+    private static func federationDeleteEvent(
+        from event: ZMUpdateEvent
+    ) throws -> FederationDeleteEvent {
+        let payload: Payload.FederationDelete
+        do {
+            payload = try EventPayloadDecoder().decode(
+                type(of: payload),
                 from: event.payload
             )
-        else {
-            return nil
+        } catch {
+            throw Failure.failedToDecodeLegacyEvent(error)
         }
 
         return FederationDeleteEvent(domain: payload.domain)

--- a/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
@@ -128,6 +128,16 @@ private extension UpdateEvent {
 
             self = .conversation(.delete(event))
 
+        case .conversationMemberLeave:
+            guard let event = Self.coversationMemberLeaveEvent(
+                from: legacyEvent,
+                localDomain: localDomain
+            ) else {
+                return nil
+            }
+
+            self = .conversation(.memberLeave(event))
+
         case .conversationMLSMessageAdd:
             guard let event = Self.conversationMLSMessageAddEvent(
                 from: legacyEvent,
@@ -207,6 +217,62 @@ private extension UpdateEvent {
             conversationID: conversationID,
             senderID: senderID,
             timestamp: timestamp
+        )
+    }
+
+    private static func coversationMemberLeaveEvent(
+        from event: ZMUpdateEvent,
+        localDomain: String
+    ) -> ConversationMemberLeaveEvent? {
+        let decoder = EventPayloadDecoder()
+        guard
+            let payload = try? decoder.decode(
+                Payload.ConversationEvent<Payload.UpdateConversationMemberLeave>.self,
+                from: event.payload
+            ),
+            let conversationID = payload.conversationID(localDomain: localDomain),
+            let senderID = payload.senderID(localDomain: localDomain),
+            let timestamp = payload.timestamp,
+            let leaveReason = payload.data.reason
+        else {
+            return nil
+        }
+
+        var removedUserIDs = Set<UserID>()
+
+        for userID in payload.data.userIDs ?? [] {
+            removedUserIDs.insert(
+                UserID(
+                    uuid: userID,
+                    domain: localDomain
+                )
+            )
+        }
+
+        for qualifiedUserID in payload.data.qualifiedUserIDs ?? [] {
+            removedUserIDs.insert(
+                UserID(
+                    uuid: qualifiedUserID.uuid,
+                    domain: qualifiedUserID.domain
+                )
+            )
+        }
+
+        let reason = switch leaveReason {
+        case .left:
+            ConversationMemberLeaveReason.userLeft
+        case .removed:
+            ConversationMemberLeaveReason.userRemoved
+        case .userDeleted:
+            ConversationMemberLeaveReason.userDeleted
+        }
+
+        return ConversationMemberLeaveEvent(
+            conversationID: conversationID,
+            senderID: senderID,
+            timestamp: timestamp,
+            removedUserIDs: removedUserIDs,
+            reason: reason
         )
     }
 

--- a/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UpdateEventMigrator.swift
@@ -129,7 +129,7 @@ private extension UpdateEvent {
             self = .conversation(.delete(event))
 
         case .conversationMemberLeave:
-            guard let event = Self.coversationMemberLeaveEvent(
+            guard let event = Self.conversationMemberLeaveEvent(
                 from: legacyEvent,
                 localDomain: localDomain
             ) else {
@@ -220,7 +220,7 @@ private extension UpdateEvent {
         )
     }
 
-    private static func coversationMemberLeaveEvent(
+    private static func conversationMemberLeaveEvent(
         from event: ZMUpdateEvent,
         localDomain: String
     ) -> ConversationMemberLeaveEvent? {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17588" title="WPB-17588" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17588</a>  [iOS] Migration from legacy sync to new sync missed member removed events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When updating to the new sync and there are legacy member leave events in the database, after migration the conversation still see the member that is no longer a participant. This is because we didn't migrate the member leave event (and was instead relying on the initial sync to update the conversation participant list, which doesn't work). The solution is to also migrate the legacy member leave event to the new member leave event.

### Testing
1. Be logged in on a previous version (e.g 3.123)
2. Be in a conversation
3. Put the app in the background
4. Another user should remove a participant in the conversation.
5. Update to 3.124
6. Assert that the participant has been removed.


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
