### PR TITLE
fix: dark mode issues - WPB-18449

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -69,6 +69,7 @@ class IconButton: ButtonWithLargerHitArea {
     var adjustsTitleWhenHighlighted = false
     var adjustsBorderColorWhenHighlighted = false
     var adjustBackgroundImageWhenHighlighted = false
+    var shouldUsePassedStateForTintAndBorder = false
 
     private var iconColorsByState: [UIControl.State.RawValue: UIColor] = [:]
     private var borderColorByState: [UIControl.State.RawValue: UIColor] = [:]
@@ -279,7 +280,7 @@ class IconButton: ButtonWithLargerHitArea {
             )
         }
 
-        updateTintColor()
+        updateTintColor(state: shouldUsePassedStateForTintAndBorder ? state : nil)
     }
 
     func iconDefinition(for state: UIControl.State) -> IconDefinition? {
@@ -352,6 +353,6 @@ class IconButton: ButtonWithLargerHitArea {
             }
         }
 
-        updateBorderColor()
+        updateBorderColor(state: shouldUsePassedStateForTintAndBorder ? state : nil)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -69,7 +69,6 @@ class IconButton: ButtonWithLargerHitArea {
     var adjustsTitleWhenHighlighted = false
     var adjustsBorderColorWhenHighlighted = false
     var adjustBackgroundImageWhenHighlighted = false
-    var shouldUsePassedStateForTintAndBorder = false
 
     private var iconColorsByState: [UIControl.State.RawValue: UIColor] = [:]
     private var borderColorByState: [UIControl.State.RawValue: UIColor] = [:]
@@ -280,7 +279,7 @@ class IconButton: ButtonWithLargerHitArea {
             )
         }
 
-        updateTintColor(state: shouldUsePassedStateForTintAndBorder ? state : nil)
+        updateTintColor()
     }
 
     func iconDefinition(for state: UIControl.State) -> IconDefinition? {
@@ -353,6 +352,6 @@ class IconButton: ButtonWithLargerHitArea {
             }
         }
 
-        updateBorderColor(state: shouldUsePassedStateForTintAndBorder ? state : nil)
+        updateBorderColor()
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -279,7 +279,7 @@ class IconButton: ButtonWithLargerHitArea {
             )
         }
 
-        updateTintColor(for: state)
+        updateTintColor()
     }
 
     func iconDefinition(for state: UIControl.State) -> IconDefinition? {
@@ -294,13 +294,12 @@ class IconButton: ButtonWithLargerHitArea {
         borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
-    private func updateBorderColor(for state: UIControl.State) {
-        layer.borderColor = borderColor(for: state)?.cgColor
+    func updateBorderColor(state newState: UIControl.State? = nil) {
+        layer.borderColor = borderColor(for: newState ?? state)?.cgColor
     }
 
-    func updateTintColor(for state: UIControl.State) {
-        tintColor = iconColor(for: state)
-        print("DS: IconButton set tintColor for state: \(state): \(tintColor ?? .clear)")
+    func updateTintColor(state newState: UIControl.State? = nil) {
+        tintColor = iconColor(for: newState ?? state)
     }
 
     private func updateCircularCornerRadius() {
@@ -330,15 +329,18 @@ class IconButton: ButtonWithLargerHitArea {
 
         priorState = state
         // Update for new state (selected, highlighted, disabled) here if needed
-        updateTintColor(for: state)
-        updateBorderColor(for: state)
+        updateTintColor()
+        updateBorderColor()
     }
 
     func icon(for state: UIControl.State) -> StyleKitIcon? {
         iconDefinition(for: state)?.type
     }
 
-    func setBorderColor(_ color: UIColor?, for state: UIControl.State) {
+    func setBorderColor(
+        _ color: UIColor?,
+        for state: UIControl.State
+    ) {
         state.expanded.forEach { expandedState in
             if color != nil {
                 borderColorByState[expandedState.rawValue] = color
@@ -350,6 +352,6 @@ class IconButton: ButtonWithLargerHitArea {
             }
         }
 
-        updateBorderColor(for: state)
+        updateBorderColor()
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -294,12 +294,12 @@ class IconButton: ButtonWithLargerHitArea {
         borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
-    func updateBorderColor(state newState: UIControl.State? = nil) {
-        layer.borderColor = borderColor(for: newState ?? state)?.cgColor
+    func updateBorderColor() {
+        layer.borderColor = borderColor(for: state)?.cgColor
     }
 
-    func updateTintColor(state newState: UIControl.State? = nil) {
-        tintColor = iconColor(for: newState ?? state)
+    func updateTintColor() {
+        tintColor = iconColor(for: state)
     }
 
     private func updateCircularCornerRadius() {

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -294,7 +294,7 @@ class IconButton: ButtonWithLargerHitArea {
         borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
-    func updateBorderColor() {
+    private func updateBorderColor() {
         layer.borderColor = borderColor(for: state)?.cgColor
     }
 
@@ -337,10 +337,7 @@ class IconButton: ButtonWithLargerHitArea {
         iconDefinition(for: state)?.type
     }
 
-    func setBorderColor(
-        _ color: UIColor?,
-        for state: UIControl.State
-    ) {
+    func setBorderColor(_ color: UIColor?, for state: UIControl.State) {
         state.expanded.forEach { expandedState in
             if color != nil {
                 borderColorByState[expandedState.rawValue] = color

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -279,7 +279,7 @@ class IconButton: ButtonWithLargerHitArea {
             )
         }
 
-        updateTintColor()
+        updateTintColor(for: state)
     }
 
     func iconDefinition(for state: UIControl.State) -> IconDefinition? {
@@ -294,12 +294,13 @@ class IconButton: ButtonWithLargerHitArea {
         borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
-    private func updateBorderColor() {
+    private func updateBorderColor(for state: UIControl.State) {
         layer.borderColor = borderColor(for: state)?.cgColor
     }
 
-    func updateTintColor() {
+    func updateTintColor(for state: UIControl.State) {
         tintColor = iconColor(for: state)
+        print("DS: IconButton set tintColor for state: \(state): \(tintColor ?? .clear)")
     }
 
     private func updateCircularCornerRadius() {
@@ -329,8 +330,8 @@ class IconButton: ButtonWithLargerHitArea {
 
         priorState = state
         // Update for new state (selected, highlighted, disabled) here if needed
-        updateTintColor()
-        updateBorderColor()
+        updateTintColor(for: state)
+        updateBorderColor(for: state)
     }
 
     func icon(for state: UIControl.State) -> StyleKitIcon? {
@@ -349,6 +350,6 @@ class IconButton: ButtonWithLargerHitArea {
             }
         }
 
-        updateBorderColor()
+        updateBorderColor(for: state)
     }
 }

--- a/wire-ios/Wire-iOS/Sources/Managers/ColorSchemeController.swift
+++ b/wire-ios/Wire-iOS/Sources/Managers/ColorSchemeController.swift
@@ -19,21 +19,12 @@
 import Foundation
 import WireSyncEngine
 
-extension Notification.Name {
-    static let colorSchemeControllerDidApplyColorSchemeChange = Self("ColorSchemeControllerDidApplyColorSchemeChange")
-}
-
 final class ColorSchemeController: NSObject {
 
     var userObserverToken: Any?
 
     init(userSession: UserSession) {
         super.init()
-
-        // When SelfUser.provider is nil, e.g. running tests, do not set up UserChangeInfo observer
-        if let user = SelfUser.provider?.providedSelfUser {
-            self.userObserverToken = userSession.addUserObserver(self, for: user)
-        }
 
         NotificationCenter.default.addObserver(
             self,
@@ -42,10 +33,6 @@ final class ColorSchemeController: NSObject {
             object: nil
         )
 
-    }
-
-    func notifyColorSchemeChange() {
-        NotificationCenter.default.post(name: .colorSchemeControllerDidApplyColorSchemeChange, object: self)
     }
 
     @objc
@@ -57,19 +44,5 @@ final class ColorSchemeController: NSObject {
         ColorScheme.default.variant = Settings.shared.colorSchemeVariant
 
         NSAttributedString.invalidateMarkdownStyle()
-
-        notifyColorSchemeChange()
-    }
-}
-
-extension ColorSchemeController: UserObserving {
-    func userDidChange(_ note: UserChangeInfo) {
-        guard note.accentColorValueChanged else { return }
-
-        let colorScheme = ColorScheme.default
-
-        if !colorScheme.isCurrentAccentColor(UIColor.accent()) {
-            notifyColorSchemeChange()
-        }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
@@ -29,6 +29,7 @@ class CallingActionButton: IconLabelButton {
         subtitleTransformLabel.textTransform = .capitalize
         titleLabel?.font = UIFont.systemFont(ofSize: 12)
         subtitleTransformLabel.font = titleLabel?.font
+        iconButton.shouldUsePassedStateForTintAndBorder = true
         iconButton.setIcon(input.icon(forState: .normal), size: iconSize, for: .normal)
         iconButton.setIcon(input.icon(forState: .selected), size: iconSize, for: .selected)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsView/CallingActionButton.swift
@@ -29,7 +29,6 @@ class CallingActionButton: IconLabelButton {
         subtitleTransformLabel.textTransform = .capitalize
         titleLabel?.font = UIFont.systemFont(ofSize: 12)
         subtitleTransformLabel.font = titleLabel?.font
-        iconButton.shouldUsePassedStateForTintAndBorder = true
         iconButton.setIcon(input.icon(forState: .normal), size: iconSize, for: .normal)
         iconButton.setIcon(input.icon(forState: .selected), size: iconSize, for: .selected)
     }
@@ -37,19 +36,51 @@ class CallingActionButton: IconLabelButton {
     override func apply(_ configuration: CallActionAppearance) {
         iconButton.borderWidth = 1
 
-        setTitleColor(SemanticColors.Button.textCallingNormal, for: .normal)
-        iconButton.setBorderColor(SemanticColors.Button.borderCallingNormal, for: .normal)
-        iconButton.setIconColor(SemanticColors.Button.iconCallingNormal, for: .normal)
-        iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingNormal, for: .normal)
+        setTitleColor(
+            SemanticColors.Button.textCallingNormal.resolvedColor(with: traitCollection),
+            for: .normal
+        )
 
-        iconButton.setBorderColor(SemanticColors.Button.borderCallingSelected, for: .selected)
-        iconButton.setIconColor(SemanticColors.Button.iconCallingSelected, for: .selected)
-        iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingSelected, for: .selected)
+        iconButton.setBorderColor(
+            SemanticColors.Button.borderCallingNormal.resolvedColor(with: traitCollection),
+            for: .normal
+        )
+        iconButton.setIconColor(
+            SemanticColors.Button.iconCallingNormal.resolvedColor(with: traitCollection),
+            for: .normal
+        )
+        iconButton.setBackgroundImageColor(
+            SemanticColors.Button.backgroundCallingNormal.resolvedColor(with: traitCollection),
+            for: .normal
+        )
+        iconButton.setBorderColor(
+            SemanticColors.Button.borderCallingSelected.resolvedColor(with: traitCollection),
+            for: .selected
+        )
+        iconButton.setIconColor(
+            SemanticColors.Button.iconCallingSelected.resolvedColor(with: traitCollection),
+            for: .selected
+        )
+        iconButton.setBackgroundImageColor(
+            SemanticColors.Button.backgroundCallingSelected.resolvedColor(with: traitCollection),
+            for: .selected
+        )
 
         setTitleColor(SemanticColors.Button.textCallingDisabled, for: .disabled)
-        iconButton.setBorderColor(SemanticColors.Button.borderCallingDisabled, for: .disabled)
-        iconButton.setIconColor(SemanticColors.Button.iconCallingDisabled, for: .disabled)
-        iconButton.setBackgroundImageColor(SemanticColors.Button.backgroundCallingDisabled, for: .disabled)
+        iconButton
+            .setBorderColor(
+                SemanticColors.Button.borderCallingDisabled
+                    .resolvedColor(with: traitCollection),
+                for: .disabled
+            )
+        iconButton.setIconColor(
+            SemanticColors.Button.iconCallingDisabled.resolvedColor(with: traitCollection),
+            for: .disabled
+        )
+        iconButton.setBackgroundImageColor(
+            SemanticColors.Button.backgroundCallingDisabled.resolvedColor(with: traitCollection),
+            for: .disabled
+        )
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -140,25 +140,17 @@ class IconLabelButton: ButtonWithLargerHitArea {
         setTitleColor(configuration.iconColorNormal, for: .normal)
         iconButton.setIconColor(configuration.iconColorNormal, for: .normal)
         iconButton.setBackgroundImageColor(configuration.backgroundColorNormal, for: .normal)
-        iconButton.updateTintColor(state: .normal)
-        iconButton.updateBorderColor(state: .normal)
 
         iconButton.setIconColor(configuration.iconColorSelected, for: .selected)
         iconButton.setBackgroundImageColor(configuration.backgroundColorSelected, for: .selected)
-        iconButton.updateTintColor(state: .selected)
-        iconButton.updateBorderColor(state: .selected)
 
         setTitleColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabled)
         iconButton.setIconColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabled)
         iconButton.setBackgroundImageColor(configuration.backgroundColorNormal, for: .disabled)
-        iconButton.updateTintColor(state: .disabled)
-        iconButton.updateBorderColor(state: .disabled)
 
         setTitleColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabledAndSelected)
         iconButton.setIconColor(configuration.iconColorSelected.withAlphaComponent(0.4), for: .disabledAndSelected)
         iconButton.setBackgroundImageColor(configuration.backgroundColorSelected, for: .disabledAndSelected)
-        iconButton.updateTintColor(state: .disabledAndSelected)
-        iconButton.updateBorderColor(state: .disabledAndSelected)
 
         iconButton.setBackgroundImageColor(
             configuration.backgroundColorSelectedAndHighlighted,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -67,7 +67,6 @@ class IconLabelButton: ButtonWithLargerHitArea {
         iconButton.isUserInteractionEnabled = false
         iconButton.borderWidth = 0
         iconButton.circular = true
-        iconButton.shouldUsePassedStateForTintAndBorder = true
         blurView.translatesAutoresizingMaskIntoConstraints = false
         blurView.clipsToBounds = true
         blurView.layer.cornerRadius = IconLabelButton.width / 2

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -34,8 +34,6 @@ class IconLabelButton: ButtonWithLargerHitArea {
     private let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     private var widthConstraint: NSLayoutConstraint!
 
-    var shouldUseCurrentStateToSetTintAndBorder: Bool = true
-
     var appearance: CallActionAppearance = .dark(blurred: false) {
         didSet {
             updateState()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -33,7 +33,7 @@ class IconLabelButton: ButtonWithLargerHitArea {
     private(set) var subtitleTransformLabel = TransformLabel()
     private let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     private var widthConstraint: NSLayoutConstraint!
-    
+
     var shouldUseCurrentStateToSetTintAndBorder: Bool = true
 
     var appearance: CallActionAppearance = .dark(blurred: false) {
@@ -62,10 +62,12 @@ class IconLabelButton: ButtonWithLargerHitArea {
     }
 
     private func setupViews() {
-        iconButton.translatesAutoresizingMaskIntoConstraints = false
+        iconButton
+            .translatesAutoresizingMaskIntoConstraints = false
         iconButton.isUserInteractionEnabled = false
         iconButton.borderWidth = 0
         iconButton.circular = true
+        iconButton.shouldUsePassedStateForTintAndBorder = true
         blurView.translatesAutoresizingMaskIntoConstraints = false
         blurView.clipsToBounds = true
         blurView.layer.cornerRadius = IconLabelButton.width / 2
@@ -146,7 +148,7 @@ class IconLabelButton: ButtonWithLargerHitArea {
         iconButton.setBackgroundImageColor(configuration.backgroundColorSelected, for: .selected)
         iconButton.updateTintColor(state: .selected)
         iconButton.updateBorderColor(state: .selected)
-        
+
         setTitleColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabled)
         iconButton.setIconColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabled)
         iconButton.setBackgroundImageColor(configuration.backgroundColorNormal, for: .disabled)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/CallActionsView/IconLabelButton.swift
@@ -33,6 +33,8 @@ class IconLabelButton: ButtonWithLargerHitArea {
     private(set) var subtitleTransformLabel = TransformLabel()
     private let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
     private var widthConstraint: NSLayoutConstraint!
+    
+    var shouldUseCurrentStateToSetTintAndBorder: Bool = true
 
     var appearance: CallActionAppearance = .dark(blurred: false) {
         didSet {
@@ -137,17 +139,25 @@ class IconLabelButton: ButtonWithLargerHitArea {
         setTitleColor(configuration.iconColorNormal, for: .normal)
         iconButton.setIconColor(configuration.iconColorNormal, for: .normal)
         iconButton.setBackgroundImageColor(configuration.backgroundColorNormal, for: .normal)
+        iconButton.updateTintColor(state: .normal)
+        iconButton.updateBorderColor(state: .normal)
 
         iconButton.setIconColor(configuration.iconColorSelected, for: .selected)
         iconButton.setBackgroundImageColor(configuration.backgroundColorSelected, for: .selected)
-
+        iconButton.updateTintColor(state: .selected)
+        iconButton.updateBorderColor(state: .selected)
+        
         setTitleColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabled)
         iconButton.setIconColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabled)
         iconButton.setBackgroundImageColor(configuration.backgroundColorNormal, for: .disabled)
+        iconButton.updateTintColor(state: .disabled)
+        iconButton.updateBorderColor(state: .disabled)
 
         setTitleColor(configuration.iconColorNormal.withAlphaComponent(0.4), for: .disabledAndSelected)
         iconButton.setIconColor(configuration.iconColorSelected.withAlphaComponent(0.4), for: .disabledAndSelected)
         iconButton.setBackgroundImageColor(configuration.backgroundColorSelected, for: .disabledAndSelected)
+        iconButton.updateTintColor(state: .disabledAndSelected)
+        iconButton.updateBorderColor(state: .disabledAndSelected)
 
         iconButton.setBackgroundImageColor(
             configuration.backgroundColorSelectedAndHighlighted,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Markdown.swift
@@ -39,22 +39,34 @@ extension ConversationInputBarViewController {
 
         if inputBar.isMarkingDown {
             color = SemanticColors.Button.textInputBarItemHighlighted
+                .resolvedColor(with: traitCollection)
             backgroundColor = SemanticColors.Button.backgroundInputBarItemHighlighted
+                .resolvedColor(with: traitCollection)
             borderColor = SemanticColors.Button.borderInputBarItemHighlighted
+                .resolvedColor(with: traitCollection)
         } else {
             color = SemanticColors.Button.textInputBarItemEnabled
+                .resolvedColor(with: traitCollection)
             backgroundColor = SemanticColors.Button.backgroundInputBarItemEnabled
+                .resolvedColor(with: traitCollection)
             borderColor = SemanticColors.Button.borderInputBarItemEnabled
+                .resolvedColor(with: traitCollection)
         }
 
         markdownButton.setIconColor(color, for: .normal)
         markdownButton.setBorderColor(borderColor, for: .normal)
         markdownButton.setBackgroundImageColor(backgroundColor, for: .normal)
 
-        markdownButton.setIconColor(SemanticColors.Button.textInputBarItemHighlighted, for: .highlighted)
-        markdownButton.setBorderColor(SemanticColors.Button.borderInputBarItemHighlighted, for: .highlighted)
+        markdownButton.setIconColor(
+            SemanticColors.Button.textInputBarItemHighlighted.resolvedColor(with: traitCollection),
+            for: .highlighted
+        )
+        markdownButton.setBorderColor(
+            SemanticColors.Button.borderInputBarItemHighlighted.resolvedColor(with: traitCollection),
+            for: .highlighted
+        )
         markdownButton.setBackgroundImageColor(
-            SemanticColors.Button.backgroundInputBarItemHighlighted,
+            SemanticColors.Button.backgroundInputBarItemHighlighted.resolvedColor(with: traitCollection),
             for: .highlighted
         )
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -383,7 +383,6 @@ final class InputBar: UIView {
 
         updateLeftAccessoryViewWidth()
         updateRightAccessoryStackViewLayoutMargins()
-
     }
 
     fileprivate func updateLeftAccessoryViewWidth() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -375,10 +375,15 @@ final class InputBar: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            updateColors()
+        }
+
         guard traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass else { return }
 
         updateLeftAccessoryViewWidth()
         updateRightAccessoryStackViewLayoutMargins()
+
     }
 
     fileprivate func updateLeftAccessoryViewWidth() {
@@ -525,17 +530,48 @@ final class InputBar: UIView {
 
             button.layer.borderWidth = 1
 
-            button.setIconColor(SemanticColors.Button.textInputBarItemEnabled, for: .normal)
-            button.setBackgroundImageColor(SemanticColors.Button.backgroundInputBarItemEnabled, for: .normal)
-            button.setBorderColor(SemanticColors.Button.borderInputBarItemEnabled, for: .normal)
+            button
+                .setIconColor(
+                    SemanticColors.Button.textInputBarItemEnabled
+                        .resolvedColor(with: traitCollection),
+                    for: .normal
+                )
+            button
+                .setBackgroundImageColor(
+                    SemanticColors.Button.backgroundInputBarItemEnabled
+                        .resolvedColor(with: traitCollection),
+                    for: .normal
+                )
+            button.setBorderColor(
+                SemanticColors.Button.borderInputBarItemEnabled.resolvedColor(with: traitCollection),
+                for: .normal
+            )
 
-            button.setIconColor(SemanticColors.Button.textInputBarItemHighlighted, for: .highlighted)
-            button.setBackgroundImageColor(SemanticColors.Button.backgroundInputBarItemHighlighted, for: .highlighted)
-            button.setBorderColor(SemanticColors.Button.borderInputBarItemHighlighted, for: .highlighted)
+            button.setIconColor(
+                SemanticColors.Button.textInputBarItemHighlighted.resolvedColor(with: traitCollection),
+                for: .highlighted
+            )
+            button.setBackgroundImageColor(
+                SemanticColors.Button.backgroundInputBarItemHighlighted.resolvedColor(with: traitCollection),
+                for: .highlighted
+            )
+            button.setBorderColor(
+                SemanticColors.Button.borderInputBarItemHighlighted.resolvedColor(with: traitCollection),
+                for: .highlighted
+            )
 
-            button.setIconColor(SemanticColors.Button.textInputBarItemHighlighted, for: .selected)
-            button.setBackgroundImageColor(SemanticColors.Button.backgroundInputBarItemHighlighted, for: .selected)
-            button.setBorderColor(SemanticColors.Button.borderInputBarItemHighlighted, for: .selected)
+            button.setIconColor(
+                SemanticColors.Button.textInputBarItemHighlighted.resolvedColor(with: traitCollection),
+                for: .selected
+            )
+            button.setBackgroundImageColor(
+                SemanticColors.Button.backgroundInputBarItemHighlighted.resolvedColor(with: traitCollection),
+                for: .selected
+            )
+            button.setBorderColor(
+                SemanticColors.Button.borderInputBarItemHighlighted.resolvedColor(with: traitCollection),
+                for: .selected
+            )
 
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MarkdownBarView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MarkdownBarView.swift
@@ -214,15 +214,15 @@ final class MarkdownBarView: UIView {
     func updateAccessibilityElements(isAccessible: Bool) {
         buttons.forEach { $0.isAccessibilityElement = isAccessible }
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        
+
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             redrawButtons()
         }
     }
-    
+
     private func redrawButtons() {
         for button in buttons {
             button.setIconColor(enabledStateIconColor, for: .normal)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MarkdownBarView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MarkdownBarView.swift
@@ -32,14 +32,35 @@ final class MarkdownBarView: UIView {
 
     private let stackView = UIStackView()
 
-    private let enabledStateIconColor = SemanticColors.Button.textInputBarItemEnabled
-    private let highlightedStateIconColor = SemanticColors.Button.textInputBarItemHighlighted
+    private var enabledStateIconColor: UIColor {
+        SemanticColors.Button.textInputBarItemEnabled
+            .resolvedColor(with: traitCollection)
+    }
 
-    private let enabledStateBackgroundColor = SemanticColors.Button.backgroundInputBarItemEnabled
-    private let highlightedStateBackgroundColor = SemanticColors.Button.backgroundInputBarItemHighlighted
+    private var highlightedStateIconColor: UIColor {
+        SemanticColors.Button.textInputBarItemHighlighted
+            .resolvedColor(with: traitCollection)
+    }
 
-    private let enabledStateBorderColor = SemanticColors.Button.borderInputBarItemEnabled
-    private let highlightedStateBorderColor = SemanticColors.Button.borderInputBarItemHighlighted
+    private var enabledStateBackgroundColor: UIColor {
+        SemanticColors.Button.backgroundInputBarItemEnabled
+            .resolvedColor(with: traitCollection)
+    }
+
+    private var highlightedStateBackgroundColor: UIColor {
+        SemanticColors.Button.backgroundInputBarItemHighlighted
+            .resolvedColor(with: traitCollection)
+    }
+
+    private var enabledStateBorderColor: UIColor {
+        SemanticColors.Button.borderInputBarItemEnabled
+            .resolvedColor(with: traitCollection)
+    }
+
+    private var highlightedStateBorderColor: UIColor {
+        SemanticColors.Button.borderInputBarItemHighlighted
+            .resolvedColor(with: traitCollection)
+    }
 
     let headerButton         = PopUpIconButton()
     let boldButton           = IconButton()
@@ -53,6 +74,8 @@ final class MarkdownBarView: UIView {
     private var buttonMargin: CGFloat {
         conversationHorizontalMargins.left / 2 - StyleKitIcon.Size.tiny.rawValue / 2
     }
+
+    private var prevMarkdown: Markdown?
 
     required init() {
         self.buttons = [headerButton, boldButton, italicButton, numberListButton, bulletListButton, codeButton]
@@ -200,6 +223,8 @@ final class MarkdownBarView: UIView {
             button.setBorderColor(borderColor, for: .normal)
             button.setBackgroundImageColor(backgroundColor, for: .normal)
         }
+
+        prevMarkdown = markdown
     }
 
     @objc
@@ -219,19 +244,7 @@ final class MarkdownBarView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-            redrawButtons()
-        }
-    }
-
-    private func redrawButtons() {
-        for button in buttons {
-            button.setIconColor(enabledStateIconColor, for: .normal)
-            button.setBorderColor(enabledStateBorderColor, for: .normal)
-            button.setBackgroundImageColor(enabledStateBackgroundColor, for: .normal)
-
-            button.setIconColor(highlightedStateIconColor, for: .highlighted)
-            button.setBorderColor(highlightedStateBorderColor, for: .highlighted)
-            button.setBackgroundImageColor(highlightedStateBackgroundColor, for: .highlighted)
+            updateIcons(for: prevMarkdown ?? Markdown())
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MarkdownBarView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/MarkdownBarView.swift
@@ -214,7 +214,26 @@ final class MarkdownBarView: UIView {
     func updateAccessibilityElements(isAccessible: Bool) {
         buttons.forEach { $0.isAccessibilityElement = isAccessible }
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            redrawButtons()
+        }
+    }
+    
+    private func redrawButtons() {
+        for button in buttons {
+            button.setIconColor(enabledStateIconColor, for: .normal)
+            button.setBorderColor(enabledStateBorderColor, for: .normal)
+            button.setBackgroundImageColor(enabledStateBackgroundColor, for: .normal)
 
+            button.setIconColor(highlightedStateIconColor, for: .highlighted)
+            button.setBorderColor(highlightedStateBorderColor, for: .highlighted)
+            button.setBackgroundImageColor(highlightedStateBackgroundColor, for: .highlighted)
+        }
+    }
 }
 
 extension MarkdownBarView: PopUpIconButtonDelegate {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -36,14 +36,12 @@ final class AnimatedPenView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        let iconColor = SemanticColors.Icon.foregroundDefault
         let backgroundColor = SemanticColors.View.backgroundConversationView
-
-        dots.setIcon(.typingDots, size: 8, color: iconColor)
-        pen.setIcon(.pencil, size: 8, color: iconColor)
         pen.backgroundColor = backgroundColor
         pen.contentMode = .center
-
+        
+        setIcons()
+        
         addSubview(dots)
         addSubview(pen)
 
@@ -110,7 +108,21 @@ final class AnimatedPenView: UIView {
     func applicationDidBecomeActive(_ notification: Notification) {
         startWritingAnimation()
     }
+    
+    fileprivate func setIcons() {
+        let iconColor = SemanticColors.Icon.foregroundDefault
+        
+        dots.setIcon(.typingDots, size: 8, color: iconColor)
+        pen.setIcon(.pencil, size: 8, color: iconColor)
+    }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
 
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            setIcons()
+        }
+    }
 }
 
 final class TypingIndicatorView: UIView {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -39,9 +39,9 @@ final class AnimatedPenView: UIView {
         let backgroundColor = SemanticColors.View.backgroundConversationView
         pen.backgroundColor = backgroundColor
         pen.contentMode = .center
-        
+
         setIcons()
-        
+
         addSubview(dots)
         addSubview(pen)
 
@@ -108,14 +108,14 @@ final class AnimatedPenView: UIView {
     func applicationDidBecomeActive(_ notification: Notification) {
         startWritingAnimation()
     }
-    
+
     fileprivate func setIcons() {
         let iconColor = SemanticColors.Icon.foregroundDefault
-        
+
         dots.setIcon(.typingDots, size: 8, color: iconColor)
         pen.setIcon(.pencil, size: 8, color: iconColor)
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/TypingIndicatorView.swift
@@ -110,7 +110,7 @@ final class AnimatedPenView: UIView {
     }
 
     fileprivate func setIcons() {
-        let iconColor = SemanticColors.Icon.foregroundDefault
+        let iconColor = SemanticColors.Icon.foregroundDefault.resolvedColor(with: traitCollection)
 
         dots.setIcon(.typingDots, size: 8, color: iconColor)
         pen.setIcon(.pencil, size: 8, color: iconColor)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18449" title="WPB-18449" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18449</a>  [iOS] [Replicating] In dark mode, the "writing" pencil icon is barely visible due to lack of contrast.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fix Dark mode issues:
https://wearezeta.atlassian.net/browse/WPB-18449
https://wearezeta.atlassian.net/browse/WPB-18453
https://wearezeta.atlassian.net/browse/WPB-18454


### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
