### PR TITLE
fix: further long sync mitigations - WPB-19298

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSClientManager.swift
+++ b/wire-ios-data-model/Source/MLS/MLSClientManager.swift
@@ -67,7 +67,13 @@ public final class MLSClientManager: MLSClientManagerProtocol {
 
     // MARK: - Private Implentation
 
+    private var didPerformMLSClientUpdate = false
+
     private func performsMLSClientUpdates() async {
+        guard !didPerformMLSClientUpdate else {
+            return
+        }
+
         do {
             try await mlsService.performPendingJoins()
         } catch {
@@ -75,6 +81,7 @@ public final class MLSClientManager: MLSClientManagerProtocol {
         }
         await mlsService.uploadKeyPackagesIfNeeded()
         await mlsService.updateKeyMaterialForAllStaleGroupsIfNeeded()
+        didPerformMLSClientUpdate = true
     }
 
     private func createMLSClient(mlsClientID: MLSClientID) async {

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1578,6 +1578,7 @@ public final class MLSService: MLSServiceInterface {
                     epoch = Int64(conversation.epoch)
                 }
                 await resetBrokenMLSConversationDelegate?.didCatchBrokenMLSConversation(groupID: groupID, epoch: epoch)
+                brokenGroupIDs.remove(groupID)
             }
         }
     }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -67,6 +67,7 @@ public final class MLSService: MLSServiceInterface {
     private weak var mlsSyncDelegate: (any MLSSyncDelegate)?
     private weak var resetBrokenMLSConversationDelegate: (any ResetBrokenMLSConversationDelegate)?
     private let onEpochChangedSubject = PassthroughSubject<MLSGroupID, Never>()
+    private var brokenGroupIDs: Set<MLSGroupID> = []
 
     private var coreCrypto: SafeCoreCryptoProtocol {
         get async throws {
@@ -1367,7 +1368,12 @@ public final class MLSService: MLSServiceInterface {
                 )
             }
 
-            guard let groupID, let timestamp else {
+            guard
+                let groupID,
+                // The pending proposal will always fail and cause
+                // recovery too many recovery syncs.
+                !brokenGroupIDs.contains(groupID),
+                let timestamp else {
                 continue
             }
 
@@ -1556,6 +1562,7 @@ public final class MLSService: MLSServiceInterface {
                         "no need to apply recovery strategy for reset broken MLS conversation, FF is OFF",
                         attributes: [.mlsGroupID: groupID.safeForLoggingDescription]
                     )
+                    brokenGroupIDs.insert(groupID)
                     throw MLSRetryError.nonRecoverableError(reason)
                 }
 

--- a/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
@@ -23,7 +23,8 @@ import WireLogging
 // sourcery: AutoMockable
 public protocol ResolveOneOnOneConversationsUseCaseProtocol {
 
-    func invoke() async throws
+    @discardableResult
+    func invoke() async throws -> Bool
 
 }
 
@@ -36,9 +37,8 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
     let resolver: any OneOnOneResolverInterface
     let pullSelfUserClientsFactory: PullSelfUserClientsFactory
 
-    static var didResolve = false
-
-    func invoke() async throws {
+    @discardableResult
+    func invoke() async throws -> Bool {
         let oldProtocols = await context.perform {
             let selfUser = ZMUser.selfUser(in: context)
             return selfUser.supportedProtocols
@@ -56,18 +56,15 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
         }
 
         if newProtocols.contains(.mls) {
-            guard !Self.didResolve else {
-                return
-            }
-
             do {
                 try await resolver.resolveAllOneOnOneConversations(in: context)
-                Self.didResolve = true
+                return true
             } catch {
-                Self.didResolve = true
                 throw error
             }
         }
+
+        return false
     }
 
     private func calculateSupportedProtocols() async -> Set<WireDataModel.MessageProtocol> {

--- a/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
@@ -36,6 +36,8 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
     let resolver: any OneOnOneResolverInterface
     let pullSelfUserClientsFactory: PullSelfUserClientsFactory
 
+    private static var didResolve = false
+
     func invoke() async throws {
         let oldProtocols = await context.perform {
             let selfUser = ZMUser.selfUser(in: context)
@@ -54,7 +56,17 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
         }
 
         if newProtocols.contains(.mls) {
-            try await resolver.resolveAllOneOnOneConversations(in: context)
+            guard !Self.didResolve else {
+                return
+            }
+
+            do {
+                try await resolver.resolveAllOneOnOneConversations(in: context)
+                didResolve = true
+            } catch {
+                didResolve = true
+                throw error
+            }
         }
     }
 

--- a/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
@@ -62,9 +62,9 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
 
             do {
                 try await resolver.resolveAllOneOnOneConversations(in: context)
-                didResolve = true
+                Self.didResolve = true
             } catch {
-                didResolve = true
+                Self.didResolve = true
                 throw error
             }
         }

--- a/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ResolveOneOnOneConversationsUseCase.swift
@@ -36,7 +36,7 @@ struct ResolveOneOnOneConversationsUseCase: ResolveOneOnOneConversationsUseCaseP
     let resolver: any OneOnOneResolverInterface
     let pullSelfUserClientsFactory: PullSelfUserClientsFactory
 
-    private static var didResolve = false
+    static var didResolve = false
 
     func invoke() async throws {
         let oldProtocols = await context.perform {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -240,6 +240,9 @@ public final class ZMUserSession: NSObject {
         managedObjectContext.conversationListDirectory()
     }
 
+    // To prevent too eagerly resolving all conversations.
+    var didAlreadyResolveAllOneOnOnes = false
+
     public private(set) var networkState: NetworkState = .online {
         didSet {
             if oldValue != networkState {
@@ -1335,11 +1338,12 @@ extension ZMUserSession: SyncAgentDelegate {
     }
 
     private func resolveOneOnOneConversationsIfNeeded() async {
-        guard mlsFeature.isEnabled else { return }
+        guard mlsFeature.isEnabled, !didAlreadyResolveAllOneOnOnes else { return }
 
         let resolveOneOnOneUseCase = makeResolveOneOnOneConversationsUseCase(context: syncContext)
         do {
-            try await resolveOneOnOneUseCase.invoke()
+            let didResolve = try await resolveOneOnOneUseCase.invoke()
+            didAlreadyResolveAllOneOnOnes = didResolve
         } catch {
             WireLogger.mls.error("Failed to resolve one on one conversations: \(String(reflecting: error))")
         }

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -668,20 +668,24 @@ public class MockResolveOneOnOneConversationsUseCaseProtocol: ResolveOneOnOneCon
 
     public var invoke_Invocations: [Void] = []
     public var invoke_MockError: Error?
-    public var invoke_MockMethod: (() async throws -> Void)?
+    public var invoke_MockMethod: (() async throws -> Bool)?
+    public var invoke_MockValue: Bool?
 
-    public func invoke() async throws {
+    @discardableResult
+    public func invoke() async throws -> Bool {
         invoke_Invocations.append(())
 
         if let error = invoke_MockError {
             throw error
         }
 
-        guard let mock = invoke_MockMethod else {
+        if let mock = invoke_MockMethod {
+            return try await mock()
+        } else if let mock = invoke_MockValue {
+            return mock
+        } else {
             fatalError("no mock for `invoke`")
         }
-
-        try await mock()
     }
 
 }

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientEventConsumerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientEventConsumerTests.swift
@@ -33,7 +33,7 @@ final class UserClientEventConsumerTests: RequestStrategyTestBase {
         super.setUp()
 
         resolveOneOnOneConversations = MockResolveOneOnOneConversationsUseCaseProtocol()
-        resolveOneOnOneConversations.invoke_MockMethod = {}
+        resolveOneOnOneConversations.invoke_MockMethod = { true }
 
         syncMOC.performGroupedAndWait {
             self.cookieStorage = ZMPersistentCookieStorage(

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
@@ -56,8 +56,6 @@ final class ResolveOneOnOneConversationsUseCaseTests: XCTestCase {
                 self.mockPullSelfUserClients
             }
         )
-
-        ResolveOneOnOneConversationsUseCase.didResolve = false
     }
 
     // MARK: - tearDown

--- a/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Use cases/ResolveOneOnOneConversationsUseCaseTests.swift
@@ -56,6 +56,8 @@ final class ResolveOneOnOneConversationsUseCaseTests: XCTestCase {
                 self.mockPullSelfUserClients
             }
         )
+
+        ResolveOneOnOneConversationsUseCase.didResolve = false
     }
 
     // MARK: - tearDown


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19298" title="WPB-19298" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19298</a>  [iOS] New incremental sync is unusually slow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
After investigation, we found that at the end of each sync (when app comes to foreground) we repeat some possibly expensive work, some of which is pointless due to broken mls groups. For instance:
- we try to join pending mls groups (will fail for all broken groups)
- we try to resolve all 1-1 conversations
- we try to commit pending proposals

These first two are sufficient to do once per launch, there is not much benefit in retrying so frequently. (Note that 1-1 conversations are resolved on an individual basic when opening a chat).

The last one is hides a nasty issue: some of the broken mls groups have pending proposals which will always fail. But the recovery strategy is to perform another sync and retry committing the proposal. This will fail each time causing another attempt, finally giving up after 3 failures. This will happen for each broken group, so if there are 10 broken groups, we will cause 10 x 3 syncs, then retry this all again when brining the app to the foreground once more.

To solve this, we shouldn't attempt to commit pending proposals for broken groups, so if we detect a broken group, we store the id, and then use this id to exclude the group from the list of those needing to commit pending proposals. 

### Testing
1. Have broken groups
2. Perform sync
3. Assert that only one sync starts and ends in a reasonable time when coming to foreground.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
