### PR TITLE
fix: critical flows run on invalid branch - WPB-18717

### DIFF
--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -21,5 +21,5 @@ jobs:
       all: true
       branch: ${{ matrix.branch }}
       notify_secret: WIRE_IOS_NIGHTLY_WEBHOOK
-      run_critical_flows: ${{ !contains(fromJson('["release/cycle-3.120","release/cycle-4.1"]'), matrix.branch) }}
+      run_critical_flows: ${{ !contains(fromJson('["release/cycle-3.120","release/cycle-4.1"]'), matrix.branch) }} # excluding branches because critical flows can't run properly
     secrets: inherit

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -21,5 +21,5 @@ jobs:
       all: true
       branch: ${{ matrix.branch }}
       notify_secret: WIRE_IOS_NIGHTLY_WEBHOOK
-      run_critical_flows: true
+      run_critical_flows: ${{ !contains(fromJson('["release/cycle-3.120","release/cycle-4.1"]'), matrix.branch) }}
     secrets: inherit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18717" title="WPB-18717" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18717</a>  [iOS] CI critical flows not runned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In #3330, Skipping 3.120 branch was removed. This PR skips it and also 4.1 as the fix for personal team registration is not there.
