### PR TITLE
feat: handle user delete event for 1:1 - WPB-18849

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -60,6 +60,16 @@ public extension ZMConversation {
         )
     }
 
+    func appendUserRemovedFromTeamSystemMessage(user: ZMUser, at timestamp: Date) {
+        appendSystemMessage(
+            type: .userRemovedFromTeam,
+            sender: user,
+            users: [user],
+            clients: nil,
+            timestamp: timestamp
+        )
+    }
+
     func appendFailedToAddUsersSystemMessage(users: Set<ZMUser>, sender: ZMUser, at timestamp: Date) {
         appendSystemMessage(
             type: .failedToAddParticipants,

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation.m
@@ -372,7 +372,8 @@ const NSUInteger ZMConversationMaxTextMessageLength = ZMConversationMaxEncodedTe
     (self.conversationType == ZMConversationTypeInvalid) ||
     (self.conversationType == ZMConversationTypeSelf) ||
     (self.conversationType == ZMConversationTypeConnection) ||
-    (self.conversationType == ZMConversationTypeGroup && !self.isSelfAnActiveMember);
+    (self.conversationType == ZMConversationTypeGroup && !self.isSelfAnActiveMember) ||
+    (self.conversationType == ZMConversationTypeOneOnOne && self.connectedUser.isAccountDeleted == YES);
 }
 
 + (NSSet *)keyPathsForValuesAffectingIsReadOnly;

--- a/wire-ios-data-model/Source/Model/User/ZMUser.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.swift
@@ -445,15 +445,16 @@ public extension ZMUser {
     }
 
     /// Mark the user's account as having been deleted. This will also remove the user from any conversations he/she
-    /// is still a participant of.
+    /// is still a participant of and add a system message to 1:1 conversations.
     @objc
     func markAccountAsDeleted(at timestamp: Date) {
         isAccountDeleted = true
-        removeFromAllConversations(at: timestamp)
+        removeFromAllGroupConversations(at: timestamp)
+        addSystemMessageInOneOnOneConversation(at: timestamp)
     }
 
     /// Remove user from all group conversations he is a participant of
-    private func removeFromAllConversations(at timestamp: Date) {
+    private func removeFromAllGroupConversations(at timestamp: Date) {
         let allGroupConversations: [ZMConversation] = participantRoles.compactMap {
             guard $0.conversation?.conversationType == .group else {
                 return nil
@@ -470,6 +471,20 @@ public extension ZMUser {
             conversation.removeParticipantAndUpdateConversationState(user: self, initiatingUser: self)
         }
     }
+
+    private func addSystemMessageInOneOnOneConversation(at timestamp: Date) {
+        let conversations: [ZMConversation] = participantRoles.compactMap {
+            guard $0.conversation?.conversationType == .oneOnOne else {
+                return nil
+            }
+            return $0.conversation
+        }
+        conversations.forEach { conversation in
+            let test = conversations.first
+            test?.appendUserRemovedFromTeamSystemMessage(user: self, at: timestamp)
+        }
+    }
+
 }
 
 public extension ZMUser {

--- a/wire-ios-data-model/Source/Model/User/ZMUser.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.swift
@@ -479,9 +479,9 @@ public extension ZMUser {
             }
             return $0.conversation
         }
+
         conversations.forEach { conversation in
-            let test = conversations.first
-            test?.appendUserRemovedFromTeamSystemMessage(user: self, at: timestamp)
+            conversation.appendUserRemovedFromTeamSystemMessage(user: self, at: timestamp)
         }
     }
 

--- a/wire-ios-data-model/Source/Public/ZMMessage.h
+++ b/wire-ios-data-model/Source/Public/ZMMessage.h
@@ -109,7 +109,8 @@ typedef NS_CLOSED_ENUM(int16_t, ZMSystemMessageType) {
     ZMSystemMessageTypeMLSMigrationUpdateVersion,
     ZMSystemMessageTypeMLSMigrationPotentialGap,
     ZMSystemMessageTypeMLSNotSupportedSelfUser,
-    ZMSystemMessageTypeMLSNotSupportedOtherUser
+    ZMSystemMessageTypeMLSNotSupportedOtherUser,
+    ZMSystemMessageTypeUserRemovedFromTeam
 };
 
 typedef NS_CLOSED_ENUM(int16_t, ZMParticipantsRemovedReason) {

--- a/wire-ios/Wire-iOS Tests/ConversationCell/ConversationSystemMessageCellSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationCell/ConversationSystemMessageCellSnapshotTests.swift
@@ -65,6 +65,11 @@ final class ConversationSystemMessageCellSnapshotTests: ConversationMessageSnaps
         verify(message: message)
     }
 
+    func test_userRemovedFromTeam() {
+        let message = makeMessage(messageType: .userRemovedFromTeam)
+        verify(message: message)
+    }
+
     // MARK: - Helpers
 
     private func makeMessage(messageType: ZMSystemMessageType) -> MockMessage {

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageCellSnapshotTests/test_userRemovedFromTeam.320-0.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageCellSnapshotTests/test_userRemovedFromTeam.320-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:871f8f629cab406282163bbede7fea59f50f35e40d112569fb8dd5c86f6248d8
+size 9537

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageCellSnapshotTests/test_userRemovedFromTeam.375-0.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageCellSnapshotTests/test_userRemovedFromTeam.375-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc1cb9165f0bec4b81501d873338998ba670935bdc0eca6b02d59ae49637319b
+size 9915

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageCellSnapshotTests/test_userRemovedFromTeam.414-0.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationSystemMessageCellSnapshotTests/test_userRemovedFromTeam.414-0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed7236ca703b1aa1b5de0906e9b6338d85deb8cd1232092e04b12a1b576ce50a
+size 10195

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -1978,6 +1978,8 @@ internal enum L10n {
         internal static func unverifiedSelfDevices(_ p1: Any) -> String {
           return L10n.tr("Localizable", "content.system.unverified_self_devices", String(describing: p1), fallback: "You unverified one of [your devices](%@)")
         }
+        /// This user is no longer available
+        internal static let userRemovedFromTeam = L10n.tr("Localizable", "content.system.user_removed_from_team", fallback: "This user is no longer available")
         /// Verify devices
         internal static let verifyDevices = L10n.tr("Localizable", "content.system.verify_devices", fallback: "Verify devices")
         /// you

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -640,6 +640,9 @@
 
 "content.system.unknown_message.body" = "This message can’t be displayed. You may be using an older version of Wire.";
 
+// user removed from team
+"content.system.user_removed_from_team" = "This user is no longer available";
+
 "content.file.uploading" = "Uploading…";
 "content.file.downloading" = "Downloading…";
 "content.file.upload_failed" = "Upload failed";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -640,6 +640,8 @@
 
 "content.system.unknown_message.body" = "Diese Meldung konnte nicht angezeigt werden. Möglicherweise verwenden Sie eine ältere Version von Wire.";
 
+"content.system.user_removed_from_team" = "Dieser Benutzer ist nicht mehr verfügbar";
+
 "content.file.uploading" = "Hochladen…";
 "content.file.downloading" = "Herunterladen…";
 "content.file.upload_failed" = "Hochladen fehlgeschlagen";

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -245,7 +245,6 @@ enum ConversationSystemMessageCellDescription {
             )
             missingMessagesCell.showEphemeralTimer = showEphemeralTimer
             return [AnyConversationMessageCellDescription(missingMessagesCell)]
-
         }
 
         return []

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -237,6 +237,15 @@ enum ConversationSystemMessageCellDescription {
             let unknownMessage = UnknownMessageCellDescription()
             unknownMessage.showEphemeralTimer = showEphemeralTimer
             return [AnyConversationMessageCellDescription(unknownMessage)]
+
+        case .userRemovedFromTeam:
+            let missingMessagesCell = UserRemovedFromTeamSystemMessageCellDescription(
+                message: message,
+                data: systemMessageData
+            )
+            missingMessagesCell.showEphemeralTimer = showEphemeralTimer
+            return [AnyConversationMessageCellDescription(missingMessagesCell)]
+
         }
 
         return []

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UserRemovedFromTeamSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/UserRemovedFromTeamSystemMessageCellDescription.swift
@@ -1,0 +1,59 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+import WireDesign
+
+final class UserRemovedFromTeamSystemMessageCellDescription: ConversationMessageCellDescription {
+
+    typealias View = ConversationSystemMessageCell<ConversationMissingMessagesSystemMessageCellDescription>
+    typealias LabelColors = SemanticColors.Label
+    typealias IconColors = SemanticColors.Icon
+
+    let configuration: View.Configuration
+
+    var message: ZMConversationMessage?
+    weak var delegate: ConversationMessageCellDelegate?
+    weak var actionController: ConversationMessageActionController?
+
+    var showEphemeralTimer: Bool = false
+    var topMargin: CGFloat = 0
+
+    let containsHighlightableContent: Bool = false
+
+    let accessibilityIdentifier: String? = nil
+    let accessibilityLabel: String?
+
+    init(message: ZMConversationMessage, data: ZMSystemMessageData) {
+        let title = NSMutableAttributedString.markdown(
+            from: L10n.Localizable.Content.System.userRemovedFromTeam,
+            style: .systemMessage
+        )
+        let icon = UIImage(resource: .attention).withTintColor(SemanticColors.Icon.backgroundDefault)
+        self.configuration = View.Configuration(
+            icon: icon,
+            attributedText: title,
+            showLine: true
+        )
+
+        self.accessibilityLabel = title.string
+        self.actionController = nil
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18849" title="WPB-18849" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18849</a>  [iOS] Can send messages to deleted users on federated backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

For 1:1 conversations with deleted user:
- Take the deletion event
- Enter a system message that says "This user is no longer available" (to be checked the exact message here)
- Make the conversation read only / remove the input bar

### Testing



### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
