### PR TITLE
fix: wrong system message user left - WPB-17642

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -402,12 +402,12 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
         reason: ConversationMemberLeaveReason
     ) async {
         let systemMessageType: SystemMessageType = switch reason {
-        case .userDeleted, .userLeft:
+        case .userDeleted:
             .teamMemberRemoved(
                 member: (senderID, senderDomain),
                 date: date
             )
-        case .userRemoved:
+        case .userRemoved, .userLeft:
             .participantsRemoved(
                 participants: removedUsers.map { ($0.uuid, $0.domain) },
                 sender: (senderID, senderDomain),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17642" title="WPB-17642" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17642</a>  [iOS] Participant leaving incorrectly says removed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When user left a group conversation by themselves, other user see a system message "user was removed by the team", it should see the system message "user left"

**Causes**: We don't use the correct system message for the .userLeft case

**Solution**: Use .participantsRemoved case from ZMSystemMessage

### Testing

- Have a user A using iOS, and a User B on any
- Log in as both A and B and make sure they are in a group together
- Have B leave the group themselves
- Look at system message with A, it should be "User B left"

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
