### PR TITLE
feat: add thumbnails to wire cells upload previews - WPB-19266

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Utilities/ThumbnailGenerator.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Utilities/ThumbnailGenerator.swift
@@ -1,0 +1,46 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+@preconcurrency import QuickLookThumbnailing
+import UIKit
+
+/// An object that generates thumbnail images based on provided requirements.
+
+protocol ThumbnailGenerator: Sendable {
+
+    /// Generates a thumbnail image for the file at the specified URL with the given size and scale.
+
+    func generateThumbnail(fileAt url: URL, size: CGSize, scale: Double) async throws -> UIImage
+
+}
+
+extension QLThumbnailGenerator: ThumbnailGenerator, @unchecked @retroactive Sendable {
+
+    func generateThumbnail(fileAt url: URL, size: CGSize, scale: Double) async throws -> UIImage {
+        let request = QLThumbnailGenerator.Request(
+            fileAt: url,
+            size: size,
+            scale: scale,
+            representationTypes: .thumbnail
+        )
+
+        return try await generateBestRepresentation(for: request).uiImage
+    }
+
+}

--- a/WireMessaging/Sources/WireMessagingUI/Utilities/ThumbnailGenerator.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Utilities/ThumbnailGenerator.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-
 @preconcurrency import QuickLookThumbnailing
 import UIKit
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -64,6 +64,8 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
     }
 
     private func refreshItems() {
+        print("REFRESH ITEMS")
+
         items = drafts.compactMap { AttachmentsCarouselItem(draft: $0, thumbnail: thumbnails[$0.versionID]) }
     }
 
@@ -72,7 +74,7 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
             !generatingThumbnailIDs.contains(draft.nodeID),
             thumbnails[draft.versionID] == nil,
             let fileType = draft.fileType,
-            fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent) // FIXME: But not audio
+            (fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent)) && !fileType.conforms(to: .audio)
         else { return }
 
         do {

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -30,13 +30,8 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
         static let thumbnailSize = CGSize(width: 74, height: 74)
     }
 
-    fileprivate struct ThumbnailID: Hashable {
-        let nodeID: UUID
-        let versionID: UUID
-    }
-
     private var drafts: [WireCellsDraft] = []
-    private var thumbnails: [ThumbnailID: UIImage] = [:]
+    private var thumbnails: [UUID: UIImage] = [:]
     private var generatingThumbnailIDs: Set<UUID> = []
 
     @Published private(set) var items: [AttachmentsCarouselItem]
@@ -66,13 +61,13 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
     }
 
     private func refreshItems() {
-        items = drafts.compactMap { AttachmentsCarouselItem(draft: $0, thumbnail: thumbnails[$0.thumbnailID]) }
+        items = drafts.compactMap { AttachmentsCarouselItem(draft: $0, thumbnail: thumbnails[$0.versionID]) }
     }
 
     private func generateThumbnail(for draft: WireCellsDraft) async {
         guard
             !generatingThumbnailIDs.contains(draft.nodeID),
-            thumbnails[draft.thumbnailID] == nil,
+            thumbnails[draft.versionID] == nil,
             let fileType = draft.fileType,
             fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent)
         else { return }
@@ -86,7 +81,7 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
 
         do {
             let result = try await QLThumbnailGenerator.shared.generateBestRepresentation(for: request)
-            thumbnails[draft.thumbnailID] = result.uiImage
+            thumbnails[draft.versionID] = result.uiImage
             refreshItems()
         } catch {
             WireLogger.wireCells.error("Failed to generate thumbnail for file type: \(fileType.identifier)")
@@ -161,10 +156,6 @@ private extension WireCellsDraft {
     var nameAndExtension: (name: String, extension: String) {
         let url = URL(fileURLWithPath: name)
         return (name: url.deletingPathExtension().lastPathComponent, extension: url.pathExtension)
-    }
-
-    var thumbnailID: AttachmentsCarouselViewModel.ThumbnailID {
-        AttachmentsCarouselViewModel.ThumbnailID(nodeID: nodeID, versionID: versionID)
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -72,7 +72,7 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
             !generatingThumbnailIDs.contains(draft.nodeID),
             thumbnails[draft.versionID] == nil,
             let fileType = draft.fileType,
-            fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent)
+            fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent) // FIXME: But not audio
         else { return }
 
         do {
@@ -140,10 +140,10 @@ private extension AttachmentsCarouselItem.Kind {
 
         if value.conforms(to: .image) {
             self = .image(thumbnail: thumbnail)
+        } else if value.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
+            self = .audio(samples: []) // FIXME: [WPB-19268] Set audio sample data
         } else if value.conforms(to: .audiovisualContent) {
             self = .video(thumbnail: thumbnail)
-        } else if value.conforms(to: .audio) {
-            self = .audio(samples: []) // FIXME: [WPB-19268] Set audio sample data
         } else {
             self = .document
         }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -19,26 +19,87 @@
 import Foundation
 import UIKit
 public import WireMessagingDomain
+@preconcurrency import QuickLookThumbnailing
 import UniformTypeIdentifiers
+import WireLogging
 
 @MainActor
 public final class AttachmentsCarouselViewModel: ObservableObject {
 
+    private enum Constants {
+        static let thumbnailSize = CGSize(width: 74, height: 74)
+    }
+
+    fileprivate struct ThumbnailID: Hashable {
+        let nodeID: UUID
+        let versionID: UUID
+    }
+
+    private var drafts: [WireCellsDraft] = []
+    private var thumbnails: [ThumbnailID: UIImage] = [:]
+    private var generatingThumbnailIDs: Set<UUID> = []
+
     @Published private(set) var items: [AttachmentsCarouselItem]
 
-    public init(items: [AttachmentsCarouselItem]) {
+    public convenience init() {
+        self.init(items: [])
+    }
+
+    init(items: [AttachmentsCarouselItem]) {
         self.items = items
     }
 
     public func update(with drafts: [WireCellsDraft]) {
-        items = drafts.compactMap { AttachmentsCarouselItem(draft: $0) }
+        self.drafts = drafts
+        refreshItems()
+
+        for draft in drafts {
+            Task { await generateThumbnail(for: draft) }
+        }
+
+        // In general there is no reason to keep thumbnails cached too long as the same thumbnail is unlikely to be
+        // needed again once a message has been sent and re-generating thumbnails is cheap. When `drafts` is empty, its
+        // a good time to remove them.
+        if drafts.isEmpty {
+            thumbnails.removeAll()
+        }
+    }
+
+    private func refreshItems() {
+        items = drafts.compactMap { AttachmentsCarouselItem(draft: $0, thumbnail: thumbnails[$0.thumbnailID]) }
+    }
+
+    private func generateThumbnail(for draft: WireCellsDraft) async {
+        guard
+            !generatingThumbnailIDs.contains(draft.nodeID),
+            thumbnails[draft.thumbnailID] == nil,
+            let fileType = draft.fileType,
+            fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent)
+        else { return }
+
+        let request = QLThumbnailGenerator.Request(
+            fileAt: draft.assetURL,
+            size: Constants.thumbnailSize,
+            scale: UIScreen.main.scale,
+            representationTypes: .thumbnail
+        )
+
+        do {
+            let result = try await QLThumbnailGenerator.shared.generateBestRepresentation(for: request)
+            thumbnails[draft.thumbnailID] = result.uiImage
+            refreshItems()
+        } catch {
+            WireLogger.wireCells.error("Failed to generate thumbnail for file type: \(fileType.identifier)")
+        }
+
+        generatingThumbnailIDs.remove(draft.nodeID)
     }
 
 }
 
 private extension AttachmentsCarouselItem {
 
-    init?(draft: WireCellsDraft) {
+    init?(draft: WireCellsDraft, thumbnail: UIImage?) {
         let state: AttachmentsCarouselItem.State
         switch draft.status {
         case let .uploading(progress):
@@ -56,7 +117,7 @@ private extension AttachmentsCarouselItem {
         self.init(
             id: draft.nodeID,
             state: state,
-            kind: AttachmentsCarouselItem.Kind(draft.fileType),
+            kind: AttachmentsCarouselItem.Kind(draft.fileType, thumbnail: thumbnail),
             name: name,
             fileExtension: fileExtension,
             size: draft.bytes.formatted(.byteCount(style: .decimal)),
@@ -76,16 +137,16 @@ private extension AttachmentsCarouselItem {
 
 private extension AttachmentsCarouselItem.Kind {
 
-    init(_ value: UTType?) {
+    init(_ value: UTType?, thumbnail: UIImage?) {
         guard let value else {
             self = .document
             return
         }
 
         if value.conforms(to: .image) {
-            self = .image(thumbnail: nil) // FIXME: [WPB-19266] Set image thumbnail data
+            self = .image(thumbnail: thumbnail)
         } else if value.conforms(to: .audiovisualContent) {
-            self = .video(thumbnail: nil) // FIXME: [WPB-19267] Set video thumbnail data
+            self = .video(thumbnail: thumbnail)
         } else if value.conforms(to: .audio) {
             self = .audio(samples: []) // FIXME: [WPB-19268] Set audio sample data
         } else {
@@ -100,6 +161,10 @@ private extension WireCellsDraft {
     var nameAndExtension: (name: String, extension: String) {
         let url = URL(fileURLWithPath: name)
         return (name: url.deletingPathExtension().lastPathComponent, extension: url.pathExtension)
+    }
+
+    var thumbnailID: AttachmentsCarouselViewModel.ThumbnailID {
+        AttachmentsCarouselViewModel.ThumbnailID(nodeID: nodeID, versionID: versionID)
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -69,11 +69,13 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
 
     private func generateThumbnail(for draft: WireCellsDraft) async {
         guard
-            !generatingThumbnailIDs.contains(draft.nodeID),
+            !generatingThumbnailIDs.contains(draft.versionID),
             thumbnails[draft.versionID] == nil,
             let fileType = draft.fileType,
             fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent), !fileType.conforms(to: .audio)
         else { return }
+
+        generatingThumbnailIDs.insert(draft.versionID)
 
         do {
             let thumbnail = try await thumbnailGenerator.generateThumbnail(
@@ -87,7 +89,7 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
             WireLogger.wireCells.error("Failed to generate thumbnail for file type: \(fileType.identifier)")
         }
 
-        generatingThumbnailIDs.remove(draft.nodeID)
+        generatingThumbnailIDs.remove(draft.versionID)
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -64,8 +64,6 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
     }
 
     private func refreshItems() {
-        print("REFRESH ITEMS")
-
         items = drafts.compactMap { AttachmentsCarouselItem(draft: $0, thumbnail: thumbnails[$0.versionID]) }
     }
 
@@ -74,7 +72,7 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
             !generatingThumbnailIDs.contains(draft.nodeID),
             thumbnails[draft.versionID] == nil,
             let fileType = draft.fileType,
-            (fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent)) && !fileType.conforms(to: .audio)
+            fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent), !fileType.conforms(to: .audio)
         else { return }
 
         do {

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -19,7 +19,7 @@
 import Foundation
 import UIKit
 public import WireMessagingDomain
-@preconcurrency import QuickLookThumbnailing
+import QuickLookThumbnailing
 import UniformTypeIdentifiers
 import WireLogging
 
@@ -29,6 +29,8 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
     private enum Constants {
         static let thumbnailSize = CGSize(width: 74, height: 74)
     }
+
+    private let thumbnailGenerator: any ThumbnailGenerator
 
     private var drafts: [WireCellsDraft] = []
     private var thumbnails: [UUID: UIImage] = [:]
@@ -40,8 +42,9 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
         self.init(items: [])
     }
 
-    init(items: [AttachmentsCarouselItem]) {
+    init(items: [AttachmentsCarouselItem], thumbnailGenerator: any ThumbnailGenerator = QLThumbnailGenerator.shared) {
         self.items = items
+        self.thumbnailGenerator = thumbnailGenerator
     }
 
     public func update(with drafts: [WireCellsDraft]) {
@@ -72,16 +75,13 @@ public final class AttachmentsCarouselViewModel: ObservableObject {
             fileType.conforms(to: .image) || fileType.conforms(to: .audiovisualContent)
         else { return }
 
-        let request = QLThumbnailGenerator.Request(
-            fileAt: draft.assetURL,
-            size: Constants.thumbnailSize,
-            scale: UIScreen.main.scale,
-            representationTypes: .thumbnail
-        )
-
         do {
-            let result = try await QLThumbnailGenerator.shared.generateBestRepresentation(for: request)
-            thumbnails[draft.versionID] = result.uiImage
+            let thumbnail = try await thumbnailGenerator.generateThumbnail(
+                fileAt: draft.assetURL,
+                size: Constants.thumbnailSize,
+                scale: UIScreen.main.scale
+            )
+            thumbnails[draft.versionID] = thumbnail
             refreshItems()
         } catch {
             WireLogger.wireCells.error("Failed to generate thumbnail for file type: \(fileType.identifier)")

--- a/WireMessaging/Tests/WireMessagingTests/Fixtures/UIImage+Fixture.swift
+++ b/WireMessaging/Tests/WireMessagingTests/Fixtures/UIImage+Fixture.swift
@@ -16,29 +16,14 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-public import UIKit
+import UIKit
 
-public struct AttachmentsCarouselItem: Identifiable, Sendable, Equatable {
+@testable import WireMessagingUI
 
-    public enum State: Sendable, Equatable {
-        case uploading(progress: Double)
-        case uploaded
-        case failed
+extension UIImage {
+
+    static func fixture() -> UIImage {
+        UIImage(resource: .dropdown) 
     }
-
-    public enum Kind: Sendable, Equatable {
-        case image(thumbnail: UIImage?)
-        case video(thumbnail: UIImage?)
-        case audio(samples: [Double]?)
-        case document
-    }
-
-    public var id: UUID
-    public var state: State
-    public var kind: Kind
-    public var name: String
-    public var fileExtension: String?
-    public var size: String
-    var fileIcon: FileIcon
 
 }

--- a/WireMessaging/Tests/WireMessagingTests/Fixtures/UIImage+Fixture.swift
+++ b/WireMessaging/Tests/WireMessagingTests/Fixtures/UIImage+Fixture.swift
@@ -23,7 +23,7 @@ import UIKit
 extension UIImage {
 
     static func fixture() -> UIImage {
-        UIImage(resource: .dropdown) 
+        UIImage(resource: .dropdown)
     }
 
 }

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/Helpers/WireCellsDraft+Fixture.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/Helpers/WireCellsDraft+Fixture.swift
@@ -18,14 +18,17 @@
 
 import Foundation
 import WireMessagingDomain
+import UniformTypeIdentifiers
 
 extension WireCellsDraft {
     static func fixture(
         nodeID: UUID = UUID(),
         versionID: UUID = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
         assetURL: URL = URL(string: "https://example.com")!,
+        fileType: UTType? = nil,
         status: WireCellsUploadStatus = .uploaded(isDraft: true),
         name: String = "Draft",
+        bytes: Int = 1024,
         mimeType: String? = nil,
         deleteAfterUpload: Bool = false
     ) -> WireCellsDraft {
@@ -33,10 +36,10 @@ extension WireCellsDraft {
             nodeID: nodeID,
             versionID: versionID,
             assetURL: assetURL,
-            fileType: nil,
+            fileType: fileType,
             status: status,
             name: name,
-            bytes: 1024,
+            bytes: bytes,
             mimeType: mimeType,
             deleteAfterUpload: deleteAfterUpload
         )

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/Helpers/WireCellsDraft+Fixture.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/Helpers/WireCellsDraft+Fixture.swift
@@ -17,8 +17,8 @@
 //
 
 import Foundation
-import WireMessagingDomain
 import UniformTypeIdentifiers
+import WireMessagingDomain
 
 extension WireCellsDraft {
     static func fixture(

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
@@ -38,7 +38,8 @@ final class AttachmentsCarouselViewModelTests {
         }.store(in: &cancellables)
     }
 
-    @Test func updateWhenSuccess() async throws {
+    @Test
+    func updateWhenSuccess() async throws {
         // given
         var imageDraft = WireCellsDraft.fixture(
             fileType: .jpeg,
@@ -120,7 +121,7 @@ final class AttachmentsCarouselViewModelTests {
 
         // update 2 - all items are uploading, but image OR video thumbnail is generated - it's non deterministic so
         // just a sanity check
-        #expect(capturedItems[1].map { $0.id } == [imageItem.id, videoItem.id, audioItem.id, documentItem.id])
+        #expect(capturedItems[1].map(\.id) == [imageItem.id, videoItem.id, audioItem.id, documentItem.id])
 
         // update 3 - all items are uploading, but image AND video thumbnails are generated
         imageItem.kind = .image(thumbnail: UIImage.fixture())
@@ -145,7 +146,8 @@ final class AttachmentsCarouselViewModelTests {
         #expect(capturedItems[3] == [imageItem, videoItem, audioItem, documentItem])
     }
 
-    @Test func updateWhenFailure() async throws {
+    @Test
+    func updateWhenFailure() async throws {
         // given
         var documentDraft = WireCellsDraft.fixture(
             fileType: .spreadsheet,
@@ -185,10 +187,8 @@ final class AttachmentsCarouselViewModelTests {
     func awaitUntilCapturedItemsCount(_ count: Int) async throws {
         guard capturedItems.count < count else { return }
 
-        for await _ in sut.$items.values {
-            if capturedItems.count >= count {
-                break
-            }
+        for await _ in sut.$items.values where capturedItems.count >= count {
+            break
         }
     }
 
@@ -197,7 +197,7 @@ final class AttachmentsCarouselViewModelTests {
 private actor ThumbnailGeneratorMock: ThumbnailGenerator {
 
     func generateThumbnail(fileAt url: URL, size: CGSize, scale: Double) async throws -> UIImage {
-        return UIImage.fixture()
+        UIImage.fixture()
     }
 
 }

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
@@ -19,6 +19,8 @@
 import Testing
 import UIKit
 
+@preconcurrency import Combine
+
 @testable import WireMessagingDomain
 @testable import WireMessagingUI
 
@@ -27,9 +29,24 @@ final class AttachmentsCarouselViewModelTests {
 
     private let thumbnailGenerator = ThumbnailGeneratorMock()
     private lazy var sut = AttachmentsCarouselViewModel(items: [], thumbnailGenerator: thumbnailGenerator)
+    private var capturedItems: [[AttachmentsCarouselItem]] = []
+    private var cancellables: Set<AnyCancellable> = []
+
+    init() {
+        sut.$items.dropFirst().sink { [weak self] items in
+            self?.capturedItems.append(items)
+        }.store(in: &cancellables)
+    }
 
     @Test func updateWhenSuccess() async throws {
-        // GIVEN
+        let token = sut.$items.sink { value in
+            print("BEGIN")
+            print(value.map { $0.kind })
+            print("END")
+        }
+
+
+        // given
         var imageDraft = WireCellsDraft.fixture(
             fileType: .jpeg,
             status: .uploading(progress: 0.5),
@@ -61,10 +78,10 @@ final class AttachmentsCarouselViewModelTests {
         var capturesUpdates: [[AttachmentsCarouselItem]] = []
         let itemUpdates = sut.$items.values
 
-        // WHEN
+        // when
         sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
 
-        // THEN 3 updates are expected to be published - an immediate update, and 2 further updates as the image & video
+        // then 3 updates are expected to be published - an immediate update, and 2 further updates as the image & video
         // thumbnails are generated - wait and capture them
         for await update in itemUpdates.prefix(3) { capturesUpdates.append(update) }
 
@@ -121,8 +138,7 @@ final class AttachmentsCarouselViewModelTests {
         videoItem.kind = .video(thumbnail: UIImage.fixture())
         #expect(capturesUpdates[2] == [imageItem, videoItem, audioItem, documentItem])
 
-
-        // WHEN upload completes
+        // when upload completes
         imageDraft.status = .uploaded(isDraft: true)
         videoDraft.status = .uploaded(isDraft: true)
         audioDraft.status = .uploaded(isDraft: true)
@@ -130,7 +146,7 @@ final class AttachmentsCarouselViewModelTests {
 
         sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
 
-        // THEN a final update is expected - wait and capture it
+        // then a final update is expected - wait and capture it
         for await update in itemUpdates.prefix(1) { capturesUpdates.append(update) }
 
         try #require(capturesUpdates.count == 4)
@@ -140,6 +156,53 @@ final class AttachmentsCarouselViewModelTests {
         audioItem.state = .uploaded
         documentItem.state = .uploaded
         #expect(capturesUpdates[3] == [imageItem, videoItem, audioItem, documentItem])
+    }
+
+    @Test func updateWhenFailure() async throws {
+        // given
+        var documentDraft = WireCellsDraft.fixture(
+            fileType: .spreadsheet,
+            status: .uploading(progress: 0.5),
+            name: "spreadsheet.xlsx",
+            bytes: 2_000_000,
+        )
+
+        // when
+        sut.update(with: [documentDraft])
+
+        documentDraft.status = .failed(error: .fileNotFound)
+        sut.update(with: [documentDraft])
+
+        try await awaitUntilCapturedItemsCount(2)
+
+        // then
+        try #require(capturedItems.count == 2)
+
+        // update 1 - document uploading
+        var documentItem = AttachmentsCarouselItem(
+            id: documentDraft.nodeID,
+            state: .uploading(progress: 0.5),
+            kind: .document,
+            name: "spreadsheet",
+            fileExtension: "xlsx",
+            size: "2 MB",
+            fileIcon: .spreadsheet
+        )
+        #expect(capturedItems[0] == [documentItem])
+
+        // update 2 - document upload failed
+        documentItem.state = .failed
+        #expect(capturedItems[1] == [documentItem])
+    }
+
+    func awaitUntilCapturedItemsCount(_ count: Int) async throws {
+        guard capturedItems.count < count else { return }
+
+        for await _ in sut.$items.values {
+            if capturedItems.count >= count {
+                break
+            }
+        }
     }
 
 }

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
@@ -1,0 +1,153 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Testing
+import UIKit
+
+@testable import WireMessagingDomain
+@testable import WireMessagingUI
+
+@MainActor
+final class AttachmentsCarouselViewModelTests {
+
+    private let thumbnailGenerator = ThumbnailGeneratorMock()
+
+    @Test func updateWhenSuccess() async throws {
+        let sut = AttachmentsCarouselViewModel(items: [], thumbnailGenerator: thumbnailGenerator)
+        var capturesUpdates: [[AttachmentsCarouselItem]] = []
+
+        let itemUpdates = sut.$items.values
+
+        var imageDraft = WireCellsDraft.fixture(
+            fileType: .jpeg,
+            status: .uploading(progress: 0.5),
+            name: "image.jpg",
+            bytes: 1024,
+        )
+
+        var videoDraft = WireCellsDraft.fixture(
+            fileType: .mpeg4Movie,
+            status: .uploading(progress: 0.5),
+            name: "video.mp4",
+            bytes: 1_000_000,
+        )
+
+        var audioDraft = WireCellsDraft.fixture(
+            fileType: .mp3,
+            status: .uploading(progress: 0.5),
+            name: "audio.mp3",
+            bytes: 3_000_000,
+        )
+
+        var documentDraft = WireCellsDraft.fixture(
+            fileType: .spreadsheet,
+            status: .uploading(progress: 0.5),
+            name: "spreadsheet.xlsx",
+            bytes: 2_000_000,
+        )
+
+        sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
+
+        for await update in itemUpdates.prefix(3) {
+            capturesUpdates.append(update)
+        }
+
+        // when uploading completes
+        imageDraft.status = .uploaded(isDraft: true)
+        videoDraft.status = .uploaded(isDraft: true)
+        audioDraft.status = .uploaded(isDraft: true)
+        documentDraft.status = .uploaded(isDraft: true)
+
+
+        sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
+
+        // wait for the next update
+        for await update in itemUpdates.prefix(1) { capturesUpdates.append(update) }
+
+        // then
+
+        // first update
+        var imageItem = AttachmentsCarouselItem(
+            id: imageDraft.nodeID,
+            state: .uploading(progress: 0.5),
+            kind: .image(thumbnail: nil),
+            name: "image",
+            fileExtension: "jpg",
+            size: "1 kB",
+            fileIcon: .image
+        )
+
+        var videoItem = AttachmentsCarouselItem(
+            id: videoDraft.nodeID,
+            state: .uploading(progress: 0.5),
+            kind: .video(thumbnail: nil),
+            name: "video",
+            fileExtension: "mp4",
+            size: "1 MB",
+            fileIcon: .video
+        )
+
+        var audioItem = AttachmentsCarouselItem(
+            id: audioDraft.nodeID,
+            state: .uploading(progress: 0.5),
+            kind: .audio(samples: []),
+            name: "audio",
+            fileExtension: "mp3",
+            size: "3 MB",
+            fileIcon: .audio
+        )
+
+        var documentItem = AttachmentsCarouselItem(
+            id: documentDraft.nodeID,
+            state: .uploading(progress: 0.5),
+            kind: .document,
+            name: "spreadsheet",
+            fileExtension: "xlsx",
+            size: "2 MB",
+            fileIcon: .spreadsheet
+        )
+
+        try #require(capturesUpdates.count == 4)
+        #expect(capturesUpdates[0] == [imageItem, videoItem, audioItem, documentItem])
+
+        // second update
+        // Either the image OR video thumbnail has been generated so it is hard to test. Lets just sanity check.
+        #expect(capturesUpdates[1].map { $0.id } == [imageItem.id, videoItem.id, audioItem.id, documentItem.id])
+
+        // third update
+        imageItem.kind = .image(thumbnail: UIImage.fixture())
+        videoItem.kind = .video(thumbnail: UIImage.fixture())
+        #expect(capturesUpdates[2] == [imageItem, videoItem, audioItem, documentItem])
+
+        // forth update
+        imageItem.state = .uploaded
+        videoItem.state = .uploaded
+        audioItem.state = .uploaded
+        documentItem.state = .uploaded
+        #expect(capturesUpdates[3] == [imageItem, videoItem, audioItem, documentItem])
+    }
+
+}
+
+private actor ThumbnailGeneratorMock: ThumbnailGenerator {
+
+    func generateThumbnail(fileAt url: URL, size: CGSize, scale: Double) async throws -> UIImage {
+        return UIImage.fixture()
+    }
+
+}

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
@@ -42,6 +42,7 @@ final class AttachmentsCarouselViewModelTests {
     func updateWhenSuccess() async throws {
         // given
         var imageDraft = WireCellsDraft.fixture(
+            versionID: UUID(),
             fileType: .jpeg,
             status: .uploading(progress: 0.5),
             name: "image.jpg",
@@ -49,6 +50,7 @@ final class AttachmentsCarouselViewModelTests {
         )
 
         var videoDraft = WireCellsDraft.fixture(
+            versionID: UUID(),
             fileType: .mpeg4Movie,
             status: .uploading(progress: 0.5),
             name: "video.mp4",
@@ -56,6 +58,7 @@ final class AttachmentsCarouselViewModelTests {
         )
 
         var audioDraft = WireCellsDraft.fixture(
+            versionID: UUID(),
             fileType: .mp3,
             status: .uploading(progress: 0.5),
             name: "audio.mp3",
@@ -63,6 +66,7 @@ final class AttachmentsCarouselViewModelTests {
         )
 
         var documentDraft = WireCellsDraft.fixture(
+            versionID: UUID(),
             fileType: .spreadsheet,
             status: .uploading(progress: 0.5),
             name: "spreadsheet.xlsx",
@@ -150,6 +154,7 @@ final class AttachmentsCarouselViewModelTests {
     func updateWhenFailure() async throws {
         // given
         var documentDraft = WireCellsDraft.fixture(
+            versionID: UUID(),
             fileType: .spreadsheet,
             status: .uploading(progress: 0.5),
             name: "spreadsheet.xlsx",

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
@@ -19,7 +19,7 @@
 import Testing
 import UIKit
 
-@preconcurrency import Combine
+import Combine
 
 @testable import WireMessagingDomain
 @testable import WireMessagingUI
@@ -39,13 +39,6 @@ final class AttachmentsCarouselViewModelTests {
     }
 
     @Test func updateWhenSuccess() async throws {
-        let token = sut.$items.sink { value in
-            print("BEGIN")
-            print(value.map { $0.kind })
-            print("END")
-        }
-
-
         // given
         var imageDraft = WireCellsDraft.fixture(
             fileType: .jpeg,
@@ -75,17 +68,13 @@ final class AttachmentsCarouselViewModelTests {
             bytes: 2_000_000,
         )
 
-        var capturesUpdates: [[AttachmentsCarouselItem]] = []
-        let itemUpdates = sut.$items.values
-
         // when
         sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
 
-        // then 3 updates are expected to be published - an immediate update, and 2 further updates as the image & video
-        // thumbnails are generated - wait and capture them
-        for await update in itemUpdates.prefix(3) { capturesUpdates.append(update) }
+        try await awaitUntilCapturedItemsCount(3)
 
-        try #require(capturesUpdates.count == 3)
+        // then 3 updates are expected to be published - an immediate update, and 2 further updates as the image & video
+        // thumbnails are generated
 
         // update 1 - all items are uploading
         var imageItem = AttachmentsCarouselItem(
@@ -127,16 +116,16 @@ final class AttachmentsCarouselViewModelTests {
             size: "2 MB",
             fileIcon: .spreadsheet
         )
-        #expect(capturesUpdates[0] == [imageItem, videoItem, audioItem, documentItem])
+        #expect(capturedItems[0] == [imageItem, videoItem, audioItem, documentItem])
 
         // update 2 - all items are uploading, but image OR video thumbnail is generated - it's non deterministic so
         // just a sanity check
-        #expect(capturesUpdates[1].map { $0.id } == [imageItem.id, videoItem.id, audioItem.id, documentItem.id])
+        #expect(capturedItems[1].map { $0.id } == [imageItem.id, videoItem.id, audioItem.id, documentItem.id])
 
         // update 3 - all items are uploading, but image AND video thumbnails are generated
         imageItem.kind = .image(thumbnail: UIImage.fixture())
         videoItem.kind = .video(thumbnail: UIImage.fixture())
-        #expect(capturesUpdates[2] == [imageItem, videoItem, audioItem, documentItem])
+        #expect(capturedItems[2] == [imageItem, videoItem, audioItem, documentItem])
 
         // when upload completes
         imageDraft.status = .uploaded(isDraft: true)
@@ -146,16 +135,14 @@ final class AttachmentsCarouselViewModelTests {
 
         sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
 
-        // then a final update is expected - wait and capture it
-        for await update in itemUpdates.prefix(1) { capturesUpdates.append(update) }
+        try await awaitUntilCapturedItemsCount(4)
 
-        try #require(capturesUpdates.count == 4)
-
+        // then a final update is expected
         imageItem.state = .uploaded
         videoItem.state = .uploaded
         audioItem.state = .uploaded
         documentItem.state = .uploaded
-        #expect(capturesUpdates[3] == [imageItem, videoItem, audioItem, documentItem])
+        #expect(capturedItems[3] == [imageItem, videoItem, audioItem, documentItem])
     }
 
     @Test func updateWhenFailure() async throws {

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/AttachmentsCarousel/AttachmentsCarouselViewModelTests.swift
@@ -26,13 +26,10 @@ import UIKit
 final class AttachmentsCarouselViewModelTests {
 
     private let thumbnailGenerator = ThumbnailGeneratorMock()
+    private lazy var sut = AttachmentsCarouselViewModel(items: [], thumbnailGenerator: thumbnailGenerator)
 
     @Test func updateWhenSuccess() async throws {
-        let sut = AttachmentsCarouselViewModel(items: [], thumbnailGenerator: thumbnailGenerator)
-        var capturesUpdates: [[AttachmentsCarouselItem]] = []
-
-        let itemUpdates = sut.$items.values
-
+        // GIVEN
         var imageDraft = WireCellsDraft.fixture(
             fileType: .jpeg,
             status: .uploading(progress: 0.5),
@@ -61,27 +58,19 @@ final class AttachmentsCarouselViewModelTests {
             bytes: 2_000_000,
         )
 
+        var capturesUpdates: [[AttachmentsCarouselItem]] = []
+        let itemUpdates = sut.$items.values
+
+        // WHEN
         sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
 
-        for await update in itemUpdates.prefix(3) {
-            capturesUpdates.append(update)
-        }
+        // THEN 3 updates are expected to be published - an immediate update, and 2 further updates as the image & video
+        // thumbnails are generated - wait and capture them
+        for await update in itemUpdates.prefix(3) { capturesUpdates.append(update) }
 
-        // when uploading completes
-        imageDraft.status = .uploaded(isDraft: true)
-        videoDraft.status = .uploaded(isDraft: true)
-        audioDraft.status = .uploaded(isDraft: true)
-        documentDraft.status = .uploaded(isDraft: true)
+        try #require(capturesUpdates.count == 3)
 
-
-        sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
-
-        // wait for the next update
-        for await update in itemUpdates.prefix(1) { capturesUpdates.append(update) }
-
-        // then
-
-        // first update
+        // update 1 - all items are uploading
         var imageItem = AttachmentsCarouselItem(
             id: imageDraft.nodeID,
             state: .uploading(progress: 0.5),
@@ -121,20 +110,31 @@ final class AttachmentsCarouselViewModelTests {
             size: "2 MB",
             fileIcon: .spreadsheet
         )
-
-        try #require(capturesUpdates.count == 4)
         #expect(capturesUpdates[0] == [imageItem, videoItem, audioItem, documentItem])
 
-        // second update
-        // Either the image OR video thumbnail has been generated so it is hard to test. Lets just sanity check.
+        // update 2 - all items are uploading, but image OR video thumbnail is generated - it's non deterministic so
+        // just a sanity check
         #expect(capturesUpdates[1].map { $0.id } == [imageItem.id, videoItem.id, audioItem.id, documentItem.id])
 
-        // third update
+        // update 3 - all items are uploading, but image AND video thumbnails are generated
         imageItem.kind = .image(thumbnail: UIImage.fixture())
         videoItem.kind = .video(thumbnail: UIImage.fixture())
         #expect(capturesUpdates[2] == [imageItem, videoItem, audioItem, documentItem])
 
-        // forth update
+
+        // WHEN upload completes
+        imageDraft.status = .uploaded(isDraft: true)
+        videoDraft.status = .uploaded(isDraft: true)
+        audioDraft.status = .uploaded(isDraft: true)
+        documentDraft.status = .uploaded(isDraft: true)
+
+        sut.update(with: [imageDraft, videoDraft, audioDraft, documentDraft])
+
+        // THEN a final update is expected - wait and capture it
+        for await update in itemUpdates.prefix(1) { capturesUpdates.append(update) }
+
+        try #require(capturesUpdates.count == 4)
+
         imageItem.state = .uploaded
         videoItem.state = .uploaded
         audioItem.state = .uploaded

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -234,7 +234,7 @@ final class ConversationInputBarViewController: UIViewController,
     private let observeDraftsUseCase: WireCellsObserveDraftsUseCaseProtocol
     private let deleteDraftUseCase: WireCellsDeleteDraftUseCaseProtocol
     private let retryUploadDraftUseCase: WireCellsRetryUploadDraftUseCaseProtocol
-    private let attachmentsCarouselViewModel = AttachmentsCarouselViewModel(items: [])
+    private let attachmentsCarouselViewModel = AttachmentsCarouselViewModel()
 
     private var inputBarButtons: [IconButton] {
         var buttonsArray: [IconButton] = []


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19266" title="WPB-19266" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19266</a>  [iOS] Generate thumbnail for image upload preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds thumbnails to the previews when uploading assets to wire cells

https://github.com/user-attachments/assets/c046c1c6-1832-48cc-9192-5f77780b8e9c


### Testing

Run unit tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
