### PR TITLE
fix: unable to pull more than 1000 conversations - WPB-19404

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
@@ -59,30 +59,37 @@ public final class PullAllConversationsSync: PullAllConversationsSyncProtocol {
             }
         }
 
-        let conversations = try await api.getConversations(for: conversationIDs)
+        while !conversationIDs.isEmpty {
+            // Fetch max 1000 at a time.
+            let idsToFetch = Array(conversationIDs.prefix(1000))
+            conversationIDs.removeFirst(idsToFetch.count)
 
-        for conversation in conversations.found {
-            await store.storeConversation(
-                conversation.toDomainModel(),
-                timestamp: .now,
-                isFederationEnabled: isFederationEnabled,
-                isMLSEnabled: isMLSEnabled
-            )
-        }
+            let conversations = try await api.getConversations(for: idsToFetch)
 
-        for id in conversations.notFound {
-            await store.storeConversation(
-                needsBackendUpdate: true,
-                conversationID: id.id,
-                conversationDomain: id.domain
-            )
-        }
+            for conversation in conversations.found {
+                await store.storeConversation(
+                    conversation.toDomainModel(),
+                    timestamp: .now,
+                    isFederationEnabled: isFederationEnabled,
+                    isMLSEnabled: isMLSEnabled
+                )
+            }
 
-        for id in conversations.failed {
-            await store.storeFailedConversation(
-                conversationID: id.id,
-                conversationDomain: id.domain
-            )
+            for id in conversations.notFound {
+                await store.storeConversation(
+                    needsBackendUpdate: true,
+                    conversationID: id.id,
+                    conversationDomain: id.domain
+                )
+            }
+
+            for id in conversations.failed {
+                await store.storeFailedConversation(
+                    conversationID: id.id,
+                    conversationDomain: id.domain
+                )
+            }
+
         }
 
         journal[.isConversationSyncRequired] = false

--- a/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
@@ -59,40 +59,64 @@ public final class PullAllConversationsSync: PullAllConversationsSyncProtocol {
             }
         }
 
-        while !conversationIDs.isEmpty {
-            // Fetch max 1000 at a time.
-            let idsToFetch = Array(conversationIDs.prefix(1000))
-            conversationIDs.removeFirst(idsToFetch.count)
+        guard !conversationIDs.isEmpty else {
+            return
+        }
 
-            let conversations = try await api.getConversations(for: idsToFetch)
-
-            for conversation in conversations.found {
-                await store.storeConversation(
-                    conversation.toDomainModel(),
-                    timestamp: .now,
-                    isFederationEnabled: isFederationEnabled,
-                    isMLSEnabled: isMLSEnabled
-                )
+        // We'll fetch the conversations in chunks and let them run in
+        // parallel.
+        try await withThrowingTaskGroup { group in
+            // Backend allows fetching max 1000 at a time.
+            let chunks = stride(
+                from: conversationIDs.startIndex,
+                to: conversationIDs.endIndex,
+                by: 1000
+            ).map { startIndex in
+                let endIndex = min(startIndex + 1000, conversationIDs.endIndex)
+                return Array(conversationIDs[startIndex ..< endIndex])
             }
 
-            for id in conversations.notFound {
-                await store.storeConversation(
-                    needsBackendUpdate: true,
-                    conversationID: id.id,
-                    conversationDomain: id.domain
-                )
+            // Enqueue each task.
+            for chunk in chunks {
+                group.addTask { [weak self] in
+                    try await self?.pullConversations(ids: chunk)
+                }
             }
 
-            for id in conversations.failed {
-                await store.storeFailedConversation(
-                    conversationID: id.id,
-                    conversationDomain: id.domain
-                )
-            }
-
+            // Wait for all tasks to complete, if any fail the
+            // group will fail.
+            while try await group.next() != nil {}
         }
 
         journal[.isConversationSyncRequired] = false
+    }
+
+    private func pullConversations(ids: [QualifiedID]) async throws {
+        let conversations = try await api.getConversations(for: ids)
+
+        for conversation in conversations.found {
+            await store.storeConversation(
+                conversation.toDomainModel(),
+                timestamp: .now,
+                isFederationEnabled: isFederationEnabled,
+                isMLSEnabled: isMLSEnabled
+            )
+        }
+
+        for id in conversations.notFound {
+            await store.storeConversation(
+                needsBackendUpdate: true,
+                conversationID: id.id,
+                conversationDomain: id.domain
+            )
+        }
+
+        for id in conversations.failed {
+            await store.storeFailedConversation(
+                conversationID: id.id,
+                conversationDomain: id.domain
+            )
+        }
     }
 
 }

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -104,6 +104,40 @@ final class PullAllConversationsSyncTests: XCTestCase {
         XCTAssertEqual(journal[.isConversationSyncRequired], false)
     }
 
+    func testPullConversationsInBatchesOf1000() async throws {
+        // Given
+        journal[.isConversationSyncRequired] = true
+
+        // Mock
+        api.getConversationIdentifiers_MockValue = .init(fetchPage: { _ in
+            .init(
+                element: Scaffolding.tooManyConverationIDs,
+                hasMore: false,
+                nextStart: .init()
+            )
+        })
+
+        // We don't care about the response in this test.
+        api.getConversationsFor_MockValue = .init(
+            found: [],
+            notFound: [],
+            failed: []
+        )
+
+        // When
+        try await sut.pull()
+
+        // Then
+        XCTAssertEqual(api.getConversationIdentifiers_Invocations.count, 1)
+
+        try XCTAssertCount(api.getConversationsFor_Invocations, count: 3)
+        XCTAssertEqual(api.getConversationsFor_Invocations[0], Array(Scaffolding.tooManyConverationIDs[0..<1000]))
+        XCTAssertEqual(api.getConversationsFor_Invocations[1], Array(Scaffolding.tooManyConverationIDs[1000..<2000]))
+        XCTAssertEqual(api.getConversationsFor_Invocations[2], Array(Scaffolding.tooManyConverationIDs[2000..<2500]))
+
+        XCTAssertEqual(journal[.isConversationSyncRequired], false)
+    }
+
     // TODO: [WPB-15185] Re-enable
     func testPull_LegacyIdentifiers() async throws {
         // Mock
@@ -179,6 +213,10 @@ private enum Scaffolding {
             conversationID2,
             conversationID3
         ]
+    }
+
+    static var tooManyConverationIDs = (1...2500).map { _ in
+        QualifiedID(id: UUID(), domain: "example.com")
     }
 
     static let remoteConversation1 = WireNetwork.Conversation(

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -131,9 +131,9 @@ final class PullAllConversationsSyncTests: XCTestCase {
         XCTAssertEqual(api.getConversationIdentifiers_Invocations.count, 1)
 
         try XCTAssertCount(api.getConversationsFor_Invocations, count: 3)
-        XCTAssertEqual(api.getConversationsFor_Invocations[0], Array(Scaffolding.tooManyConverationIDs[0..<1000]))
-        XCTAssertEqual(api.getConversationsFor_Invocations[1], Array(Scaffolding.tooManyConverationIDs[1000..<2000]))
-        XCTAssertEqual(api.getConversationsFor_Invocations[2], Array(Scaffolding.tooManyConverationIDs[2000..<2500]))
+        XCTAssertEqual(api.getConversationsFor_Invocations[0], Array(Scaffolding.tooManyConverationIDs[0 ..< 1000]))
+        XCTAssertEqual(api.getConversationsFor_Invocations[1], Array(Scaffolding.tooManyConverationIDs[1000 ..< 2000]))
+        XCTAssertEqual(api.getConversationsFor_Invocations[2], Array(Scaffolding.tooManyConverationIDs[2000 ..< 2500]))
 
         XCTAssertEqual(journal[.isConversationSyncRequired], false)
     }
@@ -215,7 +215,7 @@ private enum Scaffolding {
         ]
     }
 
-    static var tooManyConverationIDs = (1...2500).map { _ in
+    static var tooManyConverationIDs = (1 ... 2500).map { _ in
         QualifiedID(id: UUID(), domain: "example.com")
     }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -130,10 +130,13 @@ final class PullAllConversationsSyncTests: XCTestCase {
         // Then
         XCTAssertEqual(api.getConversationIdentifiers_Invocations.count, 1)
 
-        try XCTAssertCount(api.getConversationsFor_Invocations, count: 3)
-        XCTAssertEqual(api.getConversationsFor_Invocations[0], Array(Scaffolding.tooManyConverationIDs[0 ..< 1000]))
-        XCTAssertEqual(api.getConversationsFor_Invocations[1], Array(Scaffolding.tooManyConverationIDs[1000 ..< 2000]))
-        XCTAssertEqual(api.getConversationsFor_Invocations[2], Array(Scaffolding.tooManyConverationIDs[2000 ..< 2500]))
+        let invocations = api.getConversationsFor_Invocations
+        try XCTAssertCount(invocations, count: 3)
+
+        // The invocations are not always in the same order, so assert with contains.
+        XCTAssertTrue(invocations.contains(Array(Scaffolding.tooManyConverationIDs[0 ..< 1000])))
+        XCTAssertTrue(invocations.contains(Array(Scaffolding.tooManyConverationIDs[1000 ..< 2000])))
+        XCTAssertTrue(invocations.contains(Array(Scaffolding.tooManyConverationIDs[2000 ..< 2500])))
 
         XCTAssertEqual(journal[.isConversationSyncRequired], false)
     }

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIError.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIError.swift
@@ -91,4 +91,7 @@ public enum ConversationsAPIError: Error {
     /// Permission unchanged
     case permissionsUnchanged
 
+    /// An illegal argument was passed.
+    case illegalArgument(message: String)
+
 }

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV0.swift
@@ -82,7 +82,7 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
     }
 
     func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1...1000).contains(identifiers.count) else {
+        guard (1 ... 1000).contains(identifiers.count) else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV0.swift
@@ -82,7 +82,7 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
     }
 
     func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1 ... 1000).contains(identifiers.count) else {
+        guard 1 ... 1000 ~= identifiers.count else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV0.swift
@@ -82,6 +82,12 @@ class ConversationsAPIV0: ConversationsAPI, VersionedAPI {
     }
 
     func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
+        guard (1...1000).contains(identifiers.count) else {
+            throw ConversationsAPIError.illegalArgument(
+                message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
+            )
+        }
+
         let parameters = GetConversationsParametersV0(qualifiedIdentifiers: identifiers.map { $0.toNetworkModel() })
         let body = try JSONEncoder.defaultEncoder.encode(parameters)
         let path = "\(pathPrefix)\(basePath)/list/v2"

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV2.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV2.swift
@@ -22,7 +22,7 @@ class ConversationsAPIV2: ConversationsAPIV1 {
     override var apiVersion: APIVersion { .v2 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1...1000).contains(identifiers.count) else {
+        guard (1 ... 1000).contains(identifiers.count) else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV2.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV2.swift
@@ -22,7 +22,7 @@ class ConversationsAPIV2: ConversationsAPIV1 {
     override var apiVersion: APIVersion { .v2 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1 ... 1000).contains(identifiers.count) else {
+        guard 1 ... 1000 ~= identifiers.count else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV2.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV2.swift
@@ -22,6 +22,12 @@ class ConversationsAPIV2: ConversationsAPIV1 {
     override var apiVersion: APIVersion { .v2 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
+        guard (1...1000).contains(identifiers.count) else {
+            throw ConversationsAPIError.illegalArgument(
+                message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
+            )
+        }
+
         let parameters = GetConversationsParametersV0(qualifiedIdentifiers: identifiers.map { $0.toNetworkModel() })
         let body = try JSONEncoder.defaultEncoder.encode(parameters)
 

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV3.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV3.swift
@@ -22,7 +22,7 @@ class ConversationsAPIV3: ConversationsAPIV2 {
     override var apiVersion: APIVersion { .v3 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1...1000).contains(identifiers.count) else {
+        guard (1 ... 1000).contains(identifiers.count) else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV3.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV3.swift
@@ -22,6 +22,12 @@ class ConversationsAPIV3: ConversationsAPIV2 {
     override var apiVersion: APIVersion { .v3 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
+        guard (1...1000).contains(identifiers.count) else {
+            throw ConversationsAPIError.illegalArgument(
+                message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
+            )
+        }
+
         let parameters = GetConversationsParametersV0(qualifiedIdentifiers: identifiers.map { $0.toNetworkModel() })
         let body = try JSONEncoder.defaultEncoder.encode(parameters)
         let path = "\(pathPrefix)\(basePath)/list"

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV3.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV3.swift
@@ -22,7 +22,7 @@ class ConversationsAPIV3: ConversationsAPIV2 {
     override var apiVersion: APIVersion { .v3 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1 ... 1000).contains(identifiers.count) else {
+        guard 1 ... 1000 ~= identifiers.count else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV5.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV5.swift
@@ -26,7 +26,7 @@ class ConversationsAPIV5: ConversationsAPIV4 {
     }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1 ... 1000).contains(identifiers.count) else {
+        guard 1 ... 1000 ~= identifiers.count else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV5.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV5.swift
@@ -26,7 +26,7 @@ class ConversationsAPIV5: ConversationsAPIV4 {
     }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1...1000).contains(identifiers.count) else {
+        guard (1 ... 1000).contains(identifiers.count) else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV5.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV5.swift
@@ -26,6 +26,12 @@ class ConversationsAPIV5: ConversationsAPIV4 {
     }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
+        guard (1...1000).contains(identifiers.count) else {
+            throw ConversationsAPIError.illegalArgument(
+                message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
+            )
+        }
+
         let parameters = GetConversationsParametersV0(qualifiedIdentifiers: identifiers.map { $0.toNetworkModel() })
         let body = try JSONEncoder.defaultEncoder.encode(parameters)
         let path = "\(pathPrefix)\(basePath)/list"

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV8.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV8.swift
@@ -22,6 +22,12 @@ class ConversationsAPIV8: ConversationsAPIV7 {
     override var apiVersion: APIVersion { .v8 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
+        guard (1...1000).contains(identifiers.count) else {
+            throw ConversationsAPIError.illegalArgument(
+                message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
+            )
+        }
+
         let parameters = GetConversationsParametersV0(qualifiedIdentifiers: identifiers.map { $0.toNetworkModel() })
         let body = try JSONEncoder.defaultEncoder.encode(parameters)
         let path = "\(pathPrefix)\(basePath)/list"

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV8.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV8.swift
@@ -22,7 +22,7 @@ class ConversationsAPIV8: ConversationsAPIV7 {
     override var apiVersion: APIVersion { .v8 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1 ... 1000).contains(identifiers.count) else {
+        guard 1 ... 1000 ~= identifiers.count else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV8.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/ConversationsAPI/ConversationsAPIV8.swift
@@ -22,7 +22,7 @@ class ConversationsAPIV8: ConversationsAPIV7 {
     override var apiVersion: APIVersion { .v8 }
 
     override func getConversations(for identifiers: [QualifiedID]) async throws -> ConversationList {
-        guard (1...1000).contains(identifiers.count) else {
+        guard (1 ... 1000).contains(identifiers.count) else {
             throw ConversationsAPIError.illegalArgument(
                 message: "identifiers must contain between 1 and 1000 elements, got  \(identifiers.count)"
             )

--- a/WireNetwork/Tests/WireNetworkTests/APIs/ConversationsAPI/ConversationsAPITests.swift
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/ConversationsAPI/ConversationsAPITests.swift
@@ -265,18 +265,41 @@ final class ConversationsAPITests: XCTestCase {
         }
     }
 
+    func testGetConversations_givenV0_thenItValidatesArguments() async throws {
+        // given
+        let sut = ConversationsAPIV0(apiService: MockAPIServiceProtocol())
+
+        // when
+        await XCTAssertThrowsErrorAsync {
+            _ = try await sut.getConversations(for: [])
+        } errorHandler: { error in
+            switch error {
+            case ConversationsAPIError.illegalArgument:
+                break
+            default:
+                XCTFail("unexpected error")
+            }
+        }
+    }
+
     func testGetConversations_givenV0AndSuccessResponse200_thenVerifyResponse() async throws {
         // given
-
         let apiService = MockAPIServiceProtocol.withResponses([
             (.ok, "testGetConversations_givenV0AndSuccessResponse200")
         ])
 
         let api = ConversationsAPIV0(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
         // when
+        let list = try await api.getConversations(for: ids)
+
         // then
-        let list = try await api.getConversations(for: [])
         XCTAssertEqual(list.found.count, 1)
         XCTAssertEqual(list.notFound.count, 1)
         XCTAssertEqual(list.failed.count, 1)
@@ -289,12 +312,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV0(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch ConversationsAPIError.invalidBody {
+            // then
             XCTAssertTrue(true)
         } catch {
             XCTFail("expected error 'ConversationsAPIError.invalidBody'")
@@ -309,12 +338,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV0(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch let error as FailureResponse {
+            // then
             XCTAssertEqual(error.code, 503)
             XCTAssertEqual(error.label, "service unavailable")
         } catch {
@@ -324,16 +359,22 @@ final class ConversationsAPITests: XCTestCase {
 
     func testGetConversations_givenV2AndSuccessResponse200_thenVerifyResponse() async throws {
         // given
-
         let apiService = MockAPIServiceProtocol.withResponses([
             (.ok, "testGetConversations_givenV2AndSuccessResponse200")
         ])
 
         let api = ConversationsAPIV2(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
         // when
+        let list = try await api.getConversations(for: ids)
+
         // then
-        let list = try await api.getConversations(for: [])
         XCTAssertEqual(list.found.count, 1)
         XCTAssertEqual(list.notFound.count, 1)
         XCTAssertEqual(list.failed.count, 1)
@@ -346,12 +387,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV2(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch ConversationsAPIError.invalidBody {
+            // then
             XCTAssertTrue(true)
         } catch {
             XCTFail("expected error 'ConversationsAPIError.invalidBody'")
@@ -367,12 +414,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV2(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch let error as FailureResponse {
+            // then
             XCTAssertEqual(error.code, 503)
             XCTAssertEqual(error.label, "service unavailable")
         } catch {
@@ -382,16 +435,22 @@ final class ConversationsAPITests: XCTestCase {
 
     func testGetConversations_givenV3AndSuccessResponse200_thenVerifyResponse() async throws {
         // given
-
         let apiService = MockAPIServiceProtocol.withResponses([
             (.ok, "testGetConversations_givenV3AndSuccessResponse200")
         ])
 
         let api = ConversationsAPIV3(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
         // when
+        let list = try await api.getConversations(for: ids)
+
         // then
-        let list = try await api.getConversations(for: [])
         XCTAssertEqual(list.found.count, 1)
         XCTAssertEqual(list.notFound.count, 1)
         XCTAssertEqual(list.failed.count, 1)
@@ -408,12 +467,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV3(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch ConversationsAPIError.invalidBody {
+            // then
             XCTAssertTrue(true)
         } catch {
             XCTFail("expected error 'ConversationsAPIError.invalidBody'")
@@ -428,12 +493,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV3(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch let error as FailureResponse {
+            // then
             XCTAssertEqual(error.code, 503)
             XCTAssertEqual(error.label, "service unavailable")
         } catch {
@@ -443,16 +514,22 @@ final class ConversationsAPITests: XCTestCase {
 
     func testGetConversations_givenV5AndSuccessResponse200_thenVerifyResponse() async throws {
         // given
-
         let apiService = MockAPIServiceProtocol.withResponses([
             (.ok, "testGetConversations_givenV5AndSuccessResponse200")
         ])
 
         let api = ConversationsAPIV5(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
         // when
+        let list = try await api.getConversations(for: ids)
+
         // then
-        let list = try await api.getConversations(for: [])
         XCTAssertEqual(list.found.count, 1)
         XCTAssertEqual(list.notFound.count, 1)
         XCTAssertEqual(list.failed.count, 1)
@@ -470,12 +547,18 @@ final class ConversationsAPITests: XCTestCase {
         )
 
         let api = ConversationsAPIV5(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
-        // when
-        // then
         do {
-            _ = try await api.getConversations(for: [])
+            // when
+            _ = try await api.getConversations(for: ids)
         } catch let error as FailureResponse {
+            // then
             XCTAssertEqual(error.code, 503)
             XCTAssertEqual(error.label, "service unavailable")
         } catch {
@@ -485,16 +568,22 @@ final class ConversationsAPITests: XCTestCase {
 
     func testGetConversations_givenV8AndSuccessResponse200_thenVerifyResponse() async throws {
         // given
-
         let apiService = MockAPIServiceProtocol.withResponses([
             (.ok, "testGetConversations_givenV8AndSuccessResponse200")
         ])
 
         let api = ConversationsAPIV8(apiService: apiService)
+        let ids = [
+            QualifiedID(
+                id: UUID(uuidString: "99db9768-04e3-4b5d-9268-831b6a25c4ab")!,
+                domain: "example.com"
+            )
+        ]
 
         // when
+        let list = try await api.getConversations(for: ids)
+
         // then
-        let list = try await api.getConversations(for: [])
         XCTAssertEqual(list.found.count, 1)
         XCTAssertEqual(list.notFound.count, 1)
         XCTAssertEqual(list.failed.count, 1)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19404" title="WPB-19404" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19404</a>  [iOS] Can't pull conversations if there are more than 1000
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
If a user has more than 1000 conversations and tries to log in, then the initial sync will fail when trying to pull conversations because the endpoint only accepts between 1 and 1000 conversation ids.

To resolve this, we now validate the argument containing ids (at the api layer) and will pull perform multiple requests if needed to fetch > 1000 conversations.

### Testing
1. Have more than 1000 conversations
2. Log in fresh
3. Assert you can complete initial sync and see your conversations in the list.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
