### PR TITLE
feat: publish drafts use case - WPB-17977

### DIFF
--- a/WireCells/Sources/WireCellsAPI/Model/WireCellsUploadStatus.swift
+++ b/WireCells/Sources/WireCellsAPI/Model/WireCellsUploadStatus.swift
@@ -20,7 +20,7 @@ public import Foundation
 
 public enum WireCellsUploadStatus: Equatable, Hashable, Sendable {
     case uploading(progress: Float)
-    case uploaded
+    case uploaded(isDraft: Bool)
     case failed(error: WireCellsUploadError)
     case cancelled
 }

--- a/WireCells/Sources/WireCellsAPI/UseCases/WireCellsPublishDraftsUseCaseProtocol.swift
+++ b/WireCells/Sources/WireCellsAPI/UseCases/WireCellsPublishDraftsUseCaseProtocol.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+// sourcery: AutoMockable
+/// Publishes all drafts associated with a given conversation.
+
+public protocol WireCellsPublishDraftsUseCaseProtocol {
+
+    /// Publish all drafts.
+    ///
+    /// - Throws: Throws an error if not **all** drafts have been uploaded or if there are unpublished drafts remaining
+    /// once the operation completes.
+
+    func invoke() async throws
+
+}

--- a/WireCells/Sources/WireCellsBindings/WireCellsAssembly.swift
+++ b/WireCells/Sources/WireCellsBindings/WireCellsAssembly.swift
@@ -32,7 +32,8 @@ public struct WireCellsAssembly {
     private static let nodesAPI = NodesAPI(credentials: credentials)
 
     private static let draftsRepository = DraftsRepository(
-        uploadManager: WireCellsNodeUploadManager(nodesAPI: nodesAPI)
+        uploadManager: WireCellsNodeUploadManager(nodesAPI: nodesAPI),
+        nodesAPI: nodesAPI
     )
 
     public init() {}

--- a/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
+++ b/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
@@ -184,13 +184,13 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
     }
 
     #if DEBUG
-    var getDraftsForTesting: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>] {
-        drafts.value
-    }
+        var getDraftsForTesting: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>] {
+            drafts.value
+        }
 
-    func setDraftsForTesting(_ drafts: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>]) {
-        self.drafts.value = drafts
-    }
+        func setDraftsForTesting(_ drafts: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>]) {
+            self.drafts.value = drafts
+        }
     #endif
 
 }
@@ -206,9 +206,9 @@ private extension OrderedDictionary<WireCellsNodeID, WireCellsDraft> {
         allSatisfy {
             switch $0.value.status {
             case .uploaded:
-                return true
+                true
             case .uploading, .failed, .cancelled:
-                return false
+                false
             }
         }
     }

--- a/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
+++ b/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
@@ -42,15 +42,23 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
 
     typealias CellName = String
 
-    private var drafts: CurrentValueSubject<[CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>], Never> =
-        .init([:])
+    private var drafts: CurrentValueSubject<[CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>], Never>
     private var continuations: [UUID: AsyncStream<[WireCellsDraft]>.Continuation] = [:]
     private let uploadManager: any WireCellsNodeUploadManagerProtocol
     private let nodesAPI: any NodesAPIProtocol
 
     package init(uploadManager: any WireCellsNodeUploadManagerProtocol, nodesAPI: any NodesAPIProtocol) {
+        self.init(uploadManager: uploadManager, nodesAPI: nodesAPI, drafts: [:])
+    }
+
+    init(
+        uploadManager: any WireCellsNodeUploadManagerProtocol,
+        nodesAPI: any NodesAPIProtocol,
+        drafts: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>]
+    ) {
         self.uploadManager = uploadManager
         self.nodesAPI = nodesAPI
+        self.drafts = CurrentValueSubject(drafts)
     }
 
     deinit {

--- a/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
+++ b/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
@@ -27,6 +27,7 @@ package protocol DraftsRepositoryProtocol: Actor {
 
     func add(assetURL: URL, assetSize: Int, cellName: String, fileName: String, fileType: UTType?) async
     func drafts(for cellName: String) -> AsyncStream<[WireCellsDraft]>
+    func publishAll(for cellName: String) async throws
 
 }
 

--- a/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
+++ b/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
@@ -31,7 +31,7 @@ package protocol DraftsRepositoryProtocol: Actor {
 
 }
 
-enum DraftsRepositoryError: Error {
+enum DraftsRepositoryError: Error, Equatable {
 
     case notAllFilesAreUploaded
     case notAllFilesArePublished
@@ -42,7 +42,7 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
 
     typealias CellName = String
 
-    private var drafts: CurrentValueSubject<[CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>], Never>
+    private let drafts: CurrentValueSubject<[CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>], Never>
     private var continuations: [UUID: AsyncStream<[WireCellsDraft]>.Continuation] = [:]
     private let uploadManager: any WireCellsNodeUploadManagerProtocol
     private let nodesAPI: any NodesAPIProtocol
@@ -157,7 +157,7 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
         }
 
         let publishedIDs = results.compactMap { try? $0.get() }
-        for id in publishedIDs where getStatus(cellName: cellName, id: id) == .uploaded(isDraft: true) {
+        for id in publishedIDs {
             setStatus(.uploaded(isDraft: false), cellName: cellName, id: id)
         }
 
@@ -182,6 +182,16 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
     private func setStatus(_ status: WireCellsUploadStatus, cellName: CellName, id: WireCellsNodeID) {
         drafts.value[cellName]?[id]?.status = status
     }
+
+    #if DEBUG
+    var getDraftsForTesting: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>] {
+        drafts.value
+    }
+
+    func setDraftsForTesting(_ drafts: [CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>]) {
+        self.drafts.value = drafts
+    }
+    #endif
 
 }
 

--- a/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
+++ b/WireCells/Sources/WireCellsImplementation/DraftsRepository.swift
@@ -21,11 +21,19 @@ import Collections
 import Foundation
 package import UniformTypeIdentifiers
 package import WireCellsAPI
+import WireLogging
 
 package protocol DraftsRepositoryProtocol: Actor {
 
     func add(assetURL: URL, assetSize: Int, cellName: String, fileName: String, fileType: UTType?) async
     func drafts(for cellName: String) -> AsyncStream<[WireCellsDraft]>
+
+}
+
+enum DraftsRepositoryError: Error {
+
+    case notAllFilesAreUploaded
+    case notAllFilesArePublished
 
 }
 
@@ -36,10 +44,12 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
     private var drafts: CurrentValueSubject<[CellName: OrderedDictionary<WireCellsNodeID, WireCellsDraft>], Never> =
         .init([:])
     private var continuations: [UUID: AsyncStream<[WireCellsDraft]>.Continuation] = [:]
-    private var uploadManager: any WireCellsNodeUploadManagerProtocol
+    private let uploadManager: any WireCellsNodeUploadManagerProtocol
+    private let nodesAPI: any NodesAPIProtocol
 
-    package init(uploadManager: any WireCellsNodeUploadManagerProtocol) {
+    package init(uploadManager: any WireCellsNodeUploadManagerProtocol, nodesAPI: any NodesAPIProtocol) {
         self.uploadManager = uploadManager
+        self.nodesAPI = nodesAPI
     }
 
     deinit {
@@ -103,8 +113,61 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
         return stream
     }
 
+    /// Publishes **all** drafts for the specified cell name.
+    ///
+    /// - parameter cellName: The name of the cell for which to publish drafts.
+    /// - throws: An error if not **all** files have been uploaded before publishing or if not all files are published
+    /// when the method completes.
+
+    package func publishAll(for cellName: String) async throws {
+        guard let drafts = drafts.value[cellName] else { return }
+
+        guard drafts.areAllUploaded else {
+            throw DraftsRepositoryError.notAllFilesAreUploaded
+        }
+
+        let results = await withTaskGroup(
+            of: Result<WireCellsNodeID, any Error>.self,
+            returning: [Result<WireCellsNodeID, any Error>].self
+        ) { [nodesAPI] group in
+            for (nodeID, draft) in drafts where draft.status == .uploaded(isDraft: true) {
+                group.addTask {
+                    do {
+                        try await nodesAPI.publishDraft(nodeID: nodeID)
+                        return .success(nodeID)
+                    } catch {
+                        WireLogger.wireCells.error("Failed to publish draft: \(error)")
+                        return .failure(error)
+                    }
+                }
+            }
+
+            return await group.reduce(into: []) { partial, result in
+                partial.append(result)
+            }
+        }
+
+        let publishedIDs = results.compactMap { try? $0.get() }
+        for id in publishedIDs where getStatus(cellName: cellName, id: id) == .uploaded(isDraft: true) {
+            setStatus(.uploaded(isDraft: false), cellName: cellName, id: id)
+        }
+
+        guard self.drafts.value[cellName]?.areAllPublished == true else {
+            throw DraftsRepositoryError.notAllFilesArePublished
+        }
+    }
+
     private func removeContinuation(for uuid: UUID) async {
         continuations[uuid] = nil
+    }
+
+    private func allDraftsArePublished(cellName: CellName) -> Bool {
+        guard let drafts = drafts.value[cellName] else { return false }
+        return drafts.values.allSatisfy { $0.status == .uploaded(isDraft: false) }
+    }
+
+    private func getStatus(cellName: CellName, id: WireCellsNodeID) -> WireCellsUploadStatus? {
+        drafts.value[cellName]?[id]?.status
     }
 
     private func setStatus(_ status: WireCellsUploadStatus, cellName: CellName, id: WireCellsNodeID) {
@@ -116,5 +179,22 @@ package actor DraftsRepository: DraftsRepositoryProtocol {
 private extension WireCellsNodeID {
     static func new() -> WireCellsNodeID {
         WireCellsNodeID(uuid: UUID(), versionID: UUID())
+    }
+}
+
+private extension OrderedDictionary<WireCellsNodeID, WireCellsDraft> {
+    var areAllUploaded: Bool {
+        allSatisfy {
+            switch $0.value.status {
+            case .uploaded:
+                return true
+            case .uploading, .failed, .cancelled:
+                return false
+            }
+        }
+    }
+
+    var areAllPublished: Bool {
+        values.allSatisfy { $0.status == .uploaded(isDraft: false) }
     }
 }

--- a/WireCells/Sources/WireCellsImplementation/NodesAPI/NodesAPI.swift
+++ b/WireCells/Sources/WireCellsImplementation/NodesAPI/NodesAPI.swift
@@ -23,7 +23,8 @@ package enum NodesAPIError: Error {
     case failedToCreateWriteStream
 }
 
-package protocol NodesAPIProtocol: Actor {
+// sourcery: AutoMockable
+package protocol NodesAPIProtocol: Sendable {
     func preCheck(nodePath: String) async throws -> WireCellsPreCheckResult
 
     func downloadFile(

--- a/WireCells/Sources/WireCellsImplementation/NodesAPI/NodesAPI.swift
+++ b/WireCells/Sources/WireCellsImplementation/NodesAPI/NodesAPI.swift
@@ -45,7 +45,7 @@ package protocol NodesAPIProtocol: Actor {
 
     func cancelDraft(nodeID: WireCellsNodeID) async throws
 
-    func publishDrafts(nodes: [WireCellsNodeID]) async throws
+    func publishDraft(nodeID: WireCellsNodeID) async throws
 
     func getPreviews(nodeUUID: UUID) async throws -> [WireCellsNodePreview]
 
@@ -118,17 +118,8 @@ package final actor NodesAPI: NodesAPIProtocol {
         try await restAPI.delete(paths: paths)
     }
 
-    package func publishDrafts(nodes: [WireCellsNodeID]) async throws {
-        try await withThrowingTaskGroup(of: Void.self) { [weak self] group in
-            guard let self else { return }
-            for node in nodes {
-                group.addTask { [weak self] in
-                    guard let self else { return }
-                    try await restAPI.publishDraft(uuid: node.uuid, versionID: node.versionID)
-                }
-            }
-            try await group.waitForAll()
-        }
+    package func publishDraft(nodeID: WireCellsNodeID) async throws {
+        try await restAPI.publishDraft(uuid: nodeID.uuid, versionID: nodeID.versionID)
     }
 
     package func cancelDraft(nodeID: WireCellsNodeID) async throws {

--- a/WireCells/Sources/WireCellsImplementation/UseCases/PublishDraftsUseCase.swift
+++ b/WireCells/Sources/WireCellsImplementation/UseCases/PublishDraftsUseCase.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireCellsAPI
+import WireLogging
+
+package final class PublishDraftsUseCase: WireCellsPublishDraftsUseCaseProtocol {
+
+    private let cellName: String
+    private let draftRepository: any DraftsRepositoryProtocol
+
+    package init(cellName: String, draftRepository: any DraftsRepositoryProtocol) {
+        self.cellName = cellName
+        self.draftRepository = draftRepository
+    }
+
+    package func invoke() async throws {
+        try await draftRepository.publishAll(for: cellName)
+    }
+}

--- a/WireCells/Sources/WireCellsImplementation/WireCellsNodeUploadManager.swift
+++ b/WireCells/Sources/WireCellsImplementation/WireCellsNodeUploadManager.swift
@@ -118,7 +118,7 @@ package final actor WireCellsNodeUploadManager: WireCellsNodeUploadManagerProtoc
                     continuation.yield(.uploading(progress: Float(progress) / Float(assetSize)))
                 }
                 await uploads.remove(node.id)
-                continuation.yield(WireCellsUploadStatus.uploaded)
+                continuation.yield(WireCellsUploadStatus.uploaded(isDraft: true))
                 continuation.finish()
             } catch {
                 WireLogger.wireCells.info("Failed to upload file: \(error)")

--- a/WireCells/Sources/WireCellsImplementationSupport/ManualMocks/DraftsRepositoryProtocolMock.swift
+++ b/WireCells/Sources/WireCellsImplementationSupport/ManualMocks/DraftsRepositoryProtocolMock.swift
@@ -49,4 +49,6 @@ package actor DraftsRepositoryProtocolMock: DraftsRepositoryProtocol {
         draftsForCellNameStringAsyncStreamWireCellsDraftReturnValue = value
     }
 
+    func publishAll(for cellName: String) async throws {}
+
 }

--- a/WireCells/Tests/WireCellsImplementationTests/Helpers/AsyncSequence+Convenience.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/Helpers/AsyncSequence+Convenience.swift
@@ -16,21 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireCellsAPI
-import Foundation
-
-extension WireCellsDraft {
-    static func fixture(
-        id: WireCellsNodeID = .fixture(),
-        status: WireCellsUploadStatus = .uploaded(isDraft: true)
-    ) -> WireCellsDraft {
-        WireCellsDraft(
-            id: id,
-            assetURL: URL(string: "https://example.com")!,
-            fileType: nil,
-            status: status,
-            name: "Draft",
-            bytes: 1024
-        )
+extension AsyncSequence {
+    func collect() async throws -> [Element] {
+        try await reduce(into: [Element]()) { $0.append($1) }
     }
 }

--- a/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsDraft+Fixture.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsDraft+Fixture.swift
@@ -20,9 +20,9 @@ import WireCellsAPI
 import Foundation
 
 extension WireCellsDraft {
-    static func make(status: WireCellsUploadStatus = .uploaded(isDraft: true)) -> WireCellsDraft {
+    static func fixture(status: WireCellsUploadStatus = .uploaded(isDraft: true)) -> WireCellsDraft {
         WireCellsDraft(
-            id: .make(),
+            id: .fixture(),
             assetURL: URL(string: "https://example.com")!,
             fileType: nil,
             status: status,

--- a/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsDraft+Fixture.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsDraft+Fixture.swift
@@ -16,8 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import WireCellsAPI
 import Foundation
+import WireCellsAPI
 
 extension WireCellsDraft {
     static func fixture(

--- a/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsDraft+Fixture.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsDraft+Fixture.swift
@@ -1,0 +1,33 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireCellsAPI
+import Foundation
+
+extension WireCellsDraft {
+    static func make(status: WireCellsUploadStatus = .uploaded(isDraft: true)) -> WireCellsDraft {
+        WireCellsDraft(
+            id: .make(),
+            assetURL: URL(string: "https://example.com")!,
+            fileType: nil,
+            status: status,
+            name: "Draft",
+            bytes: 1024
+        )
+    }
+}

--- a/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsNodeID+Fixture.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsNodeID+Fixture.swift
@@ -1,0 +1,26 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireCellsAPI
+
+extension WireCellsNodeID {
+    static func make() -> WireCellsNodeID {
+        WireCellsNodeID(uuid: UUID(), versionID: UUID())
+    }
+}

--- a/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsNodeID+Fixture.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/Helpers/WireCellsNodeID+Fixture.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireCellsAPI
 
 extension WireCellsNodeID {
-    static func make() -> WireCellsNodeID {
+    static func fixture() -> WireCellsNodeID {
         WireCellsNodeID(uuid: UUID(), versionID: UUID())
     }
 }

--- a/WireCells/Tests/WireCellsImplementationTests/NodesAPI/NodesAPITests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/NodesAPI/NodesAPITests.swift
@@ -148,9 +148,3 @@ private extension ByteStream {
         }
     }
 }
-
-private extension AsyncSequence {
-    func collect() async throws -> [Element] {
-        try await reduce(into: [Element]()) { $0.append($1) }
-    }
-}

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/ObserveDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/ObserveDraftsUseCaseTests.swift
@@ -62,7 +62,7 @@ private extension WireCellsDraft {
             id: WireCellsNodeID(uuid: UUID(), versionID: UUID()),
             assetURL: URL(string: "https://example.com")!,
             fileType: nil,
-            status: .uploaded,
+            status: .uploaded(isDraft: true),
             name: "Draft",
             bytes: 1024
         )

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/ObserveDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/ObserveDraftsUseCaseTests.swift
@@ -55,16 +55,3 @@ struct ObserveDraftsUseCaseTests {
     }
 
 }
-
-private extension WireCellsDraft {
-    static func make() -> WireCellsDraft {
-        WireCellsDraft(
-            id: WireCellsNodeID(uuid: UUID(), versionID: UUID()),
-            assetURL: URL(string: "https://example.com")!,
-            fileType: nil,
-            status: .uploaded(isDraft: true),
-            name: "Draft",
-            bytes: 1024
-        )
-    }
-}

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/ObserveDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/ObserveDraftsUseCaseTests.swift
@@ -36,9 +36,9 @@ struct ObserveDraftsUseCaseTests {
         // When
         let output = await sut.invoke()
 
-        let a = WireCellsDraft.make()
-        let b = WireCellsDraft.make()
-        let c = WireCellsDraft.make()
+        let a = WireCellsDraft.fixture()
+        let b = WireCellsDraft.fixture()
+        let c = WireCellsDraft.fixture()
 
         continuation.yield([a, b])
         continuation.yield([b, c])

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
@@ -1,0 +1,61 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+import WireCellsAPI
+
+@testable import WireCellsImplementation
+@testable import WireCellsImplementationSupport
+
+final class PublishDraftsUseCaseTests {
+
+    private let nodesAPI = NodesAPIProtocolMock()
+    private lazy var uploadManager = WireCellsNodeUploadManager(nodesAPI: nodesAPI)
+    private lazy var draftsRepository = DraftsRepository(
+        uploadManager: uploadManager,
+        nodesAPI: nodesAPI,
+        drafts: [
+            "cell-1": [
+                WireCellsNodeID.make(): WireCellsDraft.make(status: .cancelled),
+                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploaded(isDraft: true))
+            ],
+            "cell-2": [
+                WireCellsNodeID.make(): WireCellsDraft.make(status: .failed(error: .fileNotFound)),
+                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploaded(isDraft: true))
+            ],
+            "cell-3": [
+                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploading(progress: 0.5)),
+                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploaded(isDraft: true))
+            ]
+        ]
+    )
+    private lazy var sut = PublishDraftsUseCase(cellName: "cell-name", draftRepository: draftsRepository)
+
+    @Test(arguments: ["cell-1", "cell-2", "cell-3"])
+    func invoke_whenNotAllFilesUploaded(cellName: String) async throws {
+        // Given
+        let sut = PublishDraftsUseCase(cellName: cellName, draftRepository: draftsRepository)
+
+        // When, Then
+        await #expect(throws: (any Error).self) {
+            try await sut.invoke()
+        }
+    }
+
+}

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
@@ -32,16 +32,16 @@ final class PublishDraftsUseCaseTests {
         nodesAPI: nodesAPI,
         drafts: [
             "cell-1": [
-                WireCellsNodeID.make(): WireCellsDraft.make(status: .cancelled),
-                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploaded(isDraft: true))
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .cancelled),
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploaded(isDraft: true))
             ],
             "cell-2": [
-                WireCellsNodeID.make(): WireCellsDraft.make(status: .failed(error: .fileNotFound)),
-                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploaded(isDraft: true))
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .failed(error: .fileNotFound)),
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploaded(isDraft: true))
             ],
             "cell-3": [
-                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploading(progress: 0.5)),
-                WireCellsNodeID.make(): WireCellsDraft.make(status: .uploaded(isDraft: true))
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploading(progress: 0.5)),
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploaded(isDraft: true))
             ]
         ]
     )

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
@@ -117,24 +117,16 @@ final class PublishDraftsUseCaseTests {
     func invoke_whenNewDraftAddedConcurrently() async throws {
         // Given
         let sut = PublishDraftsUseCase(cellName: "cell-4", draftRepository: draftsRepository)
-        nodesAPI.publishDraftNodeIDWireCellsNodeIDVoidClosure = { _ in
-            try await Task.sleep(nanoseconds: 2_000_000_000)
+        nodesAPI.publishDraftNodeIDWireCellsNodeIDVoidClosure = { [draftsRepository] _ in
+            // Add a new draft while invoke is running
+            var drafts = await draftsRepository.getDraftsForTesting
+            drafts["cell-4"]?[.fixture()] = WireCellsDraft.fixture(status: .uploading(progress: 0.5))
+            await draftsRepository.setDraftsForTesting(drafts)
         }
-
 
         // When, Then
-        let task = Task.detached {
-            try await sut.invoke()
-        }
-
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-        var drafts = await draftsRepository.getDraftsForTesting
-        drafts["cell-4"]?[.fixture()] = WireCellsDraft.fixture(status: .uploading(progress: 0.5))
-        await draftsRepository.setDraftsForTesting(drafts)
-
-
         await #expect(throws: DraftsRepositoryError.notAllFilesArePublished) {
-            try await task.value
+            try await sut.invoke()
         }
     }
 }

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/PublishDraftsUseCaseTests.swift
@@ -42,13 +42,18 @@ final class PublishDraftsUseCaseTests {
             "cell-3": [
                 WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploading(progress: 0.5)),
                 WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploaded(isDraft: true))
-            ]
+            ],
+            "cell-4": [
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploaded(isDraft: false)),
+                WireCellsNodeID.fixture(): WireCellsDraft.fixture(status: .uploaded(isDraft: true))
+            ],
+            "cell-5": [:] // Empty cell
         ]
     )
     private lazy var sut = PublishDraftsUseCase(cellName: "cell-name", draftRepository: draftsRepository)
 
     @Test(arguments: ["cell-1", "cell-2", "cell-3"])
-    func invoke_whenNotAllFilesUploaded(cellName: String) async throws {
+    func invoke_whenNotAllFilesUploaded(cellName: String) async {
         // Given
         let sut = PublishDraftsUseCase(cellName: cellName, draftRepository: draftsRepository)
 
@@ -58,4 +63,78 @@ final class PublishDraftsUseCaseTests {
         }
     }
 
+    @Test
+    func invoke_whenNoFilesInCell() async {
+        // Given
+        let sut = PublishDraftsUseCase(cellName: "cell-5", draftRepository: draftsRepository)
+
+        // When, Then
+        await #expect(throws: Never.self) {
+            try await sut.invoke()
+        }
+    }
+
+    @Test
+    func invoke_whenNonExistentCell() async throws {
+        // Given
+        let sut = PublishDraftsUseCase(cellName: "non-existent-cell", draftRepository: draftsRepository)
+
+        // When, Then
+        await #expect(throws: Never.self) {
+            try await sut.invoke()
+        }
+    }
+
+    @Test
+    func invoke_whenPublishingFails() async {
+        // Given
+        let sut = PublishDraftsUseCase(cellName: "cell-4", draftRepository: draftsRepository)
+        nodesAPI.publishDraftNodeIDWireCellsNodeIDVoidThrowableError = URLError(.notConnectedToInternet)
+
+        // When, Then
+        await #expect(throws: DraftsRepositoryError.notAllFilesArePublished) {
+            try await sut.invoke()
+        }
+    }
+
+    @Test
+    func invoke_whenPublishingSucceeds() async throws {
+        // Given
+        let sut = PublishDraftsUseCase(cellName: "cell-4", draftRepository: draftsRepository)
+        nodesAPI.publishDraftNodeIDWireCellsNodeIDVoidClosure = { _ in }
+
+        // When
+        try await sut.invoke()
+
+        // Then
+        let drafts = try await #require(draftsRepository.getDraftsForTesting["cell-4"]).values
+        #expect(drafts.count == 2)
+        #expect(drafts.allSatisfy { $0.status == .uploaded(isDraft: false) })
+        #expect(nodesAPI.publishDraftNodeIDWireCellsNodeIDVoidCallsCount == 1)
+    }
+
+    @Test
+    func invoke_whenNewDraftAddedConcurrently() async throws {
+        // Given
+        let sut = PublishDraftsUseCase(cellName: "cell-4", draftRepository: draftsRepository)
+        nodesAPI.publishDraftNodeIDWireCellsNodeIDVoidClosure = { _ in
+            try await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+
+
+        // When, Then
+        let task = Task.detached {
+            try await sut.invoke()
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        var drafts = await draftsRepository.getDraftsForTesting
+        drafts["cell-4"]?[.fixture()] = WireCellsDraft.fixture(status: .uploading(progress: 0.5))
+        await draftsRepository.setDraftsForTesting(drafts)
+
+
+        await #expect(throws: DraftsRepositoryError.notAllFilesArePublished) {
+            try await task.value
+        }
+    }
 }

--- a/WireCells/Tests/WireCellsImplementationTests/UseCases/UploadDraftUseCaseTests.swift
+++ b/WireCells/Tests/WireCellsImplementationTests/UseCases/UploadDraftUseCaseTests.swift
@@ -24,7 +24,7 @@ import WireCellsAPI
 @testable import WireCellsImplementation
 @testable import WireCellsImplementationSupport
 
-class UploadDraftUseCaseTests {
+final class UploadDraftUseCaseTests {
 
     private let fileURL = URL.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).txt")
     private let draftsRepository = DraftsRepositoryProtocolMock()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17977" title="WPB-17977" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17977</a>  [iOS] Create publish drafts use case
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR implements the ` WireCellsPublishDraftsUseCase`. When a user attaches a file it is uploaded to wire cells and created with a _draft_ state. This means that the file is not yet visible to other users. Once the user taps send it is promoted / published. This use case enables publishing all current drafts (attachments) for a conversation.

### Testing

Run unit tests. Manual testing is not possible.
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
