### PR TITLE
fix: incremental sync failure - WPB-17645

### DIFF
--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -92,10 +92,15 @@ public actor BackoffRetrier {
 
         let queue = DispatchQueue(label: "BackoffRetrier")
 
-        monitor.pathUpdateHandler = { [weak self] path in
-            if path.status == .satisfied {
+        monitor.pathUpdateHandler = { [weak self] newPath in
+            guard let self else { return }
+
+            let currentPath = monitor.currentPath
+            let didRetrieveConnection = currentPath.status != .satisfied && newPath.status == .satisfied
+
+            if didRetrieveConnection {
                 Task {
-                    await self?.reset()
+                    await reset()
                 }
             }
         }

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -18,18 +18,18 @@
 
 
 import Foundation
-import UIKit
 import Network
+import UIKit
 
 public actor BackoffRetrier {
     public typealias SleepFunction = @Sendable (
         _ seconds: Double
     ) async throws -> Void
-    
+
     enum Failure: Error {
         case exceededMaxAttempts(latestError: any Error)
     }
-    
+
     private let policy: BackoffRetryPolicy
     private let monitor = NWPathMonitor()
     private let sleep: SleepFunction
@@ -43,7 +43,7 @@ public actor BackoffRetrier {
     ) {
         self.policy = policy
         self.sleep = sleep
-        
+
         setupObservers()
     }
 
@@ -51,7 +51,7 @@ public actor BackoffRetrier {
         monitor.cancel()
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     public func retry<T: Sendable>(
         _ operation: @escaping () async throws -> T
     ) async throws -> T {
@@ -60,27 +60,27 @@ public actor BackoffRetrier {
             do {
                 return try await operation()
             } catch {
-                
+
                 attempt += 1
-                
+
                 guard attempt < policy.maxRetries else {
                     throw Failure.exceededMaxAttempts(latestError: error)
                 }
-                
+
                 // Exponential backoffs
                 var delay = policy.baseTime * Double(pow(policy.exponentMultiplier, Double(attempt)))
-                
+
                 if policy.jitter {
                     // Adds jitter (randomness)
-                    delay = Double.random(in: 0...min(policy.maxTime, delay))
+                    delay = Double.random(in: 0 ... min(policy.maxTime, delay))
                 }
-                
+
                 try await sleep(delay)
             }
         }
     }
 
-    nonisolated private func setupObservers() {
+    private nonisolated func setupObservers() {
         NotificationCenter.default.addObserver(
             forName: UIApplication.willEnterForegroundNotification,
             object: nil,
@@ -90,9 +90,9 @@ public actor BackoffRetrier {
                 await self?.reset()
             }
         }
-        
+
         let queue = DispatchQueue(label: "BackoffRetrier")
-        
+
         monitor.pathUpdateHandler = { [weak self] path in
             if path.status == .satisfied {
                 Task {
@@ -100,10 +100,10 @@ public actor BackoffRetrier {
                 }
             }
         }
-        
+
         monitor.start(queue: queue)
     }
-    
+
     private func reset() {
         attempt = 0
     }

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -56,7 +56,12 @@ public actor BackoffRetrier {
 
         while true {
             do {
-                return try await operation()
+                // Temporary code to test retry mechanism, to be removed after playtest
+                if attempt < policy.maxRetries {
+                    throw NSError(domain: "wire.com", code: 400)
+                } else {
+                    return try await operation()
+                }
             } catch {
 
                 guard attempt < policy.maxRetries else {

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 import Foundation
 import Network
 import UIKit

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -66,7 +66,7 @@ public actor BackoffRetrier {
                     throw Failure.exceededMaxAttempts(latestError: error)
                 }
 
-                // Exponential backoffs
+                // Exponential backoff
                 var delay = policy.baseTime * Double(pow(policy.exponentMultiplier, Double(attempt)))
 
                 if policy.jitter {

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -56,12 +56,7 @@ public actor BackoffRetrier {
 
         while true {
             do {
-                // Temporary code to test retry mechanism, to be removed after playtest
-                if attempt < policy.maxRetries {
-                    throw NSError(domain: "wire.com", code: 400)
-                } else {
-                    return try await operation()
-                }
+                return try await operation()
             } catch {
 
                 guard attempt < policy.maxRetries else {

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -48,7 +48,6 @@ public actor BackoffRetrier {
 
     deinit {
         monitor.cancel()
-        NotificationCenter.default.removeObserver(self)
     }
 
     public func retry<T: Sendable>(

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -1,0 +1,110 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import UIKit
+import Network
+
+public actor BackoffRetrier {
+    public typealias SleepFunction = @Sendable (
+        _ seconds: Double
+    ) async throws -> Void
+    
+    enum Failure: Error {
+        case exceededMaxAttempts(latestError: any Error)
+    }
+    
+    private let policy: BackoffRetryPolicy
+    private let monitor = NWPathMonitor()
+    private let sleep: SleepFunction
+    private var attempt: Int = 0
+
+    public init(
+        policy: BackoffRetryPolicy = .init(),
+        sleep: @escaping SleepFunction = { delay in
+            try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+        }
+    ) {
+        self.policy = policy
+        self.sleep = sleep
+        
+        setupObservers()
+    }
+
+    deinit {
+        monitor.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    public func retry<T: Sendable>(
+        _ operation: @escaping () async throws -> T
+    ) async throws -> T {
+
+        while true {
+            do {
+                return try await operation()
+            } catch {
+                
+                attempt += 1
+                
+                guard attempt < policy.maxRetries else {
+                    throw Failure.exceededMaxAttempts(latestError: error)
+                }
+                
+                // Exponential backoffs
+                var delay = policy.baseTime * Double(pow(policy.exponentMultiplier, Double(attempt)))
+                
+                if policy.jitter {
+                    // Adds jitter (randomness)
+                    delay = Double.random(in: 0...min(policy.maxTime, delay))
+                }
+                
+                try await sleep(delay)
+            }
+        }
+    }
+
+    nonisolated private func setupObservers() {
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.reset()
+            }
+        }
+        
+        let queue = DispatchQueue(label: "BackoffRetrier")
+        
+        monitor.pathUpdateHandler = { [weak self] path in
+            if path.status == .satisfied {
+                Task {
+                    await self?.reset()
+                }
+            }
+        }
+        
+        monitor.start(queue: queue)
+    }
+    
+    private func reset() {
+        attempt = 0
+    }
+}

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -59,8 +59,6 @@ public actor BackoffRetrier {
                 return try await operation()
             } catch {
 
-                attempt += 1
-
                 guard attempt < policy.maxRetries else {
                     throw Failure.exceededMaxAttempts(latestError: error)
                 }
@@ -74,6 +72,8 @@ public actor BackoffRetrier {
                 }
 
                 try await sleep(delay)
+
+                attempt += 1
             }
         }
     }

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetryPolicy.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetryPolicy.swift
@@ -1,0 +1,53 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+public import Foundation
+
+public struct BackoffRetryPolicy: Sendable {
+
+    /// Max number of attempts
+    public let maxRetries: Int
+
+    /// The base time used in the backoff calculation
+    public let baseTime: TimeInterval
+
+    /// The maximum amount of time in seconds to wait before the next attempt
+    public let maxTime: TimeInterval
+
+    /// When calculating backoff time, the exponent is the number of attempts multiplied by
+    /// this value. Decrease this value to shorten the backoff time.
+    public let exponentMultiplier: Double
+
+    /// Whether to introduce randomness into the backoff
+    public let jitter: Bool
+
+
+    public init(
+        maxRetries: Int = 3,
+        baseTime: TimeInterval = 1.0,
+        maxTime: TimeInterval = 30,
+        exponentMultiplier: Double = 2.0,
+        jitter: Bool = false
+    ) {
+        self.maxRetries = maxRetries
+        self.baseTime = baseTime
+        self.maxTime = maxTime
+        self.exponentMultiplier = exponentMultiplier
+        self.jitter = jitter
+    }
+}

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetryPolicy.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetryPolicy.swift
@@ -36,7 +36,6 @@ public struct BackoffRetryPolicy: Sendable {
     /// Whether to introduce randomness into the backoff
     public let jitter: Bool
 
-
     public init(
         maxRetries: Int = 3,
         baseTime: TimeInterval = 1.0,

--- a/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
+++ b/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
@@ -33,10 +33,10 @@ final class BackoffRetrierTests: XCTestCase {
         sut = nil
     }
 
-    // TODO: [WPB-17645] Assert sleep durations exponentially increased
-    func testBackOffRetrier_It_Eventually_Succeeds() async throws {
+    func testBackOffRetrier_It_Eventually_Succeeds_With_Exponential_Sleep_Durations() async throws {
         // Given
         var callCount = 0
+        let recorder = SleepRecorder()
 
         let policy = BackoffRetryPolicy(
             maxRetries: 3,
@@ -46,7 +46,9 @@ final class BackoffRetrierTests: XCTestCase {
             jitter: false // Disable jitter for deterministic testing
         )
 
-        let retrier = BackoffRetrier(policy: policy, sleep: { _ in })
+        let retrier = BackoffRetrier(policy: policy, sleep: { delay in
+            await recorder.record(delay)
+        })
 
         // When, simulating 3 calls, first 2 fail, third succeeds
         let result = try await retrier.retry {
@@ -60,6 +62,13 @@ final class BackoffRetrierTests: XCTestCase {
         // Then
         XCTAssertEqual(result, "Success")
         XCTAssertEqual(callCount, 3)
+
+        let recordedSleeps = await recorder.getAll()
+
+        // Sleep durations values are exponential
+        XCTAssertEqual(recordedSleeps.count, 2)
+        XCTAssertEqual(recordedSleeps[0], 2.0)
+        XCTAssertEqual(recordedSleeps[1], 4.0)
     }
 
     func testBackoffRetrier_It_Fails_After_Max_Retries() async {
@@ -79,5 +88,17 @@ final class BackoffRetrierTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+    }
+}
+
+private actor SleepRecorder {
+    private(set) var recordedSleeps: [Double] = []
+
+    func record(_ value: Double) {
+        recordedSleeps.append(value)
+    }
+
+    func getAll() -> [Double] {
+        recordedSleeps
     }
 }

--- a/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
+++ b/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
@@ -1,0 +1,83 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireTestingPackage
+import XCTest
+
+@testable import WireFoundation
+
+final class BackoffRetrierTests: XCTestCase {
+
+    private var sut: BackoffRetrier!
+
+    override func setUp() {
+        sut = BackoffRetrier()
+    }
+
+    override func tearDown() {
+        sut = nil
+    }
+
+    // TODO: [WPB-17645] Assert sleep durations exponentially increased
+    func testBackOffRetrier_It_Eventually_Succeeds() async throws {
+        // When
+        var callCount = 0
+
+        let policy = BackoffRetryPolicy(
+            maxRetries: 3,
+            baseTime: 1.0,
+            maxTime: 100.0,
+            exponentMultiplier: 2.0,
+            jitter: false // Disable jitter for deterministic testing
+        )
+
+        let retrier = BackoffRetrier(policy: policy, sleep: { _ in })
+
+        // When, simulating 3 calls, first 2 fail, third succeeds
+        let result = try await retrier.retry {
+            callCount += 1
+            if callCount < 3 {
+                throw NSError(domain: "Test", code: -1)
+            }
+            return "Success"
+        }
+
+        // Then
+        XCTAssertEqual(result, "Success")
+        XCTAssertEqual(callCount, 3)
+    }
+
+    func testBackoffRetrier_It_Fails_After_Max_Retries() async {
+        // Given
+        let policy = BackoffRetryPolicy()
+        let retrier = BackoffRetrier(policy: policy, sleep: { _ in })
+
+        do {
+            // When
+            _ = try await retrier.retry {
+                throw NSError(domain: "Test", code: -1)
+            }
+            XCTFail("Expected retry to fail after max retries")
+        } catch let BackoffRetrier.Failure.exceededMaxAttempts(error as NSError) {
+            // Then
+            XCTAssertEqual(error.domain, "Test")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
+++ b/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
@@ -39,7 +39,7 @@ final class BackoffRetrierTests: XCTestCase {
         let recorder = SleepRecorder()
 
         let policy = BackoffRetryPolicy(
-            maxRetries: 3,
+            maxRetries: 4,
             baseTime: 1.0,
             maxTime: 100.0,
             exponentMultiplier: 2.0,
@@ -52,8 +52,11 @@ final class BackoffRetrierTests: XCTestCase {
 
         // When, simulating 3 calls, first 2 fail, third succeeds
         let result = try await retrier.retry {
-            callCount += 1
-            if callCount < 3 {
+            defer {
+                callCount += 1
+            }
+
+            if callCount < 4 {
                 throw NSError(domain: "Test", code: -1)
             }
             return "Success"
@@ -61,14 +64,16 @@ final class BackoffRetrierTests: XCTestCase {
 
         // Then
         XCTAssertEqual(result, "Success")
-        XCTAssertEqual(callCount, 3)
+        XCTAssertEqual(callCount, 5) // initial + 4 retries
 
         let recordedSleeps = await recorder.getAll()
 
         // Sleep durations values are exponential
-        XCTAssertEqual(recordedSleeps.count, 2)
-        XCTAssertEqual(recordedSleeps[0], 2.0)
-        XCTAssertEqual(recordedSleeps[1], 4.0)
+        XCTAssertEqual(recordedSleeps.count, 4)
+        XCTAssertEqual(recordedSleeps[0], 1.0)
+        XCTAssertEqual(recordedSleeps[1], 2.0)
+        XCTAssertEqual(recordedSleeps[2], 4.0)
+        XCTAssertEqual(recordedSleeps[3], 8.0)
     }
 
     func testBackoffRetrier_It_Fails_After_Max_Retries() async {

--- a/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
+++ b/WireFoundation/Tests/WireFoundationTests/Utilities/BackoffRetrierTests.swift
@@ -35,7 +35,7 @@ final class BackoffRetrierTests: XCTestCase {
 
     // TODO: [WPB-17645] Assert sleep durations exponentially increased
     func testBackOffRetrier_It_Eventually_Succeeds() async throws {
-        // When
+        // Given
         var callCount = 0
 
         let policy = BackoffRetryPolicy(

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import WireDataModel
 import WireDomain
+import WireFoundation
 import WireLogging
 import WireUtilities
 
@@ -104,8 +105,12 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
 
     func resume() {
         Task {
+            let retrier = BackoffRetrier()
+
             do {
-                try await performSync()
+                try await retrier.retry { [self] in
+                    try await performSync()
+                }
             } catch {
                 delegate?.syncAgentDidFailSyncing(
                     self,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17645" title="WPB-17645" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17645</a>  [iOS] Incrementalsync did not start after migration
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Introduces backoff retrier to retry sync a couple of times (with exponential backoff) when it fails
After reaching the max attempts, it will throw the error and stop retry syncing

### Testing

N/A

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

