### PR TITLE
fix: verification status for self clients being lost - WPB-17594

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -212,7 +212,7 @@ public final class ClientSessionComponent {
         sharedUserDefaults: sharedUserDefaults
     )
 
-    private lazy var userClientsLocalStore: some UserClientsLocalStore = UserClientsLocalStore(
+    private lazy var userClientsLocalStore: some UserClientsLocalStoreProtocol = UserClientsLocalStore(
         context: syncContext
     )
 

--- a/WireDomain/Sources/WireDomain/Repositories/UserClients/UserClientsLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UserClients/UserClientsLocalStore.swift
@@ -19,19 +19,13 @@
 import WireDataModel
 import WireLogging
 
-public final class UserClientsLocalStore: UserClientsLocalStoreProtocol {
+public struct UserClientsLocalStore: UserClientsLocalStoreProtocol {
 
     // MARK: - Properties
 
-    private let context: NSManagedObjectContext
+    let context: NSManagedObjectContext
 
-    // MARK: - Object lifecycle
-
-    init(
-        context: NSManagedObjectContext
-    ) {
-        self.context = context
-    }
+    // MARK: - Methods
 
     public func fetchSelfClient() async -> UserClient? {
         await context.perform { [context] in
@@ -172,8 +166,10 @@ public final class UserClientsLocalStore: UserClientsLocalStoreProtocol {
                 }
             }
 
-            selfUser.selfClient()?.addNewClientToIgnored(localClient)
-            selfUser.selfClient()?.updateSecurityLevelAfterDiscovering(Set([localClient]))
+            if isNewClient {
+                selfUser.selfClient()?.addNewClientToIgnored(localClient)
+                selfUser.selfClient()?.updateSecurityLevelAfterDiscovering(Set([localClient]))
+            }
         }
     }
 

--- a/WireDomain/Tests/WireDomainTests/LocalStores/UserClientsLocalStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/LocalStores/UserClientsLocalStoreTests.swift
@@ -21,6 +21,7 @@ import WireDataModelSupport
 import WireDomainSupport
 import WireTestingPackage
 import XCTest
+
 @testable import WireDomain
 
 final class UserClientsLocalStoreTests: XCTestCase {
@@ -82,22 +83,26 @@ final class UserClientsLocalStoreTests: XCTestCase {
         }
     }
 
-    func testUpdateClient_It_Updates_Client_Info() async throws {
+    func testUpdateClient_It_Inserts_New_Client_Info() async throws {
         // Given
+
+        let selfClient = await context.perform { [context] in
+            ModelHelper().createSelfClient(in: context)
+        }
 
         let createdClient = await sut.fetchOrCreateClient(
             id: Scaffolding.userClientID
-        )
+        ).client
 
         let clientID = await context.perform {
-            createdClient.client.remoteIdentifier!
+            createdClient.remoteIdentifier!
         }
 
         // When
 
         await sut.updateClient(
             id: clientID,
-            isNewClient: createdClient.isNew,
+            isNewClient: true,
             userClientInfo: Scaffolding.selfUserClientInfo
         )
 
@@ -114,6 +119,52 @@ final class UserClientsLocalStoreTests: XCTestCase {
             XCTAssertEqual(updatedClient.label, Scaffolding.selfUserClientInfo.label)
             XCTAssertEqual(updatedClient.model, Scaffolding.selfUserClientInfo.model)
             XCTAssertEqual(updatedClient.deviceClass, .phone)
+            XCTAssertTrue(updatedClient.needsSessionMigration)
+
+            XCTAssertTrue(selfClient.ignoredClients.contains(updatedClient))
+            XCTAssertFalse(selfClient.trustedClients.contains(updatedClient))
+        }
+    }
+
+    func testUpdateClient_It_Updates_Existing_Client_Info() async throws {
+        // Given
+
+        let selfClient = await context.perform { [context] in
+            ModelHelper().createSelfClient(in: context)
+        }
+
+        let createdClient = await sut.fetchOrCreateClient(
+            id: Scaffolding.userClientID
+        ).client
+
+        let clientID = await context.perform {
+            createdClient.remoteIdentifier!
+        }
+
+        // When
+
+        await sut.updateClient(
+            id: clientID,
+            isNewClient: false,
+            userClientInfo: Scaffolding.selfUserClientInfo
+        )
+
+        // Then
+
+        try await context.perform { [context] in
+            let updatedClient = try XCTUnwrap(UserClient.fetchExistingUserClient(
+                with: Scaffolding.userClientID,
+                in: context
+            ))
+
+            XCTAssertEqual(updatedClient.remoteIdentifier, Scaffolding.userClientID)
+            XCTAssertEqual(updatedClient.type, .permanent)
+            XCTAssertEqual(updatedClient.label, Scaffolding.selfUserClientInfo.label)
+            XCTAssertEqual(updatedClient.model, Scaffolding.selfUserClientInfo.model)
+            XCTAssertEqual(updatedClient.deviceClass, .phone)
+
+            XCTAssertFalse(selfClient.ignoredClients.contains(updatedClient))
+            XCTAssertFalse(selfClient.trustedClients.contains(updatedClient))
         }
     }
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

When receiving updates for other clients of the self user we accidentally also set existing clients as untrusted.
This PR adds a missing condition.

### Testing

- Have more than one client for a user.
- After sync or restarting the app the previously verified devices must still be marked as verified.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
