### PR TITLE
fix: adding participants doesn't update UI right away - WPB-19403

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/Conversation+Participants.swift
@@ -75,6 +75,9 @@ extension ZMConversation {
                 }
 
                 try await service.addParticipants(users, to: conversation)
+                try await syncContext.perform {
+                    try syncContext.save()
+                }
             } catch {
                 Flow.addParticipants.fail(error)
                 await MainActor.run {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19403" title="WPB-19403" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19403</a>  [iOS] Sometimes adding member in group is really slow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Context**: When adding participants on an existing conversation, UI doesn't seem to update right away so we have to wait sometimes for a couple of seconds before seeing the participant show up. 

**Causes**: A delegate method is called from a notification observer which updates the UI accordingly however that notification observer is triggered only when the sync context changes (i.e adding a ZMUser to the db) is merged to the UI context. For that to happen, we wait for an explicit syncContext.save() that occurs somewhere but not **right away** after adding the participant.

**Solution**: Save the context **right away** after adding the participant.

### Testing

- Create a group conv
- Add participants
--> participants should be added right away and visible in the UI

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
