### PR TITLE
chore: enable accessibility string in WireAuthenticationUI - WPB-17409

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/.swiftgen.yml
+++ b/WireAuthentication/Sources/WireAuthenticationUI/.swiftgen.yml
@@ -7,6 +7,7 @@ output_dir: ${GENERATED}/
 
 strings:
   inputs:
+    - Resources/Localization/en.lproj/Accessibility.strings
     - Resources/Localization/en.lproj/Localizable.strings
   filter:
   outputs:

--- a/WireAuthentication/Sources/WireAuthenticationUI/Components/OnPremHeaderView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Components/OnPremHeaderView.swift
@@ -25,16 +25,18 @@ package struct OnPremHeaderView: View {
     @State private var showCustomBackendAlert = false
     private let backendConfig: BackendConfig
 
+    private typealias Strings = L10n.Localizable.OnPremUserLogin
+
     package init(backendConfig: BackendConfig) {
         self.backendConfig = backendConfig
     }
 
     private var backendInfo: String {
         [
-            L10n.OnPremUserLogin.Alert.Message.backendName,
+            Strings.Alert.Message.backendName,
             backendConfig.title,
             "",
-            L10n.OnPremUserLogin.Alert.Message.backendUrl,
+            Strings.Alert.Message.backendUrl,
             backendConfig.endpoints.backendURL.absoluteString
         ].joined(separator: "\n")
     }
@@ -43,7 +45,7 @@ package struct OnPremHeaderView: View {
         Button(action: {
             showCustomBackendAlert.toggle()
         }, label: {
-            Text(L10n.OnPremUserLogin.title(backendConfig.title) + " ")
+            Text(Strings.title(backendConfig.title) + " ")
                 .foregroundColor(ColorTheme.Buttons.Secondary.onEnabled.color)
                 + Text(Image(systemName: "info.circle"))
                 .foregroundColor(.gray)
@@ -52,8 +54,8 @@ package struct OnPremHeaderView: View {
         .font(.textStyle(.h2))
         .lineLimit(nil)
         .fixedSize(horizontal: false, vertical: true)
-        .alert(L10n.OnPremUserLogin.Alert.title, isPresented: $showCustomBackendAlert) {
-            Button(L10n.OnPremUserLogin.Alert.button, role: .cancel) {}
+        .alert(Strings.Alert.title, isPresented: $showCustomBackendAlert) {
+            Button(Strings.Alert.button, role: .cancel) {}
         } message: {
             Text(backendInfo)
         }

--- a/WireAuthentication/Sources/WireAuthenticationUI/Utilities/Alert.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Utilities/Alert.swift
@@ -34,8 +34,8 @@ package struct Alert: Hashable, Identifiable, Sendable {
 
 extension Alert {
 
-    private typealias Title = L10n.Authentication.Error.Title
-    private typealias Message = L10n.Authentication.Error.Message
+    private typealias Title = L10n.Localizable.Authentication.Error.Title
+    private typealias Message = L10n.Localizable.Authentication.Error.Message
 
     static let noInternet = Alert(
         title: Title.noInternet,
@@ -68,18 +68,18 @@ extension Alert {
     )
 
     static let obsoleteClient = Alert(
-        title: L10n.ObsoleteClient.Alert.title,
-        message: L10n.ObsoleteClient.Alert.message
+        title: L10n.Localizable.ObsoleteClient.Alert.title,
+        message: L10n.Localizable.ObsoleteClient.Alert.message
     )
 
     static let obsoleteBackend = Alert(
-        title: L10n.ObsoleteBackend.Alert.title,
-        message: L10n.ObsoleteBackend.Alert.message
+        title: L10n.Localizable.ObsoleteBackend.Alert.title,
+        message: L10n.Localizable.ObsoleteBackend.Alert.message
     )
 
     static let switchBackendFailed = Alert(
-        title: L10n.SwitchBackend.Error.Title.loggedIn,
-        message: L10n.SwitchBackend.Error.Message.loggedIn
+        title: L10n.Localizable.SwitchBackend.Error.Title.loggedIn,
+        message: L10n.Localizable.SwitchBackend.Error.Message.loggedIn
     )
 
     static let unknownError = Alert(

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/DetermineAuthMethodView.swift
@@ -41,6 +41,8 @@ package struct DetermineAuthMethodView: View {
 
     @StateObject var viewModel: DetermineAuthMethodViewModel
 
+    private typealias Strings = L10n.Localizable.Authentication
+
     package init(factory: @autoclosure @escaping () -> any DetermineAuthMethodFactory) {
         self._viewModel = StateObject(wrappedValue: factory().viewModel)
     }
@@ -68,7 +70,7 @@ package struct DetermineAuthMethodView: View {
             title: { Text($0.title) },
             message: { Text($0.message) },
             actions: { _ in
-                Button(L10n.Authentication.Error.confirm, action: viewModel.onAlertDismiss)
+                Button(Strings.Error.confirm, action: viewModel.onAlertDismiss)
             }
         )
         .navigationDestination(for: DetermineAuthMethodDestination.self) {
@@ -105,7 +107,7 @@ package struct DetermineAuthMethodView: View {
     }
 
     @ViewBuilder private var message: some View {
-        Text(L10n.Authentication.Identity.Input.body)
+        Text(Strings.Identity.Input.body)
             .multilineTextAlignment(.leading)
             .wireTextStyle(.body1)
             .lineLimit(nil)
@@ -117,8 +119,8 @@ package struct DetermineAuthMethodView: View {
         VStack(alignment: .leading, spacing: 8) {
             LabeledTextField(
                 isMandatory: false,
-                placeholder: L10n.Authentication.Identity.Input.Field.placeholder,
-                title: L10n.Authentication.Identity.Input.Field.title,
+                placeholder: Strings.Identity.Input.Field.placeholder,
+                title: Strings.Identity.Input.Field.title,
                 string: $viewModel.emailOrSSOCode
             )
             .autocapitalization(.none)
@@ -141,7 +143,7 @@ package struct DetermineAuthMethodView: View {
                     ProgressView()
                 }
 
-                Text(L10n.Authentication.Identity.Input.submit)
+                Text(Strings.Identity.Input.submit)
                     .lineLimit(nil)
             }
         })

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/SwitchBackendConfirmation.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/DetermineAuthMethod/SwitchBackendConfirmation.swift
@@ -22,7 +22,7 @@ import WireDesign
 
 public struct SwitchBackendConfirmation: View {
 
-    private typealias Strings = L10n.SwitchBackendConfirmation
+    private typealias Strings = L10n.Localizable.SwitchBackendConfirmation
 
     private struct Item {
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -41,6 +41,8 @@ package struct LoginViaEmailView: View {
 
     @StateObject private var viewModel: LoginViaEmailViewModel
 
+    private typealias Strings = L10n.Localizable
+
     package init(
         factory: @autoclosure @escaping () -> any LoginViaEmailFactory
     ) {
@@ -72,7 +74,7 @@ package struct LoginViaEmailView: View {
                     }
                 }
             }
-            .navigationTitle(L10n.CloudUserLogin.title)
+            .navigationTitle(Strings.CloudUserLogin.title)
             .navigationBarTitleDisplayMode(.inline)
             .padding(32)
             .setPreferredSize(navigationBarHidden: false)
@@ -84,7 +86,7 @@ package struct LoginViaEmailView: View {
             title: { Text($0.title) },
             message: { Text($0.message) },
             actions: { _ in
-                Button(L10n.Authentication.Error.confirm, action: {})
+                Button(Strings.Authentication.Error.confirm, action: {})
             }
         )
         .navigationDestination(for: LoginViaEmailDestination.self) { destination in
@@ -125,8 +127,8 @@ package struct LoginViaEmailView: View {
 
     @ViewBuilder private var emailField: some View {
         LabeledTextField(
-            placeholder: L10n.CloudUserLogin.InputEmail.placeholder,
-            title: L10n.CloudUserLogin.InputEmail.title,
+            placeholder: Strings.CloudUserLogin.InputEmail.placeholder,
+            title: Strings.CloudUserLogin.InputEmail.title,
             string: $viewModel.email
         )
         .autocapitalization(.none)
@@ -139,8 +141,8 @@ package struct LoginViaEmailView: View {
     @ViewBuilder private var passwordField: some View {
         PasswordField(
             password: $viewModel.password,
-            placeholder: L10n.CloudUserLogin.InputPassword.placeholder,
-            title: L10n.CloudUserLogin.InputPassword.title,
+            placeholder: Strings.CloudUserLogin.InputPassword.placeholder,
+            title: Strings.CloudUserLogin.InputPassword.title,
             passwordRules: "",
             isValidPassword: viewModel.isPasswordValid
         )
@@ -152,7 +154,7 @@ package struct LoginViaEmailView: View {
                 await viewModel.submitCredentials()
             }
         }, label: {
-            Text(L10n.CloudUserLogin.submit)
+            Text(Strings.CloudUserLogin.submit)
                 .lineLimit(nil)
         })
         .wireButtonStyle(.primary)
@@ -164,7 +166,7 @@ package struct LoginViaEmailView: View {
         Button(action: {
             viewModel.recoverPassword()
         }, label: {
-            Text(L10n.CloudUserLogin.forgotPassword)
+            Text(Strings.CloudUserLogin.forgotPassword)
                 .multilineTextAlignment(.center)
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
@@ -174,7 +176,7 @@ package struct LoginViaEmailView: View {
 
     @ViewBuilder private var createAccount: some View {
         VStack(spacing: 4) {
-            Text(L10n.CreatePersonalAccount.title)
+            Text(Strings.CreatePersonalAccount.title)
                 .multilineTextAlignment(.center)
                 .wireTextStyle(.body1)
                 .lineLimit(nil)
@@ -183,7 +185,7 @@ package struct LoginViaEmailView: View {
             Button(action: {
                 viewModel.createAccount()
             }, label: {
-                Text(L10n.CreatePersonalAccount.button)
+                Text(Strings.CreatePersonalAccount.button)
                     .multilineTextAlignment(.center)
                     .lineLimit(nil)
                     .minimumScaleFactor(0.5)
@@ -210,13 +212,13 @@ package struct LoginViaEmailView: View {
     @ViewBuilder private var proxyCredentials: some View {
         Spacer()
         VStack(spacing: 14) {
-            Text(L10n.ProxyCredentials.title)
+            Text(Strings.ProxyCredentials.title)
                 .multilineTextAlignment(.center)
                 .font(.textStyle(.h2))
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Text(L10n.ProxyCredentials.message(viewModel.proxyServer))
+            Text(Strings.ProxyCredentials.message(viewModel.proxyServer))
                 .multilineTextAlignment(.center)
                 .wireTextStyle(.body1)
                 .lineLimit(nil)
@@ -224,7 +226,7 @@ package struct LoginViaEmailView: View {
 
             LabeledTextField(
                 placeholder: "jane@example.com",
-                title: L10n.ProxyCredentials.InputEmail.title,
+                title: Strings.ProxyCredentials.InputEmail.title,
                 string: $viewModel.proxyUsername
             )
             .autocapitalization(.none)
@@ -234,8 +236,8 @@ package struct LoginViaEmailView: View {
 
             PasswordField(
                 password: $viewModel.proxyPassword,
-                placeholder: L10n.CloudUserLogin.InputPassword.placeholder,
-                title: L10n.CloudUserLogin.InputPassword.title,
+                placeholder: Strings.CloudUserLogin.InputPassword.placeholder,
+                title: Strings.CloudUserLogin.InputPassword.title,
                 passwordRules: "",
                 isValidPassword: viewModel.isPasswordValid
             )

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/NoHistory/NoHistoryView.swift
@@ -29,6 +29,8 @@ package struct NoHistoryView: View {
 
     @StateObject private var viewModel: NoHistoryViewModel
 
+    private typealias Strings = L10n.Localizable.Authentication
+
     package init(
         factory: @autoclosure @escaping () -> NoHistoryFactory
     ) {
@@ -37,12 +39,12 @@ package struct NoHistoryView: View {
 
     package var body: some View {
         VStack(spacing: 20) {
-            Text(L10n.Authentication.NoHistory.title)
+            Text(Strings.NoHistory.title)
                 .multilineTextAlignment(.center)
                 .font(.textStyle(.h2))
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
-            Text(L10n.Authentication.NoHistory.message)
+            Text(Strings.NoHistory.message)
                 .multilineTextAlignment(.center)
                 .wireTextStyle(.body1)
                 .lineLimit(nil)
@@ -56,7 +58,7 @@ package struct NoHistoryView: View {
                         ProgressView()
                     }
 
-                    Text(L10n.Authentication.NoHistory.confirm)
+                    Text(Strings.NoHistory.confirm)
                         .lineLimit(nil)
                 }
             }
@@ -70,13 +72,13 @@ package struct NoHistoryView: View {
             title: titleForAlert,
             message: messageForAlert,
             actions: { _ in
-                Button(L10n.Authentication.Error.howToChangeEmail, action: {
+                Button(Strings.Error.howToChangeEmail, action: {
                     viewModel.howToChangeEmail()
                 })
-                Button(L10n.Authentication.Error.howToDeleteAccount, action: {
+                Button(Strings.Error.howToDeleteAccount, action: {
                     viewModel.howToDeleteAccount()
                 })
-                Button(L10n.Authentication.Error.confirm, action: {
+                Button(Strings.Error.confirm, action: {
                     viewModel.confirmAlert()
                 })
             }
@@ -102,14 +104,14 @@ package struct NoHistoryView: View {
     private func titleForAlert(_ alert: NoHistoryViewModel.Alert) -> Text {
         switch alert {
         case .cloudAccountAlreadyRegistered:
-            Text(L10n.Authentication.Error.Title.emailAlreadyInUse)
+            Text(Strings.Error.Title.emailAlreadyInUse)
         }
     }
 
     private func messageForAlert(_ alert: NoHistoryViewModel.Alert) -> Text {
         switch alert {
         case .cloudAccountAlreadyRegistered:
-            Text(L10n.Authentication.Error.Message.emailAlreadyInUse)
+            Text(Strings.Error.Message.emailAlreadyInUse)
         }
     }
 

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/VerificationCode/VerificationCodeView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/VerificationCode/VerificationCodeView.swift
@@ -34,6 +34,8 @@ package struct VerificationCodeView: View {
 
     @FocusState private var focusedIndex: Int?
 
+    private typealias Strings = L10n.Localizable
+
     package init(
         factory: @autoclosure @escaping () -> VerificationCodeFactory
     ) {
@@ -42,7 +44,7 @@ package struct VerificationCodeView: View {
 
     package var body: some View {
         VStack(spacing: 20) {
-            Text(L10n.VerificationCode.message(viewModel.email))
+            Text(Strings.VerificationCode.message(viewModel.email))
                 .wireTextStyle(.body1)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(Color.primaryText)
@@ -57,7 +59,7 @@ package struct VerificationCodeView: View {
                         ProgressView()
                     }
 
-                    Text(L10n.VerificationCode.confirm)
+                    Text(Strings.VerificationCode.confirm)
                 }
             })
             .wireButtonStyle(.primary)
@@ -67,14 +69,14 @@ package struct VerificationCodeView: View {
             Button(action: {
                 Task.detached { await viewModel.requestVerificationCode() }
             }, label: {
-                Text(L10n.VerificationCode.resendCode)
+                Text(Strings.VerificationCode.resendCode)
             })
             .wireButtonStyle(.link)
             .disabled(viewModel.isResending)
         }
         .padding()
         .background(ColorTheme.Backgrounds.surface.color)
-        .navigationTitle(L10n.VerificationCode.title)
+        .navigationTitle(Strings.VerificationCode.title)
         .navigationBarTitleDisplayMode(.inline)
         .setPreferredSize(navigationBarHidden: false)
         .customBackButton()
@@ -83,7 +85,7 @@ package struct VerificationCodeView: View {
             title: { Text($0.title) },
             message: { Text($0.message) },
             actions: { _ in
-                Button(L10n.Authentication.Error.confirm, action: {})
+                Button(Strings.Authentication.Error.confirm, action: {})
             }
         )
         .navigationDestination(for: VerificationCodeDestination.self) {

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/RootView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Root/RootView.swift
@@ -33,6 +33,8 @@ package struct RootView: View {
 
     private let cornerRadius: CGFloat = 10
 
+    private typealias Strings = L10n.Localizable
+
     package init(
         factory: @autoclosure @escaping () -> any RootFactory
     ) {
@@ -70,9 +72,9 @@ package struct RootView: View {
                 actions: { alert in
                     switch alert {
                     case .obsoleteClient:
-                        Button(L10n.ObsoleteClient.Alert.okButton, action: viewModel.goToAppStore)
+                        Button(Strings.ObsoleteClient.Alert.okButton, action: viewModel.goToAppStore)
                     default:
-                        Button(L10n.Authentication.Error.confirm, action: {})
+                        Button(Strings.Authentication.Error.confirm, action: {})
                     }
                 }
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17409" title="WPB-17409" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17409</a>  [iOS] New Registrations Flows - Account creation type selector
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently no accessibility string constants are created.
This PR enables it and fixes accessing the strings.

### Testing

No changes should be notable.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
