### PR TITLE
fix: mitigate aggressively attempting to commit proposals in broken conversations - WPB-19594

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1525,6 +1525,13 @@ public final class MLSService: MLSServiceInterface {
                 )
 
                 guard retryCount <= maxRetryAttempts else {
+                    // If MLS conversation reset is DISABLED we quarantine the group to avoid repeated commit attempts
+                    // otherwise assume that things will sort themselves out through conversation reset.
+                    let feature = await featureRepository.fetchAllowedGlobalOperations()
+                    if feature.status == .disabled || feature.config.mlsConversationReset == false {
+                        brokenGroupIDs.insert(groupID)
+                    }
+
                     throw MLSRetryError.retryLimitReached
                 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19594" title="WPB-19594" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19594</a>  [iOS] Mitigate superfluous attempts to commit pending proposals in broken MLS conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR attempts to limit the amount of times we attempt to recover from a commit proposal failure in an MLS conversation for a given MLS group ID by _quarantining_ any group IDs when the retry limit is reached AND MLS reset conversation mechanism is disabled.

The reason for this PR is to mitigate repeated attempts to commit proposals which are likely to fail due to a conversation being broken.

My assumption here is that once the MLS reset conversation mechanism is enabled we won't need this mitigation - I have therefore added a check that it is disabled before quarantining. 

### Testing

I'm not sure how to test this. 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---