### PR TITLE
fix: warnings in WirePlugins - WPB-17970

### DIFF
--- a/WirePlugins/Package.swift
+++ b/WirePlugins/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 6.1
 
 import PackageDescription
 

--- a/WirePlugins/Plugins/SourceryPlugin/SourceryPlugin.swift
+++ b/WirePlugins/Plugins/SourceryPlugin/SourceryPlugin.swift
@@ -44,22 +44,22 @@ extension SourceryPlugin: BuildToolPlugin {
         context: PackagePlugin.PluginContext,
         target: PackagePlugin.Target
     ) async throws -> [PackagePlugin.Command] {
-        Diagnostics.remark("SourceryPlugin work directory: \(context.pluginWorkDirectory)")
+        Diagnostics.remark("SourceryPlugin work directory: \(context.pluginWorkDirectoryURL.path())")
 
         // Find configuration from possible paths where there may be a config file:
         // 1. root of package
         // 2. target directory
         // 3. target directory subfolder named 'Sourcery'
-        let configuration = [
-            context.package.directory,
-            target.directory,
-            target.directory.appending(subpath: "Sourcery")
+        let configURL = [
+            context.package.directoryURL,
+            target.directoryURL,
+            target.directoryURL.appending(path: "Sourcery", directoryHint: .isDirectory)
         ]
-        .map { $0.appending(Constant.configFileName) }
-        .filter { FileManager.default.fileExists(atPath: $0.string) }
+        .map { (url: URL) in url.appending(path: Constant.configFileName, directoryHint: .notDirectory) }
+        .filter { url in FileManager.default.fileExists(atPath: url.path()) }
         .first
 
-        guard let configuration else {
+        guard let configURL else {
             Diagnostics.error(
                 """
                 No configurations found for target \(target.name). If you would like to generate sources for this \
@@ -75,32 +75,32 @@ extension SourceryPlugin: BuildToolPlugin {
         return [
             try makePrebuildCommand(
                 context: context,
-                configuration: configuration,
-                targetDirectory: target.directory
+                configURL: configURL,
+                targetDirectoryURL: target.directoryURL
             )
         ]
     }
 
     private func makePrebuildCommand(
         context: PackagePlugin.PluginContext,
-        configuration: Path,
-        targetDirectory: Path
+        configURL: URL,
+        targetDirectoryURL: URL
     ) throws -> PackagePlugin.Command {
         .prebuildCommand(
             displayName: Constant.displayName,
-            executable: try context.tool(named: Constant.toolName).path,
+            executable: try context.tool(named: Constant.toolName).url,
             arguments: [
                 "--config",
-                configuration.string,
+                configURL.path(),
                 "--cacheBasePath",
-                context.pluginWorkDirectory
+                context.pluginWorkDirectoryURL.path()
             ],
             environment: [
-                Constant.Environment.derivedSourcesDirectory: context.pluginWorkDirectory,
-                Constant.Environment.packageRootDirectory: context.package.directory,
-                Constant.Environment.targetDirectory: targetDirectory.string
+                Constant.Environment.derivedSourcesDirectory: context.pluginWorkDirectoryURL.path(),
+                Constant.Environment.packageRootDirectory: context.package.directoryURL.path(),
+                Constant.Environment.targetDirectory: targetDirectoryURL.path()
             ],
-            outputFilesDirectory: context.pluginWorkDirectory
+            outputFilesDirectory: context.pluginWorkDirectoryURL
         )
     }
 }

--- a/WirePlugins/Plugins/SwiftGenPlugin/SwiftGenPlugin.swift
+++ b/WirePlugins/Plugins/SwiftGenPlugin/SwiftGenPlugin.swift
@@ -35,6 +35,24 @@ struct SwiftGenPlugin: BuildToolPlugin {
                 environment: ["GENERATED": outputFilesDirectoryURL.path()],
                 outputFilesDirectory: outputFilesDirectoryURL
             )
+        ] + existentialAnyWorkaround(context: context)
+    }
+
+    /// This workaround is needed because at the time of writing `strings/structured-swift5.stencil` of SwiftGen does
+    /// not support existential any.
+    private func existentialAnyWorkaround(context: PluginContext) -> [Command] { // TODO: [WPB-9200] delete this
+        let outputFilesDirectory = context.pluginWorkDirectoryURL
+        let tmpOutputFilesDirectory = outputFilesDirectory.appending(path: "tmp", directoryHint: .isDirectory)
+        let outputFile = outputFilesDirectory.appending(path: "Strings+Generated.swift", directoryHint: .notDirectory)
+        try? FileManager.default.createDirectory(at: tmpOutputFilesDirectory, withIntermediateDirectories: true)
+        return [
+            .prebuildCommand(
+                displayName: "Replace CVarArg by any CVarArg",
+                executable: try! context.tool(named: "sed").url,
+                arguments: ["-i", "", "s/CVarArg/any CVarArg/g", outputFile.path()],
+                // fix duplicate build file warning by providing a non-existent path
+                outputFilesDirectory: tmpOutputFilesDirectory
+            )
         ]
     }
 }

--- a/WirePlugins/Plugins/SwiftGenPlugin/SwiftGenPlugin.swift
+++ b/WirePlugins/Plugins/SwiftGenPlugin/SwiftGenPlugin.swift
@@ -24,32 +24,16 @@ struct SwiftGenPlugin: BuildToolPlugin {
     /// Entry point for creating build commands for targets in Swift packages.
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
         // regarding the warning: https://github.com/swiftlang/swift-package-manager/issues/7870
-        let configFile = URL(fileURLWithPath: target.directory.appending(subpath: ".swiftgen.yml").string)
-        let outputFilesDirectory = context.pluginWorkDirectoryURL
+        let configFileURL = target.directoryURL.appending(path: ".swiftgen.yml", directoryHint: .notDirectory)
+        let outputFilesDirectoryURL = context.pluginWorkDirectoryURL
         let tool = try context.tool(named: "swiftgen")
         return [
             .prebuildCommand(
                 displayName: "Running \(tool)",
                 executable: tool.url,
-                arguments: ["--config", configFile.path()],
-                environment: ["GENERATED": outputFilesDirectory.path()],
-                outputFilesDirectory: outputFilesDirectory
-            )
-        ] + existentialAnyWorkaround(context: context)
-    }
-
-    /// This workaround is needed because at the time of writing `strings/structured-swift5.stencil` of SwiftGen does
-    /// not support existential any.
-    private func existentialAnyWorkaround(context: PluginContext) -> [Command] {
-        let outputFilesDirectory = context.pluginWorkDirectoryURL
-        let outputFile = outputFilesDirectory.appending(path: "Strings+Generated.swift", directoryHint: .notDirectory)
-        return [
-            .prebuildCommand(
-                displayName: "Replace CVarArg by any CVarArg",
-                executable: try! context.tool(named: "sed").url,
-                arguments: ["-i", "", "s/CVarArg/any CVarArg/g", outputFile.path()],
-                // fix duplicate build file warning by providing a non-existent path
-                outputFilesDirectory: outputFilesDirectory.appending(path: "tmp", directoryHint: .isDirectory)
+                arguments: ["--config", configFileURL.path()],
+                environment: ["GENERATED": outputFilesDirectoryURL.path()],
+                outputFilesDirectory: outputFilesDirectoryURL
             )
         ]
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17970" title="WPB-17970" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17970</a>  Fix warnings in SourcerPlugin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Some warnings can only be fixed now since Swift 6.1 fixed access modifiers for `URL` type properties, which replace `Path` type properties.
This PR fixes several warnings and updates stencils.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
