### PR TITLE
feat: display skeleton multipart message - WPB-16311

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/ConversationMessage.swift
+++ b/wire-ios-data-model/Source/Model/Message/ConversationMessage.swift
@@ -99,6 +99,10 @@ public protocol ZMConversationMessage: NSObjectProtocol {
     /// The location message data associated with the message. If the message is not a location message, it will be nil
     var locationMessageData: LocationMessageData? { get }
 
+    /// The multipart message data associated with the message. If the message is not a multipart message, it will be
+    /// nil
+    var multipartMessageData: MultipartMessageData? { get }
+
     var usersReaction: [String: [UserType]] { get }
     var reactionData: Set<ReactionData> { get }
     func reactionsSortedByCreationDate() -> [ReactionData]
@@ -332,6 +336,10 @@ public extension ZMMessage {
     }
 
     @objc var locationMessageData: LocationMessageData? {
+        nil
+    }
+
+    @objc var multipartMessageData: MultipartMessageData? {
         nil
     }
 

--- a/wire-ios-data-model/Source/Model/Message/Message.swift
+++ b/wire-ios-data-model/Source/Model/Message/Message.swift
@@ -68,6 +68,10 @@ public extension ZMConversationMessage {
         systemMessageData != nil
     }
 
+    var isMultipart: Bool {
+        multipartMessageData != nil
+    }
+
     // Checks if message has link preview or link attachment
     // Does not check if there is Markdown links
     var hasLinks: Bool {

--- a/wire-ios-data-model/Source/Model/Message/MultipartMessageData.swift
+++ b/wire-ios-data-model/Source/Model/Message/MultipartMessageData.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+// TODO: [WPB-16311] This is currently just a stub and needs to be implemented properly.
+public final class MultipartMessageData: NSObject {
+
+    public struct Attachment {
+        public let fileName: String
+    }
+
+    public let attachments: [Attachment]
+
+    init(multipart: Multipart) {
+        self.attachments = multipart.attachments.map { attachment in
+            Attachment(
+                fileName: URL(string: attachment.cellAsset.initialName)?.lastPathComponent ?? "Unknown file name"
+            )
+        }
+    }
+
+}

--- a/wire-ios-data-model/Source/Model/Message/ZMClientMessage+MultipartMessageData.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMClientMessage+MultipartMessageData.swift
@@ -1,0 +1,32 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public extension ZMClientMessage {
+
+    override var multipartMessageData: MultipartMessageData? {
+        switch underlyingMessage?.content {
+        case let .multipart(multipart):
+            MultipartMessageData(multipart: multipart)
+        default:
+            nil
+        }
+    }
+
+}

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.manual.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.manual.swift
@@ -117,6 +117,10 @@ public class MockZMConversationMessage: NSObject, ZMConversationMessage {
 
     public var locationMessageData: LocationMessageData?
 
+    // MARK: - multipartMessageData
+
+    public var multipartMessageData: WireDataModel.MultipartMessageData?
+
     // MARK: - usersReaction
 
     public var usersReaction: [String: [UserType]] = [:]

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -523,6 +523,8 @@
 		CB181C7E2D3F8D8400A80AB4 /* OneOnOneSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB181C7D2D3F8D7F00A80AB4 /* OneOnOneSource.swift */; };
 		CB1821A52D412FA100A80AB4 /* OneOnOneSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1821A42D412FA100A80AB4 /* OneOnOneSourceTests.swift */; };
 		CB1BF6FC2C8AF6A5001EC670 /* ExpirationReason+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1BF6FB2C8AF6A5001EC670 /* ExpirationReason+Description.swift */; };
+		CB3437012DF32846007CFB34 /* MultipartMessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3437002DF3283E007CFB34 /* MultipartMessageData.swift */; };
+		CB3437032DF329D2007CFB34 /* ZMClientMessage+MultipartMessageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3437022DF329D2007CFB34 /* ZMClientMessage+MultipartMessageData.swift */; };
 		CB417B082D9FDA2B00F0701B /* store2-123-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = CB417B072D9FDA2B00F0701B /* store2-123-0.wiredatabase */; };
 		CB5212122D95A76800CF8099 /* ZMConversation+PrivateChannelPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5212112D95A76800CF8099 /* ZMConversation+PrivateChannelPermission.swift */; };
 		CB7979182C747652006FBA58 /* WireTransportSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB7979172C747652006FBA58 /* WireTransportSupport.framework */; };
@@ -1435,6 +1437,8 @@
 		CB181C7D2D3F8D7F00A80AB4 /* OneOnOneSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneOnOneSource.swift; sourceTree = "<group>"; };
 		CB1821A42D412FA100A80AB4 /* OneOnOneSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneOnOneSourceTests.swift; sourceTree = "<group>"; };
 		CB1BF6FB2C8AF6A5001EC670 /* ExpirationReason+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExpirationReason+Description.swift"; sourceTree = "<group>"; };
+		CB3437002DF3283E007CFB34 /* MultipartMessageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartMessageData.swift; sourceTree = "<group>"; };
+		CB3437022DF329D2007CFB34 /* ZMClientMessage+MultipartMessageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessage+MultipartMessageData.swift"; sourceTree = "<group>"; };
 		CB417B072D9FDA2B00F0701B /* store2-123-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-123-0.wiredatabase"; sourceTree = "<group>"; };
 		CB5212112D95A76800CF8099 /* ZMConversation+PrivateChannelPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMConversation+PrivateChannelPermission.swift"; sourceTree = "<group>"; };
 		CB7979172C747652006FBA58 /* WireTransportSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireTransportSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2990,6 +2994,7 @@
 				165124D32188B613006A3C75 /* ZMClientMessage+Quotes.swift */,
 				165124D52188CF66006A3C75 /* ZMClientMessage+Editing.swift */,
 				EEDA9C132513A0A5003A5B27 /* ZMClientMessage+EncryptionAtRest.swift */,
+				CB3437022DF329D2007CFB34 /* ZMClientMessage+MultipartMessageData.swift */,
 				F9A705F81CAEE01D00C2F5FE /* ZMExternalEncryptedDataWithKeys.h */,
 				F9A705F91CAEE01D00C2F5FE /* ZMExternalEncryptedDataWithKeys.m */,
 				63298D992434D04D006B6018 /* GenericMessage+External.swift */,
@@ -3025,6 +3030,7 @@
 				068DCC5629BB816300F7E4F1 /* ZMOTRMessage+FailedToSendReason.swift */,
 				CE4EDC0A1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift */,
 				CB1BF6FB2C8AF6A5001EC670 /* ExpirationReason+Description.swift */,
+				CB3437002DF3283E007CFB34 /* MultipartMessageData.swift */,
 			);
 			path = Message;
 			sourceTree = "<group>";
@@ -4100,6 +4106,7 @@
 				63B74CBD2AE1715000A73006 /* ProteusToMLSMigrationCoordinator.swift in Sources */,
 				591942B62B6A4B4D0000B390 /* UserObserving.swift in Sources */,
 				014DD8D42B6D1FF6007ECFD1 /* UUID+SafeLogging.swift in Sources */,
+				CB3437012DF32846007CFB34 /* MultipartMessageData.swift in Sources */,
 				BF1B98041EC313C600DE033B /* Team.swift in Sources */,
 				A90676E7238EAE8B006417AC /* ParticipantRole.swift in Sources */,
 				165124D82189AE90006A3C75 /* ZMAssetClientMessage+Quotes.swift in Sources */,
@@ -4534,6 +4541,7 @@
 				C9D574D32CEF630500012A0E /* TypingUsers.swift in Sources */,
 				BF10B58B1E6432ED00E7036E /* Message.swift in Sources */,
 				59F4B6F22B87563E00AC84B1 /* IsUserE2EICertifiedUseCaseProtocol.swift in Sources */,
+				CB3437032DF329D2007CFB34 /* ZMClientMessage+MultipartMessageData.swift in Sources */,
 				E6E504342BC542C5004948E7 /* BaseEARKeyDescription.swift in Sources */,
 				BF491CE81F063EEB0055EE44 /* AccountManager.swift in Sources */,
 				060C06612B73D9D400B484C6 /* E2EIActivationRepository.swift in Sources */,

--- a/wire-ios/Tests/Mocks/MockMessage.swift
+++ b/wire-ios/Tests/Mocks/MockMessage.swift
@@ -395,6 +395,8 @@ class MockMessage: NSObject, ZMConversationMessage, ConversationCompositeMessage
         backingLocationMessageData
     }
 
+    var multipartMessageData: MultipartMessageData?
+
     var textMessageData: TextMessageData? {
         backingTextMessageData
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/MultipartMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/MultipartMessageCellDescription.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+import WireDataModel
+
+// TODO: [WPB-16311] Implement fully
+/// A description for a multipart message cell.
+
+final class MultipartMessageCellDescription: ConversationMessageCellDescription {
+    typealias View = ConversationTextMessageCell
+    let configuration: ConversationTextMessageCell.Configuration
+
+    weak var message: ZMConversationMessage?
+    weak var delegate: ConversationMessageCellDelegate?
+    weak var actionController: ConversationMessageActionController?
+
+    let accessibilityIdentifier: String? = nil
+    let accessibilityLabel: String?
+
+    let containsHighlightableContent = false
+
+    init(data: MultipartMessageData) {
+        var message = "Multipart message with \(data.attachments.count) attachments"
+        for attachment in data.attachments {
+            message.append("\n - \(attachment.fileName)")
+        }
+
+        self.configuration = .init(
+            attributedText: NSAttributedString.markdown(from: message, style: NSAttributedString.style),
+            isObfuscated: false
+        )
+        self.accessibilityLabel = message
+    }
+}

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -217,6 +217,8 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             addFileMessageCell()
         } else if message.isSystem {
             addSystemMessageCell()
+        } else if message.isMultipart {
+            addMultipartMessageCell()
         } else {
             addUnknownMessageCell()
         }
@@ -352,6 +354,13 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             accentColor: (selfUser.zmAccentColor ?? .default).accentColor.uiColor,
             userSession: userSession
         )
+    }
+
+    private func addMultipartMessageCell() -> [AnyConversationMessageCellDescription] {
+        guard let data = message.multipartMessageData else { return [] }
+
+        let cellDescription = MultipartMessageCellDescription(data: data)
+        return [AnyConversationMessageCellDescription(cellDescription)]
     }
 
     private func addUnknownMessageCell() -> [AnyConversationMessageCellDescription] {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16311" title="WPB-16311" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16311</a>  [iOS] Integrate WireCells documents previews in conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Wire cells introduces a new message type - multipart - which can include text and and an array of file attachments. This PR introduces some code for handling this, which just prints a dummy message for development purposes. 

<img width="485" alt="Screenshot 2025-06-11 at 16 50 53" src="https://github.com/user-attachments/assets/a8e02465-ccf1-45d5-834d-bf9ceb73f842" />

Wire cells is not yet released so these kind of messages won't be seen in production.

### Testing

Not currently manually testable.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
