### PR TITLE
chore: Do not use feature flag when handling reset MLS event - WPB-18664

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -650,7 +650,6 @@ public final class ClientSessionComponent {
     private lazy var mlsResetEventProcessor = ConversationMLSResetEventProcessor(
         mlsService: mlsService,
         conversationLocalStore: conversationLocalStore,
-        featureConfigRepository: featureConfigRepository,
         lockRepository: resetMLSConversationLockRepository
     )
 

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessor.swift
@@ -29,18 +29,15 @@ struct ConversationMLSResetEventProcessor: ConversationMLSResetEventProcessorPro
 
     private let mlsService: any MLSServiceInterface
     private let conversationLocalStore: any ConversationLocalStoreProtocol
-    private let featureConfigRepository: any FeatureConfigRepositoryProtocol
     private let lockRepository: ResetMLSConversationLockRepositoryProtocol
 
     init(
         mlsService: any MLSServiceInterface,
         conversationLocalStore: any ConversationLocalStoreProtocol,
-        featureConfigRepository: any FeatureConfigRepositoryProtocol,
         lockRepository: ResetMLSConversationLockRepositoryProtocol
     ) {
         self.mlsService = mlsService
         self.conversationLocalStore = conversationLocalStore
-        self.featureConfigRepository = featureConfigRepository
         self.lockRepository = lockRepository
     }
 
@@ -48,14 +45,6 @@ struct ConversationMLSResetEventProcessor: ConversationMLSResetEventProcessorPro
         do {
             let attributes: LogAttributes = [.conversationId: event.conversationID.id.safeForLoggingDescription]
 
-            let feature = try await featureConfigRepository.fetchAllowedGlobalOperations()
-            guard feature.status == .enabled, feature.config?.mlsConversationReset == true else {
-                WireLogger.mls.debug(
-                    "No need to process reset broken MLS conversation, FF is OFF",
-                    attributes: attributes
-                )
-                return
-            }
             guard !lockRepository
                 .wasResetInitiated(conversationID: event.conversationID.toDomainModel()) else {
                 WireLogger.mls.info(

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
@@ -32,7 +32,6 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
     private var conversationLocalStore: MockConversationLocalStoreProtocol!
     private var mlsService: MockMLSServiceInterface!
     private var zmConversation: ZMConversation!
-    private var mockFeatureConfigRepository: MockFeatureConfigRepositoryProtocol!
     private lazy var mockResetLockRepository = MockResetMLSConversationLockRepositoryProtocol()
 
     private var context: NSManagedObjectContext {
@@ -45,11 +44,6 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
         coreDataStack = try await coreDataStackHelper.createStack()
         conversationLocalStore = MockConversationLocalStoreProtocol()
         mlsService = MockMLSServiceInterface()
-        mockFeatureConfigRepository = .init()
-        mockFeatureConfigRepository.fetchAllowedGlobalOperations_MockValue = .init(
-            status: .enabled,
-            config: .init(mlsConversationReset: true)
-        )
 
         let conversation = await context.perform { [self] in
             modelHelper.createGroupConversation(
@@ -70,7 +64,6 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
         sut = ConversationMLSResetEventProcessor(
             mlsService: mlsService,
             conversationLocalStore: conversationLocalStore,
-            featureConfigRepository: mockFeatureConfigRepository,
             lockRepository: mockResetLockRepository
 
         )
@@ -116,27 +109,6 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
                     MLSGroupID(Scaffolding.newMLSGroupIDData)
                 )
             }
-    }
-
-    func testProcessEvent_DoNothingWhenFFIsOff() async throws {
-
-        mockFeatureConfigRepository.fetchAllowedGlobalOperations_MockValue = .init(
-            status: .disabled,
-            config: .init(mlsConversationReset: false)
-        )
-
-        // When
-
-        try await sut.processEvent(Scaffolding.event)
-
-        // Then
-
-        XCTAssertEqual(mlsService.wipeGroup_Invocations.count, 0)
-
-        XCTAssertEqual(
-            conversationLocalStore.storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.count,
-            0
-        )
     }
 
     func testProcessEvent_DoNothingWhenInitiatedFromSameDevice() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18664" title="WPB-18664" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18664</a>  [iOS] Process conversation.mls-reset event
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

For rest broken MLS, when device receives event to fix broken conversation we don't need to guard it by FF, only triggering should be under FF

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
