### PR TITLE
chore: disable new sync cloud - WPB-18030

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1110,10 +1110,14 @@ public final class SessionManager: NSObject, SessionManagerType {
         guard let apiVersion = BackendInfo.apiVersion else {
             fatalError("api version unknown")
         }
+        guard isDeveloperModeEnabled else {
+            // [WPB-18030] disabled new sync for Cloud build 3.124
+            return false
+        }
 
-        let isAvailble = apiVersion >= .v8
+        let isAvailable = apiVersion >= .v8
         let isAlreadyEnabled = journal[.isSyncV2Enabled]
-        return isAvailble && !isAlreadyEnabled
+        return isAvailable && !isAlreadyEnabled
     }
 
     private func enableSyncV2(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18030" title="WPB-18030" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18030</a>  [iOS] Disable sync for Cloud 3.124
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Disable new sync for 3.124 Cloud app production. Internal builds will still use the new sync.

### Testing

* Wire Beta/ Playground should still use new sync
* Wire (white) app will use legacy sync

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
