### PR TITLE
feat: insert system message when notifications_missed received - WPB-17948

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -392,6 +392,7 @@ public final class ClientSessionComponent {
         pushChannelAPI: pushChannelV2API,
         decryptor: updateEventDecryptor,
         updateEventsStore: updateEventsLocalStore,
+        messageStore: messageLocalStore,
         processor: updateEventProcessor,
         databaseSaver: databaseSaver,
         syncStateSubject: syncStateSubject,

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
@@ -28,6 +28,7 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
     private let pushChannelAPI: any PushChannelV2API
     private let decryptor: any UpdateEventDecryptorProtocol
     private let updateEventsStore: any UpdateEventsLocalStoreProtocol
+    private let messageStore: any MessageLocalStoreProtocol
     private let processor: any UpdateEventProcessorProtocol
     private let databaseSaver: any DatabaseSaverProtocol
     private let syncStateSubject: CurrentValueSubject<SyncState, Never>
@@ -40,6 +41,7 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
         pushChannelAPI: any PushChannelV2API,
         decryptor: any UpdateEventDecryptorProtocol,
         updateEventsStore: any UpdateEventsLocalStoreProtocol,
+        messageStore: any MessageLocalStoreProtocol,
         processor: any UpdateEventProcessorProtocol,
         databaseSaver: any DatabaseSaverProtocol,
         syncStateSubject: CurrentValueSubject<SyncState, Never>,
@@ -49,6 +51,7 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
         self.pushChannelAPI = pushChannelAPI
         self.decryptor = decryptor
         self.updateEventsStore = updateEventsStore
+        self.messageStore = messageStore
         self.processor = processor
         self.databaseSaver = databaseSaver
         self.syncStateSubject = syncStateSubject
@@ -163,7 +166,7 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
                 case .missedEvents:
                     logger.debug("missedEvents event", attributes: .syncAttributes(initialSync: false))
                     await delegate?.didMissedEvents(sync: self)
-                    // TODO: [WPB-17609] insert potential gap message here with messageLocalStore
+                    try await messageStore.addPotentialGapSystemMessage()
                     try await pushChannel.acknowledgeFullSync()
                 case .syncing:
                     // ignore this event, it gives the number of messages until we're caught up

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
@@ -300,7 +300,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
                 Scaffolding.event3
             ].flatMap(\.events)
         )
-        
+
         XCTAssertEqual(messageLocalStore.addPotentialGapSystemMessage_Invocations.count, 1)
         XCTAssertEqual(liveDelegate.didMissedEventsSync_Invocations.count, 1)
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/IncrementalSyncV2Tests.swift
@@ -30,6 +30,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
     var pushChannelAPI: MockPushChannelV2API!
     var decryptor: MockUpdateEventDecryptorProtocol!
     var updateEventsStore: MockUpdateEventsLocalStoreProtocol!
+    var messageLocalStore: MockMessageLocalStoreProtocol!
     var processor: MockUpdateEventProcessorProtocol!
     var databaseSaver: MockDatabaseSaverProtocol!
     var syncStateSubject: CurrentValueSubject<SyncState, Never>!
@@ -40,6 +41,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
         pushChannelAPI = MockPushChannelV2API()
         decryptor = MockUpdateEventDecryptorProtocol()
         updateEventsStore = MockUpdateEventsLocalStoreProtocol()
+        messageLocalStore = MockMessageLocalStoreProtocol()
         processor = MockUpdateEventProcessorProtocol()
         databaseSaver = MockDatabaseSaverProtocol()
         liveDelegate = MockLiveSyncDelegate()
@@ -54,6 +56,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
             pushChannelAPI: pushChannelAPI,
             decryptor: decryptor,
             updateEventsStore: updateEventsStore,
+            messageStore: messageLocalStore,
             processor: processor,
             databaseSaver: databaseSaver,
             syncStateSubject: syncStateSubject,
@@ -70,6 +73,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
         pushChannelAPI = nil
         decryptor = nil
         updateEventsStore = nil
+        messageLocalStore = nil
         processor = nil
         databaseSaver = nil
         syncStateSubject = nil
@@ -213,6 +217,7 @@ final class IncrementalSyncV2Tests: XCTestCase {
 
     func testPerform_AcknowledgementFullSync() async throws {
         // Mock
+        messageLocalStore.addPotentialGapSystemMessage_MockMethod = {}
         let pushChannel = MockPushChannelV2Protocol()
         pushChannel.acknowledgeFullSync_MockMethod = {}
 
@@ -295,7 +300,8 @@ final class IncrementalSyncV2Tests: XCTestCase {
                 Scaffolding.event3
             ].flatMap(\.events)
         )
-
+        
+        XCTAssertEqual(messageLocalStore.addPotentialGapSystemMessage_Invocations.count, 1)
         XCTAssertEqual(liveDelegate.didMissedEventsSync_Invocations.count, 1)
 
         // Then live events were deleted.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17948" title="WPB-17948" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17948</a>  [iOS] handle gap message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR implements inserting a system message when `notifications_missed` notification is received for consumable notifications sync system.

### Testing

1. on lich env
2. enable async stream feature flag
3. login on a fresh client
4. put app in background
5. send messages from another user and wait 5 min
6. resume the app

you should see a system message
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
