### PR TITLE
fix: consumable-notifications enabled - WPB-18587

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -210,7 +210,8 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
     /// Perform an incremental sync.
 
     func performIncrementalSync() async throws {
-        let isConsumableNotificationsEnabled = journal[.isConsumableNotificationsEnabled] && DeveloperFlag.consumableNotifications.isOn
+        let isConsumableNotificationsEnabled = journal[.isConsumableNotificationsEnabled] && DeveloperFlag
+            .consumableNotifications.isOn
 
         if isSyncV2Enabled {
 

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -210,7 +210,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
     /// Perform an incremental sync.
 
     func performIncrementalSync() async throws {
-        let isConsumableNotificationsEnabled = journal[.isConsumableNotificationsEnabled]
+        let isConsumableNotificationsEnabled = journal[.isConsumableNotificationsEnabled] && DeveloperFlag.consumableNotifications.isOn
 
         if isSyncV2Enabled {
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -608,6 +608,7 @@ public final class ZMUserSession: NSObject {
     }
 
     public func migrateToConsumableNotificationsIfNeeded() async {
+        guard DeveloperFlag.consumableNotifications.isOn else { return }
         guard !journal[.isConsumableNotificationsEnabled] else { return }
         guard let migrator = clientSessionComponent?.consumableNotificationsMigrator() else {
             WireLogger.sync.warn("No consumable-notifications migrator available")

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
@@ -300,6 +300,7 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
 
     func testPerformIncrementalSync_V3() async throws {
         // Given
+        DeveloperFlag.consumableNotifications.enable(true, storage: .temporary())
         journal[.isConsumableNotificationsEnabled] = true
         journal[.isSyncV2Enabled] = true
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18587" title="WPB-18587" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18587</a>  [iOS] consumable-notifications enabled without feature flag
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Users on Edge reported that sync is not ending. It appears they use consumable-notifications but without the feature flag. They successfully pass the migration.


* Add check on FF before migration
* Add check on FF on running IncrementalSync (double security)

Note: it could be that current clients need to recreate a client because once the backend registered the client as consumable-notifications capable, they can't do /notifications/last on old system.

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
