### PR TITLE
chore: do not repair conversations (revert changes) - WPB-17469

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
@@ -124,15 +124,13 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
                             "failed to decrypt MLS due to `WrongEpoch` for group \(mlsGroupID)",
                             attributes: logAttributes
                         )
-                        await mlsService?.fetchAndRepairGroup(with: mlsGroupID)
                     default:
                         WireLogger.updateEvent.error(
                             "failed to decrypt MLS add message event, dropping: \(String(describing: error))",
                             attributes: logAttributes
                         )
-
-                        throw error
                     }
+                    throw error
                 } catch {
                     WireLogger.updateEvent.error(
                         "failed to decrypt MLS add message event, dropping: \(String(describing: error))",

--- a/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
+++ b/WireDomain/Sources/WireDomain/Event Decryption/UpdateEventDecryptor.swift
@@ -120,7 +120,7 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
                 } catch let error as MLSMessageDecryptorError {
                     switch error {
                     case let .wrongEpoch(mlsGroupID):
-                        WireLogger.updateEvent.warn(
+                        WireLogger.updateEvent.error(
                             "failed to decrypt MLS due to `WrongEpoch` for group \(mlsGroupID)",
                             attributes: logAttributes
                         )
@@ -130,7 +130,6 @@ struct UpdateEventDecryptor: UpdateEventDecryptorProtocol {
                             attributes: logAttributes
                         )
                     }
-                    throw error
                 } catch {
                     WireLogger.updateEvent.error(
                         "failed to decrypt MLS add message event, dropping: \(String(describing: error))",

--- a/WireDomain/Tests/WireDomainTests/Event Decryption/UpdateEventDecryptorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Decryption/UpdateEventDecryptorTests.swift
@@ -201,29 +201,6 @@ final class UpdateEventDecryptorTests: XCTestCase {
         XCTAssertEqual(mlsService.commitPendingProposalsIfNeeded_Invocations.count, 1)
     }
 
-    func testWhenDecryptionOfMLSMessagesThrowsWrongEpochErrorAndTriggersFetchAndRepairGroup() async throws {
-        // Given some events.
-        let envelope = UpdateEventEnvelope(
-            id: UUID(),
-            events: [
-                .conversation(.mlsMessageAdd(Scaffolding.mlsMessage)),
-                .user(.pushRemove)
-            ],
-            isTransient: false
-        )
-
-        // Mock
-        mlsService.fetchAndRepairGroupWith_MockMethod = { _ in }
-        mlsMessageDecryptor.decryptedMessageAddEventDataFrom_MockError = MLSMessageDecryptorError
-            .wrongEpoch(mlsGroupID: MLSGroupID(Data()))
-
-        // When
-        let events = try await sut.decryptEvents(in: envelope)
-
-        // Then
-        XCTAssertEqual(mlsService.fetchAndRepairGroupWith_Invocations.count, 1)
-    }
-
 }
 
 private enum Scaffolding {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17469" title="WPB-17469" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17469</a>  [iOS] Recovering from conversation being out of sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Calling `fetchAndRepairGroup` introduces an infinite sync. We need to remove it to unlock the release branch and provide another fix.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
