### PR TITLE
fix: use wrong user ID - WPB-18006

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMemberUpdateEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMemberUpdateEventProcessor.swift
@@ -26,9 +26,9 @@ struct ConversationMemberUpdateEventProcessor: ConversationMemberUpdateEventProc
     let localStore: any ConversationLocalStoreProtocol
 
     func processEvent(_ event: ConversationMemberUpdateEvent) async throws {
-        let senderID = event.senderID
         let conversationID = event.conversationID
         let memberChange = event.memberChange
+        let memberChangeID = memberChange.id
         let muteStatus = memberChange.newMuteStatus
         let muteStatusDate = memberChange.muteStatusReferenceDate
         let archivedStatus = memberChange.newArchivedStatus
@@ -40,8 +40,8 @@ struct ConversationMemberUpdateEventProcessor: ConversationMemberUpdateEventProc
         )
 
         let isSelfUser = try await userRepository.isSelfUser(
-            id: senderID.uuid,
-            domain: senderID.domain
+            id: memberChangeID.uuid,
+            domain: memberChangeID.domain
         )
 
         if isSelfUser {
@@ -57,8 +57,8 @@ struct ConversationMemberUpdateEventProcessor: ConversationMemberUpdateEventProc
         }
 
         await conversationRepository.addOrUpdateParticipant(
-            participantID: senderID.uuid,
-            participantDomain: senderID.domain,
+            participantID: memberChangeID.uuid,
+            participantDomain: memberChangeID.domain,
             participantRole: role,
             conversationID: conversationID.uuid,
             conversationDomain: conversationID.domain


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18006" title="WPB-18006" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18006</a>  [iOS] Updating the group admin toggle for participants from Web doesn't reflect on iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When turning a member into an admin (via the toggle) from Web, the changes aren't reflect on iOS, nothing happens.

**Causes**: We're not using the correct user ID, so the changes are targeting the user that initiated the changes whereas it should be targeting the user that is impacted by these changes.

**Solution**: Use the correct user ID.

### Testing

1. User B creates a group conversation from Web 
2. Adds another participant (user A on iOS)
3. Toggle on to make this participant an admin
4. on iOS, user A should be marked as admin in conversation details and toggling on/off on web should immediately be reflected on iOS 

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

