### PR TITLE
feat: add scroll view to the VerificationEmailCode view - WPB-18252

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Registration/VerificationEmailCode/VerificationEmailCodeView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Registration/VerificationEmailCode/VerificationEmailCodeView.swift
@@ -35,53 +35,54 @@ package struct VerificationEmailCodeView: View {
     }
 
     package var body: some View {
-        VStack(spacing: 20) {
-            Text(Strings.VerificationCode.message(viewModel.email))
-                .wireTextStyle(.body1)
-                .multilineTextAlignment(.center)
-                .lineLimit(3)
-                .fixedSize(horizontal: false, vertical: true)
-                .foregroundStyle(Color.primaryText)
+        ScrollView {
+            VStack(spacing: 20) {
+                Text(Strings.VerificationCode.message(viewModel.email))
+                    .wireTextStyle(.body1)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .foregroundStyle(Color.primaryText)
 
-            verificationCodeView
+                verificationCodeView
 
-            Button(action: {
-                Task { await viewModel.confirm() }
-            }, label: {
-                HStack {
-                    if viewModel.isLoading {
-                        ProgressView()
+                Button(action: {
+                    Task { await viewModel.confirm() }
+                }, label: {
+                    HStack {
+                        if viewModel.isLoading {
+                            ProgressView()
+                        }
+
+                        Text(Strings.VerificationCode.confirm)
                     }
+                })
+                .wireButtonStyle(.primary)
+                .padding(.horizontal)
+                .disabled(viewModel.isConfirmButtonDisabled)
 
-                    Text(Strings.VerificationCode.confirm)
-                }
-            })
-            .wireButtonStyle(.primary)
-            .padding(.horizontal)
-            .disabled(viewModel.isConfirmButtonDisabled)
-
-            Button(action: {
-                Task.detached { await viewModel.requestVerificationCode() }
-            }, label: {
-                Text(Strings.VerificationCode.resendCode)
-            })
-            .wireButtonStyle(.link)
-            .disabled(viewModel.isResending)
-        }
-        .padding()
-        .background(ColorTheme.Backgrounds.surface.color)
-        .navigationTitle(Strings.title)
-        .navigationBarTitleDisplayMode(.inline)
-        .setPreferredSize(navigationBarHidden: false)
-        .customBackButton()
-        .alert(
-            item: $viewModel.alert,
-            title: { Text($0.title) },
-            message: { Text($0.message) },
-            actions: { _ in
-                Button(L10n.Localizable.Authentication.Error.confirm, action: {})
+                Button(action: {
+                    Task.detached { await viewModel.requestVerificationCode() }
+                }, label: {
+                    Text(Strings.VerificationCode.resendCode)
+                })
+                .wireButtonStyle(.link)
+                .disabled(viewModel.isResending)
             }
-        )
+            .background(ColorTheme.Backgrounds.surface.color)
+            .navigationTitle(Strings.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .setPreferredSize(navigationBarHidden: false)
+            .customBackButton()
+            .alert(
+                item: $viewModel.alert,
+                title: { Text($0.title) },
+                message: { Text($0.message) },
+                actions: { _ in
+                    Button(L10n.Localizable.Authentication.Error.confirm, action: {})
+                }
+            )
+        }
     }
 
     private var verificationCodeView: some View {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18252" title="WPB-18252" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18252</a>  [iOS] verification code page overlaps with header on changing the orientation and back
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

There is an issue:
![Wire 2025-06-23 at 4_38 PM](https://github.com/user-attachments/assets/4bd45f0c-1bcf-469c-b212-024ac3d8353d)

However, we don't necessarily need to support landscape mode for login or registration, we already do that in Prod. To restrict it, it requires a lot of changes base on the  SwiftUI restrictions. It would require wrapping each sheet in the authentication flow in a UIHostingController or something similar. Adding scroll view would fix the current issue.
If there is a need to disable landscape mode, we can work on a proper solution in the future.

### Testing


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
