### PR TITLE
fix: exclude ephemeral messages from backup - WPB-17979

### DIFF
--- a/WireBackup/Sources/WireBackup/KaliumBackupAdapters/Models/BackupConversationModel+initWithBackupConversation.swift
+++ b/WireBackup/Sources/WireBackup/KaliumBackupAdapters/Models/BackupConversationModel+initWithBackupConversation.swift
@@ -22,7 +22,7 @@ import WireFoundation
 
 package extension ConversationBackupModel {
 
-    package init?(_ backupConversation: BackupConversation) {
+    init?(_ backupConversation: BackupConversation) {
         guard let qualifiedID = QualifiedID(backupConversation.id) else { return nil }
 
         self.init(

--- a/WireBackup/Sources/WireBackup/KaliumBackupAdapters/Models/BackupMessageModel+initWithBackupMessage.swift
+++ b/WireBackup/Sources/WireBackup/KaliumBackupAdapters/Models/BackupMessageModel+initWithBackupMessage.swift
@@ -23,7 +23,7 @@ import WireFoundation
 
 package extension MessageBackupModel {
 
-    package init?(_ backupMessage: BackupMessage) {
+    init?(_ backupMessage: BackupMessage) {
         guard
             let conversationID = QualifiedID(backupMessage.conversationId),
             let senderUserID = QualifiedID(backupMessage.senderUserId),

--- a/WireBackup/Sources/WireBackup/KaliumBackupAdapters/Models/BackupUserModel+initWithBackupUser.swift
+++ b/WireBackup/Sources/WireBackup/KaliumBackupAdapters/Models/BackupUserModel+initWithBackupUser.swift
@@ -22,7 +22,7 @@ import WireFoundation
 
 package extension UserBackupModel {
 
-    package init?(_ backupUser: BackupUser) {
+    init?(_ backupUser: BackupUser) {
         guard let qualifiedID = QualifiedID(backupUser.id) else { return nil }
 
         self.init(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupMessageModel+ZMMessage.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupMessageModel+ZMMessage.swift
@@ -41,6 +41,7 @@ extension MessageBackupModel {
     init?(_ message: ZMMessage, genericMessage: GenericMessage) {
 
         guard
+            !message.isEphemeral,
             let id = message.nonce,
             let senderUserID = message.senderUser?.qualifiedID,
             let creationDate = message.serverTimestamp,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17979" title="WPB-17979" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17979</a>  [iOS] Do not include self-deleting messages in backup file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently self-deleting messages ended up being backed up as well.
This PR excludes ephemeral messages.

### Testing

Create a backup, restore it on a new device (or session) and verify that self-deleting messages have been skipped.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
