### PR TITLE
fix: crash unwrapping nil - WPB-17530

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Helpers/RegistrationAnalyticsTracker.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Helpers/RegistrationAnalyticsTracker.swift
@@ -21,7 +21,7 @@ import WireFoundation
 
 struct RegistrationAnalyticsTracker: RegistrationAnalyticsTrackerProtocol {
 
-    private var analyticsTracker: (any AnalyticsEventTrackerProtocol)!
+    private var analyticsTracker: (any AnalyticsEventTrackerProtocol)?
 
     init() {}
 
@@ -34,27 +34,27 @@ struct RegistrationAnalyticsTracker: RegistrationAnalyticsTrackerProtocol {
     }
 
     func trackPersonalAccountCreationStart() {
-        analyticsTracker.trackEvent(.Registration.accountSetupStep0)
+        analyticsTracker?.trackEvent(.Registration.accountSetupStep0)
     }
 
     func trackPersonalAccountCreationReachedTermsOfUseConfirmation() {
-        analyticsTracker.trackEvent(.Registration.accountSetupStep1)
+        analyticsTracker?.trackEvent(.Registration.accountSetupStep1)
     }
 
     func trackPersonalAccountCreationReachedVerificationCode() {
-        analyticsTracker.trackEvent(.Registration.accountSetupStep2)
+        analyticsTracker?.trackEvent(.Registration.accountSetupStep2)
     }
 
     func trackPersonalAccountCreationFailedCodeVerification() {
-        analyticsTracker.trackEvent(.Registration.accountSetupStep3)
+        analyticsTracker?.trackEvent(.Registration.accountSetupStep3)
     }
 
     func trackPersonalAccountCreationReachedUsernameForm() {
-        analyticsTracker.trackEvent(.Registration.accountSetupStep4)
+        analyticsTracker?.trackEvent(.Registration.accountSetupStep4)
     }
 
     func trackPersonalAccountCreationCompletion() {
-        analyticsTracker.trackEvent(.Registration.accountSetupStep5)
+        analyticsTracker?.trackEvent(.Registration.accountSetupStep5)
     }
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17530" title="WPB-17530" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-17530</a>  [iOS] New Registration Flows - Personal account countly tracking
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes a crashing force-unwrap.

### Testing

Starting the app and logging in should work again.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
