### PR TITLE
fix: Call buttons in the landscape mode - WPB-18611

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -151,7 +151,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
 
     private func calculateHeightConstant() -> CGFloat {
         if UIDevice.current.twoDimensionOrientation.isLandscape {
-            128
+            128 + view.safeAreaInsets.bottom
         } else {
             (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18611" title="WPB-18611" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18611</a>  [iOS] On call buttons label expanding the safe area
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Call buttons label expanding the safe area in the landscape mode:
<img width="2636" height="1216" alt="image-20250707-140536" src="https://github.com/user-attachments/assets/76a51082-39ea-4dbf-b00b-f49ea36815b7" />


### Testing


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
