### PR TITLE
fix: server time delta not used in new sync - WPB-18321

### DIFF
--- a/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPI.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPI.swift
@@ -24,5 +24,5 @@ public protocol ConnectionsAPI {
 
     /// Fetch all connections .
 
-    func getConnections() async throws -> PayloadPager<Connection>
+    func getConnections() async throws -> PayloadPager<[Connection]>
 }

--- a/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConnectionsAPI/ConnectionsAPIV0.swift
@@ -38,8 +38,8 @@ class ConnectionsAPIV0: ConnectionsAPI, VersionedAPI {
         "\(pathPrefix)/list-connections"
     }
 
-    func getConnections() async throws -> PayloadPager<Connection> {
-        PayloadPager<Connection> { start in
+    func getConnections() async throws -> PayloadPager<[Connection]> {
+        PayloadPager<[Connection]> { start in
 
             // body Params
             let params = PaginationRequest(pagingState: start, size: Constants.batchSize)
@@ -79,8 +79,8 @@ private struct PaginatedConnectionListV0: Decodable, ToAPIModelConvertible {
     let pagingState: String
     let hasMore: Bool
 
-    func toAPIModel() -> PayloadPager<Connection>.Page {
-        PayloadPager<Connection>.Page(
+    func toAPIModel() -> PayloadPager<[Connection]>.Page {
+        PayloadPager<[Connection]>.Page(
             element: connections.map { $0.toAPIModel() },
             hasMore: hasMore,
             nextStart: pagingState

--- a/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPI.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPI.swift
@@ -23,10 +23,10 @@ import Foundation
 public protocol ConversationsAPI {
 
     /// Fetch all conversation identifiers in batches for ``APIVersion`` v0.
-    func getLegacyConversationIdentifiers() async throws -> PayloadPager<UUID>
+    func getLegacyConversationIdentifiers() async throws -> PayloadPager<[UUID]>
 
     /// Fetch all conversation identifiers in batches available from ``APIVersion`` v1.
-    func getConversationIdentifiers() async throws -> PayloadPager<QualifiedID>
+    func getConversationIdentifiers() async throws -> PayloadPager<[QualifiedID]>
 
     /// Fetch conversation list with qualified identifiers.
     func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList

--- a/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPIV0.swift
@@ -42,7 +42,7 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
         self.apiService = apiService
     }
 
-    func getLegacyConversationIdentifiers() async throws -> PayloadPager<UUID> {
+    func getLegacyConversationIdentifiers() async throws -> PayloadPager<[UUID]> {
         // This function needs to be used in APIVersion.v0 instead of `getConversationIdentifiers`,
         // because the backend API returns only `UUID`s instead of `QualifiedID`s in later versions.
         // We are missing the related domain to map the UUID to a valid `QualifiedID` object.
@@ -55,7 +55,7 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
         let path = "\(basePath)/list-ids/"
         let jsonEncoder = JSONEncoder.defaultEncoder
 
-        return PayloadPager<UUID> { start in
+        return PayloadPager<[UUID]> { start in
             // body Params
             let params = PaginationRequest(pagingState: start, size: Constants.batchSize)
             let body = try jsonEncoder.encode(params)
@@ -76,7 +76,7 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
         }
     }
 
-    func getConversationIdentifiers() async throws -> PayloadPager<QualifiedID> {
+    func getConversationIdentifiers() async throws -> PayloadPager<[QualifiedID]> {
         assertionFailure("not implemented! use getLegacyConversationIdentifiers() instead")
         throw ConversationsAPIError.notImplemented
     }
@@ -262,7 +262,7 @@ private struct PaginatedConversationIDsV0: Decodable, ToAPIModelConvertible {
     let pagingState: String
     let hasMore: Bool
 
-    func toAPIModel() -> PayloadPager<UUID>.Page {
+    func toAPIModel() -> PayloadPager<[UUID]>.Page {
         .init(
             element: conversationIdentifiers,
             hasMore: hasMore,

--- a/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPIV1.swift
+++ b/WireAPI/Sources/WireAPI/APIs/ConversationsAPI/ConversationsAPIV1.swift
@@ -21,16 +21,16 @@ import Foundation
 class ConversationsAPIV1: ConversationsAPIV0 {
     override var apiVersion: APIVersion { .v1 }
 
-    override func getLegacyConversationIdentifiers() async throws -> PayloadPager<UUID> {
+    override func getLegacyConversationIdentifiers() async throws -> PayloadPager<[UUID]> {
         assertionFailure("not implemented! use getConversationIdentifiers() instead")
         throw ConversationsAPIError.notImplemented
     }
 
-    override func getConversationIdentifiers() async throws -> PayloadPager<QualifiedID> {
+    override func getConversationIdentifiers() async throws -> PayloadPager<[QualifiedID]> {
         let path = "\(pathPrefix)\(basePath)/list-ids/"
         let jsonEncoder = JSONEncoder.defaultEncoder
 
-        return PayloadPager<QualifiedID> { start in
+        return PayloadPager<[QualifiedID]> { start in
             // body Params
             let params = PaginationRequest(pagingState: start, size: Constants.batchSize)
             let body = try jsonEncoder.encode(params)
@@ -66,8 +66,8 @@ private struct PaginatedConversationIDsV1: Decodable, ToAPIModelConvertible {
     let pagingState: String
     let hasMore: Bool
 
-    func toAPIModel() -> PayloadPager<QualifiedID>.Page {
-        PayloadPager<QualifiedID>.Page(
+    func toAPIModel() -> PayloadPager<[QualifiedID]>.Page {
+        PayloadPager<[QualifiedID]>.Page(
             element: conversationIDs,
             hasMore: hasMore,
             nextStart: pagingState

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Responses/UpdateEventListResponseV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Responses/UpdateEventListResponseV0.swift
@@ -32,7 +32,7 @@ struct UpdateEventListResponseV0: Decodable, ToAPIModelConvertible {
 
     }
 
-    func toAPIModel() -> PayloadPager<TimestampedUpdateEventEnvelope>.Page {
+    func toAPIModel() -> PayloadPager<UpdateEventBatch>.Page {
         let eventEnvelopes = notifications.map {
             $0.toAPIModel()
         }
@@ -41,13 +41,13 @@ struct UpdateEventListResponseV0: Decodable, ToAPIModelConvertible {
             !$0.isTransient
         }
 
-        let timestampedUpdateEventEnvelope = TimestampedUpdateEventEnvelope(
+        let updateEventBatch = UpdateEventBatch(
             time: time?.date,
             updateEventEnvelopes: notifications.map { $0.toAPIModel() }
         )
 
         return .init(
-            element: timestampedUpdateEventEnvelope,
+            element: updateEventBatch,
             hasMore: hasMore ?? false,
             nextStart: lastNonTransientEvent?.id.transportString() ?? ""
         )

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Responses/UpdateEventListResponseV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/Responses/UpdateEventListResponseV0.swift
@@ -32,7 +32,7 @@ struct UpdateEventListResponseV0: Decodable, ToAPIModelConvertible {
 
     }
 
-    func toAPIModel() -> PayloadPager<UpdateEventEnvelope>.Page {
+    func toAPIModel() -> PayloadPager<TimestampedUpdateEventEnvelope>.Page {
         let eventEnvelopes = notifications.map {
             $0.toAPIModel()
         }
@@ -41,8 +41,13 @@ struct UpdateEventListResponseV0: Decodable, ToAPIModelConvertible {
             !$0.isTransient
         }
 
+        let timestampedUpdateEventEnvelope = TimestampedUpdateEventEnvelope(
+            time: time?.date,
+            updateEventEnvelopes: notifications.map { $0.toAPIModel() }
+        )
+
         return .init(
-            element: notifications.map { $0.toAPIModel() },
+            element: timestampedUpdateEventEnvelope,
             hasMore: hasMore ?? false,
             nextStart: lastNonTransientEvent?.id.transportString() ?? ""
         )

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPI.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPI.swift
@@ -40,6 +40,6 @@ public protocol UpdateEventsAPI {
     func getUpdateEvents(
         selfClientID: String?,
         sinceEventID: UUID
-    ) -> PayloadPager<UpdateEventEnvelope>
+    ) -> PayloadPager<TimestampedUpdateEventEnvelope>
 
 }

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPI.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPI.swift
@@ -40,6 +40,6 @@ public protocol UpdateEventsAPI {
     func getUpdateEvents(
         selfClientID: String?,
         sinceEventID: UUID
-    ) -> PayloadPager<TimestampedUpdateEventEnvelope>
+    ) -> PayloadPager<UpdateEventBatch>
 
 }

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
@@ -67,7 +67,7 @@ class UpdateEventsAPIV0: UpdateEventsAPI, VersionedAPI {
     func getUpdateEvents(
         selfClientID: String?,
         sinceEventID: UUID
-    ) -> PayloadPager<UpdateEventEnvelope> {
+    ) -> PayloadPager<TimestampedUpdateEventEnvelope> {
         let resourcePath = "\(pathPrefix)\(basePath)"
 
         return PayloadPager(start: sinceEventID.transportString()) { nextSince in

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV0.swift
@@ -67,7 +67,7 @@ class UpdateEventsAPIV0: UpdateEventsAPI, VersionedAPI {
     func getUpdateEvents(
         selfClientID: String?,
         sinceEventID: UUID
-    ) -> PayloadPager<TimestampedUpdateEventEnvelope> {
+    ) -> PayloadPager<UpdateEventBatch> {
         let resourcePath = "\(pathPrefix)\(basePath)"
 
         return PayloadPager(start: sinceEventID.transportString()) { nextSince in

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV5.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV5.swift
@@ -60,7 +60,7 @@ class UpdateEventsAPIV5: UpdateEventsAPIV4 {
     override func getUpdateEvents(
         selfClientID: String?,
         sinceEventID: UUID
-    ) -> PayloadPager<UpdateEventEnvelope> {
+    ) -> PayloadPager<TimestampedUpdateEventEnvelope> {
         let resourcePath = "\(pathPrefix)\(basePath)"
 
         return PayloadPager(start: sinceEventID.transportString()) { nextSince in

--- a/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV5.swift
+++ b/WireAPI/Sources/WireAPI/APIs/UpdateEventsAPI/UpdateEventsAPIV5.swift
@@ -60,7 +60,7 @@ class UpdateEventsAPIV5: UpdateEventsAPIV4 {
     override func getUpdateEvents(
         selfClientID: String?,
         sinceEventID: UUID
-    ) -> PayloadPager<TimestampedUpdateEventEnvelope> {
+    ) -> PayloadPager<UpdateEventBatch> {
         let resourcePath = "\(pathPrefix)\(basePath)"
 
         return PayloadPager(start: sinceEventID.transportString()) { nextSince in

--- a/WireAPI/Sources/WireAPI/Components/PayloadPager.swift
+++ b/WireAPI/Sources/WireAPI/Components/PayloadPager.swift
@@ -23,7 +23,7 @@ import Foundation
 
 public struct PayloadPager<Payload>: AsyncSequence {
 
-    public typealias Element = [Payload]
+    public typealias Element = Payload
     public typealias PageFetcher = (String?) async throws -> Page
 
     var start: String?
@@ -76,7 +76,7 @@ public struct PayloadPager<Payload>: AsyncSequence {
             self.fetchPage = fetchPage
         }
 
-        public mutating func next() async throws -> [Payload]? {
+        public mutating func next() async throws -> Payload? {
             guard hasMore else { return nil }
             let page = try await fetchPage(start)
             hasMore = page.hasMore

--- a/WireAPI/Sources/WireAPI/Models/UpdateEvent/TimestampedUpdateEventEnvelope.swift
+++ b/WireAPI/Sources/WireAPI/Models/UpdateEvent/TimestampedUpdateEventEnvelope.swift
@@ -1,0 +1,24 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+public struct TimestampedUpdateEventEnvelope {
+    public let time: Date?
+    public let updateEventEnvelopes: [UpdateEventEnvelope]
+}

--- a/WireAPI/Sources/WireAPI/Models/UpdateEvent/UpdateEventBatch.swift
+++ b/WireAPI/Sources/WireAPI/Models/UpdateEvent/UpdateEventBatch.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public struct TimestampedUpdateEventEnvelope {
+public struct UpdateEventBatch {
     public let time: Date?
     public let updateEventEnvelopes: [UpdateEventEnvelope]
 }

--- a/WireAPI/Tests/WireAPITests/APIs/UpdateEventsAPI/UpdateEventsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UpdateEventsAPI/UpdateEventsAPITests.swift
@@ -112,7 +112,7 @@ final class UpdateEventsAPITests: XCTestCase {
         let sut = UpdateEventsAPIV0(apiService: apiService)
 
         // When
-        var pages = [TimestampedUpdateEventEnvelope]()
+        var pages = [UpdateEventBatch]()
         for try await page in sut.getUpdateEvents(
             selfClientID: Scaffolding.selfClientID,
             sinceEventID: Scaffolding.lastUpdateEventID
@@ -207,7 +207,7 @@ final class UpdateEventsAPITests: XCTestCase {
         let sut = UpdateEventsAPIV5(apiService: apiService)
 
         // When
-        var pages = [TimestampedUpdateEventEnvelope]()
+        var pages = [UpdateEventBatch]()
         for try await page in sut.getUpdateEvents(
             selfClientID: Scaffolding.selfClientID,
             sinceEventID: Scaffolding.lastUpdateEventID

--- a/WireAPI/Tests/WireAPITests/APIs/UpdateEventsAPI/UpdateEventsAPITests.swift
+++ b/WireAPI/Tests/WireAPITests/APIs/UpdateEventsAPI/UpdateEventsAPITests.swift
@@ -112,7 +112,7 @@ final class UpdateEventsAPITests: XCTestCase {
         let sut = UpdateEventsAPIV0(apiService: apiService)
 
         // When
-        var pages = [[UpdateEventEnvelope]]()
+        var pages = [TimestampedUpdateEventEnvelope]()
         for try await page in sut.getUpdateEvents(
             selfClientID: Scaffolding.selfClientID,
             sinceEventID: Scaffolding.lastUpdateEventID
@@ -123,10 +123,10 @@ final class UpdateEventsAPITests: XCTestCase {
         // Then
         XCTAssertEqual(pages.count, 2)
 
-        let page1 = try XCTUnwrap(pages.first)
+        let page1 = try XCTUnwrap(pages.first?.updateEventEnvelopes)
         XCTAssertEqual(page1, Scaffolding.updateEventPage1)
 
-        let page2 = try XCTUnwrap(pages.last)
+        let page2 = try XCTUnwrap(pages.last?.updateEventEnvelopes)
         XCTAssertEqual(page2, Scaffolding.updateEventPage2)
     }
 
@@ -207,7 +207,7 @@ final class UpdateEventsAPITests: XCTestCase {
         let sut = UpdateEventsAPIV5(apiService: apiService)
 
         // When
-        var pages = [[UpdateEventEnvelope]]()
+        var pages = [TimestampedUpdateEventEnvelope]()
         for try await page in sut.getUpdateEvents(
             selfClientID: Scaffolding.selfClientID,
             sinceEventID: Scaffolding.lastUpdateEventID
@@ -218,10 +218,10 @@ final class UpdateEventsAPITests: XCTestCase {
         // Then
         XCTAssertEqual(pages.count, 2)
 
-        let page1 = try XCTUnwrap(pages.first)
+        let page1 = try XCTUnwrap(pages.first?.updateEventEnvelopes)
         XCTAssertEqual(page1, Scaffolding.updateEventPage1)
 
-        let page2 = try XCTUnwrap(pages.last)
+        let page2 = try XCTUnwrap(pages.last?.updateEventEnvelopes)
         XCTAssertEqual(page2, Scaffolding.updateEventPage2)
     }
 

--- a/WireAPI/Tests/WireAPITests/PayloadPagerTests.swift
+++ b/WireAPI/Tests/WireAPITests/PayloadPagerTests.swift
@@ -23,7 +23,7 @@ final class PayloadPagerTests: XCTestCase {
 
     func test_PagerIteratesThroughPages() async throws {
         // Given
-        let sut = PayloadPager<String>(start: "first") { index in
+        let sut = PayloadPager<[String]>(start: "first") { index in
             switch index {
             case "first":
                 return PayloadPager.Page(
@@ -71,7 +71,7 @@ final class PayloadPagerTests: XCTestCase {
     func test_PagerStopIteratesThroughPagesIfThrowingError() async throws {
         // Given
         let expectedError = TestError(message: "unexpected error from api")
-        let sut = PayloadPager<String>(start: "first") { index in
+        let sut = PayloadPager<[String]>(start: "first") { index in
             switch index {
             case "first":
                 return PayloadPager.Page(

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
@@ -46,7 +46,7 @@ struct ConversationCallingEventNotificationBuilder: ConversationCallingEventNoti
         let displayCallNotification = await validator.validateCallNotification(
             conversationID: conversationID,
             senderID: senderID,
-            time: time,
+            eventTimestamp: time,
             callContent: callContent
         )
 
@@ -415,7 +415,7 @@ extension ConversationCallingEventNotificationBuilder {
         func validateCallNotification(
             conversationID: ConversationID,
             senderID: UserID,
-            time: Date?,
+            eventTimestamp: Date?,
             callContent: CallContent
         ) async -> Bool {
             let conversation = await conversationLocalStore.fetchOrCreateConversation(
@@ -430,10 +430,14 @@ extension ConversationCallingEventNotificationBuilder {
                 domain: senderID.domain
             )
 
+            let serverTimeDelta = await conversationLocalStore.fetchServerTimeDelta()
+            let currentTimestamp = Date.now.addingTimeInterval(serverTimeDelta)
+
             let mutedMessagesTypes = await conversationLocalStore
                 .conversationMutedMessageTypesIncludingAvailability(conversation)
             let isConversationMuted = mutedMessagesTypes == .all
-            let isCallTimeOut = time != nil ? Int(Date.now.timeIntervalSince(time!)) > 30 : true
+            let isCallTimeOut = eventTimestamp != nil ? Int(currentTimestamp.timeIntervalSince(eventTimestamp!)) > 30 :
+                true
             let isCallerSelf = selfUser == caller
 
             let isIncomingCall = callContent.isIncomingCall

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationCallingEventNotificationBuilder.swift
@@ -40,6 +40,7 @@ struct ConversationCallingEventNotificationBuilder: ConversationCallingEventNoti
             conversationID: conversationID,
             senderID: senderID,
             accountID: accountID,
+            eventTimestamp: time,
             callContent: callContent
         )
 
@@ -372,6 +373,7 @@ extension ConversationCallingEventNotificationBuilder {
             conversationID: ConversationID,
             senderID: UserID,
             accountID: UUID,
+            eventTimestamp: Date?,
             callContent: CallContent
         ) async -> Bool {
             let conversation = await conversationLocalStore.fetchOrCreateConversation(
@@ -402,12 +404,18 @@ extension ConversationCallingEventNotificationBuilder {
 
             let isValidState = initiatesRinging || terminatesRinging
 
+            let serverTimeDelta = await conversationLocalStore.fetchServerTimeDelta()
+            let currentTimestamp = Date.now.addingTimeInterval(serverTimeDelta)
+            let isCallTimeOut = eventTimestamp != nil ? Int(currentTimestamp.timeIntervalSince(eventTimestamp!)) > 30 :
+                true
+
             return !needsToBeUpdatedFromBackend
                 && !isConversationMuted
                 && !isConversationForcedReadOnly
                 && isAVSReady
                 && isCallKitReady
                 && isUserSessionLoaded
+                && !isCallTimeOut
                 && isValidState
         }
 

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -268,6 +268,12 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         }
     }
 
+    public func fetchServerTimeDelta() async -> TimeInterval {
+        await context.perform { [context] in
+            context.serverTimeDelta
+        }
+    }
+
     public func addParticipants(
         _ participants: [(id: UUID, domain: String?, role: String?)],
         addedBy sender: (id: UUID, domain: String?),

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -441,4 +441,6 @@ public protocol ConversationLocalStoreProtocol {
         conversation: ZMConversation
     ) async
 
+    func fetchServerTimeDelta() async -> TimeInterval
+
 }

--- a/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/Protocols/UpdateEventsLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/Protocols/UpdateEventsLocalStoreProtocol.swift
@@ -84,4 +84,8 @@ public protocol UpdateEventsLocalStoreProtocol {
     ) async throws
 
     func calculateLastUnreadMessages() async
+
+    func storeServerTimeDelta(
+        _ serverTimeDelta: TimeInterval
+    ) async
 }

--- a/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/UpdateEventsLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UpdateEvents/UpdateEventsLocalStore.swift
@@ -66,6 +66,14 @@ final class UpdateEventsLocalStore: UpdateEventsLocalStoreProtocol {
         )
     }
 
+    public func storeServerTimeDelta(
+        _ serverTimeDelta: TimeInterval
+    ) async {
+        await syncContext.perform { [syncContext] in
+            syncContext.serverTimeDelta = serverTimeDelta
+        }
+    }
+
     public func storeLastEventID(id: UUID) {
         storage.setUUID(id, forKey: .lastEventID)
     }

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
@@ -69,6 +69,13 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
             let timestamp = timestampedEnvelope.time
             let batchCount = envelopes.count
             var count = 0
+            
+            if let timestamp {
+                WireLogger.sync.debug("storing server time delta")
+                await store.storeServerTimeDelta(
+                    timestamp.timeIntervalSinceNow
+                )
+            }
 
             if batchCount > 0 {
                 WireLogger.sync.debug("fetched \(batchCount) envelopes from remote")
@@ -125,13 +132,6 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
                     store.storeLastEventID(id: lastEnvelopeID)
                 }
 
-            }
-
-            if let timestamp {
-                WireLogger.sync.debug("storing server time delta")
-                await store.storeServerTimeDelta(
-                    timestamp.timeIntervalSinceNow
-                )
             }
         }
 

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
@@ -69,7 +69,7 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
             let timestamp = timestampedEnvelope.time
             let batchCount = envelopes.count
             var count = 0
-            
+
             if let timestamp {
                 WireLogger.sync.debug("storing server time delta")
                 await store.storeServerTimeDelta(

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
@@ -58,11 +58,15 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
 
         var events: [UpdateEvent] = []
 
-        // Events are fetched in batches.
-        for try await envelopes in api.getUpdateEvents(
+        let timestampedUpdateEvents = api.getUpdateEvents(
             selfClientID: selfClientID,
             sinceEventID: lastEventID
-        ) {
+        )
+
+        // Events are fetched in batches.
+        for try await timestampedEnvelope in timestampedUpdateEvents {
+            let envelopes = timestampedEnvelope.updateEventEnvelopes
+            let timestamp = timestampedEnvelope.time
             let batchCount = envelopes.count
             var count = 0
 
@@ -121,6 +125,13 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
                     store.storeLastEventID(id: lastEnvelopeID)
                 }
 
+            }
+
+            if let timestamp {
+                WireLogger.sync.debug("storing server time delta")
+                await store.storeServerTimeDelta(
+                    timestamp.timeIntervalSinceNow
+                )
             }
         }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -3789,6 +3789,21 @@ public class MockUpdateEventsLocalStoreProtocol: UpdateEventsLocalStoreProtocol 
         await mock()
     }
 
+    // MARK: - storeServerTimeDelta
+
+    public var storeServerTimeDelta_Invocations: [TimeInterval] = []
+    public var storeServerTimeDelta_MockMethod: ((TimeInterval) async -> Void)?
+
+    public func storeServerTimeDelta(_ serverTimeDelta: TimeInterval) async {
+        storeServerTimeDelta_Invocations.append(serverTimeDelta)
+
+        guard let mock = storeServerTimeDelta_MockMethod else {
+            fatalError("no mock for `storeServerTimeDelta`")
+        }
+
+        await mock(serverTimeDelta)
+    }
+
 }
 
 public class MockUserClientsLocalStoreProtocol: UserClientsLocalStoreProtocol {

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -1357,6 +1357,24 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
         await mock(permission, conversation)
     }
 
+    // MARK: - fetchServerTimeDelta
+
+    public var fetchServerTimeDelta_Invocations: [Void] = []
+    public var fetchServerTimeDelta_MockMethod: (() async -> TimeInterval)?
+    public var fetchServerTimeDelta_MockValue: TimeInterval?
+
+    public func fetchServerTimeDelta() async -> TimeInterval {
+        fetchServerTimeDelta_Invocations.append(())
+
+        if let mock = fetchServerTimeDelta_MockMethod {
+            return await mock()
+        } else if let mock = fetchServerTimeDelta_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `fetchServerTimeDelta`")
+        }
+    }
+
 }
 
 class MockConversationLocationMessageNotificationBuilderProtocol: ConversationLocationMessageNotificationBuilderProtocol {

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCallingEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCallingEventNotificationBuilderTests.swift
@@ -386,26 +386,18 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
 
     }
 
-    func testGenerateCallNotification_IsOneOnOne_Team_Should_Build_Notification_Returns_False() async {
+    func testGenerateCallNotification_It_Does_Not_Generate_Notification_When_Timed_Out() async throws {
+
         // Mock
 
         let isGroup = false
         let isTeam = true
 
-        await setupMock(isGroup: isGroup, isTeam: isTeam)
-
-        // An example payload that will be treated as an `unhandled` case.
-        let unhandledCallJson = """
-        {
-            "type": "REJECT",
-            "src_clientid": "clientid",
-            "resp": true,
-            "props": { "videosend": "false" }
-        }
-        """
+        await setupMock(isGroup: isGroup, isTeam: isTeam, isTimeout: true)
+        let callingContent = setupCallingContentMock(type: "SETUP")
 
         var calling = Calling()
-        calling.content = unhandledCallJson
+        calling.content = callingContent
 
         sut = ConversationCallingEventNotificationBuilder(
             context: .init(
@@ -427,6 +419,53 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
             senderID: Scaffolding.userID
         )
 
+        XCTAssertNil(userNotification)
+    }
+
+    func testGenerateCallNotification_IsOneOnOne_Team_Should_Build_Notification_Returns_False() async {
+        // Mock
+
+        let isGroup = false
+        let isTeam = true
+
+        await setupMock(isGroup: isGroup, isTeam: isTeam)
+
+        // An example payload that will be treated as an `unhandled` case.
+        let unhandledCallJson = """
+        {
+            "type": "REJECT",
+            "src_clientid": "clientid",
+            "resp": true,
+            "props": { "videosend": "false" }
+        }
+        """
+
+        var calling = Calling()
+        calling.content = unhandledCallJson
+
+        // When
+
+        sut = ConversationCallingEventNotificationBuilder(
+            context: .init(
+                conversationLocalStore: conversationLocalStore,
+                userLocalStore: userLocalStore
+            ),
+            validator: .init(
+                userLocalStore: userLocalStore,
+                conversationLocalStore: conversationLocalStore,
+                userDefaults: defaults
+            ),
+            accountID: .mockID1
+        )
+
+        let userNotification = await sut.buildContent(
+            calling: calling,
+            at: .now,
+            conversationID: Scaffolding.conversationID,
+            senderID: Scaffolding.userID
+        )
+
+        // Then, not display calling notification because timed out
         XCTAssertNil(userNotification)
     }
 
@@ -552,7 +591,6 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
         XCTAssertEqual(notificationContent.userInfo["selfUserIDString"] as! String, UUID.mockID1.uuidString)
         XCTAssertNil(notificationContent.userInfo["senderIDString"])
         XCTAssertEqual(notificationContent.userInfo["conversationIDString"] as! String, UUID.mockID2.uuidString)
-
     }
 
     // MARK: - Tested use cases
@@ -639,7 +677,8 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
 
     private func setupMock(
         isGroup: Bool,
-        isTeam: Bool
+        isTeam: Bool,
+        isTimeout: Bool = false
     ) async {
 
         defaults.set(true, forKey: "isAVSReady")
@@ -668,6 +707,7 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
         userLocalStore.teamNameFor_MockValue = .some(isTeam ? Scaffolding.teamName : nil)
         conversationLocalStore.shouldHideNotification_MockValue = false
         conversationLocalStore.increaseUnreadCountFor_MockMethod = { _ in }
+        conversationLocalStore.fetchServerTimeDelta_MockValue = isTimeout ? .oneHour : .oneSecond
     }
 
     private enum Scaffolding {

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCallingEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationCallingEventNotificationBuilderTests.swift
@@ -369,6 +369,7 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
                 accountID: .mockID1
             )
 
+            // When
             let userNotification = await sut.buildContent(
                 calling: calling,
                 at: .now,
@@ -376,6 +377,7 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
                 senderID: Scaffolding.userID
             )
 
+            // Then
             try await internalTest_assertNotificationContent(
                 try XCTUnwrap(userNotification),
                 callingTestUsecase: callingTestUsecase,
@@ -399,6 +401,8 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
         var calling = Calling()
         calling.content = callingContent
 
+        // When
+
         sut = ConversationCallingEventNotificationBuilder(
             context: .init(
                 conversationLocalStore: conversationLocalStore,
@@ -419,6 +423,7 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
             senderID: Scaffolding.userID
         )
 
+        // Then, not display calling notification because timed out
         XCTAssertNil(userNotification)
     }
 
@@ -465,7 +470,7 @@ final class ConversationCallingEventNotificationBuilderTests: XCTestCase {
             senderID: Scaffolding.userID
         )
 
-        // Then, not display calling notification because timed out
+        // Then
         XCTAssertNil(userNotification)
     }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncTests.swift
@@ -87,6 +87,7 @@ final class PullPendingUpdateEventsSyncTests: XCTestCase {
 
         store.persistEventEnvelopesIndex_MockMethod = { _, _ in }
         store.storeLastEventIDId_MockMethod = { _ in }
+        store.storeServerTimeDelta_MockMethod = { _ in }
 
         // When
         try await sut.pull()
@@ -194,14 +195,14 @@ private enum Scaffolding {
     static let time20SecondsAgo = Date(timeIntervalSinceNow: -20)
     static let time10SecondsAgo = Date(timeIntervalSinceNow: -10)
 
-    nonisolated(unsafe) static let page1 = PayloadPager<UpdateEventEnvelope>.Page(
-        element: [envelope1, envelope2],
+    nonisolated(unsafe) static let page1 = PayloadPager<TimestampedUpdateEventEnvelope>.Page(
+        element: .init(time: .now, updateEventEnvelopes: [envelope1, envelope2]),
         hasMore: true,
         nextStart: "page2"
     )
 
-    nonisolated(unsafe) static let page2 = PayloadPager<UpdateEventEnvelope>.Page(
-        element: [envelope3, envelope4],
+    nonisolated(unsafe) static let page2 = PayloadPager<TimestampedUpdateEventEnvelope>.Page(
+        element: .init(time: .now, updateEventEnvelopes: [envelope3, envelope4]),
         hasMore: false,
         nextStart: ""
     )

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncTests.swift
@@ -195,13 +195,13 @@ private enum Scaffolding {
     static let time20SecondsAgo = Date(timeIntervalSinceNow: -20)
     static let time10SecondsAgo = Date(timeIntervalSinceNow: -10)
 
-    nonisolated(unsafe) static let page1 = PayloadPager<TimestampedUpdateEventEnvelope>.Page(
+    nonisolated(unsafe) static let page1 = PayloadPager<UpdateEventBatch>.Page(
         element: .init(time: .now, updateEventEnvelopes: [envelope1, envelope2]),
         hasMore: true,
         nextStart: "page2"
     )
 
-    nonisolated(unsafe) static let page2 = PayloadPager<TimestampedUpdateEventEnvelope>.Page(
+    nonisolated(unsafe) static let page2 = PayloadPager<UpdateEventBatch>.Page(
         element: .init(time: .now, updateEventEnvelopes: [envelope3, envelope4]),
         hasMore: false,
         nextStart: ""

--- a/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper.swift
+++ b/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper.swift
@@ -206,11 +206,16 @@ public final class AVSWrapper: AVSWrapperType {
             let currentTime = UInt32(callEvent.currentTimestamp.timeIntervalSince1970)
             let serverTime = UInt32(callEvent.serverTimestamp.timeIntervalSince1970)
             zmLog.debug("wcall_recv_msg: currentTime = \(currentTime), serverTime = \(serverTime)")
+            /* An OTR call-type message has been received,
+             * curr_time is the timestamp (synced as close as possible)
+             * msg_time is the backend timestamp of when the message was received
+             * to the backend time when this function is called.
+             */
             result = CallError(wcall_error: wcall_recv_msg(
                 handle,
                 bytes,
                 callEvent.data.count,
-                currentTime,
+                currentTime, 
                 serverTime,
                 callEvent.conversationId.serialized,
                 callEvent.userId.serialized,

--- a/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper.swift
+++ b/wire-ios-sync-engine/Source/Calling/AVS/AVSWrapper.swift
@@ -206,16 +206,15 @@ public final class AVSWrapper: AVSWrapperType {
             let currentTime = UInt32(callEvent.currentTimestamp.timeIntervalSince1970)
             let serverTime = UInt32(callEvent.serverTimestamp.timeIntervalSince1970)
             zmLog.debug("wcall_recv_msg: currentTime = \(currentTime), serverTime = \(serverTime)")
-            /* An OTR call-type message has been received,
-             * curr_time is the timestamp (synced as close as possible)
-             * msg_time is the backend timestamp of when the message was received
-             * to the backend time when this function is called.
-             */
+            // An OTR call-type message has been received,
+            // curr_time is the timestamp (synced as close as possible)
+            // msg_time is the backend timestamp of when the message was received
+            // to the backend time when this function is called.
             result = CallError(wcall_error: wcall_recv_msg(
                 handle,
                 bytes,
                 callEvent.data.count,
-                currentTime, 
+                currentTime,
                 serverTime,
                 callEvent.conversationId.serialized,
                 callEvent.userId.serialized,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18321" title="WPB-18321" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18321</a>  [iOS] NSE calls timed out still passing through, server time delta not updated 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR aims at aligning with legacy code on the `serverTimeDelta` usage, specifically: 

1/ In NSE, we don't rely on `serverTimeDelta` to check if a calling event is timed out. (see legacy `NotificationSession`)

2/ Server time delta value is not updated upon receiving update events envelopes, we should update the value as soon as we get an envelope (see legacy `NotificationStreamAsync`)

### Testing

N/A

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
