### PR TITLE
fix: hanging IncrementalSyncObserverTests tests - WPB-18424

### DIFF
--- a/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/IncrementalSyncObserverTests.swift
@@ -36,7 +36,12 @@ class IncrementalSyncObserverTests {
     func ifAppIsLiveThenDontWait() async {
         // Given
         syncAgent.isSyncV2Enabled = true
-        syncAgent.syncStatePublisher = Just(SyncState.liveSyncing(.ongoing)).eraseToAnyPublisher()
+        let subject = PassthroughSubject<SyncState, Never>()
+        syncAgent.syncStatePublisher = subject.eraseToAnyPublisher()
+        Task {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            subject.send(.liveSyncing(.ongoing))
+        }
 
         // When
         let before = Date.now
@@ -66,6 +71,16 @@ class IncrementalSyncObserverTests {
         syncAgent.isSyncV2Enabled = true
         let syncStateSubject = CurrentValueSubject<SyncState, Never>(.incrementalSyncing(.pullPendingEvents))
         syncAgent.syncStatePublisher = syncStateSubject.eraseToAnyPublisher()
+
+        let flag = ObserverFlag()
+
+        Task {
+            await flag.markStarted()
+            await sut.waitUntilCanSendMessage()
+        }
+
+        let didStart = await flag.waitUntilStarted()
+        #expect(didStart, "Observer never subscribed in time")
 
         Task {
             // Send the next state after a pause.
@@ -120,3 +135,20 @@ class IncrementalSyncObserverTests {
 // MARK: -
 
 private class MockNotificationContext: NSObject, NotificationContext {}
+
+private actor ObserverFlag {
+    private var started = false
+
+    func markStarted() {
+        started = true
+    }
+
+    func waitUntilStarted(timeout: TimeInterval = 1.0) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !started {
+            if Date() > deadline { return false }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return true
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18424" title="WPB-18424" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18424</a>  [iOS] Hanging tests prevent PRs from being merged fast
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Hanging `IncrementalSyncObserverTests` test.

### Solution

There are 2 test that can easy reproduce this issue by running it 100 times:
`ifAppIsLiveThenDontWait` and `waitForDecryptionToFinish`. I will explain fixes for each of them separately.

1. `ifAppIsLiveThenDontWait`
Just(...) emits and completes immediately upon subscription — there's a very short window to process the value.
If `sut.waitUntilCanSendMessage()` does any async setup after the subscription, it might miss the .liveSyncing(.ongoing) emission entirely. So even though subscription technically happens, the handler inside the Combine pipeline hasn't attached yet, and the value is lost.
**The solution** is to guarantee the value is emitted after the subscription is active.


3. `waitForDecryptionToFinish`
Sometimes, timing is such (when running test many times in a row) that `.waitUntilCanSendMessage()` subscribes after the Task sends `.processPendingEvents`. Then, it only sees the current value (which is still `.pullPendingEvents`). And since `.pullPendingEvents` doesn't satisfy the continuation → await sut.waitUntilCanSendMessage() never resumes → 💥 test hangs.
This issue cannot be reproduced by running the test only once, but it is possible to run it multiple times.
**The solution** is to add a flag to signal when the observer is active.


**My thoughts:**
In general, I would use still **XCTest** for such async tests. They have more functionality to handle complex use cases and timeout if needed without causing side hangs.

### Testing


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
