### PR TITLE
feat: wire cells credentials in app settings - WPB-17769

### DIFF
--- a/WireCells/Sources/WireCellsBindings/WireCellsAssembly.swift
+++ b/WireCells/Sources/WireCellsBindings/WireCellsAssembly.swift
@@ -22,11 +22,11 @@ import WireCellsImplementation
 
 public struct WireCellsAssembly {
 
-    // TODO: [WPB-17769] Somehow inject secrets without storing them in the code base
+    // This implementation is just for development. How authentication will be handled in production is not yet known.
     private static let credentials = WireCellsCredentials(
         serverURL: URL(string: "https://service.zeta.pydiocells.com")!,
-        accessToken: "some-access-token",
-        gatewaySecret: "some-gateway-secret"
+        accessToken: UserDefaults.standard.string(forKey: "ZMWireCellsAccessToken") ?? "unknown",
+        gatewaySecret: UserDefaults.standard.string(forKey: "ZMWireCellsGatewaySecret") ?? "unknown"
     )
 
     private static let nodesAPI = NodesAPI(credentials: credentials)

--- a/wire-ios/Wire-iOS/Resources/Settings.bundle/DeveloperSettings.plist
+++ b/wire-ios/Wire-iOS/Resources/Settings.bundle/DeveloperSettings.plist
@@ -30,6 +30,40 @@
 			<key>DefaultValue</key>
 			<string>21600</string>
 		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Wire Cells</string>
+		</dict>
+        <dict>
+            <key>Type</key>
+            <string>PSTextFieldSpecifier</string>
+            <key>Title</key>
+            <string>Access Token</string>
+            <key>Key</key>
+            <string>ZMWireCellsAccessToken</string>
+            <key>DefaultValue</key>
+            <string></string>
+            <key>AutocapitalizationType</key>
+            <string>None</string>
+            <key>AutocorrectionType</key>
+            <string>No</string>
+        </dict>
+		<dict>
+            <key>Type</key>
+            <string>PSTextFieldSpecifier</string>
+            <key>Title</key>
+            <string>Gateway Secret</string>
+            <key>Key</key>
+            <string>ZMWireCellsGatewaySecret</string>
+            <key>DefaultValue</key>
+            <string></string>
+            <key>AutocapitalizationType</key>
+            <string>None</string>
+            <key>AutocorrectionType</key>
+            <string>No</string>
+        </dict>
 	</array>
 	<key>StringsTable</key>
 	<string>DeveloperSettings</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17769" title="WPB-17769" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17769</a>  [iOS] Add means to inject wire cells secrets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds textfields to `Settings > Apps > Wire > Developer Settings` for entering secrets necessary for interacting with wire cells. This is only **temporary** developer code to work on the feature as the real way to authenticate has not yet been defined. 

![IMG_0245](https://github.com/user-attachments/assets/95d6d6c5-b867-4590-a1ab-2ea3726b21a0)

### Testing

This feature is not yet manually testable

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.