### PR TITLE
fix: app recovery update events error - WPB-17609

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -30,20 +30,17 @@ public final class ClientSessionComponent {
         let onSelfClientInvalidated: () async -> Void
         let onProcessedTypingUsers: ([ConversationTypingUsersInfo]) -> Void
         let onAuthenticationFailure: @Sendable () -> Void
-        let onMissedEvents: () -> Void
 
         public init(
             onProcessedCallEvent: @escaping (CallEventInfo) -> Void,
             onSelfClientInvalidated: @escaping () async -> Void,
             onAuthenticationFailure: @escaping @Sendable () -> Void,
             onProcessedTypingUsers: @escaping ([ConversationTypingUsersInfo]) -> Void,
-            onMissedEvents: @escaping () -> Void
         ) {
             self.onProcessedCallEvent = onProcessedCallEvent
             self.onSelfClientInvalidated = onSelfClientInvalidated
             self.onProcessedTypingUsers = onProcessedTypingUsers
             self.onAuthenticationFailure = onAuthenticationFailure
-            self.onMissedEvents = onMissedEvents
         }
     }
 
@@ -369,7 +366,8 @@ public final class ClientSessionComponent {
         pushChannelAPI: pushChannelAPI,
         updateEventsSync: pullPendingUpdateEventsSync,
         decryptor: updateEventDecryptor,
-        store: updateEventsLocalStore,
+        updateEventsStore: updateEventsLocalStore,
+        messageStore: messageLocalStore,
         processor: updateEventProcessor,
         databaseSaver: databaseSaver,
         syncStateSubject: syncStateSubject,

--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -24,19 +24,26 @@ import WireDataModel
 
 public final class ClientSessionComponent {
 
-    public struct ProcessorHandlers {
+    /// Provides callbacks for other modules.
+    public struct CompletionHandlers {
         let onProcessedCallEvent: (CallEventInfo) -> Void
         let onSelfClientInvalidated: () async -> Void
         let onProcessedTypingUsers: ([ConversationTypingUsersInfo]) -> Void
+        let onAuthenticationFailure: @Sendable () -> Void
+        let onMissedEvents: () -> Void
 
         public init(
             onProcessedCallEvent: @escaping (CallEventInfo) -> Void,
             onSelfClientInvalidated: @escaping () async -> Void,
-            onProcessedTypingUsers: @escaping ([ConversationTypingUsersInfo]) -> Void
+            onAuthenticationFailure: @escaping @Sendable () -> Void,
+            onProcessedTypingUsers: @escaping ([ConversationTypingUsersInfo]) -> Void,
+            onMissedEvents: @escaping () -> Void
         ) {
             self.onProcessedCallEvent = onProcessedCallEvent
             self.onSelfClientInvalidated = onSelfClientInvalidated
             self.onProcessedTypingUsers = onProcessedTypingUsers
+            self.onAuthenticationFailure = onAuthenticationFailure
+            self.onMissedEvents = onMissedEvents
         }
     }
 
@@ -61,8 +68,7 @@ public final class ClientSessionComponent {
     private let proteusService: any ProteusServiceInterface
     private let coreCryptoProvider: any CoreCryptoProviderProtocol
 
-    private let processorHandlers: ProcessorHandlers
-    private let onAuthenticationFailure: @Sendable () -> Void
+    private let completionHandlers: CompletionHandlers
 
     public init(
         selfUserID: UUID,
@@ -80,9 +86,8 @@ public final class ClientSessionComponent {
         mlsService: any MLSServiceInterface,
         mlsDecryptionService: any MLSDecryptionServiceInterface,
         proteusService: any ProteusServiceInterface,
-        processorHandlers: ProcessorHandlers,
         coreCryptoProvider: any CoreCryptoProviderProtocol,
-        onAuthenticationFailure: @escaping @Sendable () -> Void
+        completionHandlers: CompletionHandlers
     ) {
         self.selfUserID = selfUserID
         self.selfClientID = selfClientID
@@ -99,16 +104,15 @@ public final class ClientSessionComponent {
         self.localDomain = localDomain
         self.isFederationEnabled = isFederationEnabled
         self.isMLSEnabled = isMLSEnabled
-        self.processorHandlers = processorHandlers
         self.coreCryptoProvider = coreCryptoProvider
-        self.onAuthenticationFailure = onAuthenticationFailure
+        self.completionHandlers = completionHandlers
     }
 
     private lazy var authenticationManager = AuthenticationManager(
         clientID: selfClientID,
         cookieStorage: cookieStorage,
         networkService: networkService,
-        onAuthenticationFailure: onAuthenticationFailure
+        onAuthenticationFailure: completionHandlers.onAuthenticationFailure
     )
 
     // MARK: - Network API clients
@@ -477,7 +481,7 @@ public final class ClientSessionComponent {
         messageLocalStore: messageLocalStore,
         userLocalStore: userLocalStore,
         protobufMessageProcessor: conversationProtobufMessageProcessor,
-        onProcessedCallEvent: processorHandlers.onProcessedCallEvent
+        onProcessedCallEvent: completionHandlers.onProcessedCallEvent
     )
 
     private lazy var conversationMLSWelcomeEventProcessor = ConversationMLSWelcomeEventProcessor(
@@ -493,7 +497,7 @@ public final class ClientSessionComponent {
         messageLocalStore: messageLocalStore,
         userLocalStore: userLocalStore,
         protobufMessageProcessor: conversationProtobufMessageProcessor,
-        onProcessedCallEvent: processorHandlers.onProcessedCallEvent
+        onProcessedCallEvent: completionHandlers.onProcessedCallEvent
     )
 
     private lazy var conversationProtocolUpdateEventProcessor = ConversationProtocolUpdateEventProcessor(
@@ -515,7 +519,7 @@ public final class ClientSessionComponent {
         conversationRepository: conversationRepository,
         conversationLocalStore: conversationLocalStore,
         userRepository: userRepository,
-        onProcessedTypingUsers: processorHandlers.onProcessedTypingUsers
+        onProcessedTypingUsers: completionHandlers.onProcessedTypingUsers
     )
 
     private lazy var featureConfigUpdateEventProcessor = FeatureConfigUpdateEventProcessor(
@@ -540,7 +544,7 @@ public final class ClientSessionComponent {
         pushSupportedProtocolsUseCase: pushSupportedProtocolsUseCase,
         oneOnOneResolver: oneOnOneResolver,
         context: syncContext,
-        onSelfClientInvalidated: processorHandlers.onSelfClientInvalidated
+        onSelfClientInvalidated: completionHandlers.onSelfClientInvalidated
     )
 
     private lazy var userConnectionEventProcessor = UserConnectionEventProcessor(

--- a/WireDomain/Sources/WireDomain/Components/UserSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/UserSessionComponent.swift
@@ -126,8 +126,7 @@ public final class UserSessionComponent {
 
     public func clientSessionComponent(
         clientID: String,
-        processorHandlers: ClientSessionComponent.ProcessorHandlers,
-        onAuthenticationFailure: @escaping @Sendable () -> Void
+        completionHandlers: ClientSessionComponent.CompletionHandlers
     ) -> ClientSessionComponent {
         ClientSessionComponent(
             selfUserID: selfUserID,
@@ -145,9 +144,8 @@ public final class UserSessionComponent {
             mlsService: mlsService,
             mlsDecryptionService: mlsDecryptionService,
             proteusService: proteusService,
-            processorHandlers: processorHandlers,
             coreCryptoProvider: coreCryptoProvider,
-            onAuthenticationFailure: onAuthenticationFailure
+            completionHandlers: completionHandlers
         )
     }
 

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -122,6 +122,23 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             to: conversation
         )
     }
+    
+    public func addPotentialGapSystemMessage() async throws {
+        try await context.perform { [context] in
+            guard let conversations = try context.fetch(ZMConversation.sortedFetchRequest()) as? [ZMConversation] else {
+                return
+            }
+            for conversation in conversations {
+                let offset = 0.1
+                let timestamp = conversation.lastModifiedDate?.addingTimeInterval(offset) ?? Date()
+                
+                conversation.appendNewPotentialGapSystemMessage(
+                    users: conversation.localParticipants,
+                    timestamp: timestamp
+                )
+            }
+        }
+    }
 
     public func canAddMessage(
         conversation: ZMConversation,

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -122,7 +122,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             to: conversation
         )
     }
-    
+
     public func addPotentialGapSystemMessage() async throws {
         try await context.perform { [context] in
             guard let conversations = try context.fetch(ZMConversation.sortedFetchRequest()) as? [ZMConversation] else {
@@ -131,7 +131,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             for conversation in conversations {
                 let offset = 0.1
                 let timestamp = conversation.lastModifiedDate?.addingTimeInterval(offset) ?? Date()
-                
+
                 conversation.appendNewPotentialGapSystemMessage(
                     users: conversation.localParticipants,
                     timestamp: timestamp

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -34,10 +34,10 @@ public protocol MessageLocalStoreProtocol {
         conversationID: UUID,
         conversationDomain: String?
     ) async
-    
+
     /// Adds a system message (to all conversations) that inform that there are potential lost messages
     /// and that some users were added to the conversation
-    
+
     func addPotentialGapSystemMessage() async throws
 
     /// Fetches or creates a `ZMClientMessage` locally.

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -34,6 +34,11 @@ public protocol MessageLocalStoreProtocol {
         conversationID: UUID,
         conversationDomain: String?
     ) async
+    
+    /// Adds a system message (to all conversations) that inform that there are potential lost messages
+    /// and that some users were added to the conversation
+    
+    func addPotentialGapSystemMessage() async throws
 
     /// Fetches or creates a `ZMClientMessage` locally.
     /// - Parameters:

--- a/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/Protocols/UpdateEventsLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/Protocols/UpdateEventsLocalStoreProtocol.swift
@@ -31,6 +31,10 @@ public protocol UpdateEventsLocalStoreProtocol {
     /// - parameter id: The last event ID to store.
 
     func storeLastEventID(id: UUID)
+    
+    /// Sets last event ID to nil.
+
+    func resetLastEventID()
 
     /// Retrieves the index of the last event envelope.
     /// - returns: The last index event envelope.

--- a/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/Protocols/UpdateEventsLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/Protocols/UpdateEventsLocalStoreProtocol.swift
@@ -31,7 +31,7 @@ public protocol UpdateEventsLocalStoreProtocol {
     /// - parameter id: The last event ID to store.
 
     func storeLastEventID(id: UUID)
-    
+
     /// Sets last event ID to nil.
 
     func resetLastEventID()

--- a/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/UpdateEventsLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/UpdateEventsLocalStore.swift
@@ -69,7 +69,7 @@ final class UpdateEventsLocalStore: UpdateEventsLocalStoreProtocol {
     public func storeLastEventID(id: UUID) {
         storage.setUUID(id, forKey: .lastEventID)
     }
-    
+
     public func resetLastEventID() {
         storage.setUUID(nil, forKey: .lastEventID)
     }

--- a/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/UpdateEventsLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/UpdateEventsLocalStore.swift
@@ -69,6 +69,10 @@ final class UpdateEventsLocalStore: UpdateEventsLocalStoreProtocol {
     public func storeLastEventID(id: UUID) {
         storage.setUUID(id, forKey: .lastEventID)
     }
+    
+    public func resetLastEventID() {
+        storage.setUUID(nil, forKey: .lastEventID)
+    }
 
     public func indexOfLastEventEnvelope() async throws -> Int64 {
         try await eventContext.perform { [eventContext] in

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -22,8 +22,8 @@ import WireAPI
 import WireLogging
 
 public struct IncrementalSync: IncrementalSyncProtocol {
-    
-    enum Failure: Error {
+
+    public enum Failure: Error {
         case missedEvents
     }
 
@@ -49,8 +49,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
         processor: any UpdateEventProcessorProtocol,
         databaseSaver: any DatabaseSaverProtocol,
         syncStateSubject: CurrentValueSubject<SyncState, Never>,
-        journal: Journal,
-        onMissedEvents: @escaping () -> Void
+        journal: Journal
     ) {
         self.selfClientID = selfClientID
         self.pushChannelAPI = pushChannelAPI
@@ -83,15 +82,12 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             logger.debug("processing stored update events")
             syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
             processedEnvelopeIDs = try await processStoredEvents()
-        } catch let apiError as UpdateEventsAPIError {
-            switch apiError {
-            case .notFound, .invalidParameters:
-                try await messageStore.addPotentialGapSystemMessage()
-                throw Failure.missedEvents
-            default:
-                throw apiError
-            }
         } catch {
+            func tearDown() async {
+                logger.debug("incremental sync interrupted, tearing down...")
+                await pushChannel.close()
+            }
+
             switch error {
             case let apiError as UpdateEventsAPIError:
                 switch apiError {
@@ -100,13 +96,14 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                     // reset with a full sync (initial + incremental)
                     updateEventsStore.resetLastEventID()
                     try await messageStore.addPotentialGapSystemMessage()
+                    await tearDown()
                     throw Failure.missedEvents
                 default:
+                    await tearDown()
                     throw error
                 }
             default:
-                logger.debug("incremental sync interrupted, tearing down...")
-                await pushChannel.close()
+                await tearDown()
                 throw error
             }
         }

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -92,9 +92,23 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                 throw apiError
             }
         } catch {
-            logger.debug("incremental sync interrupted, tearing down...")
-            await pushChannel.close()
-            throw error
+            switch error {
+            case let apiError as UpdateEventsAPIError:
+                switch apiError {
+                case .notFound, .invalidParameters:
+                    // nullifying the last event ID since we missed events and we want to
+                    // reset with a full sync (initial + incremental)
+                    updateEventsStore.resetLastEventID()
+                    try await messageStore.addPotentialGapSystemMessage()
+                    throw Failure.missedEvents
+                default:
+                    throw error
+                }
+            default:
+                logger.debug("incremental sync interrupted, tearing down...")
+                await pushChannel.close()
+                throw error
+            }
         }
 
         let liveEventTask = Task { @Sendable [self] in

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -22,6 +22,10 @@ import WireAPI
 import WireLogging
 
 public struct IncrementalSync: IncrementalSyncProtocol {
+    
+    enum Failure: Error {
+        case missedEvents
+    }
 
     private let selfClientID: String
     private let pushChannelAPI: any PushChannelAPI
@@ -32,7 +36,6 @@ public struct IncrementalSync: IncrementalSyncProtocol {
     private let processor: any UpdateEventProcessorProtocol
     private let databaseSaver: any DatabaseSaverProtocol
     private let syncStateSubject: CurrentValueSubject<SyncState, Never>
-    private let onMissedEvents: () -> Void
     private let logger = WireLogger.sync
     private let journal: Journal
 
@@ -59,7 +62,6 @@ public struct IncrementalSync: IncrementalSyncProtocol {
         self.databaseSaver = databaseSaver
         self.syncStateSubject = syncStateSubject
         self.journal = journal
-        self.onMissedEvents = onMissedEvents
     }
 
     public func perform() async throws -> Token {
@@ -85,8 +87,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             switch apiError {
             case .notFound, .invalidParameters:
                 try await messageStore.addPotentialGapSystemMessage()
-                onMissedEvents()
-                throw apiError
+                throw Failure.missedEvents
             default:
                 throw apiError
             }

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -27,10 +27,12 @@ public struct IncrementalSync: IncrementalSyncProtocol {
     private let pushChannelAPI: any PushChannelAPI
     private let updateEventsSync: any PullPendingUpdateEventsSyncProtocol
     private let decryptor: any UpdateEventDecryptorProtocol
-    private let store: any UpdateEventsLocalStoreProtocol
+    private let updateEventsStore: any UpdateEventsLocalStoreProtocol
+    private let messageStore: any MessageLocalStoreProtocol
     private let processor: any UpdateEventProcessorProtocol
     private let databaseSaver: any DatabaseSaverProtocol
     private let syncStateSubject: CurrentValueSubject<SyncState, Never>
+    private let onMissedEvents: () -> Void
     private let logger = WireLogger.sync
     private let journal: Journal
 
@@ -39,21 +41,25 @@ public struct IncrementalSync: IncrementalSyncProtocol {
         pushChannelAPI: any PushChannelAPI,
         updateEventsSync: any PullPendingUpdateEventsSyncProtocol,
         decryptor: any UpdateEventDecryptorProtocol,
-        store: any UpdateEventsLocalStoreProtocol,
+        updateEventsStore: any UpdateEventsLocalStoreProtocol,
+        messageStore: any MessageLocalStoreProtocol,
         processor: any UpdateEventProcessorProtocol,
         databaseSaver: any DatabaseSaverProtocol,
         syncStateSubject: CurrentValueSubject<SyncState, Never>,
-        journal: Journal
+        journal: Journal,
+        onMissedEvents: @escaping () -> Void
     ) {
         self.selfClientID = selfClientID
         self.pushChannelAPI = pushChannelAPI
         self.updateEventsSync = updateEventsSync
         self.decryptor = decryptor
-        self.store = store
+        self.updateEventsStore = updateEventsStore
+        self.messageStore = messageStore
         self.processor = processor
         self.databaseSaver = databaseSaver
         self.syncStateSubject = syncStateSubject
         self.journal = journal
+        self.onMissedEvents = onMissedEvents
     }
 
     public func perform() async throws -> Token {
@@ -75,6 +81,15 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             logger.debug("processing stored update events")
             syncStateSubject.send(.incrementalSyncing(.processPendingEvents))
             processedEnvelopeIDs = try await processStoredEvents()
+        } catch let apiError as UpdateEventsAPIError {
+            switch apiError {
+            case .notFound, .invalidParameters:
+                try await messageStore.addPotentialGapSystemMessage()
+                onMissedEvents()
+                throw apiError
+            default:
+                throw apiError
+            }
         } catch {
             logger.debug("incremental sync interrupted, tearing down...")
             await pushChannel.close()
@@ -146,8 +161,8 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                         "storing live event envelope",
                         attributes: [.eventEnvelopeID: envelope.id]
                     )
-                    index = try await store.indexOfLastEventEnvelope() + 1
-                    try await store.persistEventEnvelope(envelope, index: index)
+                    index = try await updateEventsStore.indexOfLastEventEnvelope() + 1
+                    try await updateEventsStore.persistEventEnvelope(envelope, index: index)
                 } catch {
                     logger.error(
                         "failed to store live event envelope: \(String(describing: error))",
@@ -162,7 +177,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                         "updating last event id",
                         attributes: [.eventEnvelopeID: envelope.id]
                     )
-                    store.storeLastEventID(id: envelope.id)
+                    updateEventsStore.storeLastEventID(id: envelope.id)
                 }
 
                 // Process.
@@ -187,7 +202,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                         "deleting live event envelope",
                         attributes: [.eventEnvelopeID: envelope.id]
                     )
-                    try await store.deleteEventEnvelope(atIndex: index)
+                    try await updateEventsStore.deleteEventEnvelope(atIndex: index)
                 } catch {
                     logger.error(
                         "failed to delete live event envelope: \(String(describing: error))",
@@ -195,7 +210,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                     )
                 }
 
-                await store.calculateLastUnreadMessages()
+                await updateEventsStore.calculateLastUnreadMessages()
 
                 do {
                     // Save.
@@ -219,7 +234,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             // If we need to abort, do it before processing the next batch.
             try Task.checkCancellation()
 
-            let envelopes = try await store.fetchStoredEventEnvelopes(limit: batchSize)
+            let envelopes = try await updateEventsStore.fetchStoredEventEnvelopes(limit: batchSize)
 
             guard !envelopes.isEmpty else {
                 break
@@ -245,8 +260,8 @@ public struct IncrementalSync: IncrementalSyncProtocol {
             }
 
             processedEnvelopeIDs.formUnion(envelopes.map(\.id))
-            try await store.deleteNextPendingEvents(limit: batchSize)
-            await store.calculateLastUnreadMessages()
+            try await updateEventsStore.deleteNextPendingEvents(limit: batchSize)
+            await updateEventsStore.calculateLastUnreadMessages()
 
             do {
                 try await databaseSaver.save()

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2102,6 +2102,26 @@ public class MockMessageLocalStoreProtocol: MessageLocalStoreProtocol {
         await mock(messageType, conversationID, conversationDomain)
     }
 
+    // MARK: - addPotentialGapSystemMessage
+
+    public var addPotentialGapSystemMessage_Invocations: [Void] = []
+    public var addPotentialGapSystemMessage_MockError: Error?
+    public var addPotentialGapSystemMessage_MockMethod: (() async throws -> Void)?
+
+    public func addPotentialGapSystemMessage() async throws {
+        addPotentialGapSystemMessage_Invocations.append(())
+
+        if let error = addPotentialGapSystemMessage_MockError {
+            throw error
+        }
+
+        guard let mock = addPotentialGapSystemMessage_MockMethod else {
+            fatalError("no mock for `addPotentialGapSystemMessage`")
+        }
+
+        try await mock()
+    }
+
     // MARK: - fetchOrCreateClientMessage
 
     public var fetchOrCreateClientMessageIdConversationSenderDate_Invocations: [(id: String, conversation: ZMConversation, sender: (id: UUID, domain: String, clientID: String?), date: Date)] = []
@@ -3558,10 +3578,10 @@ public class MockUpdateEventsLocalStoreProtocol: UpdateEventsLocalStoreProtocol 
 
     // MARK: - storeLastEventID
 
-    public var storeLastEventIDId_Invocations: [UUID?] = []
-    public var storeLastEventIDId_MockMethod: ((UUID?) -> Void)?
+    public var storeLastEventIDId_Invocations: [UUID] = []
+    public var storeLastEventIDId_MockMethod: ((UUID) -> Void)?
 
-    public func storeLastEventID(id: UUID?) {
+    public func storeLastEventID(id: UUID) {
         storeLastEventIDId_Invocations.append(id)
 
         guard let mock = storeLastEventIDId_MockMethod else {
@@ -3569,6 +3589,21 @@ public class MockUpdateEventsLocalStoreProtocol: UpdateEventsLocalStoreProtocol 
         }
 
         mock(id)
+    }
+
+    // MARK: - resetLastEventID
+
+    public var resetLastEventID_Invocations: [Void] = []
+    public var resetLastEventID_MockMethod: (() -> Void)?
+
+    public func resetLastEventID() {
+        resetLastEventID_Invocations.append(())
+
+        guard let mock = resetLastEventID_MockMethod else {
+            fatalError("no mock for `resetLastEventID`")
+        }
+
+        mock()
     }
 
     // MARK: - indexOfLastEventEnvelope

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -3558,10 +3558,10 @@ public class MockUpdateEventsLocalStoreProtocol: UpdateEventsLocalStoreProtocol 
 
     // MARK: - storeLastEventID
 
-    public var storeLastEventIDId_Invocations: [UUID] = []
-    public var storeLastEventIDId_MockMethod: ((UUID) -> Void)?
+    public var storeLastEventIDId_Invocations: [UUID?] = []
+    public var storeLastEventIDId_MockMethod: ((UUID?) -> Void)?
 
-    public func storeLastEventID(id: UUID) {
+    public func storeLastEventID(id: UUID?) {
         storeLastEventIDId_Invocations.append(id)
 
         guard let mock = storeLastEventIDId_MockMethod else {

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -280,6 +280,26 @@ final class IncrementalSyncTests: XCTestCase {
         }
     }
 
+//    func test_perform_Missed_Events() async throws {
+//        // Mock
+//        let pushChannel = MockPushChannelProtocol()
+//        pushChannel.open_MockValue = AsyncThrowingStream { _ in [] }
+//        pushChannel.close_MockMethod = {}
+//        pushChannelAPI.createPushChannelClientID_MockMethod = { _ in pushChannel }
+//        updateEventsSync.pull_MockError = UpdateEventsAPIError.notFound
+//        messageStore.addPotentialGapSystemMessage_MockMethod = {}
+//        updateEventsStore.storeLastEventIDId_MockMethod = { _ in }
+//
+//        await XCTAssertThrowsErrorAsync(UpdateEventsAPIError.notFound) {
+//            // When
+//            try await self.sut.perform()
+//        }
+//
+//        // Then
+//        XCTAssertEqual(didCallMissedEventsCallback, true)
+//        XCTAssertEqual(messageStore.addPotentialGapSystemMessage_Invocations.count, 1)
+//        XCTAssertEqual(updateEventsStore.storeLastEventIDId_Invocations.count, 1)
+//    }
 }
 
 private enum Scaffolding {

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncTests.swift
@@ -30,7 +30,8 @@ final class IncrementalSyncTests: XCTestCase {
     var pushChannelAPI: MockPushChannelAPI!
     var updateEventsSync: MockPullPendingUpdateEventsSyncProtocol!
     var decryptor: MockUpdateEventDecryptorProtocol!
-    var store: MockUpdateEventsLocalStoreProtocol!
+    var updateEventsStore: MockUpdateEventsLocalStoreProtocol!
+    var messageLocalStore: MockMessageLocalStoreProtocol!
     var processor: MockUpdateEventProcessorProtocol!
     var databaseSaver: MockDatabaseSaverProtocol!
     var syncStateSubject: CurrentValueSubject<SyncState, Never>!
@@ -43,7 +44,8 @@ final class IncrementalSyncTests: XCTestCase {
         pushChannelAPI = MockPushChannelAPI()
         updateEventsSync = MockPullPendingUpdateEventsSyncProtocol()
         decryptor = MockUpdateEventDecryptorProtocol()
-        store = MockUpdateEventsLocalStoreProtocol()
+        updateEventsStore = MockUpdateEventsLocalStoreProtocol()
+        messageLocalStore = MockMessageLocalStoreProtocol()
         processor = MockUpdateEventProcessorProtocol()
         databaseSaver = MockDatabaseSaverProtocol()
         syncStateSubject = CurrentValueSubject(.idle)
@@ -52,7 +54,8 @@ final class IncrementalSyncTests: XCTestCase {
             pushChannelAPI: pushChannelAPI,
             updateEventsSync: updateEventsSync,
             decryptor: decryptor,
-            store: store,
+            updateEventsStore: updateEventsStore,
+            messageStore: messageLocalStore,
             processor: processor,
             databaseSaver: databaseSaver,
             syncStateSubject: syncStateSubject,
@@ -66,7 +69,8 @@ final class IncrementalSyncTests: XCTestCase {
         pushChannelAPI = nil
         updateEventsSync = nil
         decryptor = nil
-        store = nil
+        updateEventsStore = nil
+        messageLocalStore = nil
         processor = nil
         databaseSaver = nil
         syncStateSubject = nil
@@ -85,14 +89,14 @@ final class IncrementalSyncTests: XCTestCase {
         ]
 
         // Pendeng events are stored in batches.
-        store.fetchStoredEventEnvelopesLimit_MockMethod = { _ in
+        updateEventsStore.fetchStoredEventEnvelopesLimit_MockMethod = { _ in
             let envelopes = storedEnvelopes
             storedEnvelopes = []
             return envelopes
         }
 
         // Pending events are deleted in batches.
-        store.deleteNextPendingEventsLimit_MockMethod = { _ in }
+        updateEventsStore.deleteNextPendingEventsLimit_MockMethod = { _ in }
 
         // Some live events, some of which were already pulled.
         let pushChannel = MockPushChannelProtocol()
@@ -110,11 +114,11 @@ final class IncrementalSyncTests: XCTestCase {
 
         // Some indices at which live events will be stored.
         var indices = [Int64(10), 11, 12, 13, 14, 15]
-        store.indexOfLastEventEnvelope_MockMethod = { indices.remove(at: 0) }
+        updateEventsStore.indexOfLastEventEnvelope_MockMethod = { indices.remove(at: 0) }
 
         // Live envelopes are peristed and deleted one by one.
-        store.persistEventEnvelopeIndex_MockMethod = { _, _ async throws in }
-        store.deleteEventEnvelopeAtIndex_MockMethod = { _ in }
+        updateEventsStore.persistEventEnvelopeIndex_MockMethod = { _, _ async throws in }
+        updateEventsStore.deleteEventEnvelopeAtIndex_MockMethod = { _ in }
 
         // Live events are decrypted.
 //        decryptor.decryptEventsIn_MockMethod = { EventDecryptorResult(
@@ -126,13 +130,13 @@ final class IncrementalSyncTests: XCTestCase {
         }
 
         // Last event is being updated.
-        store.storeLastEventIDId_MockMethod = { _ in }
+        updateEventsStore.storeLastEventIDId_MockMethod = { _ in }
 
         // Events are processed.
         processor.processEvent_MockMethod = { _ in }
 
         // Unread messages are set
-        store.calculateLastUnreadMessages_MockMethod = {}
+        updateEventsStore.calculateLastUnreadMessages_MockMethod = {}
 
         // Database is saved.
         databaseSaver.save_MockMethod = {}
@@ -160,12 +164,12 @@ final class IncrementalSyncTests: XCTestCase {
         )
 
         // Then live events were stored (duplicates skipped).
-        XCTAssertEqual(store.indexOfLastEventEnvelope_Invocations.count, 2)
+        XCTAssertEqual(updateEventsStore.indexOfLastEventEnvelope_Invocations.count, 2)
 
         // Broken conversation IDs are stored
         XCTAssertEqual(journal[.brokenMLSGroupIDs].first, Scaffolding.mlsGroupID)
 
-        let storeInvocations = store.persistEventEnvelopeIndex_Invocations
+        let storeInvocations = updateEventsStore.persistEventEnvelopeIndex_Invocations
         try XCTAssertCount(storeInvocations, count: 2)
         XCTAssertEqual(storeInvocations[0].eventEnvelope, Scaffolding.event4)
         XCTAssertEqual(storeInvocations[0].index, 11)
@@ -174,8 +178,8 @@ final class IncrementalSyncTests: XCTestCase {
 
         // Then last event id was updated once (for the non-transient live
         // event)
-        try XCTAssertCount(store.storeLastEventIDId_Invocations, count: 1)
-        XCTAssertEqual(store.storeLastEventIDId_Invocations[0], Scaffolding.event5.id)
+        try XCTAssertCount(updateEventsStore.storeLastEventIDId_Invocations, count: 1)
+        XCTAssertEqual(updateEventsStore.storeLastEventIDId_Invocations[0], Scaffolding.event5.id)
 
         // Then all events were processed once (duplicates skipped).
         XCTAssertEqual(
@@ -190,14 +194,14 @@ final class IncrementalSyncTests: XCTestCase {
         )
 
         // Then pending events were deleted.
-        XCTAssertEqual(store.deleteNextPendingEventsLimit_Invocations, [500])
+        XCTAssertEqual(updateEventsStore.deleteNextPendingEventsLimit_Invocations, [500])
 
         // Then live events were deleted (duplicates skipped).
-        XCTAssertEqual(store.deleteEventEnvelopeAtIndex_Invocations, [11, 12])
+        XCTAssertEqual(updateEventsStore.deleteEventEnvelopeAtIndex_Invocations, [11, 12])
 
         // Then unread messages are calculated once after processing pending events
         // and once after processing each live event.
-        XCTAssertEqual(store.calculateLastUnreadMessages_Invocations.count, 3)
+        XCTAssertEqual(updateEventsStore.calculateLastUnreadMessages_Invocations.count, 3)
 
         // Then the database was saved once after processing pending events
         // and once after processing each live event.
@@ -217,14 +221,14 @@ final class IncrementalSyncTests: XCTestCase {
         ]
 
         // Pendeng events are stored in batches.
-        store.fetchStoredEventEnvelopesLimit_MockMethod = { _ in
+        updateEventsStore.fetchStoredEventEnvelopesLimit_MockMethod = { _ in
             let envelopes = storedEnvelopes
             storedEnvelopes = []
             return envelopes
         }
 
         // Pending events are deleted in batches.
-        store.deleteNextPendingEventsLimit_MockMethod = { _ in }
+        updateEventsStore.deleteNextPendingEventsLimit_MockMethod = { _ in }
 
         // Some live events, some of which were already pulled.
         let pushChannel = MockPushChannelProtocol()
@@ -241,11 +245,11 @@ final class IncrementalSyncTests: XCTestCase {
         pushChannelAPI.createPushChannelClientID_MockMethod = { _ in pushChannel }
         // Some indices at which live events will be stored.
         var indices = [Int64(10), 11, 12, 13, 14, 15]
-        store.indexOfLastEventEnvelope_MockMethod = { indices.remove(at: 0) }
+        updateEventsStore.indexOfLastEventEnvelope_MockMethod = { indices.remove(at: 0) }
 
         // Live envelopes are peristed and deleted one by one.
-        store.persistEventEnvelopeIndex_MockMethod = { _, _ async throws in }
-        store.deleteEventEnvelopeAtIndex_MockMethod = { _ in }
+        updateEventsStore.persistEventEnvelopeIndex_MockMethod = { _, _ async throws in }
+        updateEventsStore.deleteEventEnvelopeAtIndex_MockMethod = { _ in }
 
         // Live events are decrypted.
         decryptor.decryptEventsInContext_MockMethod = { envelope, _ async throws in .init(
@@ -254,13 +258,13 @@ final class IncrementalSyncTests: XCTestCase {
         ) }
 
         // Last event is being updated.
-        store.storeLastEventIDId_MockMethod = { _ in }
+        updateEventsStore.storeLastEventIDId_MockMethod = { _ in }
 
         // Events are processed.
         processor.processEvent_MockMethod = { _ in }
 
         // Unread messages are set
-        store.calculateLastUnreadMessages_MockMethod = {}
+        updateEventsStore.calculateLastUnreadMessages_MockMethod = {}
 
         // Database is saved.
         databaseSaver.save_MockMethod = {}
@@ -280,26 +284,26 @@ final class IncrementalSyncTests: XCTestCase {
         }
     }
 
-//    func test_perform_Missed_Events() async throws {
-//        // Mock
-//        let pushChannel = MockPushChannelProtocol()
-//        pushChannel.open_MockValue = AsyncThrowingStream { _ in [] }
-//        pushChannel.close_MockMethod = {}
-//        pushChannelAPI.createPushChannelClientID_MockMethod = { _ in pushChannel }
-//        updateEventsSync.pull_MockError = UpdateEventsAPIError.notFound
-//        messageStore.addPotentialGapSystemMessage_MockMethod = {}
-//        updateEventsStore.storeLastEventIDId_MockMethod = { _ in }
-//
-//        await XCTAssertThrowsErrorAsync(UpdateEventsAPIError.notFound) {
-//            // When
-//            try await self.sut.perform()
-//        }
-//
-//        // Then
-//        XCTAssertEqual(didCallMissedEventsCallback, true)
-//        XCTAssertEqual(messageStore.addPotentialGapSystemMessage_Invocations.count, 1)
-//        XCTAssertEqual(updateEventsStore.storeLastEventIDId_Invocations.count, 1)
-//    }
+    func test_perform_Missed_Events() async throws {
+        // Mock
+        let pushChannel = MockPushChannelProtocol()
+        pushChannel.open_MockValue = AsyncThrowingStream { _ in [] }
+        pushChannel.close_MockMethod = {}
+        pushChannelAPI.createPushChannelClientID_MockMethod = { _ in pushChannel }
+        updateEventsSync.pull_MockError = UpdateEventsAPIError.notFound
+        messageLocalStore.addPotentialGapSystemMessage_MockMethod = {}
+        updateEventsStore.storeLastEventIDId_MockMethod = { _ in }
+        updateEventsStore.resetLastEventID_MockMethod = {}
+
+        await XCTAssertThrowsErrorAsync(IncrementalSync.Failure.missedEvents) {
+            // When
+            try await self.sut.perform()
+        }
+
+        // Then
+        XCTAssertEqual(messageLocalStore.addPotentialGapSystemMessage_Invocations.count, 1)
+        XCTAssertEqual(updateEventsStore.resetLastEventID_Invocations.count, 1)
+    }
 }
 
 private enum Scaffolding {

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -552,16 +552,16 @@ public final class SharingSession {
             coreCryptoProvider: coreCryptoProvider
         )
 
-        let processHandlers = ClientSessionComponent.ProcessorHandlers(
+        let completionHandlers = ClientSessionComponent.CompletionHandlers(
             onProcessedCallEvent: { _ in },
             onSelfClientInvalidated: {},
+            onAuthenticationFailure: {},
             onProcessedTypingUsers: { _ in }
         )
 
         let clientUserSessionComponent = userSessionComponent.clientSessionComponent(
             clientID: selfClientID,
-            processorHandlers: processHandlers,
-            onAuthenticationFailure: {}
+            completionHandlers: completionHandlers
         )
 
         coreCryptoProvider.registerMlsTransport(clientUserSessionComponent.mlsTransport)

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -216,17 +216,17 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
                     incrementalSyncToken = try await incrementalSyncProvider.provideIncrementalSync().perform()
                     delegate?.syncAgentDidFinishIncrementalSync(self, isRecovering: false)
                 }
+            } catch IncrementalSync.Failure.missedEvents {
+                WireLogger.sync.error(
+                    "failed to perform new incremental sync (missed events): recovering with a full sync"
+                )
+
+                syncStateSubject.send(.suspended)
+                resume()
             } catch {
                 WireLogger.sync.error("failed to perform new incremental sync: \(String(describing: error))")
                 syncStateSubject.send(.suspended)
-
-                if let incrementalSyncError = error as? IncrementalSync.Failure,
-                   case .missedEvents = incrementalSyncError {
-                    // recovering with a full sync
-                    resume()
-                } else {
-                    throw error
-                }
+                throw error
             }
         } else {
             await legacySyncStatus.performQuickSync()

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -219,7 +219,14 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
             } catch {
                 WireLogger.sync.error("failed to perform new incremental sync: \(String(describing: error))")
                 syncStateSubject.send(.suspended)
-                throw error
+
+                if let incrementalSyncError = error as? IncrementalSync.Failure,
+                   case .missedEvents = incrementalSyncError {
+                    // recovering with a full sync
+                    resume()
+                } else {
+                    throw error
+                }
             }
         } else {
             await legacySyncStatus.performQuickSync()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -561,12 +561,13 @@ public final class ZMUserSession: NSObject {
     private func setUpSyncAgent(clientID: String, asyncStreamEnabled: Bool) {
         let clientSessionComponent = userSessionComponent.clientSessionComponent(
             clientID: clientID,
-            processorHandlers: .init(
-                onProcessedCallEvent: onProcessedCallEvent(callEventInfo:),
+            completionHandlers: .init(
+                onProcessedCallEvent: onProcessedCallEvent,
                 onSelfClientInvalidated: onSelfClientInvalidated,
-                onProcessedTypingUsers: onProcessedTypingUsers(typingUsersInfo:)
-            ),
-            onAuthenticationFailure: onAuthenticationFailure
+                onAuthenticationFailure: onAuthenticationFailure,
+                onProcessedTypingUsers: onProcessedTypingUsers,
+                onMissedEvents: onMissedEvents
+            )
         )
 
         coreCryptoProvider.registerMlsTransport(clientSessionComponent.mlsTransport)
@@ -618,108 +619,6 @@ public final class ZMUserSession: NSObject {
 
         // TODO: [WPB-17223] remove `resume` call from here
         syncAgent.resume()
-    }
-
-    // MARK: - Callbacks from WireDomain
-
-    @Sendable
-    public func onAuthenticationFailure() {
-        managedObjectContext.performGroupedBlock { [weak self] in
-            guard let self else { return }
-
-            let selfUser = ZMUser.selfUser(in: managedObjectContext)
-
-            notifyAuthenticationInvalidated(
-                NSError.userSessionError(
-                    code: .accessTokenExpired,
-                    userInfo: selfUser.loginCredentials.dictionaryRepresentation
-                )
-            )
-        }
-    }
-
-    private func onProcessedTypingUsers(
-        typingUsersInfo: [ConversationTypingUsersInfo]
-    ) {
-
-        viewContext.performGroupedBlock { [viewContext] in
-            for typingUserInfo in typingUsersInfo {
-                let conversationID = typingUserInfo.conversationID
-                let usersID = typingUserInfo.users
-
-                if let conversation = viewContext.object(with: conversationID) as? ZMConversation {
-
-                    let users = usersID.compactMap {
-                        viewContext.object(with: $0) as? ZMUser
-                    }
-
-                    viewContext.typingUsers?.update(
-                        typingUsers: Set(users),
-                        in: conversation
-                    )
-
-                    conversation.notifyTyping(typingUsers: Set(users))
-                }
-            }
-        }
-    }
-
-    func onSelfClientInvalidated() async {
-        await syncContext.perform { [self] in
-            syncContext.tearDownCryptoStack()
-
-            let clientRegistrationStatus = applicationStatusDirectory.clientRegistrationStatus
-            let clientUpdateStatus = applicationStatusDirectory.clientUpdateStatus
-
-            clientRegistrationStatus.emailCredentials = nil
-            clientRegistrationStatus.cookieProvider.deleteKeychainItems()
-
-            let selfUser = ZMUser.selfUser(in: syncContext)
-            let clientDeletedRemotelyError = NSError.userSessionError(
-                code: .clientDeletedRemotely,
-                userInfo: selfUser.loginCredentials.dictionaryRepresentation
-            )
-
-            didDeleteSelfUserClient(error: clientDeletedRemotelyError)
-
-            clientUpdateStatus.needsToVerifySelfClient = false
-        }
-    }
-
-    private func onProcessedCallEvent(callEventInfo: CallEventInfo) {
-        let serverTimeDelta = syncContext.performAndWait {
-            syncContext.serverTimeDelta // serverTimeDelta can only be accessed on the sync context
-        }
-
-        viewContext.perform { [weak self] in // callCenter can only be accessed on the ui context
-            guard let self, let callCenter else { return }
-            guard !callEventInfo.isMuted else {
-                callCenter.isMuted = true
-                return
-            }
-
-            let conversationId = AVSIdentifier(
-                identifier: callEventInfo.conversationID,
-                domain: callEventInfo.conversationDomain
-            )
-
-            let userId = AVSIdentifier(
-                identifier: callEventInfo.userID,
-                domain: callEventInfo.userDomain
-            )
-
-            let callEvent = CallEvent(
-                data: callEventInfo.data,
-                currentTimestamp: Date.now.addingTimeInterval(serverTimeDelta),
-                serverTimestamp: callEventInfo.eventTimestamp,
-                conversationId: conversationId,
-                userId: userId,
-                clientId: callEventInfo.clientID
-            )
-
-            callCenter.processCallEvent(callEvent)
-        }
-
     }
 
     // MARK: - Deinitalize
@@ -1538,4 +1437,113 @@ extension ZMUserSession: ContextProvider {
 
 public extension Notification.Name {
     static let loggingRequestLoop = Self("LoggingRequestLoopNotificationName")
+}
+
+// MARK: - Callbacks from WireDomain
+
+extension ZMUserSession {
+
+    @Sendable
+    public func onAuthenticationFailure() {
+        managedObjectContext.performGroupedBlock { [weak self] in
+            guard let self else { return }
+
+            let selfUser = ZMUser.selfUser(in: managedObjectContext)
+
+            notifyAuthenticationInvalidated(
+                NSError.userSessionError(
+                    code: .accessTokenExpired,
+                    userInfo: selfUser.loginCredentials.dictionaryRepresentation
+                )
+            )
+        }
+    }
+
+    private func onProcessedTypingUsers(
+        typingUsersInfo: [ConversationTypingUsersInfo]
+    ) {
+
+        viewContext.performGroupedBlock { [viewContext] in
+            for typingUserInfo in typingUsersInfo {
+                let conversationID = typingUserInfo.conversationID
+                let usersID = typingUserInfo.users
+
+                if let conversation = viewContext.object(with: conversationID) as? ZMConversation {
+
+                    let users = usersID.compactMap {
+                        viewContext.object(with: $0) as? ZMUser
+                    }
+
+                    viewContext.typingUsers?.update(
+                        typingUsers: Set(users),
+                        in: conversation
+                    )
+
+                    conversation.notifyTyping(typingUsers: Set(users))
+                }
+            }
+        }
+    }
+
+    func onSelfClientInvalidated() async {
+        await syncContext.perform { [self] in
+            syncContext.tearDownCryptoStack()
+
+            let clientRegistrationStatus = applicationStatusDirectory.clientRegistrationStatus
+            let clientUpdateStatus = applicationStatusDirectory.clientUpdateStatus
+
+            clientRegistrationStatus.emailCredentials = nil
+            clientRegistrationStatus.cookieProvider.deleteKeychainItems()
+
+            let selfUser = ZMUser.selfUser(in: syncContext)
+            let clientDeletedRemotelyError = NSError.userSessionError(
+                code: .clientDeletedRemotely,
+                userInfo: selfUser.loginCredentials.dictionaryRepresentation
+            )
+
+            didDeleteSelfUserClient(error: clientDeletedRemotelyError)
+
+            clientUpdateStatus.needsToVerifySelfClient = false
+        }
+    }
+
+    private func onProcessedCallEvent(callEventInfo: CallEventInfo) {
+        let serverTimeDelta = syncContext.performAndWait {
+            syncContext.serverTimeDelta // serverTimeDelta can only be accessed on the sync context
+        }
+
+        viewContext.perform { [weak self] in // callCenter can only be accessed on the ui context
+            guard let self, let callCenter else { return }
+            guard !callEventInfo.isMuted else {
+                callCenter.isMuted = true
+                return
+            }
+
+            let conversationId = AVSIdentifier(
+                identifier: callEventInfo.conversationID,
+                domain: callEventInfo.conversationDomain
+            )
+
+            let userId = AVSIdentifier(
+                identifier: callEventInfo.userID,
+                domain: callEventInfo.userDomain
+            )
+
+            let callEvent = CallEvent(
+                data: callEventInfo.data,
+                currentTimestamp: Date.now.addingTimeInterval(serverTimeDelta),
+                serverTimestamp: callEventInfo.eventTimestamp,
+                conversationId: conversationId,
+                userId: userId,
+                clientId: callEventInfo.clientID
+            )
+
+            callCenter.processCallEvent(callEvent)
+        }
+
+    }
+    
+    func onMissedEvents() {
+        triggerInitialSync()
+    }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -565,8 +565,7 @@ public final class ZMUserSession: NSObject {
                 onProcessedCallEvent: onProcessedCallEvent,
                 onSelfClientInvalidated: onSelfClientInvalidated,
                 onAuthenticationFailure: onAuthenticationFailure,
-                onProcessedTypingUsers: onProcessedTypingUsers,
-                onMissedEvents: onMissedEvents
+                onProcessedTypingUsers: onProcessedTypingUsers
             )
         )
 
@@ -1541,9 +1540,5 @@ extension ZMUserSession {
             callCenter.processCallEvent(callEvent)
         }
 
-    }
-    
-    func onMissedEvents() {
-        syncAgent?.resume()
     }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1544,6 +1544,6 @@ extension ZMUserSession {
     }
     
     func onMissedEvents() {
-        triggerInitialSync()
+        syncAgent?.resume()
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17609" title="WPB-17609" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17609</a>  [iOS] App doesn't recover from 'UpdateEventsAPIError.notFound' 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

follow up on  https://github.com/wireapp/wire-ios/pull/3099

When pulling pending events during IncrementalSync and it fails with 400 or 404, it means we have missed (too many) events and app needs to recover by:

triggering a full sync (initial + incremental)
add a system message to let user know there is a potential message gap

### Testing

tested internally by throwing a 404 error and ensuring gap system message is added and full sync is performed.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
