### PR TITLE
feat: hide password manager from the text field - WPB-18850

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
@@ -49,6 +49,7 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
     weak var textFieldValidationDelegate: TextFieldValidationDelegate?
     weak var validatedTextFieldDelegate: ValidatedTextFieldDelegate?
 
+    // Hack: disable auto fill password
     var isContextMenuAllowed: Bool {
         SecurityFlags.clipboard.isEnabled
     }
@@ -239,7 +240,6 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
         case let .passcode(rules, isNew):
             if isContextMenuAllowed {
                 isSecureTextEntry = true
-                // Hack: disable auto fill passcode
                 textContentType = .oneTimeCode
             } else {
                 isSecureTextEntry = false

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/Views/ValidatedTextField.swift
@@ -49,6 +49,10 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
     weak var textFieldValidationDelegate: TextFieldValidationDelegate?
     weak var validatedTextFieldDelegate: ValidatedTextFieldDelegate?
 
+    var isContextMenuAllowed: Bool {
+        SecurityFlags.clipboard.isEnabled
+    }
+
     override var text: String? {
         didSet {
             validateInput()
@@ -166,7 +170,6 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
             textFieldAttributes: textFieldAttributes,
             isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
         )
-        setupTextFieldProperties()
 
         setup()
         setupTextFieldProperties()
@@ -210,12 +213,17 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
             autocorrectionType = .no
             autocapitalizationType = .none
             accessibilityIdentifier = "EmailField"
-            textContentType = .emailAddress
+            textContentType = isContextMenuAllowed ? .emailAddress : .none
         case let .password(rules, isNew):
-            isSecureTextEntry = true
             accessibilityIdentifier = "PasswordField"
             autocapitalizationType = .none
-            textContentType = isNew ? .newPassword : .password
+            if isContextMenuAllowed {
+                isSecureTextEntry = true
+                textContentType = isNew ? .newPassword : .password
+            } else {
+                isSecureTextEntry = false
+                textContentType = .none
+            }
             passwordRules = rules.textInputPasswordRules
         case let .name(isTeam):
             autocapitalizationType = .words
@@ -224,18 +232,23 @@ final class ValidatedTextField: AccessoryTextField, TextContainer {
         case .username:
             autocapitalizationType = .none
             accessibilityIdentifier = "UsernameField"
-            textContentType = .username
+            textContentType = isContextMenuAllowed ? .username : .none
         case .unknown:
             keyboardType = .asciiCapable
             textContentType = nil
         case let .passcode(rules, isNew):
+            if isContextMenuAllowed {
+                isSecureTextEntry = true
+                // Hack: disable auto fill passcode
+                textContentType = .oneTimeCode
+            } else {
+                isSecureTextEntry = false
+                textContentType = .none
+            }
             keyboardType = .asciiCapable
-            isSecureTextEntry = true
             accessibilityIdentifier = "PasscodeField"
             autocapitalizationType = .none
             returnKeyType = isNew ? .default : .continue
-            // Hack: disable auto fill passcode
-            textContentType = .oneTimeCode
             passwordRules = rules.textInputPasswordRules
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18850" title="WPB-18850" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18850</a>  [iOS] Disable long-tap options in iOS column 1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR disables the use of a password manager for login and password fields.
The solution is not perfect, but we need to disable it for Col builds. We can make a better and more complex implementation within the  https://wearezeta.atlassian.net/browse/WPB-19321

### Testing



### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
