### PR TITLE
fix: wrong conditional checking when initiating call - WPB-18292

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
@@ -394,7 +394,7 @@ extension ConversationCallingEventNotificationBuilder {
             let knownCallHandles = userDefaults.object(forKey: Constants.knownCalls) as? [String] ?? []
             let wasCallHandleReported = knownCallHandles.contains(handle)
 
-            let initiatesRinging = callContent.isIncomingCall || wasCallHandleReported
+            let initiatesRinging = callContent.isIncomingCall && !wasCallHandleReported
             let terminatesRinging = (
                 callContent.isEndCall || callContent.isAnsweredElsewhere || callContent
                     .isRejected


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18292" title="WPB-18292" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18292</a>  [iOS] Calling issue when on a group conv, someone joining, it initiates ringing by that person on the same group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**:
- A group conv call is ongoing
- Someone join the call
- NSE displays calling notification from that participant on the same group

**Causes**: `initiatesRinging` condition checking is wrong, we don't discard the notification is the call was already reporter. which means we receive the event for the user that joined the group conv, it checks the calling content (which it has) then checks whether it should initiate ringing and it does.

**Solution**: Fix `initiatesRinging` condition checking logic -> discard notification if the call was already reported

_legacy code_

```
        if callContent.initiatesRinging, !wasCallHandleReported {
            WireLogger.calling.info("should initiate ringing", attributes: .legacyNSE)
            return CallEventPayload(
                accountID: accountIdentifier.uuidString,
                conversationID: conversationID.uuidString,
                shouldRing: true,
                callerName: conversation.localizedCallerName(with: caller),
                hasVideo: callContent.isVideo
            )
        }
```

### Testing

- have group conv call 
- someone join the group conv
- it should not display any notification

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
