### PR TITLE
feat: links color own bubble - WPB-19550

### DIFF
--- a/wire-ios-data-model/Source/MLS/BackendMLSPublicKeys.swift
+++ b/wire-ios-data-model/Source/MLS/BackendMLSPublicKeys.swift
@@ -41,7 +41,7 @@ public struct BackendMLSPublicKeys: Equatable {
             removal.p521
         }
 
-        return [externalSenderData].compactMap { $0 }.map(ExternalSenderKey.init)
+        return [externalSenderData].compactMap(\.self).map(ExternalSenderKey.init)
     }
 
     public struct MLSPublicKeys: Equatable {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -111,9 +111,27 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
 
     private func configureTextColor(forOwnMessage ownMessage: Bool) {
         guard DeveloperFlag.chatBubblesSimple.isOn else { return }
+
         let ownColor = SemanticColors.ChatBubble.foregroundOwnMessage
         let otherColor = SemanticColors.ChatBubble.foregroundOtherMessage
-        messageTextView.textColor = ownMessage ? ownColor : otherColor
+
+        let textForegroundColor: UIColor = ownMessage ? ownColor : otherColor
+        let linkForegroundColor: UIColor = ownMessage ? ownColor : UIColor.accent()
+
+        let linkTextAttributes: [NSAttributedString.Key: Any] = if ownMessage {
+            [
+                .foregroundColor: linkForegroundColor,
+                .underlineColor: linkForegroundColor,
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]
+        } else {
+            [
+                .foregroundColor: linkForegroundColor
+            ]
+        }
+
+        messageTextView.textColor = textForegroundColor
+        messageTextView.linkTextAttributes = linkTextAttributes
     }
 
     func configure(with object: Configuration, animated: Bool) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19550" title="WPB-19550" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19550</a>  [iOS] Mentions and Links in text color issue in Simple Chat Bubbles
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The chat bubbles for own messages make the text links invisible because the links are the same color as the bubble background.

The appearance of links and mentions in own messages is now the same color as the normal text and it has an underline.
The appearance of links and mentions in messages from other users are unchanged.

### Testing

light theme:
<img width="406" height="103" alt="Bildschirmfoto 2025-08-18 um 12 14 22" src="https://github.com/user-attachments/assets/e7711547-cdfc-42da-ae18-c2b655e781bc" />

<img width="386" height="89" alt="Bildschirmfoto 2025-08-18 um 12 14 56" src="https://github.com/user-attachments/assets/00959b87-e999-420f-bdf1-675504592b85" />

<img width="492" height="124" alt="Bildschirmfoto 2025-08-18 um 12 14 42" src="https://github.com/user-attachments/assets/feb55cc7-9f4d-4164-a952-537a6420d9ba" />

dark theme:
<img width="485" height="125" alt="Bildschirmfoto 2025-08-18 um 12 34 53" src="https://github.com/user-attachments/assets/4b3ec5f3-2719-4c04-84e5-c912fa101929" />
