### PR TITLE
fix: NextButton is enabled/disabled depending on Group name Text - WPB-12093

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -285,9 +285,9 @@ final class ConversationCreationController: UIViewController {
     private func isGroupNameValid() -> Bool {
         switch nameSection.value {
         case let .valid(name)? where !name.isEmpty:
-            return true
+            true
         default:
-            return false
+            false
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -283,13 +283,10 @@ final class ConversationCreationController: UIViewController {
     }
 
     private func isGroupNameValid() -> Bool {
-        guard let value = nameSection.value else {
-            return false
-        }
-        switch value {
-        case let .valid(text):
-            return !text.isEmpty
-        case .error:
+        switch nameSection.value {
+        case let .valid(name)? where !name.isEmpty:
+            return true
+        default:
             return false
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -249,7 +249,7 @@ final class ConversationCreationController: UIViewController {
 
         nextButtonItem.accessibilityIdentifier = "button.newgroup.next"
         nextButtonItem.tintColor = UIColor.accent()
-        nextButtonItem.isEnabled = false
+        nextButtonItem.isEnabled = isGroupNameValid()
         navigationItem.rightBarButtonItem = nextButtonItem
     }
 
@@ -280,6 +280,18 @@ final class ConversationCreationController: UIViewController {
     private func tryToProceed() {
         guard let value = nameSection.value else { return }
         proceedWith(value: value)
+    }
+
+    private func isGroupNameValid() -> Bool {
+        guard let value = nameSection.value else {
+            return false
+        }
+        switch value {
+        case let .valid(text):
+            return !text.isEmpty
+        case .error:
+            return false
+        }
     }
 
     private func updateOptions() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-12093" title="WPB-12093" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-12093</a>  [iOS] : Bug in Create group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…PB-12093

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Click on Create group ==> Give group name ==> Click Next ==> Click Back ==> Next Button is disabled

The 'Next' button on the ConversationCreationController view remains disabled upon reappearing because its isEnabled property is hardcoded to false, ignoring the state of the group name field.

Solution:

The 'Next' button's isEnabled property is now dynamically updated based on the validity of the group name.


### Testing

 Click on Create group ==> Give group name ==> Click Next ==> Click Back ==> Next Button should be disabled

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
