### PR TITLE
fix: unknown symbols issue - WPB-17820

### DIFF
--- a/WireDomain/WireDomain Project.xcodeproj/project.pbxproj
+++ b/WireDomain/WireDomain Project.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		C9B4C1F72D4915F10072A0EE /* WireCrypto in Frameworks */ = {isa = PBXBuildFile; productRef = C9B4C1F62D4915F10072A0EE /* WireCrypto */; };
 		C9E0C9BB2C91B76F00CE6607 /* WireTestingPackage in Frameworks */ = {isa = PBXBuildFile; productRef = C9E0C9BA2C91B76F00CE6607 /* WireTestingPackage */; };
 		CB6343F02DB7EF3D00A1C892 /* WireUpdateEventCoding in Frameworks */ = {isa = PBXBuildFile; productRef = CB6343EF2DB7EF3D00A1C892 /* WireUpdateEventCoding */; };
+		CB64B1362DDE0BCA00B43127 /* WireCellsAPI in Frameworks */ = {isa = PBXBuildFile; productRef = CB64B1352DDE0BCA00B43127 /* WireCellsAPI */; };
 		CB7979132C738508006FBA58 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7979122C738508006FBA58 /* WireTransportSupport.framework */; };
 /* End PBXBuildFile section */
 
@@ -95,6 +96,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB64B1362DDE0BCA00B43127 /* WireCellsAPI in Frameworks */,
 				598D042D2C89C63100B64D71 /* WireFoundation in Frameworks */,
 				CB6343F02DB7EF3D00A1C892 /* WireUpdateEventCoding in Frameworks */,
 				C91D188E2D7212FC00B63B66 /* NeedleFoundation in Frameworks */,
@@ -227,6 +229,7 @@
 				59DBDE972D395BB50069C64C /* WireDomainPackage */,
 				C91D188D2D7212FC00B63B66 /* NeedleFoundation */,
 				CB6343EF2DB7EF3D00A1C892 /* WireUpdateEventCoding */,
+				CB64B1352DDE0BCA00B43127 /* WireCellsAPI */,
 			);
 			productName = WireDomain;
 			productReference = 01D0DCA62C1C8C870076CB1C /* WireDomain.framework */;
@@ -827,6 +830,10 @@
 		CB6343EF2DB7EF3D00A1C892 /* WireUpdateEventCoding */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WireUpdateEventCoding;
+		};
+		CB64B1352DDE0BCA00B43127 /* WireCellsAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireCellsAPI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17820" title="WPB-17820" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17820</a>  [iOS] Fix compile error when building for simulator.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR attempts to fix a build failure due to unknown symbols in `WireDomain` coming from `WireCellsAPI`. This is most likely because `WireCellsAPI` is not being explicitly linked with `WireDomain`. This PR fixes that. 

The issue can be seen in these builds:

https://github.com/wireapp/wire-ios/pull/3043
https://github.com/wireapp/wire-ios/pull/3046

I'm not sure if this issue always occurs or if it is dependent on build order.

### Testing

Run automated tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
=
