### PR TITLE
fix: participants added system message wrong position - WPB-18005

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -523,7 +523,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
 
             return [systemMessage]
 
-        case let .participantsAdded(participants, sender, _):
+        case let .participantsAdded(participants, sender, date):
             guard let sender = await fetchUser(
                 id: sender.id,
                 domain: sender.domain
@@ -544,7 +544,8 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             let systemMessage = await createSystemMessage(
                 messageType: .participantsAdded,
                 sender: sender,
-                users: Set(newUsers)
+                users: Set(newUsers),
+                timestamp: date
             )
 
             return [systemMessage]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18005" title="WPB-18005" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18005</a>  [iOS] System message participants added at wrong position in group conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: participants added system message appear to be sometimes wrongly positioned in the conversation list, specifically, one could add participant then conversation goes on and the system message appear after last messages.

**Causes**: We omitted to pass the timestamp for this specific system message which is most likely the root cause of this issue as it will take the Date.now as default value if we don't pass anything.

**Solution**: Pass the timestamp so the system message timestamp is correctly set.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
