### PR TITLE
feat: add context menu to items in files view - WPB-19390

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -104,3 +104,6 @@
 "conversation.wireCells.files.navigationTitle" = "Files";
 "conversation.wireCells.files.item.subtitle" = "%@ by %@";
 "conversation.wireCells.files.loadMore.title" = "Load more";
+"conversation.wireCells.files.item.menu.download" = "Download";
+"conversation.wireCells.files.item.menu.rename" = "Rename";
+"conversation.wireCells.files.item.menu.delete" = "Delete permanently";

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -124,17 +124,40 @@ struct FilesViewItemView: View {
 
                 Spacer()
 
-                Button {
-                    // TODO: [WPB-19390] Show context menu
+                Menu {
+                    if !viewModel.isDownloaded {
+                        Button(action: download) {
+                            Label(Strings.Files.Item.Menu.download, systemImage: "square.and.arrow.down.fill")
+                        }
+                    }
+
+                    Button(action: rename) {
+                        Label(Strings.Files.Item.Menu.rename, systemImage: "pencil")
+                    }
+
+                    Button(role: .destructive, action: delete) {
+                        Label(Strings.Files.Item.Menu.delete, systemImage: "trash.fill")
+                    }
                 } label: {
                     Image(systemName: "ellipsis")
                         .foregroundStyle(ColorTheme.Base.secondaryText.color)
                 }
-                .buttonStyle(.borderless)
                 .padding(.all, 8)
             }
             Divider()
         }
+    }
+
+    private func download() {
+        // FIXME: [WPB-19436] Implement
+    }
+
+    private func rename() {
+        // FIXME: [WPB-19393] Implement
+    }
+
+    private func delete() {
+        // FIXME: [WPB-19392] Implement
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -176,6 +176,11 @@ final class FilesItemViewModel: ObservableObject {
         self.icon = item.icon
     }
 
+    var isDownloaded: Bool {
+        // FIXME: [WPB-19436] Implement
+        false
+    }
+
     private static func subtitle(
         from item: FilesViewItem,
         locale: Locale,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19390" title="WPB-19390" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-19390</a>  [iOS] As a user I want to see a context menu with file operations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a context menu with 3 options that is activated by tapping the ellipsis in an item in the `FilesView`. For now no actions are implemented.

<img width="474" height="942" alt="Screenshot 2025-08-21 at 17 48 16" src="https://github.com/user-attachments/assets/296792c6-7d10-431c-832b-aa7ffecc4216" />


### Testing

Run the preview in `FilesView.swift`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.
