### PR TITLE
chore: cherry pick conversation background - WPB-18147

### DIFF
--- a/WireUI/Sources/WireDesign/Colors/SemanticColors.swift
+++ b/WireUI/Sources/WireDesign/Colors/SemanticColors.swift
@@ -169,6 +169,14 @@ public enum SemanticColors {
         public static let backgroundAudioViewOverlay = UIColor(light: .gray20, dark: .gray100)
         public static let backgroundAudioViewOverlayActive = UIColor(light: .white, dark: .gray95)
 
+        // Conversation background based on primary color
+
+        public static let conversationBackgroundBlue = UIColor(light: .blue50Light, dark: .blue900Dark)
+        public static let conversationBackgroundGreen = UIColor(light: .green50Light, dark: .green900Dark)
+        public static let conversationBackgroundPurple = UIColor(light: .purple50Light, dark: .purple900Dark)
+        public static let conversationBackgroundAmber = UIColor(light: .amber50Light, dark: .amber900Dark)
+        public static let conversationBackgroundRed = UIColor(light: .red50Light, dark: .red900Dark)
+        public static let conversationBackgroundTurquoise = UIColor(light: .turquoise50Light, dark: .turquoise900Dark)
     }
 
     public enum TabBar {

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_Federated.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_Federated.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a45fe62eb1e28357bd28d06c0726c7da4ca9cc26a2a36787a37013eb7a9f53b
-size 213366
+oid sha256:d5d3e93576b5e89d89da601549c842faeb619db3696a4d3535441685097b7aa5
+size 212356

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_Federated.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_Federated.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bcd190fbe2b047bfc3679cc708633f65115e71567a8eb4fa12b94092300b5539
-size 200508
+oid sha256:1a45fe62eb1e28357bd28d06c0726c7da4ca9cc26a2a36787a37013eb7a9f53b
+size 213366

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_NotFederated.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_NotFederated.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09d7d4a0528955149ebc8d4686329b0a4b749daa36edf169a8cb6099ee80cb06
-size 201181
+oid sha256:2ac21a0c23622d16a6c6599ede666626da3f9ff2fdcb16248251386bb351b672
+size 222558

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_NotFederated.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForAccountGroup_NotFederated.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ac21a0c23622d16a6c6599ede666626da3f9ff2fdcb16248251386bb351b672
-size 222558
+oid sha256:51ac68006c9b534004942ff86ba744e13416e4fb3afb2361eb14b557742a7f7e
+size 219848

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForOptionsGroupFullTableView.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/SettingsTableViewControllerSnapshotTests/testForOptionsGroupFullTableView.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a32fbba4029071f612173d4c65bcb82ea0ca8a1ebfd16fb9faa8b12f707dddc4
-size 403832
+oid sha256:35afbafc153833ebc702fa7335eb755e816d7c0281ba5b9e87975b565386f0cd
+size 403899

--- a/wire-ios/Wire-iOS Tests/UserConnectionViewSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/UserConnectionViewSnapshotTests.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireDesign
 import WireTestingPackage
 import XCTest
 
@@ -74,7 +75,7 @@ final class UserConnectionViewSnapshotTests: XCTestCase {
 
         let connectionView = UserConnectionView(user: mockUser)
         connectionView.layoutForTest()
-
+        connectionView.backgroundColor = SemanticColors.View.backgroundConversationView
         return connectionView
     }
 

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5265,8 +5265,8 @@ internal enum L10n {
           }
         }
         internal enum AccountAppearanceGroup {
-          /// Your conversations will use a background based on your Profile color, with an accessible shade for light & dark mode.
-          internal static let footer = L10n.tr("Localizable", "self.settings.account_appearance_group.footer", fallback: "Your conversations will use a background based on your Profile color, with an accessible shade for light & dark mode.")
+          /// When this is on, your conversations show a background based on your profile color and light or dark theme.
+          internal static let footer = L10n.tr("Localizable", "self.settings.account_appearance_group.footer", fallback: "When this is on, your conversations show a background based on your profile color and light or dark theme.")
           /// Appearance
           internal static let title = L10n.tr("Localizable", "self.settings.account_appearance_group.title", fallback: "Appearance")
         }

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5265,6 +5265,8 @@ internal enum L10n {
           }
         }
         internal enum AccountAppearanceGroup {
+          /// Your conversations will use a background based on your Profile color, with an accessible shade for light & dark mode.
+          internal static let footer = L10n.tr("Localizable", "self.settings.account_appearance_group.footer", fallback: "Your conversations will use a background based on your Profile color, with an accessible shade for light & dark mode.")
           /// Appearance
           internal static let title = L10n.tr("Localizable", "self.settings.account_appearance_group.title", fallback: "Appearance")
         }
@@ -5356,6 +5358,10 @@ internal enum L10n {
             internal static let takePicture = L10n.tr("Localizable", "self.settings.account_picture_group.alert.take_picture", fallback: "Take Photo")
             /// Change your profile picture
             internal static let title = L10n.tr("Localizable", "self.settings.account_picture_group.alert.title", fallback: "Change your profile picture")
+          }
+          internal enum Background {
+            /// Conversation background color
+            internal static let title = L10n.tr("Localizable", "self.settings.account_picture_group.background.title", fallback: "Conversation background color")
           }
         }
         internal enum AccountSection {

--- a/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
+++ b/wire-ios/Wire-iOS/Resources/Configuration/Version.xcconfig
@@ -16,5 +16,5 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-WIRE_SHORT_VERSION = 3.124.0
+WIRE_SHORT_VERSION = 3.124.1
 MAJOR_VERSION = 3

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1329,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Previews may still be shown for links from other people.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Devices";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Wrong password";
 
 "self.settings.account_appearance_group.title" = "Appearance";
+"self.settings.account_appearance_group.footer" = "Your conversations will use a background based on your Profile color, with an accessible shade for light & dark mode.";
 
 "self.settings.privacy_section_group.title" = "Privacy";
 "self.settings.enable_read_receipts.title" = "Send Read Receipts";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Personal Information";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1158,7 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Wrong password";
 
 "self.settings.account_appearance_group.title" = "Appearance";
-"self.settings.account_appearance_group.footer" = "Your conversations will use a background based on your Profile color, with an accessible shade for light & dark mode.";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privacy";
 "self.settings.enable_read_receipts.title" = "Send Read Receipts";

--- a/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "كلمة مرور خاطئة";
 
 "self.settings.account_appearance_group.title" = "المظهر";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "الخصوصية";
 "self.settings.enable_read_receipts.title" = "إرسال إيصالات بالقراءة";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "معلومات شخصية";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "قد تظهر المعاينات للروابط من الأشخاص الآخرين.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "الأجهزة";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Forkert adgangskode";
 
 "self.settings.account_appearance_group.title" = "Udseende";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privatliv";
 "self.settings.enable_read_receipts.title" = "Send Read Receipts";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Personal Information";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Previews kan stadig blive vist for link fra andre.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Enheder";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Falsches Passwort";
 
 "self.settings.account_appearance_group.title" = "Erscheinungsbild";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Datenschutz";
 "self.settings.enable_read_receipts.title" = "Lesebestätigungen senden";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Bernstein";
 "self.settings.account_picture_group.accent_color.turquoise" = "Türkis";
 "self.settings.account_picture_group.accent_color.purple" = "Lila";
+"self.settings.account_picture_group.background.title" = "Hintergrundfarbe für Unterhaltungen";
 
 "self.settings.account_personal_information_group.title" = "Persönliche Informationen";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Vorschauen für Links von anderen Personen können weiterhin angezeigt werden.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Meine Nachrichten ausblenden";
-"self.settings.privacy_security.collapse_own_messages.footer" = "Wenn diese Option aktiviert ist, werden all Ihre Nachrichten bis auf eine Zeile ausgeblendet.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "Wenn diese Option aktiviert ist, werden all Ihre Nachrichten nach drei Zeilen ausgeblendet.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Geräte";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Contraseña incorrecta";
 
 "self.settings.account_appearance_group.title" = "Aspecto";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privacidad";
 "self.settings.enable_read_receipts.title" = "Send Read Receipts";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Información Personal";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Las vistas previas todavía pueden mostrarse para enlaces de otras personas.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Dispositivos";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Vale parool";
 
 "self.settings.account_appearance_group.title" = "Välimus";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privaatsus";
 "self.settings.enable_read_receipts.title" = "Saada lugemiskinnitusi";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Isikuandmed";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Eelvaateid võidakse siiski näidata teiste saadetud linkide puhul.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Seadmed";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Väärä salasana";
 
 "self.settings.account_appearance_group.title" = "Ulkoasu";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Tietosuoja";
 "self.settings.enable_read_receipts.title" = "Send Read Receipts";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Personal Information";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Esikatselut saattavat silti näkyä muiden lähettämissä linkeissä.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Laitteet";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Mot de passe incorrect";
 
 "self.settings.account_appearance_group.title" = "Apparence";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Confidentialité";
 "self.settings.enable_read_receipts.title" = "Envoyer des Accusés de Lecture";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Ambre";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Violet";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Données Personnelles";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Les aperçus peuvent toujours s'afficher pour les liens venant d'autres contacts.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Appareils";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Password errata";
 
 "self.settings.account_appearance_group.title" = "Aspetto";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privacy";
 "self.settings.enable_read_receipts.title" = "Invia conferme di lettura";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Informazioni personali";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "È possibile che vengano comunque mostrate delle anteprime per i link inviati dagli altri utenti.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Dispositivi";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "パスワードが間違っています";
 
 "self.settings.account_appearance_group.title" = "外観";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "プライバシー";
 "self.settings.enable_read_receipts.title" = "開封通知を送信";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "黄";
 "self.settings.account_picture_group.accent_color.turquoise" = "青緑";
 "self.settings.account_picture_group.accent_color.purple" = "紫";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "個人情報";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "他ユーザーからのリンクがプレビュー表示されれます";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "デバイス";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Neteisingas slaptažodis";
 
 "self.settings.account_appearance_group.title" = "Išvaizda";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privatumas";
 "self.settings.enable_read_receipts.title" = "Siųsti perskaitymo patvirtinimus";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Asmeninė informacija";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Kitų žmonių siunčiamų nuorodų peržiūros vis dar gali būti rodomos.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Įrenginiai";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Verkeerd wachtwoord";
 
 "self.settings.account_appearance_group.title" = "Vormgeving";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Privacy";
 "self.settings.enable_read_receipts.title" = "Stuur met leesbevestigingen";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Persoonlijke informatie";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Linkvoorbeelden kunnen nog steeds getoond worden voor links van andere mensen.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Apparaten";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Hasło nieprawidłowe";
 
 "self.settings.account_appearance_group.title" = "Wygląd";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Prywatność";
 "self.settings.enable_read_receipts.title" = "Wyświetlaj potwierdzenie przeczytania";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Bursztynowy";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turkusowy";
 "self.settings.account_picture_group.accent_color.purple" = "Fioletowy";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Twoje dane";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Podglądy linków otrzymanych od innych osób mogą być nadal wyświetlane.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Urządzenia";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Senha errada";
 
 "self.settings.account_appearance_group.title" = "Aparência";
+"self.settings.account_appearance_group.footer" = "Quando isso está ativado, as suas conversas mostram um fundo baseado na cor do seu perfil e tema claro ou escuro.";
 
 "self.settings.privacy_section_group.title" = "Privacidade";
 "self.settings.enable_read_receipts.title" = "Enviar Confirmações de Leitura";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Âmbar";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquês";
 "self.settings.account_picture_group.accent_color.purple" = "Roxo";
+"self.settings.account_picture_group.background.title" = "Cor do fundo da conversa";
 
 "self.settings.account_personal_information_group.title" = "Informações Pessoais";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Pré-Visualizações ainda serão mostradas para links de outras pessoas.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Recolher minhas mensagens";
-"self.settings.privacy_security.collapse_own_messages.footer" = "Quando isso está ativado, todas as suas mensagens são recolhidas numa única linha.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "Quando isto está ativado, suas mensagens colapsam ao fim de três linhas.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Dispositivos";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Неверный пароль";
 
 "self.settings.account_appearance_group.title" = "Внешний вид";
+"self.settings.account_appearance_group.footer" = "Когда эта функция включена, фон ваших бесед будет соответствовать цвету вашего профиля, а также светлой или темной теме.";
 
 "self.settings.privacy_section_group.title" = "Конфиденциальность";
 "self.settings.enable_read_receipts.title" = "Отправлять отчеты о прочтении";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Янтарный";
 "self.settings.account_picture_group.accent_color.turquoise" = "Бирюзовый";
 "self.settings.account_picture_group.accent_color.purple" = "Фиолетовый";
+"self.settings.account_picture_group.background.title" = "Цвет фона беседы";
 
 "self.settings.account_personal_information_group.title" = "Личные данные";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Эта опция не влияет на предварительный просмотр ссылок от других пользователей.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Свернуть мои сообщения";
-"self.settings.privacy_security.collapse_own_messages.footer" = "Когда эта функция включена, все ваши сообщения сворачиваются в одну строку.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "Когда эта функция включена, все ваши сообщения сворачиваются после трех строк.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Устройства";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Napačno geslo";
 
 "self.settings.account_appearance_group.title" = "Videz";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Zasebnost";
 "self.settings.enable_read_receipts.title" = "Send Read Receipts";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Personal Information";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Predogledi se še vedno lahko prikazujejo za povezave drugih ljudi.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Naprave";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Yanlış parola";
 
 "self.settings.account_appearance_group.title" = "Görünüm";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Gizlilik";
 "self.settings.enable_read_receipts.title" = "Okundu Bilgisi Gönder";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Kişisel Bilgiler";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Ön izlemeler hala başkalarından gelen bağlantılar için görüntülenebilir olabilir.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Cihazlar";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "Невірний пароль";
 
 "self.settings.account_appearance_group.title" = "Оформлення";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "Політики конфіденційності";
 "self.settings.enable_read_receipts.title" = "Надсилати звіти про перегляд";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "Особисті дані";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "Дана опція не впливає на попередній перегляд лінків від інших людей.";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "Пристрої";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "错误的密码";
 
 "self.settings.account_appearance_group.title" = "外观";
+"self.settings.account_appearance_group.footer" = "启用此项后，您的对话将根据您的个人资料颜色和明暗主题显示背景。";
 
 "self.settings.privacy_section_group.title" = "隐私";
 "self.settings.enable_read_receipts.title" = "发送已读回执";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "琥珀";
 "self.settings.account_picture_group.accent_color.turquoise" = "青绿";
 "self.settings.account_picture_group.accent_color.purple" = "紫";
+"self.settings.account_picture_group.background.title" = "对话背景颜色";
 
 "self.settings.account_personal_information_group.title" = "个人资料";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "仍会为其他人的链接显示预览";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "折叠我的消息";
-"self.settings.privacy_security.collapse_own_messages.footer" = "如果开启此项，您所有的消息均被折叠到一行。";
+"self.settings.privacy_security.collapse_own_messages.footer" = "启用此项后，所有消息将在三行后折叠。";
 
 "self.settings.privacy_analytics_menu.devices.title" = "设备";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -1158,6 +1158,7 @@
 "self.settings.account_details.remove_device.password.error" = "錯誤的密碼";
 
 "self.settings.account_appearance_group.title" = "外觀";
+"self.settings.account_appearance_group.footer" = "When this is on, your conversations show a background based on your profile color and light or dark theme.";
 
 "self.settings.privacy_section_group.title" = "隱私設定";
 "self.settings.enable_read_receipts.title" = "傳送讀取回條";
@@ -1176,6 +1177,7 @@
 "self.settings.account_picture_group.accent_color.amber" = "Amber";
 "self.settings.account_picture_group.accent_color.turquoise" = "Turquoise";
 "self.settings.account_picture_group.accent_color.purple" = "Purple";
+"self.settings.account_picture_group.background.title" = "Conversation background color";
 
 "self.settings.account_personal_information_group.title" = "個人資訊";
 
@@ -1327,7 +1329,7 @@
 "self.settings.privacy_security.disable_link_previews.footer" = "其他人的連結預覽可能會顯示出來";
 
 "self.settings.privacy_security.collapse_own_messages.title" = "Collapse my messages";
-"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse to a single line.";
+"self.settings.privacy_security.collapse_own_messages.footer" = "When this is on, all your messages collapse after three lines.";
 
 "self.settings.privacy_analytics_menu.devices.title" = "設備";
 

--- a/wire-ios/Wire-iOS/Sources/Components/AccentColorChangeHandler.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/AccentColorChangeHandler.swift
@@ -21,7 +21,7 @@ import WireSyncEngine
 
 final class AccentColorChangeHandler: UserObserving {
 
-    typealias AccentColorChangeHandlerBlock = (_ newColor: UIColor?, _ observer: NSObjectProtocol?) -> Void
+    typealias AccentColorChangeHandlerBlock = (_ newColor: ZMAccentColor?, _ observer: NSObjectProtocol?) -> Void
     private var handlerBlock: AccentColorChangeHandlerBlock?
     private var observer: NSObjectProtocol?
     private var userObserverToken: NSObjectProtocol?
@@ -49,7 +49,7 @@ final class AccentColorChangeHandler: UserObserving {
 
     func userDidChange(_ change: UserChangeInfo) {
         if change.accentColorValueChanged {
-            handlerBlock?(change.user.accentColor, observer)
+            handlerBlock?(change.user.zmAccentColor, observer)
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Settings/SettingsPropertyFactory.swift
@@ -19,6 +19,7 @@
 import avs
 import WireCommonComponents
 import WireFoundation
+import WireLogging
 import WireSyncEngine
 import WireUtilities
 
@@ -423,7 +424,10 @@ final class SettingsPropertyFactory {
             )
 
         case .collapseOwnMessages:
-            let userId = selfUser!.remoteIdentifier!
+            guard let userId = selfUser?.remoteIdentifier else {
+                WireLogger.system.error("No self user for settings key \(propertyName)")
+                break
+            }
             let storage = PrivateUserDefaults<CollapseKey>(userID: userId)
             return SettingsBlockProperty(
                 propertyName: propertyName,
@@ -433,6 +437,23 @@ final class SettingsPropertyFactory {
                 setAction: { _, value, _ in
                     guard case let .number(enabled) = value else { return }
                     storage.set(enabled.boolValue, forKey: .collapseOwnMessages)
+                }
+            )
+
+        case .conversationBackground:
+            guard let userId = selfUser?.remoteIdentifier else {
+                WireLogger.system.error("No self user for settings key \(propertyName)")
+                break
+            }
+            let storage = PrivateUserDefaults<ConversationBackgroundKey>(userID: userId)
+            return SettingsBlockProperty(
+                propertyName: propertyName,
+                getAction: { _ in
+                    SettingsPropertyValue(storage.bool(forKey: .conversationBackground))
+                },
+                setAction: { _, value, _ in
+                    guard case let .number(enabled) = value else { return }
+                    storage.set(enabled.boolValue, forKey: .conversationBackground)
                 }
             )
 
@@ -452,4 +473,8 @@ final class SettingsPropertyFactory {
 
 enum CollapseKey: String, DefaultsKey {
     case collapseOwnMessages
+}
+
+enum ConversationBackgroundKey: String, DefaultsKey {
+    case conversationBackground
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConnectRequests/UserConnectionView.swift
@@ -62,7 +62,7 @@ final class UserConnectionView: UIView, Copyable {
 
     private func setup() {
         labelContainer.spacing = 0.0
-        backgroundColor = SemanticColors.View.backgroundConversationView
+        backgroundColor = .clear
         [firstLabel, secondLabel].forEach {
             $0.numberOfLines = 0
             $0.textAlignment = .center

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -227,6 +227,11 @@ extension ConversationMessageCellDescription {
         cell.cellView.delegate = delegate
         cell.cellView.message = message
         cell.cellView.actionController = actionController
+        if let message {
+            // sometimes action controller still has background context message
+            // so re-set message from main context to avoid crash
+            actionController?.message = message
+        }
         cell.accessibilityCustomActions = actionController?.makeAccessibilityActions()
         return cell
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -20,6 +20,7 @@ import UIKit
 import WireCommonComponents
 import WireDataModel
 import WireDesign
+import WireFoundation
 import WireLogging
 import WireMainNavigationUI
 import WireRequestStrategy
@@ -71,6 +72,8 @@ final class ConversationContentViewController: UIViewController {
         return button
     }()
 
+    private let userDefaults: PrivateUserDefaults<ConversationBackgroundKey>
+
     let tableView: UpsideDownTableView = .init(frame: .zero, style: .plain)
     let bottomContainer: UIView = .init(frame: .zero)
     var searchQueries: [String]? {
@@ -117,6 +120,7 @@ final class ConversationContentViewController: UIViewController {
     private(set) lazy var activityIndicator = BlockingActivityIndicator(view: view)
 
     private let logger: WireLogger
+    private var accentColorChangeHandler: AccentColorChangeHandler?
 
     init(
         conversation: ZMConversation,
@@ -124,7 +128,8 @@ final class ConversationContentViewController: UIViewController {
         mediaPlaybackManager: MediaPlaybackManager?,
         userSession: UserSession,
         mainCoordinator: AnyMainCoordinator,
-        selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol
+        selfProfileUIBuilder: SelfProfileViewControllerBuilderProtocol,
+        userDefaults: UserDefaultsProtocol = UserDefaults.standard
     ) {
         self.messagePresenter = MessagePresenter(mediaPlaybackManager: mediaPlaybackManager)
         self.userSession = userSession
@@ -133,6 +138,10 @@ final class ConversationContentViewController: UIViewController {
         self.conversation = conversation
         self.messageVisibleOnLoad = message ?? conversation.firstUnreadMessage
         self.logger = .conversation
+        self.userDefaults = PrivateUserDefaults<ConversationBackgroundKey>(
+            userID: userSession.selfUser.remoteIdentifier,
+            storage: userDefaults
+        )
 
         super.init(nibName: nil, bundle: nil)
 
@@ -231,9 +240,6 @@ final class ConversationContentViewController: UIViewController {
         tableView.keyboardDismissMode = AutomationHelper.sharedHelper
             .disableInteractiveKeyboardDismissal ? .none : .interactive
 
-        tableView.backgroundColor = SemanticColors.View.backgroundConversationView
-        view.backgroundColor = SemanticColors.View.backgroundConversationView
-
         setupMentionsResultsView()
 
         NotificationCenter.default.addObserver(
@@ -249,6 +255,25 @@ final class ConversationContentViewController: UIViewController {
             name: ZMConversation.failedToSendMessageNotificationName,
             object: .none
         )
+
+        updateBackgroundColor(color: userSession.selfUser.zmAccentColor)
+
+        accentColorChangeHandler = AccentColorChangeHandler
+            .addObserver(self, userSession: userSession) { [unowned self] color, _ in
+                updateBackgroundColor(color: color)
+            }
+    }
+
+    private func updateBackgroundColor(color: ZMAccentColor?) {
+        func set(color: UIColor) {
+            tableView.backgroundColor = color
+            view.backgroundColor = color
+        }
+        guard let color, userDefaults.bool(forKey: .conversationBackground) else {
+            set(color: SemanticColors.View.backgroundConversationView)
+            return
+        }
+        set(color: color.accentColor.conversationBackgroundColor)
     }
 
     @objc
@@ -712,4 +737,23 @@ private extension UIAlertController {
         topmostViewController?.present(alertController, animated: true)
     }
 
+}
+
+extension AccentColor {
+    var conversationBackgroundColor: UIColor {
+        switch self {
+        case .blue:
+            SemanticColors.View.conversationBackgroundBlue
+        case .purple:
+            SemanticColors.View.conversationBackgroundPurple
+        case .green:
+            SemanticColors.View.conversationBackgroundGreen
+        case .amber:
+            SemanticColors.View.conversationBackgroundAmber
+        case .red:
+            SemanticColors.View.conversationBackgroundRed
+        case .turquoise:
+            SemanticColors.View.conversationBackgroundTurquoise
+        }
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -323,7 +323,7 @@ final class ConversationContentViewController: UIViewController {
         messagePresenter.modalTargetController = parent
 
         updateHeaderHeight()
-
+        updateBackgroundColor(color: userSession.selfUser.zmAccentColor)
         setNeedsStatusBarAppearanceUpdate()
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordKeyboardViewController.swift
@@ -142,7 +142,7 @@ final class AudioRecordKeyboardViewController: UIViewController, AudioRecordBase
         accentColorChangeHandler = AccentColorChangeHandler
             .addObserver(self, userSession: userSession) { [unowned self] color, _ in
                 if let color {
-                    audioPreviewView.color = color
+                    audioPreviewView.color = color.accentColor.uiColor
                 }
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/AudioRecordViewController.swift
@@ -157,7 +157,7 @@ final class AudioRecordViewController: UIViewController, AudioRecordBaseViewCont
         accentColorChangeHandler = AccentColorChangeHandler
             .addObserver(self, userSession: userSession) { [unowned self] color, _ in
                 if let color {
-                    audioPreviewView.color = color
+                    audioPreviewView.color = color.accentColor.uiColor
                 }
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -289,6 +289,8 @@ extension SettingsPropertyName {
             return SoundMenu.Ping.title
         case .accentColor:
             return Settings.AccountPictureGroup.color
+        case .conversationBackground:
+            return Settings.AccountPictureGroup.Background.title
         case .disableSendButton:
             return Settings.PopularDemand.SendButton.title
         case .disableCallKit:

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -131,8 +131,13 @@ extension SettingsCellDescriptorFactory {
 
     private func appearanceSection() -> SettingsSectionDescriptorType {
         SettingsSectionDescriptor(
-            cellDescriptors: [pictureElement(), colorElement()],
-            header: L10n.Localizable.Self.Settings.AccountAppearanceGroup.title
+            cellDescriptors: [
+                pictureElement(),
+                colorElement(),
+                conversationBackgroundEnabledElement()
+            ],
+            header: L10n.Localizable.Self.Settings.AccountAppearanceGroup.title,
+            footer: L10n.Localizable.Self.Settings.AccountAppearanceGroup.footer
         )
     }
 
@@ -328,6 +333,16 @@ extension SettingsCellDescriptorFactory {
             presentationStyle: .navigation,
             presentationAction: colorElementPresentationAction,
             settingsCoordinator: settingsCoordinator
+        )
+    }
+
+    func conversationBackgroundEnabledElement() -> any SettingsCellDescriptorType {
+
+        SettingsPropertyToggleCellDescriptor(
+            settingsProperty:
+            settingsPropertyFactory.property(.conversationBackground),
+            inverse: false,
+            identifier: "ConversationBackgroundSwitch"
         )
     }
 

--- a/wire-ios/WireCommonComponents/SettingsPropertyName.swift
+++ b/wire-ios/WireCommonComponents/SettingsPropertyName.swift
@@ -79,6 +79,8 @@ public enum SettingsPropertyName: String, CustomStringConvertible {
 
     case encryptMessagesAtRest
 
+    case conversationBackground
+
     public var changeNotificationName: String {
         description + "ChangeNotification"
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18147" title="WPB-18147" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18147</a>  [iOS] background color changes not in prod 3.124 - merge it and release a hot fix
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR cherry-picks commits and a few more localization changes from:
- https://github.com/wireapp/wire-ios/pull/2979
- https://github.com/wireapp/wire-ios/pull/3032
- https://github.com/wireapp/wire-ios/pull/3013

### Testing

In the settings there is a toggle for showing a background color in the conversation screen.
Also the color should change when changing the accent color.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
