### PR TITLE
feat: fix the guests top bar and the play button - WPB-18452

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ConversationContentViewControllerDelegate.swift
@@ -82,14 +82,16 @@ extension ConversationViewController: ConversationContentViewControllerDelegate 
         _ contentViewController: ConversationContentViewController,
         willDisplayActiveMediaPlayerFor message: ZMConversationMessage?
     ) {
-        conversationBarController.dismiss(bar: mediaBarViewController)
+        /// Do not handle intentionally due to the issue described in the
+        /// https://wearezeta.atlassian.net/browse/WPB-18452
     }
 
     func conversationContentViewController(
         _ contentViewController: ConversationContentViewController,
         didEndDisplayingActiveMediaPlayerFor message: ZMConversationMessage
     ) {
-        conversationBarController.present(bar: mediaBarViewController)
+        /// Do not handle intentionally due to the issue described in the
+        /// https://wearezeta.atlassian.net/browse/WPB-18452
     }
 
     func conversationContentViewController(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+GuestBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+GuestBar.swift
@@ -99,14 +99,4 @@ extension ConversationViewController {
         }
     }
 
-    func setGuestBarForceHidden(_ isGuestBarForceHidden: Bool) {
-        if isGuestBarForceHidden {
-            guestsBarController.setState(.hidden, animated: true)
-            guestsBarController.shouldIgnoreUpdates = true
-        } else {
-            guestsBarController.shouldIgnoreUpdates = false
-            updateGuestsBarVisibility()
-        }
-    }
-
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -84,7 +84,7 @@ final class ConversationViewController: UIViewController {
     let conversationBarController: BarController = .init()
     let guestsBarController: GuestsBarController = .init()
     let invisibleInputAccessoryView: InvisibleInputAccessoryView = .init()
-    let mediaBarViewController: MediaBarViewController
+    private let mediaBarViewController: MediaBarViewController
 
     private let titleView: WireConversationUI.ConversationTitleView
 
@@ -736,13 +736,11 @@ extension ConversationViewController: ConversationInputBarViewControllerDelegate
             contentViewController.scrollToBottomIfNeeded()
         }
 
-        setGuestBarForceHidden(true)
         return true
     }
 
     func conversationInputBarViewControllerShouldEndEditing(_ controller: ConversationInputBarViewController) -> Bool {
-        setGuestBarForceHidden(false)
-        return true
+        true
     }
 
     func conversationInputBarViewControllerDidFinishEditing(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18452" title="WPB-18452" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18452</a>  [iOS] [Replicated] Play button for a voice message appears at the top of the screen and overlaps other elements.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

1. Play button for a voice message appears at the top of the screen and overlaps other elements. https://wearezeta.atlassian.net/browse/WPB-18452
2. Information bar for federated users and guests does not stick to top of chat (not shown properly when keyboard is open). https://wearezeta.atlassian.net/browse/WPB-18451
These issues are reported by the customer.

The fix is ​​to not hide the info bar when the keyboard is open and not show the play button at the top.
I left the play button logic in just in case we want to improve the UI in the future.

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
