### PR TITLE
fix: channel deletion error pop up - WPB-17590

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1005,7 +1005,10 @@ public final class MLSService: MLSServiceInterface {
     // MARK: - Remove group
 
     public func wipeGroup(_ groupID: MLSGroupID) async throws {
-        logger.info("wiping group (\(groupID.safeForLoggingDescription))")
+        logger.info(
+            "wiping group",
+            attributes: [.mlsGroupID: groupID.safeForLoggingDescription]
+        )
 
         do {
             try await coreCrypto.perform { [self] in
@@ -1013,17 +1016,24 @@ public final class MLSService: MLSServiceInterface {
                     conversationId: groupID.data
                 ) else {
                     return logger.info(
-                        "conversation doesn't exist, nothing to wipe.."
+                        "conversation doesn't exist, nothing to wipe..",
+                        attributes: [.mlsGroupID: groupID.safeForLoggingDescription]
                     )
                 }
                 try await $0.wipeConversation(
                     conversationId: groupID.data
                 )
 
-                logger.info("wiped group (\(groupID.safeForLoggingDescription))")
+                logger.info(
+                    "wiped group",
+                    attributes: [.mlsGroupID: groupID.safeForLoggingDescription]
+                )
             }
         } catch {
-            logger.warn("failed to wipe group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
+            logger.warn(
+                "failed to wipe group \(String(describing: error))",
+                attributes: [.mlsGroupID: groupID.safeForLoggingDescription]
+            )
             throw error
         }
     }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1006,8 +1006,22 @@ public final class MLSService: MLSServiceInterface {
 
     public func wipeGroup(_ groupID: MLSGroupID) async throws {
         logger.info("wiping group (\(groupID.safeForLoggingDescription))")
+
         do {
-            try await coreCrypto.perform { try await $0.wipeConversation(conversationId: groupID.data) }
+            try await coreCrypto.perform { [self] in
+                guard try await $0.conversationExists(
+                    conversationId: groupID.data
+                ) else {
+                    return logger.info(
+                        "conversation doesn't exist, nothing to wipe.."
+                    )
+                }
+                try await $0.wipeConversation(
+                    conversationId: groupID.data
+                )
+
+                logger.info("wiped group (\(groupID.safeForLoggingDescription))")
+            }
         } catch {
             logger.warn("failed to wipe group (\(groupID.safeForLoggingDescription)): \(String(describing: error))")
             throw error

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.4 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 //
 // Wire
@@ -4624,24 +4624,6 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         }
 
         mock(delegate)
-    }
-
-    // MARK: - onEpochChanged
-
-    public var onEpochChanged_Invocations: [Void] = []
-    public var onEpochChanged_MockMethod: (() -> AnyPublisher<MLSGroupID, Never>)?
-    public var onEpochChanged_MockValue: AnyPublisher<MLSGroupID, Never>?
-
-    public func onEpochChanged() -> AnyPublisher<MLSGroupID, Never> {
-        onEpochChanged_Invocations.append(())
-
-        if let mock = onEpochChanged_MockMethod {
-            return mock()
-        } else if let mock = onEpochChanged_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `onEpochChanged`")
-        }
     }
 
     // MARK: - onNewCRLsDistributionPoints

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1647,6 +1647,19 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertEqual(count, 1)
     }
 
+    func test_WipeGroup_CoreCryptoWipeConversationNotCalledIfConversationDoesNotExist() async throws {
+        let groupID = MLSGroupID.random()
+
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
+
+        // When
+        try await sut.wipeGroup(groupID)
+
+        // Then
+        XCTAssertEqual(mockCoreCryptoContext.wipeConversationConversationId_Invocations.count, 0)
+
+    }
+
     // MARK: - Key Packages
 
     func test_UploadKeyPackages_IsSuccessful() async {

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -591,6 +591,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
                 ))
             }
         mockCoreCryptoContext.wipeConversationConversationId_MockMethod = { _ in }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // When
         await assertItThrows(error: MLSService.MLSAddMembersError.failedToClaimKeyPackages(users: usersIncludingSelf)) {
@@ -1637,6 +1638,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             count += 1
             XCTAssertEqual(id, groupID.data)
         }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // When
         try await sut.wipeGroup(groupID)
@@ -3038,6 +3040,7 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             XCTAssertEqual(conversationID, mlsGroupID.data)
             wipeConversationExpectation.fulfill()
         }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // When
         try await sut.startProteusToMLSMigration()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17590" title="WPB-17590" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17590</a>  [iOS] Get error when trying to delete channel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When deleting a channel (or a group), it is properly removed from the conversation list however an error pop up is displayed. Specifically, the error comes from CC `wipeGroup` method that throws an error saying the conversation could not be found.

**Causes**: When deleting the channel (or the group), we first send a request to the backend which returns a successful response. Separately,  this  triggers a `conversation.delete` event where we process that event by calling CC `wipeGroup` method. However, after doing so we're again trying to `wipeGroup` in `RemoveLocalConversationUseCase` and CC throws the error conversation not found.

**Solution**: In MLSService, before calling CC `wipeGroup` ensure that the conversation we want to wipe actually exists using `conversationExists`.

### Testing

Delete a channel or a group conversation, it should no longer display an error pop up.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
