### PR TITLE
fix: environment variables passed for XCUITests - WPB-17516

### DIFF
--- a/wire-ios/WireUITests/ApiClients/BackendClient.swift
+++ b/wire-ios/WireUITests/ApiClients/BackendClient.swift
@@ -21,9 +21,9 @@ import Foundation
 enum BackendClient {
 
     static func loginViaAPI(email: String, password: String) async throws -> String {
-        let backendURL = "https://\(ProcessInfo.processInfo.environment["BACKEND_URL"]!)"
-        let url = URL(string: "\(backendURL)/v8/login")
-        guard let requestUrl = url else { fatalError() }
+        let envVariables = try EnvironmentVariables()
+        let requestUrl = envVariables.backendURL.appending(path: "v8/login")
+
         var request = URLRequest(url: requestUrl)
         request.httpMethod = "POST"
         let body: [String: Any] = ["email": "\(email)", "password": "\(password)"]
@@ -45,9 +45,9 @@ enum BackendClient {
     }
 
     static func deletePersonalUser(access_token: String, password: String) async throws {
-        let backendURL = "https://\(ProcessInfo.processInfo.environment["BACKEND_URL"]!)"
-        let url = URL(string: "\(backendURL)/self")
-        guard let requestUrl = url else { fatalError() }
+        let envVariables = try EnvironmentVariables()
+        let requestUrl = envVariables.backendURL.appending(path: "self")
+
         var request = URLRequest(url: requestUrl)
         request.httpMethod = "DELETE"
         let body: [String: Any] = ["password": "\(password)"]

--- a/wire-ios/WireUITests/ApiClients/InbucketClient.swift
+++ b/wire-ios/WireUITests/ApiClients/InbucketClient.swift
@@ -21,15 +21,14 @@ import Foundation
 enum InbucketClient {
 
     static func getVerificationCode(email: String) async throws -> String {
-        let inbucketURL = "https://\(ProcessInfo.processInfo.environment["INBUCKET_URL"]!)"
-        let inbucketUsername = ProcessInfo.processInfo.environment["INBUCKET_USERNAME"]!
-        let inbucketPassword = ProcessInfo.processInfo.environment["INBUCKET_PASSWORD"]!
+        let envVariables = try EnvironmentVariables()
+
         var verificationCode = ""
-        let url = URL(string: "\(inbucketURL)api/v1/mailbox/\(email)/latest")
-        guard let requestUrl = url else { fatalError() }
+        let requestUrl = envVariables.inbucketURL.appending(path: "api/v1/mailbox/\(email)/latest")
+
         var request = URLRequest(url: requestUrl)
         request.httpMethod = "GET"
-        let loginString = String(format: "%@:%@", inbucketUsername, inbucketPassword)
+        let loginString = String(format: "%@:%@", envVariables.inbucketUsername, envVariables.inbucketPassword)
         let loginData = loginString.data(using: String.Encoding.utf8)!
         let base64LoginString = loginData.base64EncodedString()
         request.setValue("Basic \(base64LoginString)", forHTTPHeaderField: "Authorization")

--- a/wire-ios/WireUITests/Helper/EnvironmentVariables.swift
+++ b/wire-ios/WireUITests/Helper/EnvironmentVariables.swift
@@ -1,0 +1,58 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+import Foundation
+
+struct EnvironmentVariables {
+    enum Failure: Error {
+        case missingBackendURL
+        case missingInbucketURL
+        case missingInbucketUsername
+        case missingInbucketPassword
+    }
+
+    var backendURL: URL
+    var inbucketURL: URL
+    var inbucketUsername: String
+    var inbucketPassword: String
+
+    init() throws {
+        guard let backendURLString = ProcessInfo.processInfo.environment["BACKEND_URL"],
+              !backendURLString.isEmpty else {
+            throw Failure.missingBackendURL
+        }
+        guard let inbucketHostname = ProcessInfo.processInfo.environment["INBUCKET_URL"],
+              !inbucketHostname.isEmpty else {
+            throw Failure.missingInbucketURL
+        }
+
+        guard let inbucketUsername = ProcessInfo.processInfo.environment["INBUCKET_USERNAME"],
+              !inbucketUsername.isEmpty else {
+            throw Failure.missingInbucketUsername
+        }
+
+        guard let inbucketPassword = ProcessInfo.processInfo.environment["INBUCKET_PASSWORD"],
+              !inbucketPassword.isEmpty else {
+            throw Failure.missingInbucketUsername
+        }
+
+        self.backendURL = URL(string: "https://\(backendURLString)")!
+        self.inbucketURL = URL(string: "https://\(inbucketHostname)")!
+        self.inbucketUsername = inbucketUsername
+        self.inbucketPassword = inbucketPassword
+    }
+}

--- a/wire-ios/WireUITests/Pages/LogOutPage.swift
+++ b/wire-ios/WireUITests/Pages/LogOutPage.swift
@@ -28,6 +28,7 @@ class LogOutPage: PageModel {
         app.buttons["OK"]
     }
 
+    @discardableResult
     func enterPassword(_ password: String) -> WelcomePage {
         passwordField.tap()
         passwordField.typeText(password)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17516" title="WPB-17516" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17516</a>  [iOS] Personal users created without email and password
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Parse environment variables and check for empty values. If the env.xcconfig file is not generated by default the environment variables will be an empty string.

### Testing

Run XCUITests without generating env.xcconfig file.
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
