### PR TITLE
fix: condition setting UserClient.needsToNotifyUser to true - WPB-15659

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/UserClients/UserClientsLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/UserClients/UserClientsLocalStore.swift
@@ -152,24 +152,18 @@ public struct UserClientsLocalStore: UserClientsLocalStoreProtocol {
                 )
             }
 
-            let selfClient = selfUser.selfClient()
-            let isNotSameId = localClient.remoteIdentifier != selfClient?.remoteIdentifier
-            let localClientActivationDate = localClient.activationDate
-            let selfClientActivationDate = selfClient?.activationDate
+            guard let selfClient = selfUser.selfClient(), isNewClient else { return }
 
-            if selfClient != nil, isNotSameId, let localClientActivationDate, let selfClientActivationDate {
-                let comparisonResult = localClientActivationDate
-                    .compare(selfClientActivationDate)
-
-                if comparisonResult == .orderedDescending {
-                    localClient.needsToNotifyUser = true
-                }
+            if
+                localClient.remoteIdentifier != selfClient.remoteIdentifier,
+                let localClientActivationDate = localClient.activationDate,
+                let selfClientActivationDate = selfClient.activationDate,
+                localClientActivationDate.compare(selfClientActivationDate) == .orderedDescending {
+                localClient.needsToNotifyUser = true
             }
 
-            if isNewClient {
-                selfUser.selfClient()?.addNewClientToIgnored(localClient)
-                selfUser.selfClient()?.updateSecurityLevelAfterDiscovering(Set([localClient]))
-            }
+            selfClient.addNewClientToIgnored(localClient)
+            selfClient.updateSecurityLevelAfterDiscovering(Set([localClient]))
         }
     }
 


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR fixes an issue that after every sync the user is notified about new clients when entering the profile screen.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
