### PR TITLE
fix: push notification connection accepted placeholder - WPB-17903

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionEventNotificationBuilder.swift
@@ -52,9 +52,20 @@ struct UserConnectionEventNotificationBuilder {
         let connectionStatus = isPendingConnection ? ConnectionStatus.pending : .accepted
         let selfUser = await context.getSelfUser()
         let selfUserID = await context.selfUserID(selfUser: selfUser)
+        // The receiver is the user we are connecting with
         let username: String? = if let receiverQualifiedID = connection.receiverQualifiedID {
             await context.username(
-                for: context.getUser(userID: receiverQualifiedID)
+                for: context.getUser(
+                    id: receiverQualifiedID.uuid,
+                    domain: receiverQualifiedID.domain
+                )
+            )
+        } else if let receiverID = connection.receiverID {
+            await context.username(
+                for: context.getUser(
+                    id: receiverID,
+                    domain: nil
+                )
             )
         } else {
             nil
@@ -81,17 +92,31 @@ struct UserConnectionEventNotificationBuilder {
     ) -> UserNotification {
         let content = UNMutableNotificationContent()
 
-        let localizableKey: String.LocalizationValue = switch connectionStatus {
+        let body = switch connectionStatus {
         case .pending:
-            "push.notification.body.connectionPending"
+            if let username {
+                String.formated(
+                    key: "push.notification.body.connectionPending",
+                    bundle: .module, username
+                )
+            } else {
+                String.formated(
+                    key: "push.notification.body.connectionPending.noUsername",
+                    bundle: .module
+                )
+            }
         case .accepted:
-            "push.notification.body.connectionAccepted"
-        }
-
-        let body = if let username {
-            String.formated(key: localizableKey, bundle: .module, username)
-        } else {
-            String.localized(key: localizableKey, bundle: .module)
+            if let username {
+                String.formated(
+                    key: "push.notification.body.connectionAccepted",
+                    bundle: .module, username
+                )
+            } else {
+                String.formated(
+                    key: "push.notification.body.connectionAccepted.noUsername",
+                    bundle: .module
+                )
+            }
         }
 
         content.body = body
@@ -166,11 +191,12 @@ extension UserConnectionEventNotificationBuilder {
         }
 
         func getUser(
-            userID: UserID
+            id: UUID,
+            domain: String?
         ) async -> ZMUser {
             await userLocalStore.fetchOrCreateUser(
-                id: userID.uuid,
-                domain: userID.domain
+                id: id,
+                domain: domain
             )
         }
 

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionEventNotificationBuilder.swift
@@ -52,9 +52,9 @@ struct UserConnectionEventNotificationBuilder {
         let connectionStatus = isPendingConnection ? ConnectionStatus.pending : .accepted
         let selfUser = await context.getSelfUser()
         let selfUserID = await context.selfUserID(selfUser: selfUser)
-        let senderName: String? = if let senderID = connection.senderID {
-            await context.senderName(
-                sender: context.getSender(senderID: senderID)
+        let username: String? = if let receiverQualifiedID = connection.receiverQualifiedID {
+            await context.username(
+                for: context.getUser(userID: receiverQualifiedID)
             )
         } else {
             nil
@@ -62,7 +62,7 @@ struct UserConnectionEventNotificationBuilder {
 
         return buildConnectionRequestNotification(
             connectionStatus: connectionStatus,
-            username: senderName ?? event.userName,
+            username: username ?? event.userName,
             selfUserID: selfUserID,
             senderID: connection.senderID,
             conversationID: qualifiedID
@@ -165,19 +165,19 @@ extension UserConnectionEventNotificationBuilder {
             await userLocalStore.fetchSelfUser()
         }
 
-        func getSender(
-            senderID: UUID
+        func getUser(
+            userID: UserID
         ) async -> ZMUser {
             await userLocalStore.fetchOrCreateUser(
-                id: senderID,
-                domain: nil
+                id: userID.uuid,
+                domain: userID.domain
             )
         }
 
-        func senderName(
-            sender: ZMUser
+        func username(
+            for user: ZMUser
         ) async -> String? {
-            await userLocalStore.name(for: sender)
+            await userLocalStore.name(for: user)
         }
 
         func isGroupConversation(conversation: ZMConversation) async -> Bool {

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/User/UserConnectionEventNotificationBuilder.swift
@@ -52,10 +52,17 @@ struct UserConnectionEventNotificationBuilder {
         let connectionStatus = isPendingConnection ? ConnectionStatus.pending : .accepted
         let selfUser = await context.getSelfUser()
         let selfUserID = await context.selfUserID(selfUser: selfUser)
+        let senderName: String? = if let senderID = connection.senderID {
+            await context.senderName(
+                sender: context.getSender(senderID: senderID)
+            )
+        } else {
+            nil
+        }
 
         return buildConnectionRequestNotification(
             connectionStatus: connectionStatus,
-            username: event.userName,
+            username: senderName ?? event.userName,
             selfUserID: selfUserID,
             senderID: connection.senderID,
             conversationID: qualifiedID
@@ -159,11 +166,11 @@ extension UserConnectionEventNotificationBuilder {
         }
 
         func getSender(
-            senderID: UserID
+            senderID: UUID
         ) async -> ZMUser {
             await userLocalStore.fetchOrCreateUser(
-                id: senderID.uuid,
-                domain: senderID.domain
+                id: senderID,
+                domain: nil
             )
         }
 

--- a/WireDomain/Sources/WireDomain/Resources/Localization/Localizable.xcstrings
+++ b/WireDomain/Sources/WireDomain/Resources/Localization/Localizable.xcstrings
@@ -1126,6 +1126,47 @@
         }
       }
     },
+    "push.notification.body.connectionAccepted.noUsername" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie haben einen neuen Kontakt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You have a new connection"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous avez une nouvelle connexion"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Você tem uma nova conexão"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "У вас есть новый контакт"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您有一个新的好友"
+          }
+        }
+      }
+    },
     "push.notification.body.connectionPending" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1247,6 +1288,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@想連絡您"
+          }
+        }
+      }
+    },
+    "push.notification.body.connectionPending.noUsername" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jemand möchte Sie als Kontakt hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Someone wants to connect"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quelqu'un souhaite se connecter"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alguém quer se conectar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кто-то хочет подключиться"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有人想加您为好友"
           }
         }
       }

--- a/WireDomain/Tests/WireDomainTests/Notifications/User/UserConnectionEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/User/UserConnectionEventNotificationBuilderTests.swift
@@ -66,6 +66,14 @@ final class UserConnectionEventNotificationBuilderTests: XCTestCase {
             modelHelper.createSelfUser(in: context)
         }
 
+        userLocalStore.fetchOrCreateUserIdDomain_MockValue = await context.perform { [self] in
+            modelHelper.createUser(in: context)
+        }
+
+        userLocalStore.nameFor_MockValue = await context.perform {
+            Scaffolding.username
+        }
+
         userLocalStore.idFor_MockValue = .mockID1
 
         for connectionEvent in connectionEvents {

--- a/WireDomain/Tests/WireDomainTests/Notifications/User/UserConnectionEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/User/UserConnectionEventNotificationBuilderTests.swift
@@ -58,7 +58,12 @@ final class UserConnectionEventNotificationBuilderTests: XCTestCase {
 
     func testGenerateUserConnectionNotifications() async {
         // Given
-        let connectionEvents = [Scaffolding.userPendingConnectionEvent, Scaffolding.userAcceptedConnectionEvent]
+        let connectionEvents = [
+            Scaffolding.userPendingConnectionEvent,
+            Scaffolding.userAcceptedConnectionEvent,
+            Scaffolding.userPendingConnectionEventNoUsername,
+            Scaffolding.userAcceptedConnectionEventNoUsername
+        ]
 
         // Mock
 
@@ -71,7 +76,7 @@ final class UserConnectionEventNotificationBuilderTests: XCTestCase {
         }
 
         userLocalStore.nameFor_MockValue = await context.perform {
-            Scaffolding.username
+            .some(nil)
         }
 
         userLocalStore.idFor_MockValue = .mockID1
@@ -99,14 +104,24 @@ final class UserConnectionEventNotificationBuilderTests: XCTestCase {
             switch connectionEvent.connection.status {
 
             case .pending:
-                XCTAssertEqual(notificationContent.body, "\(Scaffolding.username) wants to connect")
+                if let userName = connectionEvent.userName {
+                    XCTAssertEqual(notificationContent.body, "\(Scaffolding.username) wants to connect")
+                } else {
+                    XCTAssertEqual(notificationContent.body, "Someone wants to connect")
+                }
+
                 XCTAssertEqual(
                     notificationContent.categoryIdentifier,
                     NotificationCategory.incomingConnectionRequest.rawValue
                 )
 
             case .accepted:
-                XCTAssertEqual(notificationContent.body, "You and \(Scaffolding.username) are now connected")
+                if let userName = connectionEvent.userName {
+                    XCTAssertEqual(notificationContent.body, "You and \(Scaffolding.username) are now connected")
+                } else {
+                    XCTAssertEqual(notificationContent.body, "You have a new connection")
+                }
+
                 XCTAssertEqual(notificationContent.categoryIdentifier, NotificationCategory.nonActionable.rawValue)
 
             default:
@@ -121,8 +136,19 @@ final class UserConnectionEventNotificationBuilderTests: XCTestCase {
             userName: Scaffolding.username,
             connection: pendingConnection
         )
+
+        static let userPendingConnectionEventNoUsername = UserConnectionEvent(
+            userName: nil,
+            connection: pendingConnection
+        )
+
         static let userAcceptedConnectionEvent = UserConnectionEvent(
             userName: Scaffolding.username,
+            connection: acceptedConnection
+        )
+
+        static let userAcceptedConnectionEventNoUsername = UserConnectionEvent(
+            userName: nil,
             connection: acceptedConnection
         )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17903" title="WPB-17903" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17903</a>  [iOS] Connection push notification show placeholder 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When a connection is accepted, push notification doesn't display the user we connected with.

**Causes**: We solely rely on the username value which might be null.

**Solution**: As in legacy code, rely on the sender name and fallback on the username value.

BEFORE:
<img width="495" alt="Screenshot 2025-05-27 at 08 07 38" src="https://github.com/user-attachments/assets/c3e8044f-0006-4bb7-82ad-7cccd67cc9e0" />

NOW: 
<img width="497" alt="Screenshot 2025-05-27 at 08 07 48" src="https://github.com/user-attachments/assets/0cca9dd4-d6ec-462d-8936-ac1e58314e22" />

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
