### PR TITLE
feat: add spinner - WPB-17596

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -119,10 +119,8 @@ final class ClientListViewController: UIViewController,
             self.userObserverToken = UserChangeInfo.add(observer: self, for: user, in: session)
         }
 
-        if clientsList == nil {
-            if clients.isEmpty {
-                activityIndicator.start()
-            }
+        if clients.isEmpty {
+            activityIndicator.start()
             userSession?.fetchAllClients()
         }
     }
@@ -167,14 +165,19 @@ final class ClientListViewController: UIViewController,
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        dismissLoadingView()
 
         // Prevent more then one removalObserver in self and SettingsClientViewController
         removalObserver = nil
     }
 
-    private func dismissLoadingView() {
-        activityIndicator.stop()
+    private func dismissLoadingView() async {
+        let minimumDelay: TimeInterval = 0.2
+        let nanoseconds = UInt64(minimumDelay * 1_000_000_000)
+
+        try? await Task.sleep(nanoseconds: nanoseconds)
+        await MainActor.run {
+            activityIndicator.stop()
+        }
     }
 
     func openDetailsOfClient(_ client: UserClient) {
@@ -304,14 +307,16 @@ final class ClientListViewController: UIViewController,
     func finishedFetching(_ userClients: [UserClient]) {
         Task {
             await updateCertificates(for: userClients)
-            await MainActor.run {
-                dismissLoadingView()
-            }
+            //await MainActor.run {
+            await dismissLoadingView()
+            //}
         }
     }
 
     func failedToFetchClients(_ error: Error) {
-        dismissLoadingView()
+        Task {
+            await dismissLoadingView()
+        }
 
         zmLog.error("Clients request failed: \(error.localizedDescription)")
 
@@ -513,10 +518,12 @@ final class ClientListViewController: UIViewController,
 
     @MainActor
     private func updateCertificates(for userClients: [UserClient]) async {
+        activityIndicator.start()
         guard
             let userSession,
             let selfMlsGroupID = await userSession.fetchSelfConversationMLSGroupID()
         else {
+            activityIndicator.stop()
             return
         }
 
@@ -547,10 +554,10 @@ final class ClientListViewController: UIViewController,
                     client.mlsThumbPrint = e2eiCertificate.mlsThumbprint
                 }
             }
-
         } catch {
             WireLogger.e2ei.error(String(reflecting: error))
         }
+        await dismissLoadingView()
     }
 
     private func updateAllClients(completed: (() -> Void)? = nil) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DeviceManagement/ClientListViewController.swift
@@ -307,9 +307,7 @@ final class ClientListViewController: UIViewController,
     func finishedFetching(_ userClients: [UserClient]) {
         Task {
             await updateCertificates(for: userClients)
-            //await MainActor.run {
             await dismissLoadingView()
-            //}
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -223,8 +223,6 @@ final class ProfileViewController: UIViewController {
         viewControllers.append(profileDetailsViewController)
 
         if viewModel.hasUserClientListTab {
-            print(viewModel.conversation)
-            print(viewModel.conversation?.mlsGroupID)
             let userClientListViewController = OtherUserClientsListViewController(
                 user: viewModel.user,
                 userSession: viewModel.userSession,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/ProfileViewController.swift
@@ -223,6 +223,8 @@ final class ProfileViewController: UIViewController {
         viewControllers.append(profileDetailsViewController)
 
         if viewModel.hasUserClientListTab {
+            print(viewModel.conversation)
+            print(viewModel.conversation?.mlsGroupID)
             let userClientListViewController = OtherUserClientsListViewController(
                 user: viewModel.user,
                 userSession: viewModel.userSession,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17596" title="WPB-17596" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17596</a>  [iOS] Own devices not shown as MLS enabled while they actually are
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Sometimes it takes a while to get an MLS thumbprint, and from the user's perspective it's not clear that something is fetching. 
This PR introduces a spinner for the user's device list.

### Testing


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
