### PR TITLE
fix: cross-platform backup file extension - WPB-16658

### DIFF
--- a/wire-ios/Wire-iOS/Wire-Info.plist
+++ b/wire-ios/Wire-iOS/Wire-Info.plist
@@ -188,7 +188,7 @@
 			<dict>
 				<key>public.filename-extension</key>
 				<array>
-					<string>wirebackup</string>
+					<string>wbu</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16658" title="WPB-16658" target="_blank"><img alt="Topic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/15209?size=medium" />WPB-16658</a>  Cross Platform Backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The cross-platform backup file extension has changed from .wirebackup to .wbu.
Manual cherry-pick of PR https://github.com/wireapp/wire-ios/pull/3021

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
