### PR TITLE
fix: incremental sync observer crash - WPB-17644

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
@@ -105,6 +105,7 @@ final class IncrementalSyncObserver: IncrementalSyncObserverProtocol {
                 cancellable = $decryptionState.sink { newDecryptionState in
                     if newDecryptionState == .done {
                         continuation.resume()
+                        cancellable?.cancel()
                     }
                 }
             }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
@@ -71,6 +71,11 @@ class IncrementalSyncObserverTests {
             // Send the next state after a pause.
             try? await Task.sleep(for: .seconds(0.25))
             syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
+            
+            // Sending the states again to ensure we don't crash due to a misuse of `continuation.resume()` as it must be called only once.
+            // Since we're cancelling the subscription when `DecryptionState` is `.done` `continuation.resume()` should not be called again.
+            syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
+            syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
         }
 
         // Then

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
@@ -71,9 +71,11 @@ class IncrementalSyncObserverTests {
             // Send the next state after a pause.
             try? await Task.sleep(for: .seconds(0.25))
             syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
-            
-            // Sending the states again to ensure we don't crash due to a misuse of `continuation.resume()` as it must be called only once.
-            // Since we're cancelling the subscription when `DecryptionState` is `.done` `continuation.resume()` should not be called again.
+
+            // Sending the states again to ensure we don't crash due to a misuse of `continuation.resume()` as it must
+            // be called only once.
+            // Since we're cancelling the subscription when `DecryptionState` is `.done` `continuation.resume()` should
+            // not be called again.
             syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
             syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17644" title="WPB-17644" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17644</a>  [iOS] Crash on IncrementalSyncObserver
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context:** A [crash](https://app.datadoghq.eu/logs?query=source%3Aios%20%40usr.id%3Ac101407260b1a76e956b1f9395a2b8369d915114a8fc686a57d5604492e62895%20-status%3A%28warn%20OR%20info%20OR%20debug%29&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2C%40tag&event=AwAAAZbJ1aUNou0OVAAAABhBWmJKMkVJT0FBQjhPSU55Qzl1d0lBQUkAAABdMDE5NmM5ZGItNDNhOS00NWJhLWE2ZjctMmNmNWZmMzM2MDRiLXN5bnRoZXRpYy10aW1lLTE3NDcxNDEyMDAwMDAwMDAwMDBjLTE3NDcxNDMzMTIyOTcwMDAwMDFvAABa3A&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=136700&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1747142573785&to_ts=1747143473785&live=true) occured on `IncrementalSyncObserver`

**Causes**: Best guess given the crash log and my testing, is that issue is caused by a misuse of `continuation.resume()` which **must** be called only once. Since we're not cancelling the Combine subscription, it remains active and when the stream is triggered again it calls `continuation.resume()` a second time which ends up with a Swift crash as this is illegal.

**Solution**: Cancel the subscription.

### Testing

In UTs, we're sending a couple of events to force the subscription to be called a second time which should not cause any crashes (note: if you remove the subscription cancellation it will crash the UTs).

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
