### PR TITLE
fix: nonce force unwrapping - WPB-18559

### DIFF
--- a/WireFoundation/Sources/WireFoundation/ThreadSafeDictionary.swift
+++ b/WireFoundation/Sources/WireFoundation/ThreadSafeDictionary.swift
@@ -31,9 +31,8 @@ public class ThreadSafeDictionary<Key: Hashable, Value> {
         }
     }
 
-    public func get(for key: Key?) -> Value? {
-        guard let key else { return nil }
-        return queue.sync {
+    public func get(for key: Key) -> Value? {
+        queue.sync {
             self.dictionary[key]
         }
     }

--- a/WireFoundation/Sources/WireFoundation/ThreadSafeDictionary.swift
+++ b/WireFoundation/Sources/WireFoundation/ThreadSafeDictionary.swift
@@ -31,8 +31,9 @@ public class ThreadSafeDictionary<Key: Hashable, Value> {
         }
     }
 
-    public func get(for key: Key) -> Value? {
-        queue.sync {
+    public func get(for key: Key?) -> Value? {
+        guard let key else { return nil }
+        return queue.sync {
             self.dictionary[key]
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -155,8 +155,8 @@ final class ConversationTableViewDataSource: NSObject {
                     messages: messages
                 )
 
-                let sectionController = if let cachedSectionController = self.sectionControllers
-                    .get(for: element.nonce) {
+                let sectionController = if let nonce = element.nonce,
+                                           let cachedSectionController = self.sectionControllers.get(for: nonce) {
                     cachedSectionController
                 } else {
                     self.makeSectionController(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -303,7 +303,7 @@ final class ConversationTableViewDataSource: NSObject {
         selfUser: any UserType
     ) -> ConversationMessageActionController {
         if let nonce = message.nonce,
-            let cachedEntry = actionControllers.get(for: nonce) {
+           let cachedEntry = actionControllers.get(for: nonce) {
             return cachedEntry
         }
 
@@ -370,7 +370,7 @@ final class ConversationTableViewDataSource: NSObject {
         messages: [ZMMessage]
     ) -> ConversationMessageSectionController {
         if let nonce = message.nonce,
-            let cachedEntry = sectionControllers.get(for: nonce) {
+           let cachedEntry = sectionControllers.get(for: nonce) {
             cachedEntry.contentWidth = contentWidth
             return cachedEntry
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -156,7 +156,7 @@ final class ConversationTableViewDataSource: NSObject {
                 )
 
                 let sectionController = if let cachedSectionController = self.sectionControllers
-                    .get(for: element.nonce!) {
+                    .get(for: element.nonce) {
                     cachedSectionController
                 } else {
                     self.makeSectionController(
@@ -222,9 +222,8 @@ final class ConversationTableViewDataSource: NSObject {
     func calculateSections(
         updating sectionController: ConversationMessageSectionController
     ) -> [Section] {
-        let sectionIdentifier = sectionController.message.nonce!
-
-        guard let section = currentSections.firstIndex(where: { $0.model == sectionIdentifier })
+        guard let sectionIdentifier = sectionController.message.nonce,
+              let section = currentSections.firstIndex(where: { $0.model == sectionIdentifier })
         else { return currentSections }
 
         for (row, description) in sectionController.tableViewCellDescriptions.enumerated() {
@@ -303,7 +302,8 @@ final class ConversationTableViewDataSource: NSObject {
         sectionController: ConversationMessageSectionController,
         selfUser: any UserType
     ) -> ConversationMessageActionController {
-        if let cachedEntry = actionControllers.get(for: message.nonce!) {
+        if let nonce = message.nonce,
+            let cachedEntry = actionControllers.get(for: nonce) {
             return cachedEntry
         }
 
@@ -369,7 +369,8 @@ final class ConversationTableViewDataSource: NSObject {
         selfUser: any UserType,
         messages: [ZMMessage]
     ) -> ConversationMessageSectionController {
-        if let cachedEntry = sectionControllers.get(for: message.nonce!) {
+        if let nonce = message.nonce,
+            let cachedEntry = sectionControllers.get(for: nonce) {
             cachedEntry.contentWidth = contentWidth
             return cachedEntry
         }
@@ -382,7 +383,9 @@ final class ConversationTableViewDataSource: NSObject {
             firstUnreadMessageNonce: firstUnreadMessage?.nonce
         )
 
-        sectionControllers.set(value: sectionController, for: message.nonce!)
+        if let nonce = message.nonce {
+            sectionControllers.set(value: sectionController, for: nonce)
+        }
 
         return sectionController
     }
@@ -659,7 +662,7 @@ extension ConversationTableViewDataSource: UITableViewDataSource {
     }
 
     func collapse(message: ZMConversationMessage) {
-        guard let section = sectionControllers.get(for: message.nonce!) else {
+        guard let nonce = message.nonce, let section = sectionControllers.get(for: nonce) else {
             return
         }
         section.collapse()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18559" title="WPB-18559" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18559</a>  [iOS] Crash on message.nonce
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Remove nonce force unwrapping in Coversation table view datasource

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
