### PR TITLE
fix: missing sync bar - WPB-17717

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1137,6 +1137,16 @@ extension ZMUserSession: SyncAgentDelegate {
         syncContext.performGroupedBlock { [weak self] in
             guard let self else { return }
             WireLogger.sync.debug("did finish incremental sync")
+
+            func showSyncBar(_ show: Bool) {
+                managedObjectContext.performGroupedBlock { [weak self] in
+                    self?.isPerformingSync = show
+                    self?.updateNetworkState()
+                }
+            }
+
+            showSyncBar(true)
+
             processLegacyEvents()
 
             NotificationInContext(
@@ -1146,7 +1156,7 @@ extension ZMUserSession: SyncAgentDelegate {
 
             guard !isRecovering else {
                 // in case of recovery, we don't need more
-                return
+                return showSyncBar(false)
             }
 
             WaitingGroupTask(context: syncContext) { [weak self] in
@@ -1179,6 +1189,8 @@ extension ZMUserSession: SyncAgentDelegate {
 
                 await calculateSelfSupportedProtocolsIfNeeded()
                 await resolveOneOnOneConversationsIfNeeded()
+
+                showSyncBar(false)
             }
 
             recurringActionService.performActionsIfNeeded()
@@ -1278,11 +1290,6 @@ extension ZMUserSession: SyncAgentDelegate {
     }
 
     func processLegacyEvents() {
-        managedObjectContext.performGroupedBlock { [weak self] in
-            self?.isPerformingSync = true
-            self?.updateNetworkState()
-        }
-
         let groups = syncContext.enterAllGroupsExceptSecondary()
         Task {
             var processingInterrupted = false
@@ -1302,10 +1309,6 @@ extension ZMUserSession: SyncAgentDelegate {
                 }
             }
 
-            await managedObjectContext.perform { [weak self] in
-                self?.isPerformingSync = isSyncing || processingInterrupted
-                self?.updateNetworkState()
-            }
             self.syncContext.leaveAllGroups(groups)
         }
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1292,7 +1292,7 @@ extension ZMUserSession: SyncAgentDelegate {
         guard !journal[.isSyncV2Enabled] else {
             return
         }
-        
+
         managedObjectContext.performGroupedBlock { [weak self] in
             self?.isPerformingSync = true
             self?.updateNetworkState()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1147,8 +1147,6 @@ extension ZMUserSession: SyncAgentDelegate {
 
             showSyncBar(true)
 
-            processLegacyEvents()
-
             NotificationInContext(
                 name: .quickSyncCompletedNotification,
                 context: notificationContext
@@ -1190,6 +1188,7 @@ extension ZMUserSession: SyncAgentDelegate {
                 await calculateSelfSupportedProtocolsIfNeeded()
                 await resolveOneOnOneConversationsIfNeeded()
 
+                // TODO: [WPB-18175] Port MLS client creation and related MLS operations from here to the InitialSync
                 showSyncBar(false)
             }
 
@@ -1290,6 +1289,15 @@ extension ZMUserSession: SyncAgentDelegate {
     }
 
     func processLegacyEvents() {
+        guard !journal[.isSyncV2Enabled] else {
+            return
+        }
+        
+        managedObjectContext.performGroupedBlock { [weak self] in
+            self?.isPerformingSync = true
+            self?.updateNetworkState()
+        }
+
         let groups = syncContext.enterAllGroupsExceptSecondary()
         Task {
             var processingInterrupted = false
@@ -1309,6 +1317,10 @@ extension ZMUserSession: SyncAgentDelegate {
                 }
             }
 
+            await managedObjectContext.perform { [weak self] in
+                self?.isPerformingSync = isSyncing || processingInterrupted
+                self?.updateNetworkState()
+            }
             self.syncContext.leaveAllGroups(groups)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17717" title="WPB-17717" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17717</a>  [iOS] Sync bar missing with new Sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**:  Sync bar seems to be missing when the sync is not completely done

**Causes**: When the incremental sync is done, we may have many pending MLS groups to join (see `performPendingJoins()`)  which can take some time to complete however we hide the sync bar too early so it looks like the app is synced and ready to be used whereas we still see group conversations being added and ordered in the conversation list (as shown in the video attached to the ticket and also reproducible on my side)

**Solutions**: Ensure we hide the sync bar only after all these operations are completed (see `func didFinishIncrementalSync(isRecovering: Bool)` in `ZMUserSession`.

### Testing

Not easily reproducible but if you have many pending MLS groups to join, you wouldn't see any sync bar, looking like app is ready to be used but then gradually see group conversations being added to the list.

With the above fix, we do see the sync bar and it hides when all group conversations are there.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.


