### PR TITLE
fix: setting up Countly on main thread - WPB-17530

### DIFF
--- a/WireAnalytics/Sources/WireAnalytics/Service/AnalyticsService.swift
+++ b/WireAnalytics/Sources/WireAnalytics/Service/AnalyticsService.swift
@@ -76,6 +76,7 @@ public final class AnalyticsService: AnalyticsServiceProtocol {
 
     /// Start sending analytics data.
 
+    @MainActor
     public func enableTracking() {
 
         logger.debug("enabling tracking")

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -367,6 +367,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     private let sharedUserDefaults: UserDefaults
 
+    @MainActor
     public convenience init(
         maxNumberAccounts: Int = defaultMaxNumberAccounts,
         appVersion: String,
@@ -480,6 +481,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     }
 
+    @MainActor
     init(
         maxNumberAccounts: Int = defaultMaxNumberAccounts,
         appVersion: String,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17530" title="WPB-17530" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17530</a>  [iOS] New Registration Flows - Personal account countly tracking
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

[PR #3159](https://github.com/wireapp/wire-ios/pull/3159/files#diff-e20a5b04b6a570e38adff8f4e8d53ec6ec7bdc758310e42eb031d42e93afe152L87-R79) introduced the issue that Countly is setup on a background thread.
This PR fixes it.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
