### PR TITLE
fix: versioning of `/get-domain-registration` - WPB-19619

### DIFF
--- a/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIV10.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIV10.swift
@@ -23,8 +23,7 @@ final class AuthenticationAPIV10: AuthenticationAPIV9 {
     override var apiVersion: APIVersion { .v10 }
 
     override func getDomainRegistration(forEmail email: String) async throws -> DomainRegistrationConfiguration {
-        // no need to have api version prefix
-        let path = "/get-domain-registration"
+        let path = "\(pathPrefix)/get-domain-registration"
         let body = GetDomainRegistrationParametersV8(email: email)
 
         let encodedJSON: Data

--- a/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/AuthenticationAPI/AuthenticationAPIV8.swift
@@ -25,8 +25,7 @@ class AuthenticationAPIV8: AuthenticationAPIV7 {
     }
 
     override func getDomainRegistration(forEmail email: String) async throws -> DomainRegistrationConfiguration {
-        // no need to have api version prefix
-        let path = "/get-domain-registration"
+        let path = "\(pathPrefix)/get-domain-registration"
         let body = GetDomainRegistrationParametersV8(email: email)
 
         let encodedJSON: Data

--- a/WireNetwork/Tests/WireNetworkTests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testGetDomainRegistration_Request_Generation_V8_Onwards.request-0-v10.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testGetDomainRegistration_Request_Generation_V8_Onwards.request-0-v10.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\"}" \
-	"/get-domain-registration"
+	"/v10/get-domain-registration"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testGetDomainRegistration_Request_Generation_V8_Onwards.request-0-v8.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testGetDomainRegistration_Request_Generation_V8_Onwards.request-0-v8.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\"}" \
-	"/get-domain-registration"
+	"/v8/get-domain-registration"

--- a/WireNetwork/Tests/WireNetworkTests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testGetDomainRegistration_Request_Generation_V8_Onwards.request-0-v9.txt
+++ b/WireNetwork/Tests/WireNetworkTests/APIs/AuthenticationAPI/__Snapshots__/AuthenticationAPITests/testGetDomainRegistration_Request_Generation_V8_Onwards.request-0-v9.txt
@@ -2,4 +2,4 @@ curl \
 	--request POST \
 	--header "Content-Type: application/json" \
 	--data "{\"email\":\"email@example.com\"}" \
-	"/get-domain-registration"
+	"/v9/get-domain-registration"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19619" title="WPB-19619" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19619</a>  [iOS] Something went wrong error on redirecting to IDP
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently calls to `/get-domain-registration` is missing the version prefix (eg. v8). With the introduction of `v10` we call the `v8` endpoint but attempt to parse the response as `v10` which can fail depending on the use case. This PR adds the path prefix to the request paths.

### Testing

Perform steps outlined in the JIRA ticket.
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---