### PR TITLE
fix: prevent logging authentication token - WPB-18207

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationEventResponderChain.swift
@@ -48,7 +48,8 @@ final class AuthenticationEventResponderChain {
 
     /// The supported event types.
 
-    enum EventType {
+    enum EventType: CustomStringConvertible {
+
         case wireAuthenticationModuleComplete(AuthenticationResult)
         case flowStart(NSError?, Int)
         case backupReady(Bool)
@@ -61,6 +62,36 @@ final class AuthenticationEventResponderChain {
         case userProfileChange(UserChangeInfo)
         case userInput(Any)
         case deviceConfigurationComplete
+
+        var description: String {
+            switch self {
+            case .wireAuthenticationModuleComplete:
+                "wireAuthenticationModuleComplete"
+            case .flowStart:
+                "flowStart"
+            case .backupReady:
+                "backupReady"
+            case .clientRegistrationError:
+                "clientRegistrationError"
+            case .clientRegistrationSuccess:
+                "clientRegistrationSuccess"
+            case .authenticationFailure:
+                "authenticationFailure"
+            case .loginCodeAvailable:
+                "loginCodeAvailable"
+            case .registrationError:
+                "registrationError"
+            case .registrationStepSuccess:
+                "registrationStepSuccess"
+            case .userProfileChange:
+                "userProfileChange"
+            case .userInput:
+                "userInput"
+            case .deviceConfigurationComplete:
+                "deviceConfigurationComplete"
+            }
+        }
+
     }
 
     // MARK: - Properties
@@ -182,8 +213,8 @@ final class AuthenticationEventResponderChain {
 
     // MARK: - Event Handling
 
-    /// Call this method to notify the responder chain that a supported event occured.
-    /// - parameter eventType: The type of event that occured, and any required context.
+    /// Call this method to notify the responder chain that a supported event occurred.
+    /// - parameter eventType: The type of event that occurred, and any required context.
 
     func handleEvent(ofType eventType: EventType) {
         if case .userInput = eventType {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18207" title="WPB-18207" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18207</a>  [iOS] authentication token was printed in clear text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Adds `CustomStringConvertible` conformance to control how `AuthenticationEventResponderChain.EventType` is converted to string.
This prevents authentication tokens from being logged.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
