### PR TITLE
feat: DeveloperFlag for simple chat bubbles - WPB-19253

### DIFF
--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -40,6 +40,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case newRegistration
     case showUnreadConversationsFilter
     case channelsHistory
+    case chatBubblesSimple
 
     public var description: String {
         switch self {
@@ -96,6 +97,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .channelsHistory:
             "Turn on to enable channels history"
+
+        case .chatBubblesSimple:
+            "Turn on the simplified version of chat bubbles"
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19253" title="WPB-19253" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19253</a>  [iOS] Feature Flag for simple chat bubbles
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Add a DeveloperFlag for the simplified chat bubbles

### Testing

See if the developer flag is visible in the developer tools when shaking the device.
