### PR TITLE
fix: Countly host configuration - WPB-18184

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -945,6 +945,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         }
     }
 
+    @MainActor
     func configureAnalytics(for userSession: ZMUserSession) async {
         guard let isTrackingEnabled = analyticsService?.isTrackingEnabled, isTrackingEnabled else {
             return

--- a/wire-ios/Configuration/Backend.bundle/default.json
+++ b/wire-ios/Configuration/Backend.bundle/default.json
@@ -7,7 +7,7 @@
         "teamsURL": "https://teams.wire.com",
         "accountsURL": "https://account.wire.com",
         "websiteURL": "https://wire.com",
-        "countlyURL": "https://35.205.132.205"
+        "countlyURL": "https://wire.count.ly"
     },
     "pinned_keys": [
         {

--- a/wire-ios/Configuration/Backend.bundle/staging.json
+++ b/wire-ios/Configuration/Backend.bundle/staging.json
@@ -7,6 +7,6 @@
         "teamsURL": "https://wire-teams-staging.zinfra.io",
         "accountsURL": "https://wire-account-staging.zinfra.io",
         "websiteURL": "https://wire.com",
-        "countlyURL": "https://35.205.132.205"
+        "countlyURL": "https://wire.count.ly"
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18184" title="WPB-18184" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18184</a>  [iOS] Modify Countly Instance IP
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fix the host in the Countly configuration.
We can't just specify the ID of the instance, but we need to put in the domain.

### Testing

Start the app and observe that Countly tracks the session and events.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
