### PR TITLE
fix: messages not being sent, waiting forever for decryption to finish - WPB-17866

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -63,8 +63,14 @@ public struct IncrementalSync: IncrementalSyncProtocol {
         let liveEventStream = try await pushChannel.open()
 
         logger.debug("pulling pending update events")
-        syncStateSubject.send(.incrementalSyncing(.pullPendingEvents))
-        try await updateEventsSync.pull()
+        syncStateSubject.send(.incrementalSyncing(.pullPendingEvents(.inProgress)))
+        do {
+            try await updateEventsSync.pull()
+        } catch {
+            logger.debug("pulling pending update events interrupted \(String(describing: error))")
+            syncStateSubject.send(.incrementalSyncing(.pullPendingEvents(.interrupted)))
+            throw error
+        }
 
         logger.debug("processing stored update events")
         syncStateSubject.send(.incrementalSyncing(.processPendingEvents))

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -63,14 +63,8 @@ public struct IncrementalSync: IncrementalSyncProtocol {
         let liveEventStream = try await pushChannel.open()
 
         logger.debug("pulling pending update events")
-        syncStateSubject.send(.incrementalSyncing(.pullPendingEvents(.inProgress)))
-        do {
-            try await updateEventsSync.pull()
-        } catch {
-            logger.debug("pulling pending update events interrupted \(String(describing: error))")
-            syncStateSubject.send(.incrementalSyncing(.pullPendingEvents(.interrupted)))
-            throw error
-        }
+        syncStateSubject.send(.incrementalSyncing(.pullPendingEvents))
+        try await updateEventsSync.pull()
 
         logger.debug("processing stored update events")
         syncStateSubject.send(.incrementalSyncing(.processPendingEvents))

--- a/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullPendingUpdateEventsSyncProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/Protocols/PullPendingUpdateEventsSyncProtocol.swift
@@ -27,6 +27,7 @@ public protocol PullPendingUpdateEventsSyncProtocol {
     /// Pull pending update events from the remote, decrypt (if needed),
     /// and store them locally.
 
+    @discardableResult
     func pull() async throws -> AsyncStream<[UpdateEvent]>
 
 }

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -35,6 +35,10 @@ public enum SyncState: Equatable {
     /// App is up to date and processing live events.
 
     case liveSyncing
+    
+    /// Sync was suspended
+    
+    case suspended
 
     public enum InitialSyncState: Equatable {
 
@@ -49,8 +53,13 @@ public enum SyncState: Equatable {
 
         case createPushChannel
         case openPushChannel
-        case pullPendingEvents
+        case pullPendingEvents(PullPendingEventsState)
         case processPendingEvents
+        
+        public enum PullPendingEventsState {
+            case inProgress
+            case interrupted
+        }
 
     }
 

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -35,9 +35,9 @@ public enum SyncState: Equatable {
     /// App is up to date and processing live events.
 
     case liveSyncing
-    
+
     /// Sync was suspended
-    
+
     case suspended
 
     public enum InitialSyncState: Equatable {
@@ -55,7 +55,7 @@ public enum SyncState: Equatable {
         case openPushChannel
         case pullPendingEvents(PullPendingEventsState)
         case processPendingEvents
-        
+
         public enum PullPendingEventsState {
             case inProgress
             case interrupted

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -53,13 +53,8 @@ public enum SyncState: Equatable {
 
         case createPushChannel
         case openPushChannel
-        case pullPendingEvents(PullPendingEventsState)
+        case pullPendingEvents
         case processPendingEvents
-
-        public enum PullPendingEventsState {
-            case inProgress
-            case interrupted
-        }
 
     }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2709,6 +2709,7 @@ public class MockPullPendingUpdateEventsSyncProtocol: PullPendingUpdateEventsSyn
     public var pull_MockMethod: (() async throws -> AsyncStream<[UpdateEvent]>)?
     public var pull_MockValue: AsyncStream<[UpdateEvent]>?
 
+    @discardableResult
     public func pull() async throws -> AsyncStream<[UpdateEvent]> {
         pull_Invocations.append(())
 

--- a/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
@@ -55,9 +55,16 @@ final class IncrementalSyncObserver: IncrementalSyncObserverProtocol {
                 .receive(on: decryptionQueue)
                 .sink { [weak self] syncState in
                     switch syncState {
-                    case .incrementalSyncing(.pullPendingEvents):
-                        self?.decryptionState = .inProgress
+                    case .incrementalSyncing(.pullPendingEvents(let state)):
+                        switch state {
+                        case .inProgress:
+                            self?.decryptionState = .inProgress
+                        case .interrupted:
+                            self?.decryptionState = .done
+                        }
                     case .incrementalSyncing(.processPendingEvents), .liveSyncing:
+                        self?.decryptionState = .done
+                    case .suspended:
                         self?.decryptionState = .done
                     default:
                         self?.decryptionState = .notStarted

--- a/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
@@ -55,7 +55,7 @@ final class IncrementalSyncObserver: IncrementalSyncObserverProtocol {
                 .receive(on: decryptionQueue)
                 .sink { [weak self] syncState in
                     switch syncState {
-                    case .incrementalSyncing(.pullPendingEvents(let state)):
+                    case let .incrementalSyncing(.pullPendingEvents(state)):
                         switch state {
                         case .inProgress:
                             self?.decryptionState = .inProgress

--- a/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
@@ -55,16 +55,11 @@ final class IncrementalSyncObserver: IncrementalSyncObserverProtocol {
                 .receive(on: decryptionQueue)
                 .sink { [weak self] syncState in
                     switch syncState {
-                    case let .incrementalSyncing(.pullPendingEvents(state)):
-                        switch state {
-                        case .inProgress:
-                            self?.decryptionState = .inProgress
-                        case .interrupted:
-                            self?.decryptionState = .done
-                        }
-                    case .incrementalSyncing(.processPendingEvents), .liveSyncing:
-                        self?.decryptionState = .done
-                    case .suspended:
+                    case .incrementalSyncing(.pullPendingEvents):
+                        self?.decryptionState = .inProgress
+                    case .incrementalSyncing(.processPendingEvents),
+                            .suspended,
+                            .liveSyncing:
                         self?.decryptionState = .done
                     default:
                         self?.decryptionState = .notStarted

--- a/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/IncrementalSyncObserver.swift
@@ -58,8 +58,8 @@ final class IncrementalSyncObserver: IncrementalSyncObserverProtocol {
                     case .incrementalSyncing(.pullPendingEvents):
                         self?.decryptionState = .inProgress
                     case .incrementalSyncing(.processPendingEvents),
-                            .suspended,
-                            .liveSyncing:
+                         .suspended,
+                         .liveSyncing:
                         self?.decryptionState = .done
                     default:
                         self?.decryptionState = .notStarted

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -132,6 +132,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         WireLogger.sync.debug("suspending sync")
         await incrementalSyncToken?.suspend()
         incrementalSyncToken = nil
+        syncStateSubject.send(.suspended)
     }
 
     /// Performs the appropriate sync depending in the local state.

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -211,6 +211,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
                 }
             } catch {
                 WireLogger.sync.error("failed to perform new incremental sync: \(String(describing: error))")
+                syncStateSubject.send(.suspended)
                 throw error
             }
         } else {

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
@@ -208,4 +208,76 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
         XCTAssertEqual(incrementalSync.perform_Invocations.count, 1)
     }
 
+    func testPerformIncrementalSync_Sync_State_Update_To_Suspended_When_Throwing_Error() async throws {
+        // Given
+        journal[.isSyncV2Enabled] = true
+        let expectation = XCTestExpectation()
+
+        enum Failure: Error {
+            case failed
+        }
+
+        // Mock
+        incrementalSync.perform_MockMethod = {
+            throw Failure.failed
+        }
+
+        var cancellable: AnyCancellable?
+
+        cancellable = syncStateSubject
+            .dropFirst()
+            .sink { state in
+                switch state {
+                case .suspended:
+                    // Then
+                    expectation.fulfill()
+                default:
+                    XCTFail("Sync should be suspended when an error is thrown")
+                }
+            }
+
+
+        do {
+            // When
+            try await sut.performIncrementalSync()
+        } catch {}
+
+        await fulfillment(of: [expectation])
+    }
+
+    func testPerformIncrementalSync_Sync_State_Update_To_Suspended() async throws {
+        // Given
+        journal[.isSyncV2Enabled] = true
+        let expectation = XCTestExpectation()
+
+        enum Failure: Error {
+            case failed
+        }
+
+        // Mock
+        incrementalSync.perform_MockMethod = {
+            throw Failure.failed
+        }
+
+        var cancellable: AnyCancellable?
+
+        cancellable = syncStateSubject
+            .dropFirst()
+            .sink { state in
+                switch state {
+                case .suspended:
+                    // Then
+                    expectation.fulfill()
+                default:
+                    XCTFail("Sync should be suspended")
+                }
+            }
+
+
+        // When
+        sut.suspend()
+
+        await fulfillment(of: [expectation])
+    }
+
 }

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
@@ -236,7 +236,6 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
                 }
             }
 
-
         do {
             // When
             try await sut.performIncrementalSync()
@@ -272,7 +271,6 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
                     XCTFail("Sync should be suspended")
                 }
             }
-
 
         // When
         sut.suspend()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17866" title="WPB-17866" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17866</a>  [iOS] Not able to send messages on mobile data
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: Messages are stuck forever in a sending state, no way to recover. Next messages can't be sent as well, stuck in same state.

We introduced in this [PR](https://github.com/wireapp/wire-ios/pull/2966) a mechanism that waits for pending events to be decrypted before proceeding to message sending.

Specifically in `MessageSender`, we await for `incrementalSyncObserver.waitUntilCanSendMessage()` and it only gets through when finishing decrypting the pending events and setting the `decryptionState` to done at the  `IncrementalSyncObserver` level.

**Causes**:  The decryption state might never gets updated to `.done` hence blocking the message sender to proceed the message which can lead to the bugs mentioned [here](https://wearezeta.atlassian.net/browse/WPB-17772) and [here](https://wearezeta.atlassian.net/browse/WPB-17866).

What happens after is that if we try to send a message again we'll be stuck in a loop in `try await messageDependencyResolver.waitForDependenciesToResolve(for: message)` where the dependencies never resolve specifically `dependentObjectNeedingUpdateBeforeProcessing` (code doc below) will never be nil, probably because the initial message was never really processed and it blocks the next messages.

`    
/// Other entities which has to complete an update before this entity can be processed, i.e. another message
/// needs to be sent first because it was scheduled for sending before this message.
`

**Solution**: Update the sync state whenever the sync is suspended or when an error occurs while pulling (and decrypting) pending events so we ensure the decryption state is changed to done so the `MessageSender` method is "unlocked" and the messages are sent or at least attempted to be sent.

### Testing

Tested internally
- Comment out the code where the sync state is updated so the MessageSender gets stuck and the message not sent.
- try to send message again and again
- messages shows up as in sending state just like the screenshots from the Jira tickets

![Capture d’écran   2025-05-23 à 16 47 36](https://github.com/user-attachments/assets/e99868b3-c972-4698-9804-6f250a9795f5)

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
