### PR TITLE
feat: files view model - WPB-19563

### DIFF
--- a/WireMessaging/Sources/WireMessagingAssembly/WireCellsFactory.swift
+++ b/WireMessaging/Sources/WireMessagingAssembly/WireCellsFactory.swift
@@ -88,8 +88,13 @@ public struct WireCellsFactory {
 public extension WireCellsFactory {
 
     @MainActor
-    func makeFilesView() -> UIViewController {
-        let viewModel = FilesViewModel()
+    func makeFilesView(cellName: String) -> UIViewController {
+        let viewModel = FilesViewModel(
+            fetchNodesUseCase: WireCellsFetchNodesUseCase(
+                configuration: .conversationFileView(root: .path(cellName)),
+                repository: nodesAPI
+            )
+        )
 
         return FilesHostingController(
             viewModel: viewModel

--- a/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeDTO.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeDTO.swift
@@ -17,6 +17,7 @@
 //
 
 import CellsSDK
+import WireFoundation
 package import WireMessagingDomain
 package import Foundation
 
@@ -34,6 +35,7 @@ package struct WireCellsNodeDTO: Equatable, Hashable, Sendable {
     package let mimeType: String?
     package let previews: [PreviewDTO]
     package let ownerUserId: String?
+    package let ownerUserName: String?
     package let conversationId: String?
     package let publicLinkId: String?
 
@@ -51,6 +53,7 @@ package struct WireCellsNodeDTO: Equatable, Hashable, Sendable {
         mimeType: String? = nil,
         previews: [PreviewDTO] = [],
         ownerUserId: String? = nil,
+        ownerUserName: String?,
         conversationId: String? = nil,
         publicLinkId: String? = nil
     ) {
@@ -67,6 +70,7 @@ package struct WireCellsNodeDTO: Equatable, Hashable, Sendable {
         self.mimeType = mimeType
         self.previews = previews
         self.ownerUserId = ownerUserId
+        self.ownerUserName = ownerUserName
         self.conversationId = conversationId
         self.publicLinkId = publicLinkId
     }
@@ -87,7 +91,7 @@ package extension WireCellsNodeDTO {
             contentHash: contentHash,
             mimeType: mimeType,
             previews: previews.map { $0.toModel() },
-            ownerUserID: ownerUserId,
+            ownerUserID: ownerUserId.flatMap { QualifiedID(string: $0) },
             conversationID: conversationId.flatMap(WireCellsConversationID.init(string:)),
             publicLinkID: publicLinkId.map(WireCellsPublicLinkID.init(string:))
         )
@@ -109,7 +113,8 @@ package extension WireCellsNode {
             contentHash: contentHash,
             mimeType: mimeType,
             previews: previews.map { PreviewDTO(url: $0.url, dimension: $0.dimension) },
-            ownerUserId: ownerUserID,
+            ownerUserId: ownerUserID?.transportString,
+            ownerUserName: ownerUserName,
             conversationId: conversationID?.pydioQualifiedID,
             publicLinkId: publicLinkID?.string
         )
@@ -139,7 +144,10 @@ package extension RestNode {
             } ?? [],
             ownerUserId: userMetadata?
                 .first(where: { $0.namespace == "usermeta-owner-uuid" })?
-                .jsonValue.trimmingCharacters(in: CharacterSet(charactersIn: "\"")),
+                .valueAsString,
+            ownerUserName: userMetadata?
+                .first(where: { $0.namespace == "usermeta-owner" })?
+                .valueAsString,
             conversationId: contextWorkspace?.uuid,
             publicLinkId: shares?.first?.uuid
         )
@@ -157,5 +165,27 @@ package extension PreviewDTO {
             url: url,
             dimension: dimension ?? 0
         )
+    }
+}
+
+private extension WireFoundation.QualifiedID {
+
+    /// Creates a QualifiedID from a string in the format `domain@uuid`.
+    init?(string: String) {
+        let components = string.split(separator: "@")
+        guard components.count == 2, let uuid = UUID(uuidString: String(components[1])) else {
+            return nil
+        }
+        self.init(id: uuid, domain: String(components[0]))
+    }
+
+    var transportString: String {
+        return "\(domain)@\(id.uuidString.lowercased())"
+    }
+}
+
+private extension RestUserMeta {
+    var valueAsString: String? {
+        try? JSONDecoder().decode(String.self, from: Data(jsonValue.utf8))
     }
 }

--- a/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeDTO.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeDTO.swift
@@ -180,7 +180,7 @@ private extension WireFoundation.QualifiedID {
     }
 
     var transportString: String {
-        return "\(domain)@\(id.uuidString.lowercased())"
+        "\(domain)@\(id.uuidString.lowercased())"
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeDTO.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeDTO.swift
@@ -81,7 +81,7 @@ package extension WireCellsNodeDTO {
         WireCellsNode(
             uuid: uuid,
             path: path,
-            modified: modified,
+            modified: modified.map { Date(timeIntervalSince1970: Double($0)) },
             size: size,
             eTag: eTag,
             type: type,
@@ -103,7 +103,7 @@ package extension WireCellsNode {
         WireCellsNodeDTO(
             uuid: id,
             path: path,
-            modified: modified,
+            modified: modified.map { UInt64($0.timeIntervalSince1970) },
             size: size,
             eTag: eTag,
             type: type,

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsNode.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsNode.swift
@@ -17,6 +17,7 @@
 //
 
 public import Foundation
+public import WireFoundation
 
 public struct WireCellsPublicLinkID: Codable, Equatable, Hashable, Sendable {
     public let string: String
@@ -39,7 +40,8 @@ public struct WireCellsNode: Equatable, Identifiable, Sendable {
     public let contentHash: String?
     public let mimeType: String?
     public let previews: [WireCellsNodePreview]
-    public let ownerUserID: String?
+    public let ownerUserID: QualifiedID?
+    public let ownerUserName: String?
     public let conversationID: WireCellsConversationID?
     public let publicLinkID: WireCellsPublicLinkID?
 
@@ -56,7 +58,8 @@ public struct WireCellsNode: Equatable, Identifiable, Sendable {
         contentHash: String? = nil,
         mimeType: String? = nil,
         previews: [WireCellsNodePreview] = [],
-        ownerUserID: String? = nil,
+        ownerUserID: QualifiedID? = nil,
+        ownerUserName: String? = nil,
         conversationID: WireCellsConversationID? = nil,
         publicLinkID: WireCellsPublicLinkID? = nil
     ) {
@@ -73,6 +76,7 @@ public struct WireCellsNode: Equatable, Identifiable, Sendable {
         self.mimeType = mimeType
         self.previews = previews
         self.ownerUserID = ownerUserID
+        self.ownerUserName = ownerUserName
         self.conversationID = conversationID
         self.publicLinkID = publicLinkID
     }

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsNode.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsNode.swift
@@ -30,7 +30,7 @@ public struct WireCellsPublicLinkID: Codable, Equatable, Hashable, Sendable {
 public struct WireCellsNode: Equatable, Identifiable, Sendable {
     public let id: UUID
     public let path: String
-    public let modified: UInt64?
+    public let modified: Date?
     public let size: UInt64?
     public let eTag: String?
     public let type: String?
@@ -48,7 +48,7 @@ public struct WireCellsNode: Equatable, Identifiable, Sendable {
     package init(
         uuid: UUID,
         path: String,
-        modified: UInt64? = nil,
+        modified: Date? = nil,
         size: UInt64? = nil,
         eTag: String? = nil,
         type: String? = nil,

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -94,4 +94,7 @@
 "conversation.file.preview.open" = "Open preview";
 "conversation.draft.attachmentMenu.retry" = "Retry";
 "conversation.draft.attachmentMenu.remove" = "Remove File";
+
+// MARK: Conversation Files View
 "conversation.wireCells.files.navigationTitle" = "Files";
+"conversation.wireCells.files.item.subtitle" = "%@ by %@";

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -18,6 +18,8 @@
 
 import SwiftUI
 import WireDesign
+import WireMessagingDomain
+import WireMessagingDomainSupport
 
 package struct FilesView: View {
     @ObservedObject var viewModel: FilesViewModel
@@ -32,29 +34,75 @@ package struct FilesView: View {
 
     var body: some View {
         NavigationStack {
-            Text("")
-                .toolbar {
-                    ToolbarItem(placement: .principal) {
-                        Text(Strings.Files.navigationTitle)
-                            .font(.system(size: 17, weight: .semibold))
-                            .foregroundStyle(SemanticColors.Label.textDefault.color)
-                    }
-
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image(.close)
-                                .foregroundStyle(SemanticColors.Icon.foregroundDefaultBlack.color)
-                        }
-                        .accessibilityLabel(Accessibility.Files.close)
-                        .accessibilityIdentifier("close")
-                    }
+            List {
+                ForEach(Array(viewModel.items.enumerated()), id: \.offset) { index, _ in
+                    FilesViewItemView(viewModel: viewModel.itemViewModel(index: index))
+                        .onAppear { Task { await viewModel.loadMoreIfNeeded(index: index) } }
                 }
+            }
+            .onAppear { Task { await viewModel.reload() } }
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(Strings.Files.navigationTitle)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(SemanticColors.Label.textDefault.color)
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(.close)
+                            .foregroundStyle(SemanticColors.Icon.foregroundDefaultBlack.color)
+                    }
+                    .accessibilityLabel(Accessibility.Files.close)
+                    .accessibilityIdentifier("close")
+                }
+            }
         }
     }
 }
 
+private struct FilesViewItemView: View {
+    @StateObject var viewModel: FilesItemViewModel
+
+    init(viewModel: @autoclosure @escaping () -> FilesItemViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel())
+    }
+
+    var body: some View {
+        VStack {
+            Text(viewModel.fileName)
+            Text(viewModel.subtitle ?? "")
+        }
+
+    }
+}
+
 #Preview {
-    FilesView(viewModel: FilesViewModel())
+    FilesView(
+        viewModel: FilesViewModel(
+            fetchNodesUseCase: WireCellsFetchNodesUseCase(
+                configuration: .conversationFileView(root: .path("root")),
+                repository: makeNodesRepository()
+            )
+        )
+    )
+}
+
+private func makeNodesRepository() -> MockWireCellsNodesRepositoryProtocol {
+    let repository = MockWireCellsNodesRepositoryProtocol()
+    repository.getNodes_MockMethod = { request in
+        let nodes = (request.offset ..< request.offset + 30).map { index in
+            WireCellsNode(
+                uuid: UUID(),
+                path: "root/foo-\(index).jpg",
+                modified: UInt64(Date().timeIntervalSince1970),
+                ownerUserName: "Person \(index)"
+            )
+        }
+        let nextOffset = request.offset == 0 ? 30 : nil
+        return (nodes, nextOffset)
+    }
+    return repository
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -97,7 +97,7 @@ private func makeNodesRepository() -> MockWireCellsNodesRepositoryProtocol {
             WireCellsNode(
                 uuid: UUID(),
                 path: "root/foo-\(index).jpg",
-                modified: UInt64(Date().timeIntervalSince1970),
+                modified: Date(),
                 ownerUserName: "Person \(index)"
             )
         }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -60,7 +60,7 @@ package class FilesViewModel: ObservableObject {
         static let loadMoreThreshold = 5
     }
 
-    enum Alert {
+    enum Alert: Equatable {
         case noInternet
         case unknownError
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -120,7 +120,6 @@ package class FilesViewModel: ObservableObject {
             let (newItems, nextPage) = try await task.value
             items.append(contentsOf: newItems)
             nextPageToken = nextPage
-            print(">>>> \(nextPage)")
         } catch URLError.notConnectedToInternet, URLError.networkConnectionLost {
             alert = .noInternet
         } catch {
@@ -139,7 +138,7 @@ package class FilesViewModel: ObservableObject {
                 id: node.id,
                 filename: URL(string: node.path)?.lastPathComponent ?? node.path,
                 ownedBy: node.ownerUserName,
-                modifiedAt: node.modified.map { Date(timeIntervalSince1970: Double($0)) }
+                modifiedAt: node.modified
             )
         }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -17,10 +17,134 @@
 //
 
 import SwiftUI
+import WireFoundation
+package import WireMessagingDomain
+
+struct FilesViewItem: Identifiable {
+    let id: UUID
+    let filename: String
+    let ownedBy: String?
+    let modifiedAt: Date?
+}
+
+@MainActor
+class FilesItemViewModel: ObservableObject {
+
+    let fileName: String
+    let subtitle: String?
+
+    init(item: FilesViewItem) {
+        self.fileName = item.filename
+        self.subtitle = Self.subtitle(from: item)
+    }
+
+    private static func subtitle(from item: FilesViewItem) -> String? {
+        let modifiedAt = item.modifiedAt.map { $0.formatted(date: .abbreviated, time: .shortened) }
+        return if let modifiedAt, let ownedBy = item.ownedBy {
+            L10n.Localizable.Conversation.WireCells.Files.Item.subtitle(modifiedAt, ownedBy)
+        } else {
+            [modifiedAt, item.ownedBy].compactMap(\.self).first
+        }
+    }
+
+}
 
 @MainActor
 package class FilesViewModel: ObservableObject {
 
-    package init() {}
+    private typealias LoadItemsTask = Task<(items: [FilesViewItem], nextPage: WireCellsPageToken?), any Error>
+
+    private enum Constants {
+
+        /// How close to the end of the list before loading more items.
+        static let loadMoreThreshold = 5
+    }
+
+    enum Alert {
+        case noInternet
+        case unknownError
+    }
+
+    private let fetchNodesUseCase: WireCellsFetchNodesUseCase
+
+    package init(fetchNodesUseCase: WireCellsFetchNodesUseCase) {
+        self.fetchNodesUseCase = fetchNodesUseCase
+    }
+
+    @Published private(set) var items: [FilesViewItem] = []
+    @Published private var nextPageToken: WireCellsPageToken?
+    @Published private var loadMoreTask: LoadItemsTask?
+    @Published var alert: Alert?
+
+    var hasMore: Bool {
+        nextPageToken != nil
+    }
+
+    var isLoading: Bool {
+        loadMoreTask != nil
+    }
+
+    func reload() async {
+        cancelLoad()
+        items = []
+        nextPageToken = nil
+
+        await loadMore()
+    }
+
+    func loadMoreIfNeeded(index: Int) async {
+        let remaining = items.count - index - 1
+        if remaining < Constants.loadMoreThreshold, nextPageToken != nil {
+            await loadMore()
+        }
+    }
+
+    func itemViewModel(index: Int) -> FilesItemViewModel {
+        FilesItemViewModel(item: items[index])
+    }
+
+    // MARK: - Private
+
+    private func cancelLoad() {
+        loadMoreTask?.cancel()
+        loadMoreTask = nil
+    }
+
+    private func loadMore() async {
+        guard loadMoreTask == nil else { return }
+
+        let task = Task { try await fetchItems(token: nextPageToken) }
+
+        loadMoreTask = task
+        do {
+            let (newItems, nextPage) = try await task.value
+            items.append(contentsOf: newItems)
+            nextPageToken = nextPage
+            print(">>>> \(nextPage)")
+        } catch URLError.notConnectedToInternet, URLError.networkConnectionLost {
+            alert = .noInternet
+        } catch {
+            alert = .unknownError
+        }
+        loadMoreTask = nil
+    }
+
+    private nonisolated func fetchItems(
+        token: WireCellsPageToken?
+    ) async throws -> (items: [FilesViewItem], nextPage: WireCellsPageToken?) {
+        let (nodes, nextPage) = try await fetchNodesUseCase.invoke(searchTerm: nil, token: token)
+
+        let items = nodes.map { node in
+            FilesViewItem(
+                id: node.id,
+                filename: URL(string: node.path)?.lastPathComponent ?? node.path,
+                ownedBy: node.ownerUserName,
+                modifiedAt: node.modified.map { Date(timeIntervalSince1970: Double($0)) }
+            )
+        }
+
+        try Task.checkCancellation()
+        return (items, nextPage)
+    }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -20,7 +20,7 @@ import SwiftUI
 import WireFoundation
 package import WireMessagingDomain
 
-struct FilesViewItem: Identifiable {
+struct FilesViewItem: Identifiable, Equatable {
     let id: UUID
     let filename: String
     let ownedBy: String?

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -20,37 +20,25 @@ import SwiftUI
 import WireFoundation
 package import WireMessagingDomain
 
+/// An item in the `FilesView`.
 struct FilesViewItem: Identifiable, Equatable {
+
+    /// Identifier of this item on the wire cells backend.
     let id: UUID
+
+    /// The filename of the file including its extension.
     let filename: String
+
+    /// The name of the user who owns (uploaded) this file.
     let ownedBy: String?
+
+    /// The date when the file was last modified.
     let modifiedAt: Date?
 }
 
 @MainActor
-class FilesItemViewModel: ObservableObject {
-
-    let fileName: String
-    let subtitle: String?
-
-    init(item: FilesViewItem) {
-        self.fileName = item.filename
-        self.subtitle = Self.subtitle(from: item)
-    }
-
-    private static func subtitle(from item: FilesViewItem) -> String? {
-        let modifiedAt = item.modifiedAt.map { $0.formatted(date: .abbreviated, time: .shortened) }
-        return if let modifiedAt, let ownedBy = item.ownedBy {
-            L10n.Localizable.Conversation.WireCells.Files.Item.subtitle(modifiedAt, ownedBy)
-        } else {
-            [modifiedAt, item.ownedBy].compactMap(\.self).first
-        }
-    }
-
-}
-
-@MainActor
-package class FilesViewModel: ObservableObject {
+/// View model for the `FilesView`.
+package final class FilesViewModel: ObservableObject {
 
     private typealias LoadItemsTask = Task<(items: [FilesViewItem], nextPage: WireCellsPageToken?), any Error>
 
@@ -76,14 +64,19 @@ package class FilesViewModel: ObservableObject {
     @Published private var loadMoreTask: LoadItemsTask?
     @Published var alert: Alert?
 
+    /// Whether there are more items to load.
     var hasMore: Bool {
         nextPageToken != nil
     }
 
+    /// Whether the view model is currently loading items.
     var isLoading: Bool {
         loadMoreTask != nil
     }
 
+    /// Reloads the items, clearing any previously loaded items.
+    ///
+    /// This method cancels any ongoing load operation and starts a new one.
     func reload() async {
         cancelLoad()
         items = []
@@ -92,6 +85,13 @@ package class FilesViewModel: ObservableObject {
         await loadMore()
     }
 
+    /// Loads more items if available and `index` is towards the end of the list.
+    ///
+    /// This method checks if the `index` is within the threshold for loading more items. For example given a threshold
+    /// of 5, when 10 items are loaded, it will load more when the index is 5 or above - i.e. when one of the last 5
+    /// items is being displayed.
+    ///
+    /// - Parameter index: The index of the item which requested load more.
     func loadMoreIfNeeded(index: Int) async {
         let remaining = items.count - index - 1
         if remaining < Constants.loadMoreThreshold, nextPageToken != nil {
@@ -99,6 +99,7 @@ package class FilesViewModel: ObservableObject {
         }
     }
 
+    /// Returns a `FilesItemViewModel` for the item at the given index.
     func itemViewModel(index: Int) -> FilesItemViewModel {
         FilesItemViewModel(item: items[index])
     }
@@ -144,6 +145,33 @@ package class FilesViewModel: ObservableObject {
 
         try Task.checkCancellation()
         return (items, nextPage)
+    }
+
+}
+
+@MainActor
+/// A view model for a single item in the `FilesView`.
+///
+/// A view model is needed as the item is _live_ - it can be updated remotely, it's file downloaded locally, and so on.
+/// A locally downloaded file may also become out of date and need to be re-downloaded. Using a view model allows us to
+/// have granular subscriptions to events that are cancelled when the view is no longer in view.
+final class FilesItemViewModel: ObservableObject {
+
+    let fileName: String
+    let subtitle: String?
+
+    init(item: FilesViewItem) {
+        self.fileName = item.filename
+        self.subtitle = Self.subtitle(from: item)
+    }
+
+    private static func subtitle(from item: FilesViewItem) -> String? {
+        let modifiedAt = item.modifiedAt.map { $0.formatted(date: .abbreviated, time: .shortened) }
+        return if let modifiedAt, let ownedBy = item.ownedBy {
+            L10n.Localizable.Conversation.WireCells.Files.Item.subtitle(modifiedAt, ownedBy)
+        } else {
+            [modifiedAt, item.ownedBy].compactMap(\.self).first
+        }
     }
 
 }

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/Helpers/WireCellsNode+Fixture.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/Helpers/WireCellsNode+Fixture.swift
@@ -23,10 +23,14 @@ extension WireCellsNode {
     static func fixture(
         uuid: UUID = UUID(),
         path: String = "some/path",
+        modified: Date? = nil,
+        ownerUserName: String? = nil,
     ) -> WireCellsNode {
         WireCellsNode(
             uuid: uuid,
-            path: "some/path"
+            path: path,
+            modified: modified,
+            ownerUserName: ownerUserName
         )
     }
 }

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/Files/FilesViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/Files/FilesViewModelTests.swift
@@ -45,14 +45,38 @@ final class FilesViewModelTests {
         }.store(in: &cancellables)
     }
 
-    @Test func isLoading() async throws {
+    @Test
+    func hasMore() async throws {
+        // given
+        nodesRepository.getNodes_MockMethod = { request in
+            let page1 = (nodes: [WireCellsNode.fixture()], nextOffset: 1)
+            let page2 = (nodes: [WireCellsNode.fixture()], nextOffset: Int?.none)
+            return request.offset == 0 ? page1 : page2
+        }
+        #expect(sut.hasMore == false)
+
+        // when
+        await sut.reload()
+
+        // then
+        #expect(sut.hasMore == true)
+
+        // when
+        await sut.loadMoreIfNeeded(index: 0)
+
+        // then
+        #expect(sut.hasMore == false)
+    }
+
+    @Test
+    func isLoading() async throws {
         // given
         nodesRepository.getNodes_MockMethod = { [sut] request in
             // Here we assert that loading is true when the methods under test are called.
             #expect(sut.isLoading == true)
 
             let page1 = (nodes: [WireCellsNode.fixture()], nextOffset: 1)
-            let page2 = (nodes: [WireCellsNode.fixture()], nextOffset: Optional<Int>.none)
+            let page2 = (nodes: [WireCellsNode.fixture()], nextOffset: Int?.none)
             return request.offset == 0 ? page1 : page2
         }
         #expect(sut.isLoading == false)
@@ -67,6 +91,174 @@ final class FilesViewModelTests {
         await sut.loadMoreIfNeeded(index: 0)
 
         // then
+        #expect(sut.isLoading == false)
+    }
+
+    @Test
+    func reload_clearsItemsBeforeLoading() async throws {
+        // given
+        let node = WireCellsNode.fixture(path: "some-cell/a.jpg", modified: nil, ownerUserName: nil)
+        nodesRepository.getNodes_MockMethod = { _ in (nodes: [node], nextOffset: nil) }
+
+        // when
+        await sut.reload()
+        await sut.reload()
+
+        // then
+        #expect(itemsUpdates == [
+            [], // Clears items
+            [FilesViewItem(id: node.id, filename: "a.jpg", ownedBy: nil, modifiedAt: nil)],
+            [], // Clears items
+            [FilesViewItem(id: node.id, filename: "a.jpg", ownedBy: nil, modifiedAt: nil)]
+        ])
+    }
+
+    @Test
+    func reload_alwaysLoadsFirstPage() async throws {
+        // given
+        nodesRepository.getNodes_MockMethod = { _ in
+            (nodes: [WireCellsNode.fixture()], nextOffset: 1) // There is a new page available
+        }
+
+        await sut.reload()
+        #expect(sut.hasMore == true)
+
+        // when
+        await sut.reload()
+
+        // then
+        #expect(nodesRepository.getNodes_Invocations.last?.offset == 0)
+    }
+
+    @Test
+    func reload_updatesItems() async throws {
+        // given
+        let now = Date()
+        let node1 = WireCellsNode.fixture(path: "some-cell/a.jpg", modified: now, ownerUserName: "Emel")
+        let node2 = WireCellsNode.fixture(path: "some-cell/b.jpg", modified: nil, ownerUserName: nil)
+        nodesRepository.getNodes_MockMethod = { _ in (nodes: [node1, node2], nextOffset: nil) }
+
+        // when
+        await sut.reload()
+
+        // then
+        #expect(sut.items == [
+            FilesViewItem(id: node1.id, filename: "a.jpg", ownedBy: "Emel", modifiedAt: now),
+            FilesViewItem(id: node2.id, filename: "b.jpg", ownedBy: nil, modifiedAt: nil)
+        ])
+    }
+
+    @Test
+    func loadMoreIfNeeded_appendsItems() async throws {
+        // given
+        let now = Date()
+        let node1 = WireCellsNode.fixture(path: "some-cell/a.jpg", modified: now, ownerUserName: "Emel")
+        let node2 = WireCellsNode.fixture(path: "some-cell/b.jpg", modified: nil, ownerUserName: nil)
+        let node3 = WireCellsNode.fixture(path: "some-cell/c.jpg", modified: nil, ownerUserName: nil)
+        nodesRepository.getNodes_MockMethod = { request in
+            switch request.offset {
+            case 0:
+                (nodes: [node1], nextOffset: 1)
+            case 1:
+                (nodes: [node2], nextOffset: 2)
+            default:
+                (nodes: [node3], nextOffset: nil)
+            }
+        }
+
+        // when
+        await sut.reload()
+        await sut.loadMoreIfNeeded(index: 0) // Index doesn't related to pagination
+        await sut.loadMoreIfNeeded(index: 0) // Index doesn't related to pagination
+
+        // then
+        #expect(sut.items == [
+            FilesViewItem(id: node1.id, filename: "a.jpg", ownedBy: "Emel", modifiedAt: now),
+            FilesViewItem(id: node2.id, filename: "b.jpg", ownedBy: nil, modifiedAt: nil),
+            FilesViewItem(id: node3.id, filename: "c.jpg", ownedBy: nil, modifiedAt: nil)
+        ])
+    }
+
+    @Test
+    func loadMoreIfNeeded_doesNothingWhenNoMoreToLoad() async throws {
+        // given
+        nodesRepository.getNodes_MockMethod = { _ in
+            (nodes: [WireCellsNode.fixture()], nextOffset: nil) // No more pages available
+        }
+        await sut.reload()
+        #expect(sut.items.count == 1)
+        itemsUpdates = [] // Reset updates to track only the next ones
+
+        // when
+        await sut.loadMoreIfNeeded(index: 0) // Index doesn't related to pagination
+
+        // then
+        #expect(itemsUpdates.isEmpty)
+    }
+
+    @Test
+    func loadMoreIfNeeded_respectsThreshold() async throws {
+        // given
+        let nodes = (0 ..< 10).map { i in
+            WireCellsNode.fixture(path: "some-cell/\(i).jpg", modified: nil, ownerUserName: nil)
+        }
+        nodesRepository.getNodes_MockMethod = { _ in (nodes: nodes, nextOffset: 10) }
+
+        await sut.reload()
+        #expect(sut.items.count == 10)
+        nodesRepository.getNodes_Invocations.removeAll() // Reset invocations to track only the next ones
+
+        // when
+        await sut.loadMoreIfNeeded(index: 4) // index is not one of the last 5 rows
+
+        // then
+        #expect(nodesRepository.getNodes_Invocations.isEmpty)
+
+        // when
+        await sut.loadMoreIfNeeded(index: 5) // index is one of the last 5 rows
+
+        // then
+        #expect(nodesRepository.getNodes_Invocations.count == 1)
+    }
+
+    @Test
+    func loadMoreIfNeeded_discardsConcurrentRequests() async throws {
+        // given
+        nodesRepository.getNodes_MockMethod = { request in
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+            return (nodes: [WireCellsNode.fixture()], nextOffset: request.offset + 1)
+        }
+        await sut.reload()
+        #expect(sut.items.count == 1)
+        nodesRepository.getNodes_Invocations.removeAll() // Reset invocations to track only the next ones
+
+        // when
+        let task1 = Task { await sut.loadMoreIfNeeded(index: 0) }
+        let task2 = Task { await sut.loadMoreIfNeeded(index: 0) }
+
+        // Wait for both tasks to complete
+        await task1.value
+        await task2.value
+
+        // then
+        #expect(nodesRepository.getNodes_Invocations.count == 1)
+        #expect(sut.items.count == 2)
+    }
+
+    @Test(arguments: [
+        (error: URLError(.notConnectedToInternet), expectedAlert: FilesViewModel.Alert.noInternet),
+        (error: URLError(.networkConnectionLost), expectedAlert: FilesViewModel.Alert.noInternet),
+        (error: URLError(.badURL), expectedAlert: FilesViewModel.Alert.unknownError)
+    ])
+    func loadFailure(error: any Error, expectedAlert: FilesViewModel.Alert) async throws {
+        // given
+        nodesRepository.getNodes_MockError = error
+
+        // when
+        await sut.reload()
+
+        // then
+        #expect(sut.alert == expectedAlert)
         #expect(sut.isLoading == false)
     }
 

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/Files/FilesViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/Files/FilesViewModelTests.swift
@@ -1,0 +1,73 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Combine
+import Foundation
+import Testing
+import WireMessagingDomain
+
+@testable import WireMessagingDomainSupport
+@testable import WireMessagingUI
+
+@MainActor
+final class FilesViewModelTests {
+
+    private let nodesRepository = MockWireCellsNodesRepositoryProtocol()
+    private let sut: FilesViewModel
+    private var itemsUpdates: [[FilesViewItem]] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        self.sut = FilesViewModel(
+            fetchNodesUseCase: WireCellsFetchNodesUseCase(
+                configuration: .conversationFileView(root: .path("some-cell")),
+                repository: nodesRepository
+            )
+        )
+
+        sut.$items.dropFirst().sink { [weak self] items in
+            self?.itemsUpdates.append(items)
+        }.store(in: &cancellables)
+    }
+
+    @Test func isLoading() async throws {
+        // given
+        nodesRepository.getNodes_MockMethod = { [sut] request in
+            // Here we assert that loading is true when the methods under test are called.
+            #expect(sut.isLoading == true)
+
+            let page1 = (nodes: [WireCellsNode.fixture()], nextOffset: 1)
+            let page2 = (nodes: [WireCellsNode.fixture()], nextOffset: Optional<Int>.none)
+            return request.offset == 0 ? page1 : page2
+        }
+        #expect(sut.isLoading == false)
+
+        // when
+        await sut.reload()
+
+        // then
+        #expect(sut.isLoading == false)
+
+        // when
+        await sut.loadMoreIfNeeded(index: 0)
+
+        // then
+        #expect(sut.isLoading == false)
+    }
+
+}

--- a/WirePlugins/Plugins/SourceryPlugin/Stencils/LegacyAutoMockable.stencil
+++ b/WirePlugins/Plugins/SourceryPlugin/Stencils/LegacyAutoMockable.stencil
@@ -260,6 +260,7 @@ package import {{ import }}
     // MARK: - Life cycle
 
     {% if type.accessLevel == "public" %}public init() {}{% endif %}
+    {% if type.accessLevel == "package" %}package init() {}{% endif %}
 
 {% for variable in type.allVariables|!definedInExtension %}
     // MARK: - {{ variable.name }}

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -1784,20 +1784,20 @@ class MockWireCellsFactoryProtocol: WireCellsFactoryProtocol {
 
     // MARK: - makeFilesView
 
-    var makeFilesView_Invocations: [Void] = []
-    var makeFilesView_MockMethod: (() -> UIViewController)?
-    var makeFilesView_MockValue: UIViewController?
+    var makeFilesViewCellName_Invocations: [String] = []
+    var makeFilesViewCellName_MockMethod: ((String) -> UIViewController)?
+    var makeFilesViewCellName_MockValue: UIViewController?
 
     @MainActor
-    func makeFilesView() -> UIViewController {
-        makeFilesView_Invocations.append(())
+    func makeFilesView(cellName: String) -> UIViewController {
+        makeFilesViewCellName_Invocations.append(cellName)
 
-        if let mock = makeFilesView_MockMethod {
-            return mock()
-        } else if let mock = makeFilesView_MockValue {
+        if let mock = makeFilesViewCellName_MockMethod {
+            return mock(cellName)
+        } else if let mock = makeFilesViewCellName_MockValue {
             return mock
         } else {
-            fatalError("no mock for `makeFilesView`")
+            fatalError("no mock for `makeFilesViewCellName`")
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -863,7 +863,7 @@ extension ConversationViewController: ConversationInputBarViewControllerDelegate
     @objc
     private func onFilesButtonPressed(_ sender: AnyObject?) {
         let filesView = wireCellsFactory
-            .makeFilesView()
+            .makeFilesView(cellName: conversation.wireCellName)
 
         filesView.presentOverAll(animated: true)
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/WireCellsFactoryProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/WireCellsFactoryProtocol.swift
@@ -31,7 +31,7 @@ protocol WireCellsFactoryProtocol {
     func makeDeleteDraftUseCase(cellName: String) -> WireCellsDeleteDraftUseCaseProtocol
     func makeRetryUploadDraftUseCase(cellName: String) -> WireCellsRetryUploadDraftUseCaseProtocol
     @MainActor
-    func makeFilesView() -> UIViewController
+    func makeFilesView(cellName: String) -> UIViewController
 }
 
 extension WireCellsFactory: WireCellsFactoryProtocol {}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19563" title="WPB-19563" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19563</a>  [iOS] File View ViewModel
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR implements the `FilesViewModel` that will be used by the `FilesView` to display a list of wire cells files for a given conversation.

Currently this view model is only concerned with fetching and displaying the list of items, not any actions such as downloading a file, etc. 

This PR contains some minimal changes to `FilesView` so things compile and loading can be tried. However these views are currently only in a dummy state so don't review them too closely.

### Testing

Try the preview in `FilesView.swift`.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
