### PR TITLE
feat: process call events - WPB-18521

### DIFF
--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -148,7 +148,6 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
             )
         }
 
-
         Task {
             Self.logger.debug("processPendingCallEvents")
             await delegate?.processPendingCallEvents(accountID: accountID)

--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -150,9 +150,8 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
         
 
         Task {
-            Self.logger.debug("processPendingCallEvents begin")
+            Self.logger.debug("processPendingCallEvents")
             await delegate?.processPendingCallEvents(accountID: accountID)
-            Self.logger.debug("processPendingCallEvents end")
         }
     }
 }

--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -147,7 +147,7 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
                 reason: .unanswered
             )
         }
-        
+
 
         Task {
             Self.logger.debug("processPendingCallEvents")

--- a/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
+++ b/wire-ios-sync-engine/Source/Notifications/VoIPPushManager.swift
@@ -147,9 +147,12 @@ public final class VoIPPushManager: NSObject, PKPushRegistryDelegate {
                 reason: .unanswered
             )
         }
+        
 
         Task {
+            Self.logger.debug("processPendingCallEvents begin")
             await delegate?.processPendingCallEvents(accountID: accountID)
+            Self.logger.debug("processPendingCallEvents end")
         }
     }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1390,7 +1390,7 @@ extension ZMUserSession: SyncAgentDelegate {
     func processPendingCallEvents() async {
         if journal[.isSyncV2Enabled] {
             WireLogger.sync.debug(
-                "process pending callEvents for sync v2 aka resume sync",
+                "process pending call events",
                 attributes: .syncAttributes
             )
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1388,12 +1388,21 @@ extension ZMUserSession: SyncAgentDelegate {
     }
 
     func processPendingCallEvents() async {
-        WireLogger.updateEvent.info("process pending call events")
-        do {
-            // TODO: [WPB-15391] why not processing only the call events (should be stored here?)
-            try await legacyUpdateEventProcessor!.processBufferedEvents()
-        } catch {
-            WireLogger.updateEvent.error("Failed to process pending call events: \(String(reflecting: error))")
+        if journal[.isSyncV2Enabled] {
+            WireLogger.sync.debug(
+                "process pending callEvents for sync v2 aka resume sync",
+                attributes: .syncAttributes
+            )
+
+            syncAgent?.resume()
+        } else {
+            WireLogger.updateEvent.info("process pending call events")
+            do {
+                // TODO: [WPB-15391] why not processing only the call events (should be stored here?)
+                try await legacyUpdateEventProcessor!.processBufferedEvents()
+            } catch {
+                WireLogger.updateEvent.error("Failed to process pending call events: \(String(reflecting: error))")
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18521" title="WPB-18521" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18521</a>  [iOS] process call events
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

With new sync enabled, and the NSE needs to report a callkit call, we currently don't process the call event. Only when the user accept the call we resume the sync and process the event.

Solution:

resume the sync so IncrementalSync process the call event.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
