### PR TITLE
fix: marking imported conversations as read - WPB-18002

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -87,7 +87,7 @@ extension BackupLocalStore {
 
         // restore `lastReadServerTimeStamp`, messages imported from backups shouldn't be marked as unread
         await context.perform {
-            conversation.lastReadServerTimeStamp = lastReadServerTimeStamp
+            conversation.lastReadServerTimeStamp = lastReadServerTimeStamp ?? .now
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18002" title="WPB-18002" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18002</a>  [iOS] All conversations should be marked as read after restoring backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In certain cases imported conversations from a backup have unread messages.
This PR is supposed to fix this.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
