### PR TITLE
fix: decoding error client add event - WPB-17753

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Event decoding/User/UserClientAddEventDecoder.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Event decoding/User/UserClientAddEventDecoder.swift
@@ -32,7 +32,7 @@ struct UserClientAddEventDecoder {
             client: SelfUserClient(
                 id: payload.id,
                 type: payload.type,
-                activationDate: payload.activationDate.date,
+                activationDate: payload.activationDate?.date,
                 label: payload.label,
                 model: payload.model,
                 deviceClass: payload.deviceClass,
@@ -48,7 +48,7 @@ struct UserClientAddEventDecoder {
 
         let id: String
         let type: UserClientType
-        let activationDate: UTCTime
+        let activationDate: UTCTime?
         let label: String?
         let model: String?
         let deviceClass: DeviceClass?

--- a/WireAPI/Sources/WireAPI/APIs/UserClientsAPI/UserClientsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UserClientsAPI/UserClientsAPIV0.swift
@@ -90,7 +90,7 @@ struct SelfUserClientV0: Decodable, ToAPIModelConvertible {
 
     let id: String
     let type: UserClientType
-    let activationDate: UTCTime
+    let activationDate: UTCTime?
     let label: String?
     let model: String?
     let deviceClass: DeviceClass?
@@ -124,7 +124,7 @@ struct SelfUserClientV0: Decodable, ToAPIModelConvertible {
         SelfUserClient(
             id: id,
             type: type,
-            activationDate: activationDate.date,
+            activationDate: activationDate?.date,
             label: label,
             model: model,
             deviceClass: deviceClass,

--- a/WireAPI/Sources/WireAPI/APIs/UserClientsAPI/UserClientsAPIV7.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UserClientsAPI/UserClientsAPIV7.swift
@@ -61,7 +61,7 @@ private struct SelfUserClientV7: Decodable, ToAPIModelConvertible {
 
     let id: String
     let type: UserClientType
-    let activationDate: UTCTime
+    let activationDate: UTCTime?
     let label: String?
     let model: String?
     let deviceClass: DeviceClass?
@@ -89,7 +89,7 @@ private struct SelfUserClientV7: Decodable, ToAPIModelConvertible {
         SelfUserClient(
             id: id,
             type: type,
-            activationDate: activationDate.date,
+            activationDate: activationDate?.date,
             label: label,
             model: model,
             deviceClass: deviceClass,

--- a/WireAPI/Sources/WireAPI/Models/UserClient/SelfUserClient.swift
+++ b/WireAPI/Sources/WireAPI/Models/UserClient/SelfUserClient.swift
@@ -32,7 +32,7 @@ public struct SelfUserClient: Equatable, Identifiable, Codable, Sendable {
 
     /// The date when the client was activated.
 
-    public let activationDate: Date
+    public let activationDate: Date?
 
     /// A label describing the client.
 
@@ -79,7 +79,7 @@ public struct SelfUserClient: Equatable, Identifiable, Codable, Sendable {
     public init(
         id: String,
         type: UserClientType,
-        activationDate: Date,
+        activationDate: Date?,
         label: String? = nil,
         model: String? = nil,
         deviceClass: DeviceClass? = nil,

--- a/WireDomain/Sources/WireDomain/Repositories/UserClients/Models/UserClientInfo.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UserClients/Models/UserClientInfo.swift
@@ -24,7 +24,7 @@ public struct UserClientInfo: Sendable {
     let id: String
     let label: String?
     let type: WireDataModel.DeviceType
-    let activationDate: Date
+    let activationDate: Date?
     let model: String?
     let deviceClass: WireDataModel.DeviceClass?
     let lastActiveDate: Date?

--- a/WireDomain/Sources/WireUpdateEventCoding/Models/UserEvent/StorableUserClientAddEvent.swift
+++ b/WireDomain/Sources/WireUpdateEventCoding/Models/UserEvent/StorableUserClientAddEvent.swift
@@ -79,7 +79,7 @@ private struct StorableSelfUserClient: Equatable, Identifiable, Codable, Sendabl
 
     let id: String
     let type: StorableUserClientType
-    let activationDate: Date
+    let activationDate: Date?
     let label: String?
     let model: String?
     let deviceClass: StorableDeviceClass?


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17753" title="WPB-17753" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17753</a>  [iOS] Decoding error for client event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**:  A decoding error sometimes occur while trying to decode the stored update event envelope.

![Uploading Screenshot 2025-05-20 at 12.12.17.png…]()

**Causes**: Obvious cause is that the "time" value we're trying to decode should be optional when decoding.
As to why we ended up storing an envelope with an optional "time" value is less obvious since it looks like we've been working with a non optional until now. Could have been related to migration from legacy event but looks like we don't map that event either.

**Solution**: Quick win solution is to make the "time" value optional just like in legacy code (`Payload.UserClient` creationDate property) to avoid that decoding error.

### Testing

Couldn't reproduce

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
