### PR TITLE
fix: use wrong user id cherry pick - WPB-18006

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMemberUpdateEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMemberUpdateEventProcessor.swift
@@ -26,9 +26,9 @@ struct ConversationMemberUpdateEventProcessor: ConversationMemberUpdateEventProc
     let localStore: any ConversationLocalStoreProtocol
 
     func processEvent(_ event: ConversationMemberUpdateEvent) async throws {
-        let senderID = event.senderID
         let conversationID = event.conversationID
         let memberChange = event.memberChange
+        let memberChangeID = memberChange.id
         let muteStatus = memberChange.newMuteStatus
         let muteStatusDate = memberChange.muteStatusReferenceDate
         let archivedStatus = memberChange.newArchivedStatus
@@ -40,8 +40,8 @@ struct ConversationMemberUpdateEventProcessor: ConversationMemberUpdateEventProc
         )
 
         let isSelfUser = try await userRepository.isSelfUser(
-            id: senderID.uuid,
-            domain: senderID.domain
+            id: memberChangeID.uuid,
+            domain: memberChangeID.domain
         )
 
         if isSelfUser {
@@ -57,8 +57,8 @@ struct ConversationMemberUpdateEventProcessor: ConversationMemberUpdateEventProc
         }
 
         await conversationRepository.addOrUpdateParticipant(
-            participantID: senderID.uuid,
-            participantDomain: senderID.domain,
+            participantID: memberChangeID.uuid,
+            participantDomain: memberChangeID.domain,
             participantRole: role,
             conversationID: conversationID.uuid,
             conversationDomain: conversationID.domain


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18006" title="WPB-18006" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18006</a>  [iOS] Updating the group admin toggle for participants from Web doesn't reflect on iOS
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

manual cherry-pick from https://github.com/wireapp/wire-ios/pull/3112

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
