### PR TITLE
feat: Replace compositions with separate string entries - WPB-18448

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationViewController+GuestBarTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationViewController+GuestBarTests.swift
@@ -1,0 +1,124 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireTestingPackage
+import XCTest
+
+@testable import Wire
+
+final class ConversationViewControllerGuestBarTests: XCTestCase, CoreDataFixtureTestHelper  {
+
+    private var mockMainCoordinator: AnyMainCoordinator!
+    private var sut: ConversationViewController!
+    private var userSession: UserSessionMock!
+    var coreDataFixture: CoreDataFixture!
+
+    @MainActor
+    override func setUp() {
+        coreDataFixture = CoreDataFixture()
+        userSession = UserSessionMock(mockUser: .createSelfUser(name: "Bob"))
+        mockMainCoordinator = .init(mainCoordinator: MockMainCoordinator())
+        let conversation = createTeamGroupConversation()
+        sut = ConversationViewController(
+            conversation: conversation,
+            visibleMessage: nil,
+            userSession: userSession,
+            mainCoordinator: mockMainCoordinator,
+            selfProfileUIBuilder: MockSelfProfileViewControllerBuilderProtocol(),
+            mediaPlaybackManager: nil,
+            classificationProvider: nil,
+            networkStatusObservable: MockNetworkStatusObservable(),
+            getParticipantImageSourceUseCase: MockGetParticipantImageSourceUseCaseProtocol()
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockMainCoordinator = nil
+        userSession = nil
+        coreDataFixture = nil
+
+        super.tearDown()
+    }
+
+    func testAllKnownStatesAreHandled() {
+        typealias BannerStrings = L10n.Localizable.Conversation.Banner
+
+        assertLabel(for: [.visibleRemotes],
+                    expected: BannerStrings.remotesPresent)
+
+        assertLabel(for: [.visibleExternals],
+                    expected: BannerStrings.externalsPresent)
+
+        assertLabel(for: [.visibleGuests],
+                    expected: BannerStrings.guestsPresent)
+
+        assertLabel(for: [.visibleServices],
+                    expected: BannerStrings.servicesActive)
+
+        assertLabel(for: [.visibleRemotes, .visibleExternals],
+                    expected: BannerStrings.remotesExternalsPresent)
+
+        assertLabel(for: [.visibleRemotes, .visibleGuests],
+                    expected: BannerStrings.remotesGuestsPresent)
+
+        assertLabel(for: [.visibleRemotes, .visibleServices],
+                    expected: BannerStrings.remotesServicesPresent)
+
+        assertLabel(for: [.visibleExternals, .visibleGuests],
+                    expected: BannerStrings.externalsGuestsPresent)
+
+        assertLabel(for: [.visibleExternals, .visibleServices],
+                    expected: BannerStrings.externalsServicesPresent)
+
+        assertLabel(for: [.visibleGuests, .visibleServices],
+                    expected: BannerStrings.guestsServicesPresent)
+
+        assertLabel(for: [.visibleRemotes, .visibleExternals, .visibleGuests],
+                    expected: BannerStrings.remotesExternalsGuestsPresent)
+
+        assertLabel(for: [.visibleRemotes, .visibleExternals, .visibleServices],
+                    expected: BannerStrings.remotesExternalsServicesPresent)
+
+        assertLabel(for: [.visibleRemotes, .visibleGuests, .visibleServices],
+                    expected: BannerStrings.remotesGuestsServicesPresent)
+
+        assertLabel(for: [.visibleExternals, .visibleGuests, .visibleServices],
+                    expected: BannerStrings.externalsGuestsServicesPresent)
+
+        assertLabel(for: [.visibleRemotes, .visibleExternals, .visibleGuests, .visibleServices],
+                    expected: BannerStrings.remotesExternalsGuestsServicesPresent)
+    }
+
+    // MARK: - Helper Method
+
+    private func assertLabel(
+        for state: ZMConversation.ExternalParticipantsState,
+        expected: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let result = sut.label(for: state)
+        XCTAssertEqual(result, expected, file: file, line: line)
+    }
+
+    func createTeamGroupConversation() -> ZMConversation {
+        ZMConversation.createTeamGroupConversation(moc: coreDataFixture.uiMOC, otherUser: otherUser, selfUser: selfUser)
+    }
+
+}

--- a/wire-ios/Wire-iOS Tests/ConversationViewController+GuestBarTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationViewController+GuestBarTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 @testable import Wire
 
-final class ConversationViewControllerGuestBarTests: XCTestCase, CoreDataFixtureTestHelper  {
+final class ConversationViewControllerGuestBarTests: XCTestCase, CoreDataFixtureTestHelper {
 
     private var mockMainCoordinator: AnyMainCoordinator!
     private var sut: ConversationViewController!
@@ -59,50 +59,80 @@ final class ConversationViewControllerGuestBarTests: XCTestCase, CoreDataFixture
     func testAllKnownStatesAreHandled() {
         typealias BannerStrings = L10n.Localizable.Conversation.Banner
 
-        assertLabel(for: [.visibleRemotes],
-                    expected: BannerStrings.remotesPresent)
+        assertLabel(
+            for: [.visibleRemotes],
+            expected: BannerStrings.remotesPresent
+        )
 
-        assertLabel(for: [.visibleExternals],
-                    expected: BannerStrings.externalsPresent)
+        assertLabel(
+            for: [.visibleExternals],
+            expected: BannerStrings.externalsPresent
+        )
 
-        assertLabel(for: [.visibleGuests],
-                    expected: BannerStrings.guestsPresent)
+        assertLabel(
+            for: [.visibleGuests],
+            expected: BannerStrings.guestsPresent
+        )
 
-        assertLabel(for: [.visibleServices],
-                    expected: BannerStrings.servicesActive)
+        assertLabel(
+            for: [.visibleServices],
+            expected: BannerStrings.servicesActive
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleExternals],
-                    expected: BannerStrings.remotesExternalsPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleExternals],
+            expected: BannerStrings.remotesExternalsPresent
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleGuests],
-                    expected: BannerStrings.remotesGuestsPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleGuests],
+            expected: BannerStrings.remotesGuestsPresent
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleServices],
-                    expected: BannerStrings.remotesServicesPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleServices],
+            expected: BannerStrings.remotesServicesPresent
+        )
 
-        assertLabel(for: [.visibleExternals, .visibleGuests],
-                    expected: BannerStrings.externalsGuestsPresent)
+        assertLabel(
+            for: [.visibleExternals, .visibleGuests],
+            expected: BannerStrings.externalsGuestsPresent
+        )
 
-        assertLabel(for: [.visibleExternals, .visibleServices],
-                    expected: BannerStrings.externalsServicesPresent)
+        assertLabel(
+            for: [.visibleExternals, .visibleServices],
+            expected: BannerStrings.externalsServicesPresent
+        )
 
-        assertLabel(for: [.visibleGuests, .visibleServices],
-                    expected: BannerStrings.guestsServicesPresent)
+        assertLabel(
+            for: [.visibleGuests, .visibleServices],
+            expected: BannerStrings.guestsServicesPresent
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleExternals, .visibleGuests],
-                    expected: BannerStrings.remotesExternalsGuestsPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleExternals, .visibleGuests],
+            expected: BannerStrings.remotesExternalsGuestsPresent
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleExternals, .visibleServices],
-                    expected: BannerStrings.remotesExternalsServicesPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleExternals, .visibleServices],
+            expected: BannerStrings.remotesExternalsServicesPresent
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleGuests, .visibleServices],
-                    expected: BannerStrings.remotesGuestsServicesPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleGuests, .visibleServices],
+            expected: BannerStrings.remotesGuestsServicesPresent
+        )
 
-        assertLabel(for: [.visibleExternals, .visibleGuests, .visibleServices],
-                    expected: BannerStrings.externalsGuestsServicesPresent)
+        assertLabel(
+            for: [.visibleExternals, .visibleGuests, .visibleServices],
+            expected: BannerStrings.externalsGuestsServicesPresent
+        )
 
-        assertLabel(for: [.visibleRemotes, .visibleExternals, .visibleGuests, .visibleServices],
-                    expected: BannerStrings.remotesExternalsGuestsServicesPresent)
+        assertLabel(
+            for: [.visibleRemotes, .visibleExternals, .visibleGuests, .visibleServices],
+            expected: BannerStrings.remotesExternalsGuestsServicesPresent
+        )
     }
 
     // MARK: - Helper Method

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -650,6 +650,7 @@
 				ConversationStatusTests.swift,
 				"ConversationStatusTests+Icon.swift",
 				ConversationTitleViewTests.swift,
+				"ConversationViewController+GuestBarTests.swift",
 				ConversationViewControllerSnapshotTests.swift,
 				CreateSecureGuestLinkViewModelTests.swift,
 				CustomAppLock/AppLockChangeWarningViewControllerTests.swift,

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -2428,14 +2428,44 @@ internal enum L10n {
         }
         /// Externals
         internal static let externals = L10n.tr("Localizable", "conversation.banner.externals", fallback: "Externals")
+        /// Externals and guests are present
+        internal static let externalsGuestsPresent = L10n.tr("Localizable", "conversation.banner.externals_guests_present", fallback: "Externals and guests are present")
+        /// Externals, guests and services are present
+        internal static let externalsGuestsServicesPresent = L10n.tr("Localizable", "conversation.banner.externals_guests_services_present", fallback: "Externals, guests and services are present")
+        /// Externals are present
+        internal static let externalsPresent = L10n.tr("Localizable", "conversation.banner.externals_present", fallback: "Externals are present")
+        /// Externals and services are present
+        internal static let externalsServicesPresent = L10n.tr("Localizable", "conversation.banner.externals_services_present", fallback: "Externals and services are present")
         /// Guests
         internal static let guests = L10n.tr("Localizable", "conversation.banner.guests", fallback: "Guests")
+        /// Guests are present
+        internal static let guestsPresent = L10n.tr("Localizable", "conversation.banner.guests_present", fallback: "Guests are present")
+        /// Guests and services are present
+        internal static let guestsServicesPresent = L10n.tr("Localizable", "conversation.banner.guests_services_present", fallback: "Guests and services are present")
         /// Federated users
         internal static let remotes = L10n.tr("Localizable", "conversation.banner.remotes", fallback: "Federated users")
+        /// Federated users, externals and guests are present
+        internal static let remotesExternalsGuestsPresent = L10n.tr("Localizable", "conversation.banner.remotes_externals_guests_present", fallback: "Federated users, externals and guests are present")
+        /// Federated users, externals, guests and services are present
+        internal static let remotesExternalsGuestsServicesPresent = L10n.tr("Localizable", "conversation.banner.remotes_externals_guests_services_present", fallback: "Federated users, externals, guests and services are present")
+        /// Federated users and externals are present
+        internal static let remotesExternalsPresent = L10n.tr("Localizable", "conversation.banner.remotes_externals_present", fallback: "Federated users and externals are present")
+        /// Federated users, externals and services are present
+        internal static let remotesExternalsServicesPresent = L10n.tr("Localizable", "conversation.banner.remotes_externals_services_present", fallback: "Federated users, externals and services are present")
+        /// Federated users and guests are present
+        internal static let remotesGuestsPresent = L10n.tr("Localizable", "conversation.banner.remotes_guests_present", fallback: "Federated users and guests are present")
+        /// Federated users, guests and services are present
+        internal static let remotesGuestsServicesPresent = L10n.tr("Localizable", "conversation.banner.remotes_guests_services_present", fallback: "Federated users, guests and services are present")
+        /// Federated users are present
+        internal static let remotesPresent = L10n.tr("Localizable", "conversation.banner.remotes_present", fallback: "Federated users are present")
+        /// Federated users and services are present
+        internal static let remotesServicesPresent = L10n.tr("Localizable", "conversation.banner.remotes_services_present", fallback: "Federated users and services are present")
         ///  and 
         internal static let separator = L10n.tr("Localizable", "conversation.banner.separator", fallback: " and ")
         /// Services
         internal static let services = L10n.tr("Localizable", "conversation.banner.services", fallback: "Services")
+        /// Services are active
+        internal static let servicesActive = L10n.tr("Localizable", "conversation.banner.services_active", fallback: "Services are active")
       }
       internal enum Call {
         internal enum ManyParticipantsConfirmation {

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -369,6 +369,22 @@
 "conversation.banner.are_active" = "%@ are active";
 "conversation.banner.separator" = " and ";
 
+"conversation.banner.remotes_externals_guests_services_present" = "Federated users, externals, guests and services are present";
+"conversation.banner.remotes_externals_guests_present" = "Federated users, externals and guests are present";
+"conversation.banner.remotes_externals_services_present" = "Federated users, externals and services are present";
+"conversation.banner.remotes_guests_services_present" = "Federated users, guests and services are present";
+"conversation.banner.externals_guests_services_present" = "Externals, guests and services are present";
+"conversation.banner.remotes_externals_present" = "Federated users and externals are present";
+"conversation.banner.remotes_guests_present" = "Federated users and guests are present";
+"conversation.banner.remotes_services_present" = "Federated users and services are present";
+"conversation.banner.externals_guests_present" = "Externals and guests are present";
+"conversation.banner.externals_services_present" = "Externals and services are present";
+"conversation.banner.guests_services_present" = "Guests and services are present";
+"conversation.banner.remotes_present" = "Federated users are present";
+"conversation.banner.externals_present" = "Externals are present";
+"conversation.banner.guests_present" = "Guests are present";
+"conversation.banner.services_active" = "Services are active";
+
 "conversation.action.search" = "Search";
 "conversation.action.conversationDetails" = "Conversation Details";
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+GuestBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+GuestBar.swift
@@ -28,40 +28,67 @@ extension ConversationViewController {
 
         let state = conversation.externalParticipantsState
 
-        if state.isEmpty {
+        guard
+            !state.isEmpty,
+            let labelKey = label(for: state)
+        else {
             return .hidden
-        } else {
-            return .visible(labelKey: label(for: state), identifier: identifier(for: state))
         }
+        return .visible(labelKey: labelKey, identifier: identifier(for: state))
+
     }
 
-    func label(for state: ZMConversation.ExternalParticipantsState) -> String {
-        var states: [String] = []
+    func label(for state: ZMConversation.ExternalParticipantsState) -> String? {
+        typealias BannerStrings = L10n.Localizable.Conversation.Banner
 
-        if conversation.externalParticipantsState.contains(.visibleRemotes) {
-            states.append(ConversationBanner.remotes)
-        }
+        switch state {
+        case [.visibleRemotes, .visibleExternals, .visibleGuests, .visibleServices]:
+            return BannerStrings.remotesExternalsGuestsServicesPresent
 
-        if conversation.externalParticipantsState.contains(.visibleExternals) {
-            states.append(ConversationBanner.externals)
-        }
+        case [.visibleRemotes, .visibleExternals, .visibleGuests]:
+            return BannerStrings.remotesExternalsGuestsPresent
 
-        if conversation.externalParticipantsState.contains(.visibleGuests) {
-            states.append(ConversationBanner.guests)
-        }
+        case [.visibleRemotes, .visibleExternals, .visibleServices]:
+            return BannerStrings.remotesExternalsServicesPresent
 
-        if conversation.externalParticipantsState.contains(.visibleServices) {
-            states.append(ConversationBanner.services)
-        }
+        case [.visibleRemotes, .visibleGuests, .visibleServices]:
+            return BannerStrings.remotesGuestsServicesPresent
 
-        let head = states[0]
-        let tail = states.dropFirst().map(\.localizedLowercase)
-        let list = ([head] + tail).joined(separator: ConversationBanner.separator)
+        case [.visibleExternals, .visibleGuests, .visibleServices]:
+            return BannerStrings.externalsGuestsServicesPresent
 
-        if state == .visibleServices {
-            return ConversationBanner.areActive(list)
-        } else {
-            return ConversationBanner.arePresent(list)
+        case [.visibleRemotes, .visibleExternals]:
+            return BannerStrings.remotesExternalsPresent
+
+        case [.visibleRemotes, .visibleGuests]:
+            return BannerStrings.remotesGuestsPresent
+
+        case [.visibleRemotes, .visibleServices]:
+            return BannerStrings.remotesServicesPresent
+
+        case [.visibleExternals, .visibleGuests]:
+            return BannerStrings.externalsGuestsPresent
+
+        case [.visibleExternals, .visibleServices]:
+            return BannerStrings.externalsServicesPresent
+
+        case [.visibleGuests, .visibleServices]:
+            return BannerStrings.guestsServicesPresent
+
+        case [.visibleRemotes]:
+            return BannerStrings.remotesPresent
+
+        case [.visibleExternals]:
+            return BannerStrings.externalsPresent
+
+        case [.visibleGuests]:
+            return BannerStrings.guestsPresent
+
+        case [.visibleServices]:
+            return BannerStrings.servicesActive
+
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18448" title="WPB-18448" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18448</a>  [iOS] [Replicated] When a group contains federated users and guests, display issues occur with spelling mistakes and double spaces
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

There is a spelling mistakes in German (gäste instead of Gäste) and double spaces in the "Federated users and guests ..." bar.
The problem is that localized strings are being composed from multiple strings.

### Solution

The solution is to move all of these compositions and have a separate string entry for every possible case.

### Testing

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
