### PR TITLE
fix: user availability - WPB-17586

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
@@ -154,14 +154,22 @@ public struct ConversationProtobufMessageProcessor: ConversationProtobufMessageP
                 conversationDomain: conversationID.domain
             )
 
-        case .calling, .availability:
+        case let .availability(availability):
+            let userID = WireDataModel.QualifiedID(uuid: senderID.uuid, domain: senderID.domain)
+            let userAvailability = WireDataModel.Availability(proto: availability)
+            await userLocalStore.updateUser(
+                with: userID,
+                availability: userAvailability
+            )
 
-            // cases not handled
+        case .calling:
+
+            // case not handled here, see `onProcessedCallEvent`
             break
 
         case .inCallEmoji:
 
-            // Not supported yet, just discard.
+            // Not supported yet, just discard. TODO: [WPB-11770] implement here
             break
 
         case .image, .asset:
@@ -214,7 +222,7 @@ public struct ConversationProtobufMessageProcessor: ConversationProtobufMessageP
             break
 
         case .inCallHandRaise:
-            break // Not handled yet
+            break // Not handled yet, TODO: [WPB-11769] implement here
         }
     }
 

--- a/WireDomain/Sources/WireDomain/Repositories/User/Protocols/UserLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/Protocols/UserLocalStoreProtocol.swift
@@ -178,4 +178,5 @@ public protocol UserLocalStoreProtocol {
 
     func fetchSelfUserAvailability() async -> Availability
 
+    func updateUser(with userID: WireDataModel.QualifiedID, availability: Availability) async
 }

--- a/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireAPI
 import WireDataModel
 import WireLogging
 
@@ -405,6 +406,14 @@ public final class UserLocalStore: UserLocalStoreProtocol {
     public func fetchSelfUserAvailability() async -> Availability {
         await context.perform { [context] in
             ZMUser.selfUser(in: context).availability
+        }
+    }
+
+    public func updateUser(with userID: WireDataModel.QualifiedID, availability: Availability) async {
+        await context.perform { [context] in
+            let user = ZMUser.fetch(with: userID.uuid, domain: userID.domain, in: context)
+            user?.updateAvailability(availability)
+            context.saveOrRollback()
         }
     }
 

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -4644,6 +4644,21 @@ public class MockUserLocalStoreProtocol: UserLocalStoreProtocol {
         }
     }
 
+    // MARK: - updateUser
+
+    public var updateUserWithAvailability_Invocations: [(userID: WireDataModel.QualifiedID, availability: Availability)] = []
+    public var updateUserWithAvailability_MockMethod: ((WireDataModel.QualifiedID, Availability) async -> Void)?
+
+    public func updateUser(with userID: WireDataModel.QualifiedID, availability: Availability) async {
+        updateUserWithAvailability_Invocations.append((userID: userID, availability: availability))
+
+        guard let mock = updateUserWithAvailability_MockMethod else {
+            fatalError("no mock for `updateUserWithAvailability`")
+        }
+
+        await mock(userID, availability)
+    }
+
 }
 
 public class MockUserRepositoryProtocol: UserRepositoryProtocol {

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
@@ -148,6 +148,38 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
         XCTAssertEqual(invocation.date, Scaffolding.eventDate)
     }
 
+    func testProcessEvent_Availability_Invokes_UserLocalStoreMethod() async throws {
+        // Given
+        let conversation = await context.perform { [self] in
+            modelHelper.createGroupConversation(in: context)
+        }
+        userLocalStore.updateUserWithAvailability_MockMethod = { _, _ in }
+        messageLocalStore.addMessageConfirmationInSenderIDSenderDomainDate_MockMethod = { _, _, _, _, _ in }
+
+        let genericMessage = GenericMessage.with {
+            $0.messageID = UUID().uuidString
+            $0.availability = WireProtos.Availability(.available)
+        }
+
+        // When
+        try await sut.processProtobufMessage(
+            genericMessage,
+            content: try XCTUnwrap(genericMessage.content),
+            conversation: conversation,
+            conversationID: Scaffolding.conversationID,
+            senderID: Scaffolding.userID,
+            senderClientID: "clientID123",
+            date: Scaffolding.eventDate,
+            eventMessage: "confirmation"
+        )
+
+        // Then
+        let invocation = try XCTUnwrap(userLocalStore.updateUserWithAvailability_Invocations.first)
+        XCTAssertEqual(invocation.availability, .available)
+        XCTAssertEqual(invocation.userID.uuid, Scaffolding.userID.uuid)
+        XCTAssertEqual(invocation.userID.domain, Scaffolding.userID.domain)
+    }
+
     private enum Scaffolding {
         static let eventDate = Date()
         static let conversationID = ConversationID(uuid: .mockID1, domain: "domain.com")

--- a/WireDomain/Tests/WireDomainTests/LocalStores/UserLocalStoreTests.swift
+++ b/WireDomain/Tests/WireDomainTests/LocalStores/UserLocalStoreTests.swift
@@ -313,6 +313,24 @@ final class UserLocalStoreTests: XCTestCase {
         }
     }
 
+    func testUpdateUserAvailability() async throws {
+        // Mock
+        let selfUser = await context.perform { [self] in
+            return modelHelper.createSelfUser(id: Scaffolding.selfUserID, in: context)
+        }
+
+        // When
+        await sut.updateUser(
+            with: QualifiedID(uuid: Scaffolding.selfUserID, domain: Scaffolding.domain),
+            availability: .available
+        )
+
+        // Then
+        await context.perform {
+            XCTAssertEqual(selfUser.availability, .available)
+        }
+    }
+
     func testIsSelfUser_It_Returns_Correct_Flag() async throws {
         // Mock
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17586" title="WPB-17586" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17586</a>  [iOS] Availability status not syncing correctly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This fixes missing implementation of processing user availability.

### Testing

Receive user status change from different client
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
