### PR TITLE
fix: CallKit crashes when in background - WPB-17848

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -409,7 +409,7 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
 
         // Don't use the async version, it's broken
         // It doesn't get executed when waking up the app from the background and ends up crashing
-        // See latest comments https://developer.apple.com/documentation/callkit/sending_end-to-end_encrypted_voip_calls
+        // See latest comments https://stackoverflow.com/questions/56788314/ios-13-killing-app-because-it-never-posted-an-incoming-call-to-the-system-after
         provider.reportNewIncomingCall(
             with: call.id,
             update: update

--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -388,7 +388,7 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
         handle: CallHandle,
         callerName: String,
         hasVideo: Bool
-    ) async {
+    ) {
         logger.info("report incoming call preemptively")
 
         guard !callRegister.callExists(for: handle) else {
@@ -407,12 +407,18 @@ public class CallKitManager: NSObject, CallKitManagerInterface {
         update.supportsGrouping = false
         update.supportsUngrouping = false
 
-        do {
-            try await provider.reportNewIncomingCall(with: call.id, update: update)
-        } catch {
-            logger.error("fail: report incoming call preemptively: \(error)")
-            log("Cannot preemptively report incoming call: \(error)")
-            callRegister.unregisterCall(call)
+        // Don't use the async version, it's broken
+        // It doesn't get executed when waking up the app from the background and ends up crashing
+        // See latest comments https://developer.apple.com/documentation/callkit/sending_end-to-end_encrypted_voip_calls
+        provider.reportNewIncomingCall(
+            with: call.id,
+            update: update
+        ) { [weak self] error in
+            if let error {
+                self?.logger.error("fail: report incoming call preemptively: \(error)")
+                self?.log("Cannot preemptively report incoming call: \(error)")
+                self?.callRegister.unregisterCall(call)
+            }
         }
     }
 

--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -87,20 +87,30 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
         // do nothing
     }
 
+    // Don't use the async version, it's broken
+    // It doesn't properly get called when waking up the app from the background and ends up crashing
+    // See latest comments https://stackoverflow.com/questions/56788314/ios-13-killing-app-because-it-never-posted-an-incoming-call-to-the-system-after
     public func pushRegistry(
         _ registry: PKPushRegistry,
         didReceiveIncomingPushWith payload: PKPushPayload,
-        for type: PKPushType
-    ) async {
+        for type: PKPushType,
+        completion: @escaping () -> Void
+    ) {
         Self.logger.debug("did receive incoming push")
 
         // We're only interested in voIP tokens.
-        guard type == .voIP else { return }
+        guard type == .voIP else { return completion() }
 
-        await processNSEPush(payload: payload.dictionaryPayload)
+        processNSEPush(
+            payload: payload.dictionaryPayload,
+            completion: completion
+        )
     }
 
-    private func processNSEPush(payload: [AnyHashable: Any]) async {
+    private func processNSEPush(
+        payload: [AnyHashable: Any],
+        completion: @escaping () -> Void
+    ) {
         Self.logger.debug("process NSE push, payload: \(payload)")
 
         guard
@@ -125,7 +135,7 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
         // See https://developer.apple.com/documentation/callkit/sending_end-to-end_encrypted_voip_calls
         if shouldRing {
             Self.logger.info("will report new incoming call")
-            await callKitManager.reportIncomingCallPreemptively(
+            callKitManager.reportIncomingCallPreemptively(
                 handle: handle,
                 callerName: callerName,
                 hasVideo: hasVideo
@@ -138,6 +148,8 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
             )
         }
 
-        await delegate?.processPendingCallEvents(accountID: accountID)
+        Task {
+            await delegate?.processPendingCallEvents(accountID: accountID)
+        }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17848" title="WPB-17848" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17848</a>  [iOS] App crashes in background when there are CallKit calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When incoming calls arrive in the background and they're handled with CallKit, app crashes.

**Causes**: Some changes were introduced recently in this [PR](https://github.com/wireapp/wire-ios/pull/2916) where we replaced `pushRetry` and `reportNewIncomingCall` completionHandler versions of Apple's API with their async versions which appear to be broken as they're not called properly when waking up the app from the background. 

It ends up crashing as since iOS 13:
> if you fail to report a call to CallKit, the system will terminate your app.

..which is what we experienced when looking at the console.

**Solution**: As mentioned in the latest comments in this [SO](https://stackoverflow.com/questions/56788314/ios-13-killing-app-because-it-never-posted-an-incoming-call-to-the-system-after) post and after testing with both versions (async vs. completionHandler), the issue was reproducible with the async version and appeared to work properly with the completionHandler one.
Solution is to revert these changes to make sure we use the completionHandler API versions as before, thus properly report the call and avoid crashing.

### Testing

Tested internally on both async / completionHandler versions, issue was reproducible on the async version, not the completionHandler one.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
