### PR TITLE
fix: modify log values  - WPB-18024

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationFlowStep.swift
@@ -111,6 +111,70 @@ indirect enum AuthenticationFlowStep: Equatable {
 
 }
 
+extension AuthenticationFlowStep: CustomStringConvertible {
+
+    // Don't include any of the associated values as they may be
+    // sensitve and it's know everywhere we log steps.
+
+    var description: String {
+        switch self {
+        case .start:
+            "start"
+        case .wireAuthenticationModule:
+            "wireAuthenticationModule"
+        case .landingScreen:
+            "landingScreen"
+        case .reauthenticate:
+            "reauthenticate"
+        case .provideCredentials:
+            "provideCredentials"
+        case .enterEmailVerificationCode:
+            "enterEmailVerificationCode"
+        case .authenticateEmailCredentials:
+            "authenticateEmailCredentials"
+        case .companyLogin:
+            "companyLogin"
+        case .switchBackend:
+            "switchBackend"
+        case .noHistory:
+            "noHistory"
+        case .clientManagement:
+            "clientManagement"
+        case .deleteClient:
+            "deleteClient"
+        case .addEmailAndPassword:
+            "addEmailAndPassword"
+        case .enrollE2EIdentity:
+            "enrollE2EIdentity"
+        case .enrollE2EIdentitySuccess:
+            "enrollE2EIdentitySuccess"
+        case .addUsername:
+            "addUsername"
+        case .registerEmailCredentials:
+            "registerEmailCredentials"
+        case .pendingEmailLinkVerification:
+            "pendingEmailLinkVerification"
+        case .pendingInitialSync:
+            "pendingInitialSync"
+        case .createCredentials:
+            "createCredentials"
+        case .sendActivationCode:
+            "sendActivationCode"
+        case .enterActivationCode:
+            "enterActivationCode"
+        case .activateCredentials:
+            "activateCredentials"
+        case .incrementalUserCreation:
+            "incrementalUserCreation"
+        case .createUser:
+            "createUser"
+        case .configureDevice:
+            "configureDevice"
+        }
+    }
+
+}
+
 // MARK: - Intermediate Steps
 
 /// Intermediate steps required for user registration.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18024" title="WPB-18024" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18024</a>  [iOS] obfuscation in logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When we log authentication flow steps their associated values are logged too. This PR provides an explicit conformance to `CustomStringConvertible` which only logs the step name.

### Testing
1. Disable the new WireAuthentication flow
2. Log in with an account that requires 2FA
3. Check the logs and ensure that no email, password, or 2FA codes are logged.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
