### PR TITLE
fix: additional tap added to enable field to type - WPB-19001

### DIFF
--- a/wire-ios/WireUITests/Pages/LoginPage.swift
+++ b/wire-ios/WireUITests/Pages/LoginPage.swift
@@ -36,7 +36,7 @@ class LoginPage: PageModel {
 
     var nextButton: XCUIElement {
         let elementsQuery = app.scrollViews.otherElements
-        return elementsQuery.buttons["Next"]
+        return elementsQuery.buttons["Next"].firstMatch
     }
 
     var passwordField: XCUIElement {

--- a/wire-ios/WireUITests/Pages/SetUsernamePage.swift
+++ b/wire-ios/WireUITests/Pages/SetUsernamePage.swift
@@ -36,6 +36,8 @@ class SetUsernamePage: PageModel {
 
     func setUsername(_ username: String) throws -> ConversationsPage {
         usernameField.tap()
+        // Note: addtional tap as sometime tapping once doesn't enable the field to type
+        usernameField.tap()
         usernameField.typeText(username)
         usernameConfirmButton.tap()
         return try ConversationsPage()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19001" title="WPB-19001" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19001</a>  [iOS] Fix:username textfield not enabling on tap, adding additional tap action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
