### PR TITLE
feat: swap order of toolbox and reactions - WPB-19628

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -460,14 +460,26 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             to: &cellDescriptions
         )
 
-        if isToolboxVisible(in: context) {
-            let description = ConversationMessageToolboxCellDescription(message: message, isRedundant: false)
-            cellDescriptions.append(AnyConversationMessageCellDescription(description))
+        func addToolbox() {
+            if isToolboxVisible(in: context) {
+                let description = ConversationMessageToolboxCellDescription(message: message, isRedundant: false)
+                cellDescriptions.append(AnyConversationMessageCellDescription(description))
+            }
         }
 
-        if !message.isSystem, !message.isEphemeral, message.hasReactions() {
-            let description = MessageReactionsCellDescription(message: message)
-            cellDescriptions.append(AnyConversationMessageCellDescription(description))
+        func addReactions() {
+            if !message.isSystem, !message.isEphemeral, message.hasReactions() {
+                let description = MessageReactionsCellDescription(message: message)
+                cellDescriptions.append(AnyConversationMessageCellDescription(description))
+            }
+        }
+
+        if DeveloperFlag.chatBubblesSimple.isOn {
+            addReactions()
+            addToolbox()
+        } else {
+            addToolbox()
+            addReactions()
         }
 
         if isFailedRecipientsVisible(in: context) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19628" title="WPB-19628" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19628</a>  [iOS] Swap layout position of timestamp and reactions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

For simple chat bubbles, the layout position of the timestamp (toolbox) and the reactions is now swapped so that the reactions appear before the timestamp.

The new order is:
* bubble
* reactions
* timestamp

### Testing

Enable simple chat bubbles.
Write a message and react on it or on a different message. The reaction should come before the timestamp.

<img width="650" height="221" alt="Bildschirmfoto 2025-08-18 um 17 13 38" src="https://github.com/user-attachments/assets/1d3bf3dc-3ce3-4e20-922a-ef7850073fae" />
