### PR TITLE
fix: restrict to safe public logging - WPB-18207

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -86,7 +86,7 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
                 // This is an issue in some other part of SyncEngine but as a quick fix we will log and abort here.
                 let phaseString = registrationStatus.phase.map { "\($0)" } ?? "<nil>"
                 WireLogger.authentication.error(
-                    "Recieved unsuccessful response for invalid phase (\(phaseString))"
+                    "Received unsuccessful response for invalid phase (\(phaseString))"
                 )
                 return assertionFailure("Error occurs for invalid phase: \(phaseString)")
             }

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/RegistationCredentialVerificationStrategy.swift
@@ -86,8 +86,7 @@ extension RegistationCredentialVerificationStrategy: ZMSingleRequestTranscoder {
                 // This is an issue in some other part of SyncEngine but as a quick fix we will log and abort here.
                 let phaseString = registrationStatus.phase.map { "\($0)" } ?? "<nil>"
                 WireLogger.authentication.error(
-                    "Recieved unsuccessful response for invalid phase (\(phaseString))",
-                    attributes: .safePublic
+                    "Recieved unsuccessful response for invalid phase (\(phaseString))"
                 )
                 return assertionFailure("Error occurs for invalid phase: \(phaseString)")
             }

--- a/wire-ios-transport/Source/Logging/RequestLog.swift
+++ b/wire-ios-transport/Source/Logging/RequestLog.swift
@@ -176,6 +176,10 @@ extension WireLoggerObjC {
 
     @objc(logRequestLoopAtPath:)
     static func logRequestLoop(at path: String) {
-        WireLogger.network.warn("Request loop detected for \(path)", attributes: .safePublic)
+        if let endpointDescription = URL(string: path)?.endpointRemoteLogDescription {
+            WireLogger.network.warn("Request loop detected for \(endpointDescription)", attributes: .safePublic)
+        } else {
+            WireLogger.network.warn("Request loop detected for \(path)")
+        }
     }
 }

--- a/wire-ios/WireCommonComponents/Logging/CocoaLumberjackLogger.swift
+++ b/wire-ios/WireCommonComponents/Logging/CocoaLumberjackLogger.swift
@@ -69,12 +69,11 @@ final class CocoaLumberjackLogger: LoggerProtocol {
             mergedAttributes.merge($0) { _, new in new }
         }
 
-        // TODO: [WPB-6432] enable when ZMSLog is cleaned up
-        // let isSafe = mergedAttributes[.public] as? Bool == true
-        // guard isDebug || isSafe else {
-        //    // skips logs in production builds with non redacted info
-        //    return
-        // }
+        let isSafe = mergedAttributes[.public] as? Bool == true
+        guard isDebug || isSafe else {
+            // skips logs in production builds with non redacted info
+            return
+        }
 
         // Filter logs by level:
         // Only continue if we're running a DEBUG build or


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18207" title="WPB-18207" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18207</a>  [iOS] authentication token was printed in clear text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR attempts to reduce the risk of logging sensible information by enabling the filter for safe-public log messages in CocoaLumberjackLogger.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
