### PR TITLE
fix: Not able to swipe - WPB-17839

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -570,20 +570,38 @@ extension ConversationContentViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         willSelectRow(at: indexPath, tableView: tableView)
     }
+    
+    private func actionControllerToSwipe(indexPath: IndexPath, isLeading: Bool) -> ConversationMessageActionController? {
+        
+        let section = dataSource.currentSections[ifExists: indexPath.section]?.elements[ifExists: indexPath.row]
+        let actionController = section?.actionController
+        let cellDescription = section?.instance
+        // There were a bug with no able to swipe https://wearezeta.atlassian.net/browse/WPB-17839
+        // Happened because action controller of a section controller was nil and
+        // different to actionControllers[<message.nonce>], so it was out of sync
+        // it was fixed but for extra safety backup action controller if not found
+        var backupActionController: ConversationMessageActionController?
+        if let nonce = cellDescription?.message?.nonce {
+            backupActionController = dataSource.sectionControllers.get(for: nonce)?.actionController
+        }
+        
+        if (cellDescription?.supportsActions ?? false),
+           let actionController = actionController ?? backupActionController,
+           isLeading ? actionController.message.canAddReaction : actionController.canPerformAction(action: .react("❤️")) {
+            return actionController
+        }
+        
+        return nil
+    }
 
     func tableView(
         _ tableView: UITableView,
         leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
 
-        let sections = dataSource.currentSections
-        guard
-            sections.indices.contains(indexPath.section),
-            sections[indexPath.section].elements.indices.contains(indexPath.row),
-            sections[indexPath.section].elements[indexPath.row].instance.supportsActions,
-            let actionController = sections[indexPath.section].elements[indexPath.row].actionController,
-            actionController.message.canAddReaction
-        else { return nil }
+        guard let actionController = actionControllerToSwipe(indexPath: indexPath, isLeading: true) else {
+            return nil
+        }
 
         // setting an empty title string since it would be displayed upside down
         // TODO: [WPB-16341] set "Reply" as text for accessibility reasons
@@ -608,14 +626,9 @@ extension ConversationContentViewController: UITableViewDelegate {
         trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
 
-        let sections = dataSource.currentSections
-        guard
-            sections.indices.contains(indexPath.section),
-            sections[indexPath.section].elements.indices.contains(indexPath.row),
-            sections[indexPath.section].elements[indexPath.row].instance.supportsActions,
-            let actionController = sections[indexPath.section].elements[indexPath.row].actionController,
-            actionController.canPerformAction(action: .react("❤️"))
-        else { return nil }
+        guard let actionController = actionControllerToSwipe(indexPath: indexPath, isLeading: true) else {
+            return nil
+        }
 
         // since the table view is flipped vertically we also render the image flipped
         // TODO: [WPB-16341] use the real image, remove the upsideDownImage

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -570,9 +570,12 @@ extension ConversationContentViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         willSelectRow(at: indexPath, tableView: tableView)
     }
-    
-    private func actionControllerToSwipe(indexPath: IndexPath, isLeading: Bool) -> ConversationMessageActionController? {
-        
+
+    private func actionControllerToSwipe(
+        indexPath: IndexPath,
+        isLeading: Bool
+    ) -> ConversationMessageActionController? {
+
         let section = dataSource.currentSections[ifExists: indexPath.section]?.elements[ifExists: indexPath.row]
         let actionController = section?.actionController
         let cellDescription = section?.instance
@@ -584,13 +587,14 @@ extension ConversationContentViewController: UITableViewDelegate {
         if let nonce = cellDescription?.message?.nonce {
             backupActionController = dataSource.sectionControllers.get(for: nonce)?.actionController
         }
-        
-        if (cellDescription?.supportsActions ?? false),
+
+        if cellDescription?.supportsActions ?? false,
            let actionController = actionController ?? backupActionController,
-           isLeading ? actionController.message.canAddReaction : actionController.canPerformAction(action: .react("❤️")) {
+           isLeading ? actionController.message.canAddReaction : actionController
+           .canPerformAction(action: .react("❤️")) {
             return actionController
         }
-        
+
         return nil
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -177,7 +177,6 @@ final class ConversationTableViewDataSource: NSObject {
             DispatchQueue.main.async {
                 var sections = [Section]()
 
-                let allMessages = messagesOnMainThread
                 for (messageObjectId, sectionController, context) in result {
 
                     // saving calculations result in local cache
@@ -285,11 +284,13 @@ final class ConversationTableViewDataSource: NSObject {
     }
 
     func resetSectionControllers() {
-        sectionControllers.reset()
-        calculateSections { [weak self] sections in
-            guard let self else { return }
-            currentSections = sections
-            tableView.reloadData()
+        debouncer.call(id: nil) { [weak self] in
+            self?.sectionControllers.reset()
+            self?.calculateSections { [weak self] sections in
+                guard let self else { return }
+                currentSections = sections
+                tableView.reloadData()
+            }
         }
     }
 
@@ -464,10 +465,12 @@ final class ConversationTableViewDataSource: NSObject {
         hasNewerMessagesToLoad = offset > 0
         firstUnreadMessage = conversation.firstUnreadMessage
 
-        calculateSections(forceRecalculate: forceRecalculate) { [weak self] sections in
-            self?.currentSections = sections
-            self?.tableView.reloadData()
-            completion?()
+        debouncer.call(id: nil) { [weak self] in
+            self?.calculateSections(forceRecalculate: forceRecalculate) { [weak self] sections in
+                self?.currentSections = sections
+                self?.tableView.reloadData()
+                completion?()
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17839" title="WPB-17839" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17839</a>  [iOS] Not Able to swipe react reply
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Turned out to be that when there are not read messages, when you open conversation, there was a several calls to re-calculate sections at same time which made data, in particular action controllers, not in sync. `actionContollers` dict has correct action controller for a message but not in `sectionController.actionController`. 

Fix is to sync calls to calculate sections using leading and trailing debouncer so at a given moment there is only one calculation.

### Testing

As per ticket steps

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
