### PR TITLE
fix: weird transition conversation going offline + background to foreground - WPB-17982

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -36,6 +36,24 @@ public extension Bundle {
     @objc var appGroupIdentifier: String? {
         bundleIdentifier.map { "group." + $0 }
     }
+    
+    static var developerModeEnabled: Bool {
+        Bundle.appMainBundle.infoForKey("EnableDeveloperMenu") == "1"
+    }
+    
+    private static var appMainBundle: Bundle {
+        let mainBundle: Bundle
+        let runningInExtension = Bundle.main.bundlePath.hasSuffix(".appex")
+        if runningInExtension {
+            let extensionBundleURL = Bundle.main.bundleURL
+            let mainAppBundleURL = extensionBundleURL.deletingLastPathComponent().deletingLastPathComponent()
+            guard let bundle = Bundle(url: mainAppBundleURL) else { fatalError("Failed to find main app bundle") }
+            mainBundle = bundle
+        } else {
+            mainBundle = .main
+        }
+        return mainBundle
+    }
 }
 
 @objc

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -36,11 +36,11 @@ public extension Bundle {
     @objc var appGroupIdentifier: String? {
         bundleIdentifier.map { "group." + $0 }
     }
-    
+
     static var developerModeEnabled: Bool {
         Bundle.appMainBundle.infoForKey("EnableDeveloperMenu") == "1"
     }
-    
+
     private static var appMainBundle: Bundle {
         let mainBundle: Bundle
         let runningInExtension = Bundle.main.bundlePath.hasSuffix(".appex")

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1155,19 +1155,21 @@ extension ZMUserSession: SyncAgentDelegate {
     }
 
     func syncAgentDidFailSyncing(_ syncAgent: SyncAgent, error: any Error) {
-        let onRetry: () -> Void = { [weak self] in
-            self?.managedObjectContext.performGroupedBlock {
-                self?.isPerformingSync = true
-                self?.updateNetworkState()
+        if Bundle.developerModeEnabled { // Only show sync error alert for debugging
+            let onRetry: () -> Void = { [weak self] in
+                self?.managedObjectContext.performGroupedBlock {
+                    self?.isPerformingSync = true
+                    self?.updateNetworkState()
+                }
+
+                syncAgent.resume()
             }
 
-            syncAgent.resume()
+            delegate?.clientDidFailSyncing(
+                error: error,
+                retryHandler: onRetry
+            )
         }
-
-        delegate?.clientDidFailSyncing(
-            error: error,
-            retryHandler: onRetry
-        )
 
         WireLogger.sync.error("failed to perform sync: \(String(describing: error))")
 

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -259,11 +259,6 @@ extension AppRootRouter: AppStateCalculatorDelegate {
         error: any Error,
         onRetry: @escaping () -> Void
     ) {
-        // Only show sync error alert for debugging
-        guard Bundle.developerModeEnabled else {
-            return appStateTransitionGroup.leave()
-        }
-
         let alert = UIAlertController(
             title: L10n.Localizable.General.failure,
             message: (error as NSError).description,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17982" title="WPB-17982" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17982</a>  [iOS] App goes abruptly from conversation to conversation list 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When app is opened on a specific conversation, switch Wifi off then go to background, return to foreground. The app abruptly goes back to conversation list whereas it should remain on the conversation it was before.

**Causes**: The app transition router ends up in a weird state when showing the debug sync error alert multiple times and causes that abrupt transition to the conversation list. The sync error alert is intended for debug builds only however the problem is that where we check that developer flag is enabled in code should be higher in the hierarchy (basically where it's initially called) so there could be a risk that issue also happens in release builds.

**Solution**:  Move the developer flag check higher in the hierarchy so we don't start anything if it is on. This ensures we don't end up with that weird transition in production. 

### Testing

In debug builds: issue would still occur but that's fine, not really blocking anything, just an awkward transition.
In release builds: be on a conversation, switch Wifi off, go to background and back to foreground, still on the same conversation (it should not transition to the conversation list)

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
