### PR TITLE
fix: use legacy sync in NSE - WPB-18060

### DIFF
--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -68,13 +68,13 @@ final class NotificationService: UNNotificationServiceExtension {
             WireLogger.notifications.warn("no resolved api version, not loading service")
             return nil
         }
-        
+
         /// With v8, the new extension is available, but not necessarily
         /// turned on yet. Regardless, we will use it and later check
         /// if the new sync is enabled.
         ///
         /// WPB-18030 disable new sync for prod for now
-        if apiVersion >= .v8 && Bundle.developerModeEnabled {
+        if apiVersion >= .v8, Bundle.developerModeEnabled {
             WireLogger.notifications.warn("loading new notification service")
             return NotificationServiceExtension()
         } else {

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -68,11 +68,13 @@ final class NotificationService: UNNotificationServiceExtension {
             WireLogger.notifications.warn("no resolved api version, not loading service")
             return nil
         }
-
+        
         /// With v8, the new extension is available, but not necessarily
         /// turned on yet. Regardless, we will use it and later check
         /// if the new sync is enabled.
-        if apiVersion >= .v8 {
+        ///
+        /// WPB-18030 disable new sync for prod for now
+        if apiVersion >= .v8 && Bundle.developerModeEnabled {
             WireLogger.notifications.warn("loading new notification service")
             return NotificationServiceExtension()
         } else {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18060" title="WPB-18060" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18060</a>  [iOS] Not getting notifications with the Prod 3.124 Build
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Follow up of #3121, the **new (sync)** NSE was used for 3.124 this PR enables it only for internal builds.

### Testing

1. install Testflight prod app
2. check notifications are received

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
