### PR TITLE
fix: message sending stuck - WPB-17866

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -80,7 +80,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
 
         let liveEventTask = Task { @Sendable [self] in
             logger.debug("handling live event stream")
-            syncStateSubject.send(.liveSyncing)
+            syncStateSubject.send(.liveSyncing(.ongoing))
 
             await processLiveEvents(
                 liveEventStream: liveEventStream,
@@ -88,6 +88,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             )
 
             logger.debug("live event stream did finish")
+            syncStateSubject.send(.liveSyncing(.terminated))
         }
 
         return Token(task: liveEventTask, closePushChannel: {

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -88,7 +88,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             )
 
             logger.debug("live event stream did finish")
-            syncStateSubject.send(.liveSyncing(.terminated))
+            syncStateSubject.send(.liveSyncing(.finished))
         }
 
         return Token(task: liveEventTask, closePushChannel: {

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -88,7 +88,6 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             )
 
             logger.debug("live event stream did finish")
-            syncStateSubject.send(.idle)
         }
 
         return Token(task: liveEventTask, closePushChannel: {

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -57,7 +57,7 @@ public enum SyncState: Equatable {
         case processPendingEvents
 
     }
-    
+
     public enum LiveSyncState: Equatable {
         case ongoing
         case terminated

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -34,7 +34,7 @@ public enum SyncState: Equatable {
 
     /// App is up to date and processing live events.
 
-    case liveSyncing
+    case liveSyncing(LiveSyncState)
 
     /// Sync was suspended
 
@@ -56,6 +56,11 @@ public enum SyncState: Equatable {
         case pullPendingEvents
         case processPendingEvents
 
+    }
+    
+    public enum LiveSyncState: Equatable {
+        case ongoing
+        case terminated
     }
 
 }

--- a/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/SyncState.swift
@@ -60,7 +60,7 @@ public enum SyncState: Equatable {
 
     public enum LiveSyncState: Equatable {
         case ongoing
-        case terminated
+        case finished
     }
 
 }

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -94,7 +94,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         self.legacySyncStatus = legacySyncStatus
         self.syncStateSubject = syncStateSubject
         super.init()
-        
+
         setupBindings()
     }
 
@@ -109,7 +109,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
 
     func resume() {
         syncStateSubject.send(.idle)
-        
+
         ongoingSyncTask = Task {
             WireLogger.sync.debug(
                 "resuming sync"
@@ -225,14 +225,14 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
             await legacySyncStatus.performQuickSync()
         }
     }
-    
+
     private func setupBindings() {
         subscription = syncStateSubject
             .receive(on: DispatchQueue.main)
             .filter {
                 let liveSyncTerminated = $0 == .liveSyncing(.terminated)
                 let isAppInForeground = UIApplication.shared.applicationState != .background
-                
+
                 return liveSyncTerminated && isAppInForeground
             }
             .sink { [weak self] _ in

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -61,6 +61,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
     private let incrementalSyncTaskManager = NonReentrantTaskManager()
     private var incrementalSyncToken: IncrementalSync.Token?
     private var ongoingSyncTask: Task<Void, Never>?
+    private var subscription: AnyCancellable?
 
     private var hasCompletedInitialSync: Bool {
         lastUpdateEventIDRepository.fetchLastEventID() != nil
@@ -68,7 +69,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
 
     var isLive: Bool {
         if isSyncV2Enabled {
-            syncStateSubject.value == .liveSyncing
+            syncStateSubject.value == .liveSyncing(.ongoing)
         } else {
             legacySyncStatus.isLive
         }
@@ -93,6 +94,8 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         self.legacySyncStatus = legacySyncStatus
         self.syncStateSubject = syncStateSubject
         super.init()
+        
+        setupBindings()
     }
 
     // MARK: - API
@@ -221,6 +224,22 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         } else {
             await legacySyncStatus.performQuickSync()
         }
+    }
+    
+    private func setupBindings() {
+        subscription = syncStateSubject
+            .receive(on: DispatchQueue.main)
+            .filter {
+                let liveSyncTerminated = $0 == .liveSyncing(.terminated)
+                let isAppInForeground = UIApplication.shared.applicationState != .background
+                
+                return liveSyncTerminated && isAppInForeground
+            }
+            .sink { [weak self] _ in
+                // if live sync terminated and we're in foreground
+                // app will try to recover by performing an incremental sync again
+                self?.resume()
+            }
     }
 
 }

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -230,7 +230,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         subscription = syncStateSubject
             .receive(on: DispatchQueue.main)
             .filter {
-                let liveSyncTerminated = $0 == .liveSyncing(.terminated)
+                let liveSyncTerminated = $0 == .liveSyncing(.finished)
                 let isAppInForeground = UIApplication.shared.applicationState != .background
 
                 return liveSyncTerminated && isAppInForeground

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -105,6 +105,8 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
     /// This method logs any errors and does not wait for the sync to finish.
 
     func resume() {
+        syncStateSubject.send(.idle)
+        
         ongoingSyncTask = Task {
             WireLogger.sync.debug(
                 "resuming sync"

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
@@ -36,7 +36,7 @@ class IncrementalSyncObserverTests {
     func ifAppIsLiveThenDontWait() async {
         // Given
         syncAgent.isSyncV2Enabled = true
-        syncAgent.syncStatePublisher = Just(SyncState.liveSyncing).eraseToAnyPublisher()
+        syncAgent.syncStatePublisher = Just(SyncState.liveSyncing(.ongoing)).eraseToAnyPublisher()
 
         // When
         let before = Date.now


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17866" title="WPB-17866" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17866</a>  [iOS] Not able to send messages on mobile data
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: While in foreground and switching Wifi off, sending a message gets stuck in sending without the ability to retry (button doesn't show up) and when turning the Wifi on again, it still gets stuck. It only gets resolved when going to the background and foreground again.

**Causes**: When switching Wifi off, the live events Task finishes and we update the sync state to .idle which turns the decryption state to `.notStarted` and the MessageSender gets stuck again waiting for the decryption state to be `.done`. 

**Solution**: Don't update the state in the live events Task. If we reach this point, we know the decryption was already done (current state) and the decryption state should remain to .done (done should always be the final state) to not block any message sending.

### Testing

- open the app, keep in foreground, send message it works, switch Wifi off, send message, retry button now shows up, switch Wifi on again, hit retry, message gets sent. 

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
