### PR TITLE
fix: nightly CI tests - WPB-18237

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -36,7 +36,7 @@ env: # https://docs.fastlane.tools/getting-started/ios/setup/
   PACKAGES_DIR: ${{ github.workspace }}/DerivedData/CachedSwiftPackages
   UI_TEST_LOGIN_EMAIL: ${{ secrets.UI_TEST_LOGIN_EMAIL }}
   UI_TEST_LOGIN_PASSWORD: ${{ secrets.UI_TEST_LOGIN_PASSWORD }}
-
+  RUN_CRITICAL_FLOWS: ${{ inputs.test_dependencies == false && inputs.branch != 'release/cycle-3.120' && inputs.branch != 'release/cycle-3.124' }} # remove specific branches when not supported anymore
 jobs:
   run-tests:
     name: Run tests
@@ -124,16 +124,16 @@ jobs:
           bundle exec fastlane prepare_for_tests
 
       - name: Install 1Password
-        if: ${{ inputs.test_dependencies == false && github.base_ref != 'release/cycle-3.120' && github.base_ref != 'release/cycle-3.124' }} # remove specific branches when not supported anymore
+        if: ${{ env.RUN_CRITICAL_FLOWS }}
         uses: 1password/install-cli-action@v1
 
       - name: Generate env file
-        if: ${{ inputs.test_dependencies == false && github.base_ref != 'release/cycle-3.120' && github.base_ref != 'release/cycle-3.124' }} # remove specific branches when not supported anymore
+        if: ${{ env.RUN_CRITICAL_FLOWS }}
         run: |
           bundle exec fastlane generate_env
 
       - name: "Test new critical flows"
-        if: ${{ inputs.test_dependencies == false && github.base_ref != 'release/cycle-3.120' && github.base_ref != 'release/cycle-3.124' }} # remove specific branches when not supported anymore
+        if: ${{ env.RUN_CRITICAL_FLOWS }}
         run: |
           bundle exec fastlane run_uitests
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18237" title="WPB-18237" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18237</a>  [iOS] CI nightly tests broken because of missing critical flows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following #3198, this tries to fix the issue with missing critical flows on release branches.

The github.base_ref referred to the wrong branch, this PR uses the passed inputs.branch instead   

### Testing

Can't test until it's merged, needs to trigger nightly tests

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
