### PR TITLE
fix: Collapsed message text color as link  - WPB-17726

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -166,28 +166,28 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
                     )
             }
         } else {
-            messageTextView.font = UIFont.normalLightFont.italic
-            messageTextView.textColor = SemanticColors.Label.textDefault
+            var text: String = ""
             typeIcon.isHidden = false
             if message.isImage {
                 typeIcon.image = .init(resource: .image)
-                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Image.title.attributedString
+                text = L10n.Localizable.Content.Collapsed.Image.title
             } else if message.isVideo {
                 typeIcon.image = .init(resource: .play)
-                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Video.title.attributedString
+                text = L10n.Localizable.Content.Collapsed.Video.title
             } else if message.isAudio {
                 typeIcon.image = .init(resource: .micOn)
-                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Audio.title.attributedString
+                text = L10n.Localizable.Content.Collapsed.Audio.title
             } else if message.isLocation {
                 typeIcon.image = .init(resource: .location)
-                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Location.title.attributedString
+                text = L10n.Localizable.Content.Collapsed.Location.title
             } else if message.isFile {
                 typeIcon.image = .init(resource: .file)
-                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.File.title.attributedString
+                text = L10n.Localizable.Content.Collapsed.File.title
             } else if message.hasLinks {
                 typeIcon.image = .init(resource: .link)
-                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Link.title.attributedString
+                text = L10n.Localizable.Content.Collapsed.Link.title
             }
+            messageTextView.attributedText = text.attributedString && UIFont.normalLightFont.italic && SemanticColors.Label.textDefault
         }
 
         wholeViewTapButton.removeTarget(nil, action: nil, for: .allEvents)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -171,22 +171,22 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
             typeIcon.isHidden = false
             if message.isImage {
                 typeIcon.image = .init(resource: .image)
-                messageTextView.text = L10n.Localizable.Content.Collapsed.Image.title
+                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Image.title.attributedString
             } else if message.isVideo {
                 typeIcon.image = .init(resource: .play)
-                messageTextView.text = L10n.Localizable.Content.Collapsed.Video.title
+                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Video.title.attributedString
             } else if message.isAudio {
                 typeIcon.image = .init(resource: .micOn)
-                messageTextView.text = L10n.Localizable.Content.Collapsed.Audio.title
+                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Audio.title.attributedString
             } else if message.isLocation {
                 typeIcon.image = .init(resource: .location)
-                messageTextView.text = L10n.Localizable.Content.Collapsed.Location.title
+                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Location.title.attributedString
             } else if message.isFile {
                 typeIcon.image = .init(resource: .file)
-                messageTextView.text = L10n.Localizable.Content.Collapsed.File.title
+                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.File.title.attributedString
             } else if message.hasLinks {
                 typeIcon.image = .init(resource: .link)
-                messageTextView.text = L10n.Localizable.Content.Collapsed.Link.title
+                messageTextView.attributedText = L10n.Localizable.Content.Collapsed.Link.title.attributedString
             }
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -84,8 +84,8 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
     private lazy var messageTextView: LinkInteractionTextView = {
         let view = LinkInteractionTextView()
 
-        view.isEditable = false
-        view.isSelectable = false
+        view.isEditable = true
+        view.isSelectable = true
         view.backgroundColor = .clear
         view.isScrollEnabled = false
         view.textContainerInset = UIEdgeInsets.zero

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -91,6 +91,7 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
         view.textContainerInset = UIEdgeInsets.zero
         view.textContainer.lineFragmentPadding = 0
         view.isUserInteractionEnabled = false
+        view.dataDetectorTypes = []
         view.accessibilityIdentifier = "Message"
         view.accessibilityElementsHidden = false
         view.setContentHuggingPriority(.required, for: .vertical)
@@ -138,8 +139,13 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     func configure(with object: Configuration, animated: Bool) {
+        
+        messageTextView.text = nil
+        messageTextView.attributedText = nil
+        messageTextView.textColor = SemanticColors.Label.textDefault
+    
         let user = object.message.senderUser
         avatar.user = user
         availabilityIndicatorView.availability = user?.availability.mapToAccountImageAvailability()
@@ -149,7 +155,6 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
         }
 
         let message = object.message
-        messageTextView.textColor = SemanticColors.Label.textDefault
         if message.isText, !message.hasLinks {
             typeIcon.isHidden = true
             if let textMessageData = message.textMessageData {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -84,8 +84,8 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
     private lazy var messageTextView: LinkInteractionTextView = {
         let view = LinkInteractionTextView()
 
-        view.isEditable = true
-        view.isSelectable = true
+        view.isEditable = false
+        view.isSelectable = false
         view.backgroundColor = .clear
         view.isScrollEnabled = false
         view.textContainerInset = UIEdgeInsets.zero
@@ -186,8 +186,8 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
                 typeIcon.image = .init(resource: .link)
                 text = L10n.Localizable.Content.Collapsed.Link.title
             }
-            messageTextView.attributedText = text.attributedString && UIFont.normalLightFont.italic && SemanticColors
-                .Label.textDefault
+            messageTextView.attributedText = text.attributedString &&
+                UIFont.normalLightFont.italic && SemanticColors.Label.textDefault
         }
 
         wholeViewTapButton.removeTarget(nil, action: nil, for: .allEvents)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -139,13 +139,12 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func configure(with object: Configuration, animated: Bool) {
-        
         messageTextView.text = nil
         messageTextView.attributedText = nil
         messageTextView.textColor = SemanticColors.Label.textDefault
-    
+
         let user = object.message.senderUser
         avatar.user = user
         availabilityIndicatorView.availability = user?.availability.mapToAccountImageAvailability()
@@ -166,7 +165,7 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
                     )
             }
         } else {
-            var text: String = ""
+            var text = ""
             typeIcon.isHidden = false
             if message.isImage {
                 typeIcon.image = .init(resource: .image)
@@ -187,7 +186,8 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
                 typeIcon.image = .init(resource: .link)
                 text = L10n.Localizable.Content.Collapsed.Link.title
             }
-            messageTextView.attributedText = text.attributedString && UIFont.normalLightFont.italic && SemanticColors.Label.textDefault
+            messageTextView.attributedText = text.attributedString && UIFont.normalLightFont.italic && SemanticColors
+                .Label.textDefault
         }
 
         wholeViewTapButton.removeTarget(nil, action: nil, for: .allEvents)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17726" title="WPB-17726" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17726</a>  [iOS] Collapsed message color is blue
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Potential fix of link text color 
### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
