### PR TITLE
fix: critical flows run - WPB-18717

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -16,7 +16,9 @@ on:
       test_dependencies:
         type: boolean
         default: false
-      
+      run_critical_flows:
+        type: boolean
+        required: true
     secrets:
       ZENKINS_USERNAME:
         required: true
@@ -36,7 +38,7 @@ env: # https://docs.fastlane.tools/getting-started/ios/setup/
   PACKAGES_DIR: ${{ github.workspace }}/DerivedData/CachedSwiftPackages
   UI_TEST_LOGIN_EMAIL: ${{ secrets.UI_TEST_LOGIN_EMAIL }}
   UI_TEST_LOGIN_PASSWORD: ${{ secrets.UI_TEST_LOGIN_PASSWORD }}
-  RUN_CRITICAL_FLOWS: ${{ inputs.test_dependencies == false && inputs.branch != 'release/cycle-3.120' && inputs.branch != 'release/cycle-3.124' }} # remove specific branches when not supported anymore
+
 jobs:
   run-tests:
     name: Run tests
@@ -125,16 +127,16 @@ jobs:
           bundle exec fastlane prepare_for_tests
 
       - name: Install 1Password
-        if: ${{ env.RUN_CRITICAL_FLOWS == true }}
+        if: ${{ inputs.run_critical_flows }}
         uses: 1password/install-cli-action@v1
 
       - name: Generate env file
-        if: ${{ env.RUN_CRITICAL_FLOWS == true }}
+        if: ${{ inputs.run_critical_flows }}
         run: |
           bundle exec fastlane generate_env
 
       - name: "Test new critical flows"
-        if: ${{ env.RUN_CRITICAL_FLOWS == true }}
+        if: ${{ inputs.run_critical_flows }}
         run: |
           bundle exec fastlane run_uitests
 

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -14,11 +14,12 @@ jobs:
   trigger_tests:
     strategy:
       matrix:
-        branch: [develop, release/cycle-3.120, release/cycle-4.0, release/cycle-4.1]  # List other branches here
+        branch: [develop, release/cycle-3.120, release/cycle-4.1]  # List other branches here
       fail-fast: false # avoid to fail one job
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:
       all: true
       branch: ${{ matrix.branch }}
       notify_secret: WIRE_IOS_NIGHTLY_WEBHOOK
+      run_critical_flows: true
     secrets: inherit

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -98,5 +98,6 @@ jobs:
     with:
       folders: ${{ join(fromJson(needs.detect-changes.outputs.folders), ',') }}
       notify_secret: WIRE_IOS_CI_WEBHOOK
-      test_dependencies: ${{ github.event_name != 'pull_request' || startsWith(github.base_ref, 'release/cycle') }}
+      test_dependencies: ${{ github.event_name != 'pull_request' || startsWith(github.base_ref, 'release/cycle') }} # run on merge_queue or release branch PRs
+      run_critical_flows: ${{ github.event_name != 'pull_request' || startsWith(github.base_ref, 'release/cycle') }} # run on merge_queue or release branch PRs
     secrets: inherit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18717" title="WPB-18717" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18717</a>  [iOS] CI critical flows not runned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Critical flows are always skipped. Probably the env variable is not read by the step.

Solution: Use input variable.

* Adjust critical flows run: now it runs on merge queue for develop and every PRs to release branches.
* Also run for nightly.
* Removed 4.0 branch
