### PR TITLE
feat: add context menu to attachments carousel - WPB-17617

### DIFF
--- a/WireCells/Sources/WireCellsUI/Components/AttachmentsCarousel/AttachmentsCarousel.swift
+++ b/WireCells/Sources/WireCellsUI/Components/AttachmentsCarousel/AttachmentsCarousel.swift
@@ -23,18 +23,18 @@ public struct AttachmentsCarousel: View {
     @ObservedObject private var viewModel: AttachmentsCarouselViewModel
     private let onTap: (AttachmentsCarouselItem) -> Void
     private let onRemove: (AttachmentsCarouselItem) -> Void
-    private let onOptions: (AttachmentsCarouselItem) -> Void
+    private let onRetry: (AttachmentsCarouselItem) -> Void
 
     public init(
         viewModel: AttachmentsCarouselViewModel,
         onTap: @escaping (AttachmentsCarouselItem) -> Void,
         onRemove: @escaping (AttachmentsCarouselItem) -> Void,
-        onOptions: @escaping (AttachmentsCarouselItem) -> Void
+        onRetry: @escaping (AttachmentsCarouselItem) -> Void
     ) {
         self.viewModel = viewModel
         self.onTap = onTap
         self.onRemove = onRemove
-        self.onOptions = onOptions
+        self.onRetry = onRetry
     }
 
     public var body: some View {
@@ -45,7 +45,7 @@ public struct AttachmentsCarousel: View {
                         item: item,
                         onTap: { onTap(item) },
                         onRemove: { onRemove(item) },
-                        onOptions: { onOptions(item) }
+                        onRetry: { onRetry(item) }
                     )
                 }
             }
@@ -66,7 +66,7 @@ private struct AttachmentsCarouselItemView: View {
     let item: AttachmentsCarouselItem
     let onTap: () -> Void
     let onRemove: () -> Void
-    let onOptions: () -> Void
+    let onRetry: () -> Void
 
     var body: some View {
         ZStack {
@@ -95,19 +95,31 @@ private struct AttachmentsCarouselItemView: View {
             .onTapGesture(perform: onTap)
     }
 
+    // TODO: [WPB-17604] Add missing accessibility labels
     var cornerButton: some View {
         VStack {
             HStack {
                 Spacer()
-                Button(
-                    action: item.state.isFailed ? onOptions : onRemove,
-                    label: {
-                        Image(systemName: item.state.isFailed ? "ellipsis.circle.fill" : "xmark.circle.fill")
-                            .font(.system(size: Constants.cornerButtonRadius * 2))
-                            .foregroundStyle(.black)
+
+                if item.state.isFailed {
+                    Menu {
+                        Button(L10n.Conversation.Draft.AttachmentMenu.retry, action: onRetry)
+                        Button(L10n.Conversation.Draft.AttachmentMenu.remove, action: onRemove)
+                    } label: {
+                        Image(systemName: "ellipsis.circle.fill")
                     }
-                )
+                } else {
+                    Button(
+                        action: onRemove,
+                        label: {
+                            Image(systemName: "xmark.circle.fill")
+                        }
+                    )
+                }
             }
+            .font(.system(size: Constants.cornerButtonRadius * 2))
+            .foregroundStyle(.black)
+
             Spacer()
         }
     }
@@ -167,7 +179,7 @@ private extension AttachmentsCarouselItem.State {
             items: [
                 AttachmentsCarouselItem(
                     id: UUID(),
-                    state: .uploaded,
+                    state: .failed,
                     kind: .image(thumbnail: UIImage()),
                     name: "Image",
                     size: "1.2 MB"
@@ -183,7 +195,7 @@ private extension AttachmentsCarouselItem.State {
         ),
         onTap: { _ in },
         onRemove: { _ in },
-        onOptions: { _ in }
+        onRetry: { _ in }
     )
     .frame(height: 74)
     .background(Color.red)

--- a/WireCells/Sources/WireCellsUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireCells/Sources/WireCellsUI/Resources/Localization/en.lproj/Localizable.strings
@@ -17,3 +17,5 @@
 //
 
 "conversation.file.preview.open" = "Open preview";
+"conversation.draft.attachmentMenu.retry" = "Retry";
+"conversation.draft.attachmentMenu.remove" = "Remove File";

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -1089,7 +1089,7 @@ extension ConversationInputBarViewController: UIGestureRecognizerDelegate {
                 viewModel: attachmentsCarouselViewModel,
                 onTap: { WireLogger.conversation.debug("Did tap draft attachment: \($0)") },
                 onRemove: { WireLogger.conversation.debug("Did tap remove draft attachment: \($0)") },
-                onOptions: { WireLogger.conversation.debug("Did tap options on draft attachment: \($0)") }
+                onRetry: { WireLogger.conversation.debug("Did tap retry on draft attachment: \($0)") }
             )
         )
         addChild(carouselViewController)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17617" title="WPB-17617" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-17617</a>  [iOS] Add file carousel failure options menu
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a context menu to the attachments carousel that can be shown when a file fails to upload. Note that this SwiftUI view is only a functional placeholder that will change.

<img src="https://github.com/user-attachments/assets/e9b5628a-90e0-4a35-a1b8-d96b33b78410" width="400">

### Testing

This is not currently manually testable.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
