### PR TITLE
feat: Changed Poll Buttons corner radius - WPB-19657

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDesign
 import WireReusableUIComponents
+import WireUtilities
 
 extension UIColor {
     enum AlarmButton {
@@ -128,6 +129,9 @@ final class SpinnerButton: LegacyButton {
     // MARK: - factory method
 
     static func alarmButton() -> SpinnerButton {
-        SpinnerButton(legacyStyle: .empty, cornerRadius: 6, fontSpec: .smallSemiboldFont)
+        let cornerRadius: CGFloat = DeveloperFlag.chatBubblesSimple.isOn ?
+            ConversationMessageContainerView.bubbleCornerRadius : 6
+
+        return SpinnerButton(legacyStyle: .empty, cornerRadius: cornerRadius, fontSpec: .smallSemiboldFont)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19657" title="WPB-19657" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19657</a>  [iOS] Change Poll Buttons corner radius to match with the existing simple chatBubbles corner radius when SimpleChatBubbles flag is on 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…chatBubbles corner radius when SimpleChatBubbles flag is on

<!--do not remove the jira markers to link tickets automatically -->


### Issue

We want to match the Poll corner radius with the existing Chat bubbles corner radius when **chatBubblesSimple** Developerflag is on 

We are adding corner radius as 16.0 if DeveloperFlag.chatBubblesSimple.isOn is true and if is false we are setting existing value 6.0

_Optional: reference dependencies to other pull requests etc._

### Testing

Please find the screen shots regarding how it should look. Text message chat bubble corner radius and Poll button corner radius must be same 
<img width="200" height="500" alt="Screenshot 2025-08-22 at 11 07 23" src="https://github.com/user-attachments/assets/b1878495-d25b-46d2-afde-f96ec37042c3" />

 


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
