### PR TITLE
fix: max participants 2000 formatting with locale - WPB-17344

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -1172,13 +1172,13 @@ internal enum L10n {
         /// The conversation is full
         internal static let title = L10n.tr("Localizable", "add_participants.alert.title", fallback: "The conversation is full")
         internal enum Message {
-          /// Up to %1$d people can join a conversation. Currently there is only room for %2$d more.
-          internal static func existingConversation(_ p1: Int, _ p2: Int) -> String {
-            return L10n.tr("Localizable", "add_participants.alert.message.existing_conversation", p1, p2, fallback: "Up to %1$d people can join a conversation. Currently there is only room for %2$d more.")
+          /// Up to %@ people can join a conversation. Currently there is only room for %@ more.
+          internal static func existingConversation(_ p1: Any, _ p2: Any) -> String {
+            return L10n.tr("Localizable", "add_participants.alert.message.existing_conversation", String(describing: p1), String(describing: p2), fallback: "Up to %@ people can join a conversation. Currently there is only room for %@ more.")
           }
-          /// Up to %d people can join a conversation.
-          internal static func newConversation(_ p1: Int) -> String {
-            return L10n.tr("Localizable", "add_participants.alert.message.new_conversation", p1, fallback: "Up to %d people can join a conversation.")
+          /// Up to %@ people can join a conversation.
+          internal static func newConversation(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "add_participants.alert.message.new_conversation", String(describing: p1), fallback: "Up to %@ people can join a conversation.")
           }
         }
       }
@@ -4465,9 +4465,9 @@ internal enum L10n {
           internal static let footer = L10n.tr("Localizable", "participants.section.members.footer", fallback: "There are no members.")
         }
         internal enum Name {
-          /// Up to %1$d participants can join a conversation.
-          internal static func footer(_ p1: Int) -> String {
-            return L10n.tr("Localizable", "participants.section.name.footer", p1, fallback: "Up to %1$d participants can join a conversation.")
+          /// Up to %@ participants can join a conversation.
+          internal static func footer(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "participants.section.name.footer", String(describing: p1), fallback: "Up to %@ participants can join a conversation.")
           }
         }
       }

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -102,8 +102,8 @@
 "peoplepicker.federation.domain_unvailable" = "The federated domain is currently not available. [Learn more](%@)";
 
 "add_participants.alert.title" = "The conversation is full";
-"add_participants.alert.message.new_conversation" = "Up to %d people can join a conversation.";
-"add_participants.alert.message.existing_conversation" = "Up to %1$d people can join a conversation. Currently there is only room for %2$d more.";
+"add_participants.alert.message.new_conversation" = "Up to %@ people can join a conversation.";
+"add_participants.alert.message.existing_conversation" = "Up to %@ people can join a conversation. Currently there is only room for %@ more.";
 
 // Channel Creation UI - Navigation
 "conversation.create.channel.title" = "New channel";
@@ -859,7 +859,7 @@
 "participants.section.services" = "Services (%d)";
 "participants.section.settings" = "Options";
 "participants.footer.add_title" = "Add Participants";
-"participants.section.name.footer" = "Up to %1$d participants can join a conversation.";
+"participants.section.name.footer" = "Up to %@ participants can join a conversation.";
 "participants.section.admins.footer" = "There are no admins.";
 "participants.section.members.footer" = "There are no members.";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -102,8 +102,8 @@
 "peoplepicker.federation.domain_unvailable" = "Die föderierte Domain ist derzeit nicht verfügbar. [Mehr erfahren](%@)";
 
 "add_participants.alert.title" = "Die Unterhaltung ist voll";
-"add_participants.alert.message.new_conversation" = "Bis zu %d Personen können an einer Unterhaltung teilnehmen.";
-"add_participants.alert.message.existing_conversation" = "Bis zu %1$d Personen können an einer Unterhaltung teilnehmen. Jetzt ist noch Platz für %2$d weitere.";
+"add_participants.alert.message.new_conversation" = "Bis zu %@ Personen können an einer Unterhaltung teilnehmen.";
+"add_participants.alert.message.existing_conversation" = "Bis zu %@ Personen können an einer Unterhaltung teilnehmen. Jetzt ist noch Platz für %2$d weitere.";
 
 // Channel Creation UI - Navigation
 "conversation.create.channel.title" = "Neuer Channel";
@@ -859,7 +859,7 @@
 "participants.section.services" = "Dienste (%d)";
 "participants.section.settings" = "Optionen";
 "participants.footer.add_title" = "Teilnehmer hinzufügen";
-"participants.section.name.footer" = "Bis zu %1$d Personen können an einer Unterhaltung teilnehmen.";
+"participants.section.name.footer" = "Bis zu %@ Personen können an einer Unterhaltung teilnehmen.";
 "participants.section.admins.footer" = "Es gibt keine Admins.";
 "participants.section.members.footer" = "Es gibt keine Mitglieder.";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 "peoplepicker.federation.domain_unvailable" = "Федеративный домен в настоящее время недоступен. [Подробнее](%@)";
 
 "add_participants.alert.title" = "Беседа переполнена";
-"add_participants.alert.message.new_conversation" = "К беседе могут присоединиться до %d человек.";
+"add_participants.alert.message.new_conversation" = "К беседе могут присоединиться до %@ человек.";
 "add_participants.alert.message.existing_conversation" = "К беседе может присоединиться до %1$d человек. На текущий момент в комнате есть места еще для %2$d.";
 
 // Channel Creation UI - Navigation
@@ -859,7 +859,7 @@
 "participants.section.services" = "Сервисы (%d)";
 "participants.section.settings" = "Настройки";
 "participants.footer.add_title" = "Добавить участников";
-"participants.section.name.footer" = "К беседе могут присоединиться до %1$d участников.";
+"participants.section.name.footer" = "К беседе могут присоединиться до %@ участников.";
 "participants.section.admins.footer" = "Здесь нет администраторов.";
 "participants.section.members.footer" = "Здесь нет участников.";
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -592,10 +592,6 @@ extension Int {
         formatter.numberStyle = .decimal
         formatter.locale = Locale.current
 
-        if let formatted = formatter.string(from: NSNumber(value: self)) {
-            return formatted
-        } else {
-            return String(intValue: self) ?? String(format: "%1$d", self)
-        }
+        return formatter.string(from: NSNumber(value: self)) ?? String(self)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -77,10 +77,12 @@ extension AddParticipantsViewController.Context {
         case let .add(conversation):
             let freeSpace = conversation.freeParticipantSlots
             let max = ZMConversation.getMaxParticipants(isChannel: conversation.isChannel)
-            message = AddParticipantsAlert.Message.existingConversation(max, freeSpace)
+            message = AddParticipantsAlert.Message
+                .existingConversation(max.participantsFormatted,
+                                      freeSpace.participantsFormatted)
         case let .create(context):
             message = AddParticipantsAlert.Message
-                .newConversation(ZMConversation.getMaxParticipants(isChannel: context.isChannel))
+                .newConversation(ZMConversation.getMaxParticipants(isChannel: context.isChannel).participantsFormatted)
         }
 
         let controller = UIAlertController(
@@ -578,6 +580,20 @@ extension AddParticipantsViewController: EmptySearchResultsViewDelegate {
             URL.manageTeam(source: .onboarding).openInApp(above: self)
         case .openSearchSupportPage:
             WireURLs.shared.searchSupport.open()
+        }
+    }
+}
+
+extension Int {
+    var participantsFormatted: String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale.current
+
+        if let formatted = formatter.string(from: NSNumber(value: self)) {
+            return formatted
+        } else {
+            return String(intValue: self) ?? String(format: "%1$d", self)
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -78,8 +78,10 @@ extension AddParticipantsViewController.Context {
             let freeSpace = conversation.freeParticipantSlots
             let max = ZMConversation.getMaxParticipants(isChannel: conversation.isChannel)
             message = AddParticipantsAlert.Message
-                .existingConversation(max.participantsFormatted,
-                                      freeSpace.participantsFormatted)
+                .existingConversation(
+                    max.participantsFormatted,
+                    freeSpace.participantsFormatted
+                )
         case let .create(context):
             message = AddParticipantsAlert.Message
                 .newConversation(ZMConversation.getMaxParticipants(isChannel: context.isChannel).participantsFormatted)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -79,12 +79,12 @@ extension AddParticipantsViewController.Context {
             let max = ZMConversation.getMaxParticipants(isChannel: conversation.isChannel)
             message = AddParticipantsAlert.Message
                 .existingConversation(
-                    max.participantsFormatted,
-                    freeSpace.participantsFormatted
+                    max.formatted(.number),
+                    freeSpace.formatted(.number)
                 )
         case let .create(context):
             message = AddParticipantsAlert.Message
-                .newConversation(ZMConversation.getMaxParticipants(isChannel: context.isChannel).participantsFormatted)
+                .newConversation(ZMConversation.getMaxParticipants(isChannel: context.isChannel).formatted(.number))
         }
 
         let controller = UIAlertController(
@@ -583,15 +583,5 @@ extension AddParticipantsViewController: EmptySearchResultsViewDelegate {
         case .openSearchSupportPage:
             WireURLs.shared.searchSupport.open()
         }
-    }
-}
-
-extension Int {
-    var participantsFormatted: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.locale = Locale.current
-
-        return formatter.string(from: NSNumber(value: self)) ?? String(self)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateNameSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateNameSectionController.swift
@@ -38,7 +38,7 @@ final class ConversationCreateNameSectionController: NSObject, CollectionViewSec
     private let isChannel: Bool
 
     private lazy var footerText: String = L10n.Localizable.Participants.Section.Name
-        .footer(ZMConversation.getMaxParticipants(isChannel: isChannel).participantsFormatted)
+        .footer(ZMConversation.getMaxParticipants(isChannel: isChannel).formatted(.number))
 
     init(
         selfUser: UserType,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateNameSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/Sections/ConversationCreateNameSectionController.swift
@@ -38,7 +38,7 @@ final class ConversationCreateNameSectionController: NSObject, CollectionViewSec
     private let isChannel: Bool
 
     private lazy var footerText: String = L10n.Localizable.Participants.Section.Name
-        .footer(ZMConversation.getMaxParticipants(isChannel: isChannel))
+        .footer(ZMConversation.getMaxParticipants(isChannel: isChannel).participantsFormatted)
 
     init(
         selfUser: UserType,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
@@ -35,7 +35,7 @@ final class RenameGroupSectionController: NSObject, CollectionViewSectionControl
 
     var titleFooter: String {
         L10n.Localizable.Participants.Section.Name
-            .footer(ZMConversation.getMaxParticipants(isChannel: conversation.isChannel))
+            .footer(ZMConversation.getMaxParticipants(isChannel: conversation.isChannel).participantsFormatted)
     }
 
     init(conversation: GroupDetailsConversationType, userSession: UserSession) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/RenameGroupSectionController.swift
@@ -35,7 +35,7 @@ final class RenameGroupSectionController: NSObject, CollectionViewSectionControl
 
     var titleFooter: String {
         L10n.Localizable.Participants.Section.Name
-            .footer(ZMConversation.getMaxParticipants(isChannel: conversation.isChannel).participantsFormatted)
+            .footer(ZMConversation.getMaxParticipants(isChannel: conversation.isChannel).formatted(.number))
     }
 
     init(conversation: GroupDetailsConversationType, userSession: UserSession) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17344" title="WPB-17344" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17344</a>  [iOS] Adjust channels string for maximum participants to 2000
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When formatting max participants number it was not based on current device locale

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
