### PR TITLE
fix: for failing flaky tests + increased timeout to load Page - WPB-19174

### DIFF
--- a/wire-ios/WireUITests/Pages/FirstTimePage.swift
+++ b/wire-ios/WireUITests/Pages/FirstTimePage.swift
@@ -20,9 +20,8 @@ import XCTest
 
 /// Page for popup on first time user login
 class FirstTimePage: PageModel {
-    override func assertHasLoaded() {
-        let expectation = okButton.waitForExistence(timeout: 10)
-        XCTAssert(expectation, "First time page not loaded - can't find Ok button")
+    override var pageMainElement: XCUIElement {
+        okButton
     }
 
     var okButton: XCUIElement {

--- a/wire-ios/WireUITests/Pages/LoginPage.swift
+++ b/wire-ios/WireUITests/Pages/LoginPage.swift
@@ -39,6 +39,10 @@ class LoginPage: PageModel {
         return elementsQuery.buttons["Next"].firstMatch
     }
 
+    var emailField: XCUIElement {
+        app.textFields["Enter email"]
+    }
+
     var passwordField: XCUIElement {
         app.secureTextFields["Enter password"]
     }

--- a/wire-ios/WireUITests/Pages/PageModel.swift
+++ b/wire-ios/WireUITests/Pages/PageModel.swift
@@ -35,16 +35,32 @@ class PageModel {
 
     init() throws {
         self.app = XCUIApplication()
-        try assertHasLoaded()
+        assertHasLoaded()
     }
 
     var pageMainElement: XCUIElement {
         fatalError("override this in subclass \(String(describing: self))")
     }
 
-    func assertHasLoaded() throws {
-        guard pageMainElement.waitForExistence(timeout: 10) else {
-            throw Failure.notLoaded(self)
+    func assertHasLoaded(
+        timeout: TimeInterval = 15,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let loaded = pageMainElement.waitForExistence(timeout: timeout)
+        guard loaded else {
+            XCTContext.runActivity(named: "Debug UI on failure") { activity in
+                let screenshot = XCUIScreen.main.screenshot()
+                let screenshotAttachment = XCTAttachment(screenshot: screenshot)
+                screenshotAttachment.lifetime = .keepAlways
+                activity.add(screenshotAttachment)
+
+                let hierarchyAttachment = XCTAttachment(string: app.debugDescription)
+                hierarchyAttachment.lifetime = .keepAlways
+                activity.add(hierarchyAttachment)
+            }
+            XCTFail("Page main element did not load within \(timeout)s", file: file, line: line)
+            return
         }
     }
 }

--- a/wire-ios/WireUITests/Pages/PageModel.swift
+++ b/wire-ios/WireUITests/Pages/PageModel.swift
@@ -35,32 +35,16 @@ class PageModel {
 
     init() throws {
         self.app = XCUIApplication()
-        assertHasLoaded()
+        try assertHasLoaded()
     }
 
     var pageMainElement: XCUIElement {
         fatalError("override this in subclass \(String(describing: self))")
     }
 
-    func assertHasLoaded(
-        timeout: TimeInterval = 15,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        let loaded = pageMainElement.waitForExistence(timeout: timeout)
-        guard loaded else {
-            XCTContext.runActivity(named: "Debug UI on failure") { activity in
-                let screenshot = XCUIScreen.main.screenshot()
-                let screenshotAttachment = XCTAttachment(screenshot: screenshot)
-                screenshotAttachment.lifetime = .keepAlways
-                activity.add(screenshotAttachment)
-
-                let hierarchyAttachment = XCTAttachment(string: app.debugDescription)
-                hierarchyAttachment.lifetime = .keepAlways
-                activity.add(hierarchyAttachment)
-            }
-            XCTFail("Page main element did not load within \(timeout)s", file: file, line: line)
-            return
+    func assertHasLoaded() throws {
+        guard pageMainElement.waitForExistence(timeout: 15) else {
+            throw Failure.notLoaded(self)
         }
     }
 }

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -125,7 +125,7 @@ final class TeamManageTests: WireUITestCase {
         let senderName = try XCTUnwrap(groupConversationPage.getSenderName())
         XCTAssertEqual(senderName, teamOwner.name, "Sender info didn't match expected value \(teamOwner.name)")
 
-        let sentMessages = groupConversationPage.getSentMessages()
+        let sentMessages = try XCTUnwrap(groupConversationPage.getSentMessages())
         XCTAssertTrue(
             sentMessages.contains(messageFromOwner),
             "Expected message '\(messageFromOwner)' not found in sent messages: \(sentMessages)"

--- a/wire-ios/WireUITests/WireAuthenticationTests.swift
+++ b/wire-ios/WireUITests/WireAuthenticationTests.swift
@@ -39,6 +39,7 @@ final class WireAuthenticationTests: WireUITestCase {
         let loginPage = try WelcomePage()
             .enterEmailOrSSO(LoginCredentials.email)
 
+        XCTAssertEqual(loginPage.emailField.value as? String, LoginCredentials.email)
         XCTAssertFalse(loginPage.nextButton.isEnabled, "nextButton should be disabled if no password")
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19174" title="WPB-19174" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19174</a>  [iOS] Fix:keyboard not focused creating issue randomly before typeText() + some flaky behaviours
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

### Testing
<img width="1438" height="824" alt="image" src="https://github.com/user-attachments/assets/5ac1b9cc-f7cd-48d3-8b85-98663f47acb7" />

_Describe how to test._


_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
