### PR TITLE
fix: detecting urls in messages - WPB-18146

### DIFF
--- a/wire-ios-link-preview/WireLinkPreviewTests/NSDataDetectorLinksTests.swift
+++ b/wire-ios-link-preview/WireLinkPreviewTests/NSDataDetectorLinksTests.swift
@@ -19,18 +19,16 @@
 import WireLinkPreview
 import XCTest
 
-class NSDataDetectorLinksTests: XCTestCase {
+final class NSDataDetectorLinksTests: XCTestCase {
 
     var detector: NSDataDetector!
 
     override func setUp() {
-        super.setUp()
         detector = NSDataDetector.linkDetector
     }
 
     override func tearDown() {
         detector = nil
-        super.tearDown()
     }
 
     func testThatItReturnsTheDetectedLinkAndOffsetInAText() {
@@ -119,6 +117,31 @@ class NSDataDetectorLinksTests: XCTestCase {
 
         // then
         XCTAssertEqual(links.count, 1)
+    }
+
+    func testThatDetectLinksRecognizesASingleLink() {
+        // given
+        let text = "https://example.com/?redirect=https://evilsite.com"
+
+        // when
+        let links = detector.detectLinks(in: text)
+
+        // then
+        XCTAssertEqual(links.count, 1)
+        XCTAssertEqual(links.first, URL(string: text))
+    }
+
+    func testThatDetectLinksAndRangesRecognizesASingleLink() {
+        // given
+        let text = "https://example.com/?redirect=https://evilsite.com"
+
+        // when
+        let links = detector.detectLinksAndRanges(in: text)
+
+        // then
+        XCTAssertEqual(links.count, 1)
+        XCTAssertEqual(links.first?.URL, URL(string: text))
+        XCTAssertEqual(links.first?.range, .init(location: 0, length: 50))
     }
 
 }

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5696,8 +5696,8 @@ internal enum L10n {
           /// Lock With Passcode
           internal static let lockApp = L10n.tr("Localizable", "self.settings.privacy_security.lock_app", fallback: "Lock With Passcode")
           internal enum CollapseOwnMessages {
-            /// When this is on, all your messages collapse to a single line.
-            internal static let footer = L10n.tr("Localizable", "self.settings.privacy_security.collapse_own_messages.footer", fallback: "When this is on, all your messages collapse to a single line.")
+            /// When this is on, all your messages collapse after three lines.
+            internal static let footer = L10n.tr("Localizable", "self.settings.privacy_security.collapse_own_messages.footer", fallback: "When this is on, all your messages collapse after three lines.")
             /// Collapse my messages
             internal static let title = L10n.tr("Localizable", "self.settings.privacy_security.collapse_own_messages.title", fallback: "Collapse my messages")
           }

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversationMessage+Reactions.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMConversationMessage+Reactions.swift
@@ -19,6 +19,8 @@
 import Foundation
 import WireDataModel
 
+private let linkDetector = NSDataDetector.linkDetector
+
 extension ZMConversationMessage {
 
     var canAddReaction: Bool {
@@ -58,14 +60,9 @@ extension ZMConversationMessage {
     }
 
     var canVisitLink: Bool {
-        guard let url = URL(
-            string: textMessageData?.linkPreview?.originalURLString ?? textMessageData?.messageText
-                ?? ""
-        ),
-            UIApplication.shared.canOpenURL(url) else {
-            return false
-        }
-        return true
+        let content = textMessageData?.linkPreview?.originalURLString ?? textMessageData?.messageText
+        guard let content, let url = linkDetector?.detectLinks(in: content).first else { return false }
+        return UIApplication.shared.canOpenURL(url)
     }
 
     func selfUserReactions() -> Set<Emoji.ID> {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -247,7 +247,7 @@ extension ArticleView: UIContextMenuInteractionDelegate {
 
 extension LinkMetadata {
 
-    /// Returns a `URL` that can be openened using `openURL()` on `UIApplication` or `nil` if no openable `URL` could be
+    /// Returns a `URL` that can be opened using `openURL()` on `UIApplication` or `nil` if no openable `URL` could be
     /// created.
     var openableURL: URL? {
         let application = UIApplication.shared

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+MessageAction.swift
@@ -180,12 +180,10 @@ extension ConversationContentViewController {
                 useCase.invoke(reaction, for: message, in: self.conversation)
             }
         case .visitLink:
-            if let textMessageData = message.textMessageData,
-               let path = textMessageData.linkPreview?.originalURLString ?? textMessageData.messageText,
-               let url = URL(string: path),
-               UIApplication.shared.canOpenURL(url) {
-                UIApplication.shared.open(url)
-            }
+            let textMessageData = message.textMessageData
+            let content = textMessageData?.linkPreview?.originalURLString ?? textMessageData?.messageText
+            guard let content, let url = linkDetector?.detectLinks(in: content).first else { return }
+            UIApplication.shared.open(url)
         case .collapse:
             dataSource.collapse(message: message)
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -118,6 +118,7 @@ final class ConversationContentViewController: UIViewController {
     private var token: NSObjectProtocol?
 
     private(set) lazy var activityIndicator = BlockingActivityIndicator(view: view)
+    let linkDetector = NSDataDetector.linkDetector
 
     private let logger: WireLogger
     private var accentColorChangeHandler: AccentColorChangeHandler?


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18146" title="WPB-18146" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18146</a>  [sec] Message content being logged in clear text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes the way it is detected if an "Open URL" action is displayed in the long-press context menu of a message.
Instead of passing the content of a message into `URL.init` right away, first a link detection is executed in order to find out if the message contains at least one url/link.
This fixes an issue where contents of text messages are printed into the operating system's log.

### Testing

Observe the log stream of a device and make sure, no message content is printed under any circumstances.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
