### PR TITLE
fix: revisit conditions to display channel creation option - WPB-18788

### DIFF
--- a/wire-ios/Wire-iOS Tests/ReferenceImages/StartUIViewControllerSnapshotTests/testStartUIViewControllerHideNewChannelOptionForTeamUser.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/StartUIViewControllerSnapshotTests/testStartUIViewControllerHideNewChannelOptionForTeamUser.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1baccff41a2ebc3a938b62fb69b14d6590a3890835725dbfb78c2bd2bf62cae3
+size 99294

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/StartUIViewControllerSnapshotTests/testStartUIViewControllerShowNewChannelOptionForPersonalUser.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/StartUIViewControllerSnapshotTests/testStartUIViewControllerShowNewChannelOptionForPersonalUser.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35141c5c3b5aa04b8a84933e7769278063e861c3d4682d4cabcc7adb8047735b
+size 115306

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/StartUIViewControllerSnapshotTests/testStartUIViewControllerShowNewChannelOptionForTeamUser.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/StartUIViewControllerSnapshotTests/testStartUIViewControllerShowNewChannelOptionForTeamUser.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35141c5c3b5aa04b8a84933e7769278063e861c3d4682d4cabcc7adb8047735b
+size 115306

--- a/wire-ios/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/StartUIViewControllerSnapshotTests.swift
@@ -123,4 +123,66 @@ final class StartUIViewControllerSnapshotTests: CoreDataSnapshotTestCase {
                 .verify(matching: navigationController.view)
         }
     }
+
+    func testStartUIViewControllerShowNewChannelOptionForPersonalUser() {
+        // Given, channels are supported and user is a personal user
+        BackendInfo.apiVersion = .v8
+        BackendInfo.isMLSEnabled = true
+
+        nonTeamTest {
+            let navigationController = setupNavigationController()
+            snapshotHelper
+                .withUserInterfaceStyle(.dark)
+                .verify(matching: navigationController.view)
+        }
+    }
+
+    func testStartUIViewControllerShowNewChannelOptionForTeamUser() {
+        // Given, channels are supported
+        BackendInfo.apiVersion = .v8
+        BackendInfo.isMLSEnabled = true
+        // channels are enabled
+        userSession.channelsFeature = Feature.Channels(
+            status: .enabled,
+            config: .init(
+                allowedToCreateChannels: .teamMembers,
+                allowedToOpenChannels: .admins
+            )
+        )
+        // user is in a team and is allowed to create a channel
+        let mockUserType = MockUserType()
+        mockUserType.hasTeam = true
+        mockUserType.teamRole = .member
+        userSession.selfUser = mockUserType
+
+        let navigationController = setupNavigationController()
+        snapshotHelper
+            .withUserInterfaceStyle(.dark)
+            .verify(matching: navigationController.view)
+    }
+
+    func testStartUIViewControllerHideNewChannelOptionForTeamUser() {
+        // Given, channels are supported
+        BackendInfo.apiVersion = .v8
+        BackendInfo.isMLSEnabled = true
+
+        // user is in a team
+        let mockUserType = MockUserType()
+        mockUserType.hasTeam = true
+        userSession.selfUser = mockUserType
+
+        // but channels are disabled
+        userSession.channelsFeature = Feature.Channels(
+            status: .disabled,
+            config: .init(
+                allowedToCreateChannels: .teamMembers,
+                allowedToOpenChannels: .admins
+            )
+        )
+
+        let navigationController = setupNavigationController()
+        snapshotHelper
+            .withUserInterfaceStyle(.dark)
+            .verify(matching: navigationController.view)
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -44,7 +44,15 @@ final class StartUIViewController: UIViewController {
     let groupSelector = SearchGroupSelector()
 
     lazy var conversationTypePicker: UIViewController = {
-        let availableConversationTypes: Set<WireMultiParticipantConversationType> = if areChannelsSupported {
+        let canCreateChannels = userSession.channelsFeature.canCreateChannels(
+            role: userSession.selfUser.teamRole
+        )
+
+        let isTeamUser = userSession.selfUser.hasTeam
+
+        let availableConversationTypes: Set<WireMultiParticipantConversationType> = if areChannelsSupported,
+                                                                                       canCreateChannels ||
+                                                                                       !isTeamUser {
             [.channel, .group]
         } else {
             [.group]
@@ -62,7 +70,7 @@ final class StartUIViewController: UIViewController {
                 case .channel:
                     Task { @MainActor [weak self] in
                         guard let self else { return }
-                        if userSession.channelsFeature.canCreateChannels(role: userSession.selfUser.teamRole) {
+                        if canCreateChannels {
                             navigateToChannelCreation()
                         } else {
                             presentCreateTeamBanner()
@@ -331,6 +339,7 @@ final class StartUIViewController: UIViewController {
         guard backendInfoApiVersion >= .v8 else {
             return false
         }
+
         return true
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18788" title="WPB-18788" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18788</a>  [iOS] Channel upgrade flow leads to already on a team
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: on team user account, tapping on "New channel" to create a new channel ends up showing a banner to upgrade to a team although we're already in a team

**Causes**: Conditional checking was incomplete, user could not actually create a channel as feature config is either disabled / he doesn't have the channel permission to do so. 

**Solution**: Conditional checking logic was revisited a bit in this PR:
- if user is a personal user, display new channel creation option -> tapping on it will show the personal to team migration banner
- if user is a team user and **can** create a channel, display new channel creation option -> tapping on it user will be able to create the channel
- if user is a team user and **cannot** create a channel -> **don't** show the new channel creation option

### Testing

- login on a personal user account, see new channel creation option, tap -> banner to upgrade to a team should show up
- login on a team user account where channel feature config is disabled -> new channel creation option will not show up
- login on a team user account where channel feature config is enabled and user has the permission to create a channel -> user will be able to create a channel

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
