### PR TITLE
fix: pull self user after pulling known users - WPB-17516

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/PullResourcesSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullResourcesSync.swift
@@ -69,6 +69,13 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
 
     func pull() async throws {
         try await logger.measureTime(label: "pull resources") {
+            try await pullUserConnections()
+            try await pullAllConversations()
+
+            // Pulling known users must happen after we've discovered
+            // user ids from user connections and conversations.
+            try await pullKnownUsers()
+
             let teamID = try await pullSelfUser()
             try await pullSelfUserClients()
             try await pullSelfUserSettings()
@@ -79,13 +86,6 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
                 try await pullSelfTeamMembers(teamID: teamID)
                 try await pullSelfLegalholdInfo(teamID: teamID)
             }
-
-            try await pullUserConnections()
-            try await pullAllConversations()
-
-            // Pulling known users must happen after we've discovered
-            // user ids from user connections and conversations.
-            try await pullKnownUsers()
 
             try await pullConversationLabels()
             try await pullFeatureConfigs()

--- a/WireDomain/Sources/WireDomain/Synchronization/PullResourcesSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullResourcesSync.swift
@@ -76,6 +76,8 @@ struct PullResourcesSync: PullResourcesSyncProtocol {
             // user ids from user connections and conversations.
             try await pullKnownUsers()
 
+            // Pulling self user must happen after we've pulled known users
+            // otherwise some self user values might be overwritten with nil values.
             let teamID = try await pullSelfUser()
             try await pullSelfUserClients()
             try await pullSelfUserSettings()

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullResourcesSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullResourcesSyncTests.swift
@@ -126,6 +126,89 @@ final class PullResourcesSyncTests: XCTestCase {
         XCTAssertEqual(pullMLSStatusSync.pull_Invocations.count, 1)
     }
 
+    func testPull_Resources_Are_Called_In_Right_Order() async throws {
+        // Given
+        var callOrder: [String] = []
+
+        // Mock
+        pullSelfUserSync.pull_MockMethod = {
+            callOrder.append("pullSelfUserSync")
+            return (
+                id: Scaffolding.userID,
+                domain: Scaffolding.domain,
+                teamID: Scaffolding.teamID
+            )
+        }
+
+        pullSelfUserClientsSync.pull_MockMethod = {
+            callOrder.append("pullSelfUserClientsSync")
+        }
+
+        pullSelfUserSettingsSync.pull_MockMethod = {
+            callOrder.append("pullSelfUserSettingsSync")
+        }
+
+        pullSelfTeamSync.pullSelfTeamID_MockMethod = { _ in
+            callOrder.append("pullSelfTeamSync")
+        }
+
+        pullSelfTeamRolesSync.pullSelfTeamID_MockMethod = { _ in
+            callOrder.append("pullSelfTeamRolesSync")
+        }
+
+        pullSelfTeamMembersSync.pullSelfTeamID_MockMethod = { _ in
+            callOrder.append("pullSelfTeamMembersSync")
+        }
+
+        pullSelfLegalholdInfoSync.pullSelfTeamID_MockMethod = { _ in
+            callOrder.append("pullSelfLegalholdInfoSync")
+        }
+
+        pullUserConnectionsSync.pull_MockMethod = {
+            callOrder.append("pullUserConnectionsSync")
+        }
+
+        pullAllConversationsSync.pull_MockMethod = {
+            callOrder.append("pullAllConversationsSync")
+        }
+
+        pullKnownUsersSync.pull_MockMethod = {
+            callOrder.append("pullKnownUsersSync")
+        }
+
+        pullConversationLabelsSync.pull_MockMethod = {
+            callOrder.append("pullConversationLabelsSync")
+        }
+
+        pullAllFeatureConfigsSync.pull_MockMethod = {
+            callOrder.append("pullAllFeatureConfigsSync")
+        }
+
+        pullMLSStatusSync.pull_MockMethod = {
+            callOrder.append("pullMLSStatusSync")
+        }
+
+        // When
+        try await sut.pull()
+
+        // Then, assert resources are called in right order.
+        XCTAssertEqual(callOrder, [
+            "pullUserConnectionsSync",
+            "pullAllConversationsSync",
+            "pullKnownUsersSync",
+            "pullSelfUserSync",
+            "pullSelfUserClientsSync",
+            "pullSelfUserSettingsSync",
+            "pullSelfTeamSync",
+            "pullSelfTeamRolesSync",
+            "pullSelfTeamMembersSync",
+            "pullSelfLegalholdInfoSync",
+            "pullConversationLabelsSync",
+            "pullAllFeatureConfigsSync",
+            "pullMLSStatusSync"
+        ])
+    }
+
 }
 
 private enum Scaffolding {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17516" title="WPB-17516" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17516</a>  [iOS] Personal users created without email and password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: After doing a personal user registration, go to the settings, the user email doesn't show up. Issue happens on syncV2 only.

**Causes**: After registration is completed, we perform an initial sync by pulling ressources (syncV2) where first we `pullSelfUser`: backend sends back the user info including the email that we persist correctly in database. Once this phase is completed, we `pullKnownUsers`: backend sends back the known users which only includes one user at this point (the self one) however the response object doesn't contain the email value (null) and we persist that to the database ending up in a state where self user has no longer an email address.

**Solution**: When pulling resources, first `pullKnownUsers` then `pullSelfUser`, issue doesn't happen on syncV1 because we already do pull known users before pulling self user.

### Testing

Go through personal user registration, then go to settings, check the email, value should be present.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
