### PR TITLE
fix: extra dash missed call message - WPB-17974

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxDataSource.swift
@@ -214,7 +214,7 @@ final class MessageToolboxDataSource {
     private func makeCallList() -> String {
         guard let childMessages = message.systemMessageData?.childMessages, !childMessages.isEmpty,
               let timestamp = timestampString(message) else {
-            return timestampString(message) ?? "-"
+            return timestampString(message) ?? ""
         }
 
         let childrenTimestamps = childMessages


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17974" title="WPB-17974" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17974</a>  [iOS] Missed call indicator has an extra "-"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: The missed call system message in a conversation is followed by a cell that only contains an extra dash "-" whenever we don't have a timestamp

**Solution**: unless I'm missing some context and there's a specific reason why we do that simply return an empty string instead of "-" if we don't have a timestamp

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
