### PR TITLE
fix: crash on log - WPB-17129

### DIFF
--- a/wire-ios/WireCommonComponents/Logging/CocoaLumberjackLogger.swift
+++ b/wire-ios/WireCommonComponents/Logging/CocoaLumberjackLogger.swift
@@ -26,6 +26,7 @@ final class CocoaLumberjackLogger: LoggerProtocol {
 
     private let fileLogger: DDFileLogger = .init() // File Logger
     private var tags = [LogAttributesKey: String]()
+    private let tagsQueue = DispatchQueue(label: "CocoaLumberjackLogger.tagsQueue", attributes: .concurrent)
 
     init() {
         fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours
@@ -94,8 +95,13 @@ final class CocoaLumberjackLogger: LoggerProtocol {
         var entry =
             "[\(formattedLevel(level))] \(message.logDescription)\(attributesDescription(from: mergedAttributes))"
 
-        if !tags.isEmpty {
-            let extraInfo = tags.map { key, value in "[\(key.rawValue):\(value)]" }.joined()
+        var currentTags: [LogAttributesKey: String] = [:]
+        tagsQueue.sync {
+            currentTags = tags
+        }
+
+        if !currentTags.isEmpty {
+            let extraInfo = currentTags.map { key, value in "[\(key.rawValue):\(value)]" }.joined()
             entry += extraInfo
         }
 
@@ -108,10 +114,12 @@ final class CocoaLumberjackLogger: LoggerProtocol {
     }
 
     func addTag(_ key: LogAttributesKey, value: String?) {
-        if let value {
-            tags[key] = value
-        } else {
-            tags.removeValue(forKey: key)
+        tagsQueue.async(flags: .barrier) { [weak self] in
+            if let value {
+                self?.tags[key] = value
+            } else {
+                self?.tags.removeValue(forKey: key)
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17129" title="WPB-17129" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17129</a>  [iOS] Crash on (logging on AVS) when enabling MLS for a team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Crash on logging because of logger is not thread safe. 
Added thread safety

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
