### PR TITLE
fix: token-issue - WPB-18218

### DIFF
--- a/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
+++ b/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
@@ -22,25 +22,18 @@ import WireLogging
 
 // sourcery: AutoMockable
 public protocol AuthenticationManagerProtocol {
-
     func getValidAccessToken() async throws -> AccessToken
     func refreshAccessToken() async throws -> AccessToken
-
 }
 
 public actor AuthenticationManager: AuthenticationManagerProtocol {
-
     enum Failure: Error, Equatable {
-
         case invalidCredentials
-
     }
 
     private enum CurrentToken {
-
         case cached(AccessToken)
         case renewing(Task<AccessToken, any Error>)
-
     }
 
     private var currentToken: CurrentToken?
@@ -148,6 +141,13 @@ public actor AuthenticationManager: AuthenticationManagerProtocol {
                 .withAcceptType(.json)
                 .withCookies(cookies)
 
+            if let clientID {
+                requestBuilder = requestBuilder.withQueryItem(
+                    name: "client_id",
+                    value: clientID
+                )
+            }
+
             var request = requestBuilder.build()
 
             if let lastKnownToken {
@@ -165,20 +165,16 @@ public actor AuthenticationManager: AuthenticationManagerProtocol {
                 .parse(code: response.statusCode, data: data)
         }
     }
-
 }
 
 extension AccessToken {
-
     var isExpiring: Bool {
         let secondsRemaining = expirationDate.timeIntervalSinceNow
         return secondsRemaining < 40
     }
-
 }
 
 private struct AccessTokenPayload: Decodable, ToAPIModelConvertible {
-
     let user: UUID
     let accessToken: String
     let tokenType: String
@@ -192,5 +188,4 @@ private struct AccessTokenPayload: Decodable, ToAPIModelConvertible {
             expirationDate: Date(timeIntervalSinceNow: TimeInterval(expiresIn))
         )
     }
-
 }

--- a/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
+++ b/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
@@ -22,18 +22,25 @@ import WireLogging
 
 // sourcery: AutoMockable
 public protocol AuthenticationManagerProtocol {
+
     func getValidAccessToken() async throws -> AccessToken
     func refreshAccessToken() async throws -> AccessToken
+
 }
 
 public actor AuthenticationManager: AuthenticationManagerProtocol {
+
     enum Failure: Error, Equatable {
+
         case invalidCredentials
+
     }
 
     private enum CurrentToken {
+
         case cached(AccessToken)
         case renewing(Task<AccessToken, any Error>)
+
     }
 
     private var currentToken: CurrentToken?
@@ -141,13 +148,6 @@ public actor AuthenticationManager: AuthenticationManagerProtocol {
                 .withAcceptType(.json)
                 .withCookies(cookies)
 
-            if let clientID {
-                requestBuilder = requestBuilder.withQueryItem(
-                    name: "client_id",
-                    value: clientID
-                )
-            }
-
             var request = requestBuilder.build()
 
             if let lastKnownToken {
@@ -165,16 +165,20 @@ public actor AuthenticationManager: AuthenticationManagerProtocol {
                 .parse(code: response.statusCode, data: data)
         }
     }
+
 }
 
 extension AccessToken {
+
     var isExpiring: Bool {
         let secondsRemaining = expirationDate.timeIntervalSinceNow
         return secondsRemaining < 40
     }
+
 }
 
 private struct AccessTokenPayload: Decodable, ToAPIModelConvertible {
+
     let user: UUID
     let accessToken: String
     let tokenType: String
@@ -188,4 +192,5 @@ private struct AccessTokenPayload: Decodable, ToAPIModelConvertible {
             expirationDate: Date(timeIntervalSinceNow: TimeInterval(expiresIn))
         )
     }
+
 }

--- a/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
+++ b/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
@@ -148,13 +148,6 @@ public actor AuthenticationManager: AuthenticationManagerProtocol {
                 .withAcceptType(.json)
                 .withCookies(cookies)
 
-            if let clientID {
-                requestBuilder = requestBuilder.withQueryItem(
-                    name: "client_id",
-                    value: clientID
-                )
-            }
-
             var request = requestBuilder.build()
 
             if let lastKnownToken {

--- a/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
+++ b/WireAPI/Sources/WireAPI/Authentication/AuthenticationManager.swift
@@ -148,6 +148,13 @@ public actor AuthenticationManager: AuthenticationManagerProtocol {
                 .withAcceptType(.json)
                 .withCookies(cookies)
 
+            if let clientID {
+                requestBuilder = requestBuilder.withQueryItem(
+                    name: "client_id",
+                    value: clientID
+                )
+            }
+
             var request = requestBuilder.build()
 
             if let lastKnownToken {

--- a/wire-ios/WireUITests/Helper/UserManager.swift
+++ b/wire-ios/WireUITests/Helper/UserManager.swift
@@ -35,7 +35,7 @@ class UserManager {
         networkStack = NetworkStack(backendEnvironment: .staging, minTLSVersion: .v1_2, cookieEncryptionKey: Data())
         cookieStorage = MockCookieStorage()
         authenticationManager = AuthenticationManager(
-            clientID: "selfClientID",
+            clientID: nil,
             cookieStorage: cookieStorage,
             networkService: networkStack.apiNetworkService,
             onAuthenticationFailure: { @Sendable () in return}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18218" title="WPB-18218" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18218</a>  [QA] Fix authentication issue for existing user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


(https://wearezeta.atlassian.net/browse/WPB-18218)

_Please describe the issue._

passing clientID as nil as not required for accesstoken
![image](https://github.com/user-attachments/assets/96db92dd-b516-4c59-b72d-cdbf35763045)

_Optional: reference dependencies to other pull requests etc._

### Testing

![image](https://github.com/user-attachments/assets/19376baf-5487-405c-b686-9c53cc990e31)

_Optional: attachments like images, videos, etc._

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-18218]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.


[WPB-18218]: https://wearezeta.atlassian.net/browse/WPB-18218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ