### PR TITLE
fix: read receipts not working - WPB-18016

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
@@ -106,10 +106,15 @@ public struct ConversationProtobufMessageProcessor: ConversationProtobufMessageP
                 date: date
             )
 
-        case .confirmation:
+        case let .confirmation(confirmation):
 
-            // Some logic was done here but it seems unnecessary - see legacy `ZMOTRMessage+UpdateEvent`
-            break
+            await messageLocalStore.addMessageConfirmation(
+                confirmation,
+                in: conversation,
+                senderID: senderID.uuid,
+                senderDomain: senderID.domain,
+                date: date
+            )
 
         case let .buttonActionConfirmation(buttonActionConfirmation):
 

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -305,6 +305,24 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
         }
     }
 
+    public func addMessageConfirmation(
+        _ confirmation: WireProtos.Confirmation,
+        in conversation: ZMConversation,
+        senderID: UUID,
+        senderDomain: String,
+        date: Date
+    ) async {
+        await context.perform {
+            _ = ZMMessageConfirmation.createMessageConfirmations(
+                confirmation,
+                conversation: conversation,
+                senderUUID: senderID,
+                senderDomain: senderDomain,
+                timestamp: date
+            )
+        }
+    }
+
     public func updateButtonStates(
         _ buttonActionConfirmation: ButtonActionConfirmation,
         in conversation: ZMConversation

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -156,6 +156,22 @@ public protocol MessageLocalStoreProtocol {
         date: Date
     ) async
 
+    /// Adds a message confirmation to a message. This is used for read receipts.
+    /// - Parameters:
+    ///    - confirmation: The confirmation protobuf object.
+    ///    - conversation: The related conversation.
+    ///    - senderID: The message sender id.
+    ///    - senderDomain: The message sender domain.
+    ///    - date: The date the confirmation was added.
+
+    func addMessageConfirmation(
+        _ confirmation: WireProtos.Confirmation,
+        in conversation: ZMConversation,
+        senderID: UUID,
+        senderDomain: String,
+        date: Date
+    ) async
+
     /// Updates button states.
     /// - Parameters:
     ///     - buttonActionConfirmation: The button action confirmation protobuf object.

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2241,6 +2241,21 @@ public class MockMessageLocalStoreProtocol: MessageLocalStoreProtocol {
         await mock(messageReaction, conversation, senderID, date)
     }
 
+    // MARK: - addMessageConfirmation
+
+    public var addMessageConfirmationInSenderIDSenderDomainDate_Invocations: [(confirmation: WireProtos.Confirmation, conversation: ZMConversation, senderID: UUID, senderDomain: String, date: Date)] = []
+    public var addMessageConfirmationInSenderIDSenderDomainDate_MockMethod: ((WireProtos.Confirmation, ZMConversation, UUID, String, Date) async -> Void)?
+
+    public func addMessageConfirmation(_ confirmation: WireProtos.Confirmation, in conversation: ZMConversation, senderID: UUID, senderDomain: String, date: Date) async {
+        addMessageConfirmationInSenderIDSenderDomainDate_Invocations.append((confirmation: confirmation, conversation: conversation, senderID: senderID, senderDomain: senderDomain, date: date))
+
+        guard let mock = addMessageConfirmationInSenderIDSenderDomainDate_MockMethod else {
+            fatalError("no mock for `addMessageConfirmationInSenderIDSenderDomainDate`")
+        }
+
+        await mock(confirmation, conversation, senderID, senderDomain, date)
+    }
+
     // MARK: - updateButtonStates
 
     public var updateButtonStatesIn_Invocations: [(buttonActionConfirmation: ButtonActionConfirmation, conversation: ZMConversation)] = []

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
@@ -19,6 +19,7 @@
 import WireDataModel
 import WireDataModelSupport
 import WireDomainSupport
+import WireTestingPackage
 import XCTest
 @testable import WireAPI
 @testable import WireDomain
@@ -95,7 +96,7 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
             conversationID: Scaffolding.conversationID,
             senderID: Scaffolding.userID,
             senderClientID: "",
-            date: .now,
+            date: Scaffolding.eventDate,
             eventMessage: ""
         )
 
@@ -107,7 +108,48 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
         )
     }
 
+    func testProcessEvent_It_Invokes_Local_Store_Add_Message_Confirmation_Method() async throws {
+        // Given
+        let conversation = await context.perform { [self] in
+            modelHelper.createGroupConversation(in: context)
+        }
+
+        messageLocalStore.addMessageConfirmationInSenderIDSenderDomainDate_MockMethod = { _, _, _, _, _ in }
+
+        let confirmation = Confirmation.with {
+            $0.firstMessageID = UUID().uuidString
+            $0.type = .read
+        }
+        let genericMessage = GenericMessage.with {
+            $0.messageID = UUID().uuidString
+            $0.confirmation = confirmation
+        }
+
+        // When
+        try await sut.processProtobufMessage(
+            genericMessage,
+            content: try XCTUnwrap(genericMessage.content),
+            conversation: conversation,
+            conversationID: Scaffolding.conversationID,
+            senderID: Scaffolding.userID,
+            senderClientID: "clientID123",
+            date: Scaffolding.eventDate,
+            eventMessage: "confirmation"
+        )
+
+        // Then
+        try XCTAssertCount(messageLocalStore.addMessageConfirmationInSenderIDSenderDomainDate_Invocations, count: 1)
+
+        let invocation = messageLocalStore.addMessageConfirmationInSenderIDSenderDomainDate_Invocations[0]
+        XCTAssertEqual(invocation.confirmation, confirmation)
+        XCTAssertEqual(invocation.conversation, conversation)
+        XCTAssertEqual(invocation.senderID, Scaffolding.userID.uuid)
+        XCTAssertEqual(invocation.senderDomain, Scaffolding.userID.domain)
+        XCTAssertEqual(invocation.date, Scaffolding.eventDate)
+    }
+
     private enum Scaffolding {
+        static let eventDate = Date()
         static let conversationID = ConversationID(uuid: .mockID1, domain: "domain.com")
         static let userID = ConversationID(uuid: .mockID1, domain: "domain.com")
         static let base64EncodedString = "CiQ5ZTU2NTQwOS0xODZiLTRlN2YtYTE4NC05NzE4MGE0MDAwMDQSDAoKRXZlcnl0aGluZw=="

--- a/wire-ios-data-model/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/wire-ios-data-model/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -69,7 +69,6 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
     ) -> [ZMMessageConfirmation] {
 
         guard
-            let managedObjectContext = conversation.managedObjectContext,
             let senderUUID = updateEvent.senderUUID,
             let timestamp = updateEvent.timestamp
         else {

--- a/wire-ios-data-model/Source/Model/Confirmation/ZMMessageConfirmation.swift
+++ b/wire-ios-data-model/Source/Model/Confirmation/ZMMessageConfirmation.swift
@@ -68,17 +68,41 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
         updateEvent: ZMUpdateEvent
     ) -> [ZMMessageConfirmation] {
 
-        let type = MessageConfirmationType.convert(confirmation.type)
-
         guard
             let managedObjectContext = conversation.managedObjectContext,
             let senderUUID = updateEvent.senderUUID,
-            let serverTimestamp = updateEvent.timestamp
+            let timestamp = updateEvent.timestamp
         else {
             return []
         }
 
-        let sender = ZMUser.fetchOrCreate(with: senderUUID, domain: updateEvent.senderDomain, in: managedObjectContext)
+        return createMessageConfirmations(
+            confirmation,
+            conversation: conversation,
+            senderUUID: senderUUID,
+            senderDomain: updateEvent.senderDomain,
+            timestamp: timestamp
+        )
+    }
+
+    @discardableResult
+    public static func createMessageConfirmations(
+        _ confirmation: Confirmation,
+        conversation: ZMConversation,
+        senderUUID: UUID,
+        senderDomain: String?,
+        timestamp: Date
+    ) -> [ZMMessageConfirmation] {
+
+        let type = MessageConfirmationType.convert(confirmation.type)
+
+        guard
+            let managedObjectContext = conversation.managedObjectContext
+        else {
+            return []
+        }
+
+        let sender = ZMUser.fetchOrCreate(with: senderUUID, domain: senderDomain, in: managedObjectContext)
         let moreMessageIds = confirmation.moreMessageIds
         let confirmedMesssageIds = ([confirmation.firstMessageID] + moreMessageIds).compactMap { UUID(uuidString: $0) }
 
@@ -94,7 +118,7 @@ open class ZMMessageConfirmation: ZMManagedObject, ReadReceipt {
                 type: type,
                 message: message,
                 sender: sender,
-                serverTimestamp: serverTimestamp,
+                serverTimestamp: timestamp,
                 managedObjectContext: managedObjectContext
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18016" title="WPB-18016" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18016</a>  [iOS] : No read receipts
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Read receipts are not working in the new sync. This is because we are currently ignoring the message confirmation type update event, which is used to create `ZMMessageConfirmation` objects which is the source of our read receipt data. 

This PR fixes that so that the confirmation update events are no longer ignored.

### Testing

1. Post a message in a 1:1 or group proteus conversation (MLS groups don't have read receipts)
2. Have another user read that message.
3. Confirm that the read receipt (eye icon) for the message is visible.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

