### PR TITLE
fix: link `Wire-iOS` with `WireCellsAPI` - WPB-17860

### DIFF
--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		CB43D9BD2CDBBBB900BF5AEB /* WireFolderPickerUI in Frameworks */ = {isa = PBXBuildFile; productRef = CB43D9BC2CDBBBB900BF5AEB /* WireFolderPickerUI */; };
 		CB4870F22C7F4FE5001E9151 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4870F12C7F4FE5001E9151 /* WireTransportSupport.framework */; };
 		CB4E15122C81CC81005DDEC8 /* Down in Frameworks */ = {isa = PBXBuildFile; productRef = CB4E15112C81CC81005DDEC8 /* Down */; };
+		CB71EE212DDF5A1000E7A3AF /* WireCellsAPI in Frameworks */ = {isa = PBXBuildFile; productRef = CB71EE202DDF5A1000E7A3AF /* WireCellsAPI */; };
 		CBDDB1832DD4BCA700A0A1F3 /* WireCellsBindings in Frameworks */ = {isa = PBXBuildFile; productRef = CBDDB1822DD4BCA700A0A1F3 /* WireCellsBindings */; };
 		E40050762D71A80100B7962B /* WireConversationUI in Frameworks */ = {isa = PBXBuildFile; productRef = E40050752D71A80100B7962B /* WireConversationUI */; };
 		E6C25FC52AFFAAC300406A1C /* WireTesting.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6C25FC42AFFAAC300406A1C /* WireTesting.framework */; };
@@ -920,6 +921,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB71EE212DDF5A1000E7A3AF /* WireCellsAPI in Frameworks */,
 				0619A95C2D3FE78700876BDE /* WireAuthenticationUI in Frameworks */,
 				EEE25B4129719C750008B894 /* WireRequestStrategy.framework in Frameworks */,
 				EE543B4A2D564AC000CA96BA /* WireAuthentication in Frameworks */,
@@ -1371,6 +1373,7 @@
 				CB1428442DCB8A820092E7AE /* WireCellsUI */,
 				59703B272DD4A42000B45773 /* ZIPFoundation */,
 				CBDDB1822DD4BCA700A0A1F3 /* WireCellsBindings */,
+				CB71EE202DDF5A1000E7A3AF /* WireCellsAPI */,
 			);
 			productName = "ZClient iOS";
 			productReference = 8F42C538199244A700288E4D /* Wire.app */;
@@ -2965,6 +2968,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CB4E15102C81CC81005DDEC8 /* XCRemoteSwiftPackageReference "Down" */;
 			productName = Down;
+		};
+		CB71EE202DDF5A1000E7A3AF /* WireCellsAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireCellsAPI;
 		};
 		CBDDB1822DD4BCA700A0A1F3 /* WireCellsBindings */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17860" title="WPB-17860" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17860</a>  [iOS] Fix crash due to library not loaded
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

There is a crash related to linking `WireCellsAPI` immediately when app opens on `release/cycle-3.125` & `develop`

```shell
Library not loaded: @rpath/WireCellsAPI_3E453E69D626BF70_PackageProduct.framework/WireCellsAPI_3E453E69D626BF70_PackageProduct
  Referenced from: <FCACDFF8-3436-3F11-9968-3FDE95491801> /private/var/containers/Bundle/Application/B96AE8ED-C709-41AE-84EC-5381FBF86D0B/Wire.app/Frameworks/WireDataModel.framework/WireDataModel
  Reason: tried: '/Users/samwyndham/Library/Developer/Xcode/DerivedData/wire-ios-mono-fqrnhkhsugrzddgufgdztbdvjwfj/Build/Products/Debug-iphoneos/PackageFrameworks/WireCellsAPI_3E453E69D626BF70_PackageProduct.framework/WireCellsAPI_3E453E69D626BF70_PackageProduct' (no such file), '/private/preboot/Cryptexes/OS/Users/samwyndham/Library/Developer/Xcode/DerivedData/wire-ios-mono-fqrnhkhsugrzddgufgdztbdvjwfj/Build/Products/Debug-iphoneos/PackageFrameworks/WireCellsAPI_3E453E69D626BF70_PackageProduct.framework/WireCellsAPI_3E453E69D626BF70_PackageProduct' (no such file), '/private/var/containers/Bundle/Application/B96AE8ED-C709-41AE-84EC-5381FBF86D0B/Wire.app/Frameworks/WireCellsAPI_3E453E69D626BF
dyld config: DYLD_LIBRARY_PATH=/usr/lib/system/introspection DYLD_INSERT_LIBRARIES=/usr/lib/libLogRedirect.dylib:/usr/lib/libBacktraceRecording.dylib:/usr/lib/libMainThreadChecker.dylib:/usr/lib/libRPAC.dylib:/usr/lib/libViewDebuggerSupport.dylib
```

This PR links `Wire-iOS` to `WireCellsAPI` which fixes the issue. I'm not sure if there is a better way of addressing this.

I have tested this both on simulator and device builds from Xcode.

A edge build will be available here: https://github.com/wireapp/wire-ios/actions/runs/15189376088

### Testing

Run the app. It shouldn't crash immediately.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.