### PR TITLE
fix: ask user whether to erase data on logout - WPB-18862

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -796,8 +796,8 @@ public final class SessionManager: NSObject, SessionManagerType {
         }
     }
 
-    public func delete(account: Account) {
-        delete(account: account, reason: .userInitiated)
+    public func delete(account: Account, eraseData: Bool = true) {
+        delete(account: account, reason: .userInitiated, eraseData: eraseData)
     }
 
     public func wipeDatabase(for account: Account) {
@@ -814,29 +814,31 @@ public final class SessionManager: NSObject, SessionManagerType {
         }
     }
 
-    func delete(account: Account, reason: ZMAccountDeletedReason) {
+    func delete(account: Account, reason: ZMAccountDeletedReason, eraseData: Bool = true) {
         WireLogger.sessionManager.debug("Deleting account \(account.userIdentifier)...")
         if let secondAccount = accountManager.inactiveAccounts.first {
             // Deleted an account but we can switch to another account
             select(secondAccount, tearDownCompletion: { [weak self] in
-                self?.tearDownSessionAndDelete(account: account)
+                self?.tearDownSessionAndDelete(account: account, eraseData: eraseData)
             })
         } else if accountManager.selectedAccount != account {
             // Deleted an inactive account, there's no need notify the UI
-            tearDownSessionAndDelete(account: account)
+            tearDownSessionAndDelete(account: account, eraseData: eraseData)
         } else {
             // Deleted the last account so we need to return to the logged out area
             logoutCurrentSession(
-                deleteCookie: true,
-                deleteAccount: true,
+                deleteCookie: eraseData,
+                deleteAccount: eraseData,
                 error: NSError(userSessionErrorCode: .accountDeleted, userInfo: [ZMAccountDeletedReasonKey: reason])
             )
         }
     }
 
-    fileprivate func tearDownSessionAndDelete(account: Account) {
+    fileprivate func tearDownSessionAndDelete(account: Account, eraseData: Bool) {
         tearDownBackgroundSession(for: account.userIdentifier) {
-            self.deleteAccountData(for: account)
+            if eraseData {
+                self.deleteAccountData(for: account)
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5314,10 +5314,10 @@ internal enum L10n {
             }
             internal enum EraseData {
               internal enum Alert {
+                /// Delete all your personal information and conversations on this device ?
+                internal static let message = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.message", fallback: "Delete all your personal information and conversations on this device ?")
                 /// No
                 internal static let no = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.no", fallback: "No")
-                /// Delete all your personal information and conversations on this device ?
-                internal static let title = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.title", fallback: "Delete all your personal information and conversations on this device ?")
                 /// Yes
                 internal static let yes = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.yes", fallback: "Yes")
               }

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5312,6 +5312,16 @@ internal enum L10n {
               /// Log out
               internal static let title = L10n.tr("Localizable", "self.settings.account_details.log_out.alert.title", fallback: "Log out")
             }
+            internal enum EraseData {
+              internal enum Alert {
+                /// No
+                internal static let no = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.no", fallback: "No")
+                /// Delete all your personal information and conversations on this device ?
+                internal static let title = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.title", fallback: "Delete all your personal information and conversations on this device ?")
+                /// Yes
+                internal static let yes = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.yes", fallback: "Yes")
+              }
+            }
           }
           internal enum RemoveDevice {
             /// Your password is required to remove the device

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -5314,12 +5314,14 @@ internal enum L10n {
             }
             internal enum EraseData {
               internal enum Alert {
-                /// Delete all your personal information and conversations on this device ?
-                internal static let message = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.message", fallback: "Delete all your personal information and conversations on this device ?")
-                /// No
-                internal static let no = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.no", fallback: "No")
-                /// Yes
-                internal static let yes = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.yes", fallback: "Yes")
+                /// Log out and clear data
+                internal static let logoutAndClear = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.logoutAndClear", fallback: "Log out and clear data")
+                /// Log out and keep data
+                internal static let logoutAndKeep = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.logoutAndKeep", fallback: "Log out and keep data")
+                /// Delete all your personal information and conversations on this device?
+                internal static let message = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.message", fallback: "Delete all your personal information and conversations on this device?")
+                /// Log out
+                internal static let title = L10n.tr("Localizable", "self.settings.account_details.log_out.erase_data.alert.title", fallback: "Log out")
               }
             }
           }

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1199,7 +1199,7 @@
 "self.settings.account_details.log_out.alert.title" = "Log out";
 "self.settings.account_details.log_out.alert.message" = "Your message history will be erased on this device.";
 "self.settings.account_details.log_out.alert.password" = "Password";
-"self.settings.account_details.log_out.erase_data.alert.title" = "Delete all your personal information and conversations on this device ?";
+"self.settings.account_details.log_out.erase_data.alert.message" = "Delete all your personal information and conversations on this device ?";
 "self.settings.account_details.log_out.erase_data.alert.yes" = "Yes";
 "self.settings.account_details.log_out.erase_data.alert.no" = "No";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1199,6 +1199,9 @@
 "self.settings.account_details.log_out.alert.title" = "Log out";
 "self.settings.account_details.log_out.alert.message" = "Your message history will be erased on this device.";
 "self.settings.account_details.log_out.alert.password" = "Password";
+"self.settings.account_details.log_out.erase_data.alert.title" = "Delete all your personal information and conversations on this device ?";
+"self.settings.account_details.log_out.erase_data.alert.yes" = "Yes";
+"self.settings.account_details.log_out.erase_data.alert.no" = "No";
 
 // Settings - Personal information
 "self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1199,9 +1199,10 @@
 "self.settings.account_details.log_out.alert.title" = "Log out";
 "self.settings.account_details.log_out.alert.message" = "Your message history will be erased on this device.";
 "self.settings.account_details.log_out.alert.password" = "Password";
-"self.settings.account_details.log_out.erase_data.alert.message" = "Delete all your personal information and conversations on this device ?";
-"self.settings.account_details.log_out.erase_data.alert.yes" = "Yes";
-"self.settings.account_details.log_out.erase_data.alert.no" = "No";
+"self.settings.account_details.log_out.erase_data.alert.title" = "Log out";
+"self.settings.account_details.log_out.erase_data.alert.message" = "Delete all your personal information and conversations on this device?";
+"self.settings.account_details.log_out.erase_data.alert.logoutAndClear" = "Log out and clear data";
+"self.settings.account_details.log_out.erase_data.alert.logoutAndKeep" = "Log out and keep data";
 
 // Settings - Personal information
 "self.settings.privacy_analytics_section.title" = "Usage and Crash Reports";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -1199,6 +1199,9 @@
 "self.settings.account_details.log_out.alert.title" = "Abmelden";
 "self.settings.account_details.log_out.alert.message" = "Der Nachrichtenverlauf wird auf diesem Gerät gelöscht.";
 "self.settings.account_details.log_out.alert.password" = "Passwort";
+"self.settings.account_details.log_out.erase_data.alert.title" = "Alle Ihre persönlichen Daten und Gespräche auf diesem Gerät löschen ?";
+"self.settings.account_details.log_out.erase_data.alert.yes" = "Ja";
+"self.settings.account_details.log_out.erase_data.alert.no" = "Nein";
 
 // Settings - Personal information
 "self.settings.privacy_analytics_section.title" = "Nutzungs- und Fehlerberichte";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -1199,7 +1199,7 @@
 "self.settings.account_details.log_out.alert.title" = "Abmelden";
 "self.settings.account_details.log_out.alert.message" = "Der Nachrichtenverlauf wird auf diesem Gerät gelöscht.";
 "self.settings.account_details.log_out.alert.password" = "Passwort";
-"self.settings.account_details.log_out.erase_data.alert.title" = "Alle Ihre persönlichen Daten und Gespräche auf diesem Gerät löschen ?";
+"self.settings.account_details.log_out.erase_data.alert.message" = "Alle Ihre persönlichen Daten und Gespräche auf diesem Gerät löschen ?";
 "self.settings.account_details.log_out.erase_data.alert.yes" = "Ja";
 "self.settings.account_details.log_out.erase_data.alert.no" = "Nein";
 

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -1199,9 +1199,10 @@
 "self.settings.account_details.log_out.alert.title" = "Abmelden";
 "self.settings.account_details.log_out.alert.message" = "Der Nachrichtenverlauf wird auf diesem Gerät gelöscht.";
 "self.settings.account_details.log_out.alert.password" = "Passwort";
-"self.settings.account_details.log_out.erase_data.alert.message" = "Alle Ihre persönlichen Daten und Gespräche auf diesem Gerät löschen ?";
-"self.settings.account_details.log_out.erase_data.alert.yes" = "Ja";
-"self.settings.account_details.log_out.erase_data.alert.no" = "Nein";
+"self.settings.account_details.log_out.erase_data.alert.title" = "Abmelden";
+"self.settings.account_details.log_out.erase_data.alert.message" = "hre persönlichen Daten und Unterhaltungen vollständig von diesem Gerät entfernen?";
+"self.settings.account_details.log_out.erase_data.alert.logoutAndClear" = "Abmelden und Daten löschen";
+"self.settings.account_details.log_out.erase_data.alert.logoutAndKeep" = "Abmelden und Daten behalten";
 
 // Settings - Personal information
 "self.settings.privacy_analytics_section.title" = "Nutzungs- und Fehlerberichte";

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
@@ -1199,6 +1199,9 @@
 "self.settings.account_details.log_out.alert.title" = "Se déconnecter";
 "self.settings.account_details.log_out.alert.message" = "L'historique de vos messages sera effacé de cet appareil.";
 "self.settings.account_details.log_out.alert.password" = "Mot de passe";
+"self.settings.account_details.log_out.erase_data.alert.title" = "Supprimer toutes vos informations personnelles et conversations sur cet appareil ?";
+"self.settings.account_details.log_out.erase_data.alert.yes" = "Oui";
+"self.settings.account_details.log_out.erase_data.alert.no" = "Non";
 
 // Settings - Personal information
 "self.settings.privacy_analytics_section.title" = "Rapports d’utilisation et de plantage";

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
@@ -1199,9 +1199,10 @@
 "self.settings.account_details.log_out.alert.title" = "Se déconnecter";
 "self.settings.account_details.log_out.alert.message" = "L'historique de vos messages sera effacé de cet appareil.";
 "self.settings.account_details.log_out.alert.password" = "Mot de passe";
+"self.settings.account_details.log_out.erase_data.alert.title" = "Se déconnecter";
 "self.settings.account_details.log_out.erase_data.alert.message" = "Supprimer toutes vos informations personnelles et conversations sur cet appareil ?";
-"self.settings.account_details.log_out.erase_data.alert.yes" = "Oui";
-"self.settings.account_details.log_out.erase_data.alert.no" = "Non";
+"self.settings.account_details.log_out.erase_data.alert.logoutAndClear" = "Déconnexion et suppression des données";
+"self.settings.account_details.log_out.erase_data.alert.logoutAndKeep" = "Déconnexion sans suppression";
 
 // Settings - Personal information
 "self.settings.privacy_analytics_section.title" = "Rapports d’utilisation et de plantage";

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
@@ -1199,7 +1199,7 @@
 "self.settings.account_details.log_out.alert.title" = "Se déconnecter";
 "self.settings.account_details.log_out.alert.message" = "L'historique de vos messages sera effacé de cet appareil.";
 "self.settings.account_details.log_out.alert.password" = "Mot de passe";
-"self.settings.account_details.log_out.erase_data.alert.title" = "Supprimer toutes vos informations personnelles et conversations sur cet appareil ?";
+"self.settings.account_details.log_out.erase_data.alert.message" = "Supprimer toutes vos informations personnelles et conversations sur cet appareil ?";
 "self.settings.account_details.log_out.erase_data.alert.yes" = "Oui";
 "self.settings.account_details.log_out.erase_data.alert.no" = "Non";
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -509,7 +509,7 @@ extension AuthenticationCoordinator {
             let yesAction = AuthenticationCoordinatorAlertAction(
                 title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.yes,
                 coordinatorActions: [.showLoadingView, .deleteSession(eraseData: true)],
-                style: .default
+                style: .destructive
             )
 
             let noAction = AuthenticationCoordinatorAlertAction(
@@ -519,8 +519,8 @@ extension AuthenticationCoordinator {
             )
 
             let alertModel = AuthenticationCoordinatorAlert(
-                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.title,
-                message: nil,
+                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.Alert.title,
+                message: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.message,
                 actions: [yesAction, noAction, .cancel]
             )
 

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -506,22 +506,25 @@ extension AuthenticationCoordinator {
     /// Signs the current user out with a warning.
     private func signOut(warn: Bool) {
         if warn {
-            let yesAction = AuthenticationCoordinatorAlertAction(
-                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.yes,
+
+            typealias l10nAlert = L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert
+
+            let logoutDeleteDataAction = AuthenticationCoordinatorAlertAction(
+                title: l10nAlert.logoutAndClear,
                 coordinatorActions: [.showLoadingView, .deleteSession(eraseData: true)],
                 style: .destructive
             )
 
-            let noAction = AuthenticationCoordinatorAlertAction(
-                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.no,
+            let logoutKeepDataAction = AuthenticationCoordinatorAlertAction(
+                title: l10nAlert.logoutAndKeep,
                 coordinatorActions: [.showLoadingView, .deleteSession(eraseData: false)],
                 style: .default
             )
 
             let alertModel = AuthenticationCoordinatorAlert(
-                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.Alert.title,
-                message: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.message,
-                actions: [yesAction, noAction, .cancel]
+                title: l10nAlert.title,
+                message: l10nAlert.message,
+                actions: [logoutKeepDataAction, logoutDeleteDataAction, .cancel]
             )
 
             presentAlert(for: alertModel)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -416,9 +416,9 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
 
             case let .signOut(warn):
                 signOut(warn: warn)
-                
+
             case let .deleteSession(eraseData):
-                
+
                 deleteSession(eraseData: eraseData)
 
             case let .addEmailAndPassword(newCredentials):
@@ -511,7 +511,7 @@ extension AuthenticationCoordinator {
                 coordinatorActions: [.showLoadingView, .deleteSession(eraseData: true)],
                 style: .default
             )
-            
+
             let noAction = AuthenticationCoordinatorAlertAction(
                 title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.no,
                 coordinatorActions: [.showLoadingView, .deleteSession(eraseData: false)],
@@ -529,19 +529,19 @@ extension AuthenticationCoordinator {
             deleteSession(eraseData: true)
         }
     }
-    
-    
+
+
     func deleteSession(eraseData: Bool) {
         guard let accountId = unauthenticatedSession.accountId,
               let unauthenticatedAccount = sessionManager.accountManager.account(with: accountId) else {
             fatal("No unauthenticated account to log out from")
         }
-        
+
         sessionManager.delete(
             account: unauthenticatedAccount,
             eraseData: eraseData
         )
-        
+
     }
 
     /// Repeats the current action.

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -530,7 +530,6 @@ extension AuthenticationCoordinator {
         }
     }
 
-
     func deleteSession(eraseData: Bool) {
         guard let accountId = unauthenticatedSession.accountId,
               let unauthenticatedAccount = sessionManager.accountManager.account(with: accountId) else {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Coordinator/AuthenticationCoordinator.swift
@@ -416,6 +416,10 @@ extension AuthenticationCoordinator: AuthenticationActioner, SessionManagerCreat
 
             case let .signOut(warn):
                 signOut(warn: warn)
+                
+            case let .deleteSession(eraseData):
+                
+                deleteSession(eraseData: eraseData)
 
             case let .addEmailAndPassword(newCredentials):
                 setEmailCredentialsForCurrentUser(newCredentials)
@@ -502,32 +506,42 @@ extension AuthenticationCoordinator {
     /// Signs the current user out with a warning.
     private func signOut(warn: Bool) {
         if warn {
-            let signOutAction = AuthenticationCoordinatorAlertAction(
-                title: L10n.Localizable.General.ok,
-                coordinatorActions: [
-                    .showLoadingView,
-                    .signOut(
-                        warn: false
-                    )
-                ],
-                style: .destructive
+            let yesAction = AuthenticationCoordinatorAlertAction(
+                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.yes,
+                coordinatorActions: [.showLoadingView, .deleteSession(eraseData: true)],
+                style: .default
+            )
+            
+            let noAction = AuthenticationCoordinatorAlertAction(
+                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.no,
+                coordinatorActions: [.showLoadingView, .deleteSession(eraseData: false)],
+                style: .default
             )
 
             let alertModel = AuthenticationCoordinatorAlert(
-                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.Alert.title,
-                message: L10n.Localizable.Self.Settings.AccountDetails.LogOut.Alert.message,
-                actions: [.cancel, signOutAction]
+                title: L10n.Localizable.Self.Settings.AccountDetails.LogOut.EraseData.Alert.title,
+                message: nil,
+                actions: [yesAction, noAction, .cancel]
             )
 
             presentAlert(for: alertModel)
         } else {
-            guard let accountId = unauthenticatedSession.accountId,
-                  let unauthenticatedAccount = sessionManager.accountManager.account(with: accountId) else {
-                fatal("No unauthenticated account to log out from")
-            }
-
-            sessionManager.delete(account: unauthenticatedAccount)
+            deleteSession(eraseData: true)
         }
+    }
+    
+    
+    func deleteSession(eraseData: Bool) {
+        guard let accountId = unauthenticatedSession.accountId,
+              let unauthenticatedAccount = sessionManager.accountManager.account(with: accountId) else {
+            fatal("No unauthenticated account to log out from")
+        }
+        
+        sessionManager.delete(
+            account: unauthenticatedAccount,
+            eraseData: eraseData
+        )
+        
     }
 
     /// Repeats the current action.

--- a/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Event Handlers/AuthenticationCoordinatorAction.swift
@@ -50,6 +50,7 @@ enum AuthenticationCoordinatorAction {
     case startCompanyLogin(code: UUID?)
     case startSSOFlow
     case signOut(warn: Bool)
+    case deleteSession(eraseData: Bool)
     case addEmailAndPassword(UserEmailCredentials)
     case configureDevicePermissions
     case startE2EIEnrollment

--- a/wire-ios/Wire-iOS/Sources/Authentication/Helpers/ObservableSessionManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Helpers/ObservableSessionManager.swift
@@ -54,7 +54,7 @@ protocol ObservableSessionManager: SessionManagerType {
     func addSessionManagerCreatedSessionObserver(_ observer: SessionManagerCreatedSessionObserver) -> Any
 
     /// Deletes the selected account.
-    func delete(account: Account)
+    func delete(account: Account, eraseData: Bool)
 
     /// Add a new account.
     func addAccount(userInfo: [String: Any]?)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18862" title="WPB-18862" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18862</a>  [iOS] Random device session expired
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: A customer is blocked on login screen after session expired message, cannot reauthenticate then forced to logout hence losing all history data.

**Causes**: This is a hotfix to prevent that issue from happening so.. root cause is not clearly identified yet. 

**Solution**: Temporary solution to fix this blocking issue for that customer is provide a pop up on logout to ask whether data should be erased or not - which also aligns with what other platforms currently do -

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 18 5 - 2025-07-18 at 12 10 07" src="https://github.com/user-attachments/assets/6e633b22-cd5f-4ad2-b54e-48c6440ca4c4" />

**Note:** translations have been validated and added directly here as it is for a hotfix release.

### Testing

- in debug actions, trigger "simulate access token failure" 
- tap on logout top right button
- "new" pop up shows up, tap "no"
- session will logout then login again
- all conversations history should be there (not erased)
