### PR TITLE
feat: chat bubbles simple featue flag adaptations - WPB-19699

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/UserSession.swift
@@ -222,6 +222,8 @@ public protocol UserSession: AnyObject {
 
     var channelsFeature: Feature.Channels { get }
 
+    var isChatBubbleSimpleEnabled: Bool { get }
+
     func fetchAllClients()
 
     func createTeamOneOnOne(

--- a/wire-ios/Tests/Mocks/UserSessionMock.swift
+++ b/wire-ios/Tests/Mocks/UserSessionMock.swift
@@ -382,6 +382,8 @@ final class UserSessionMock: UserSession {
         config: .init(defaultCipherSuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519)
     )
 
+    var isChatBubbleSimpleEnabled: Bool = false
+
     func fetchAllClients() {}
 
     var createTeamOneOnOneWithCompletion_Invocations: [(

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSectionControllerTests.swift
@@ -516,7 +516,8 @@ final class ConversationMessageSectionControllerTests: XCTestCase {
             userSession: userSession,
             useInvertedIndices: useInvertedIndices,
             contentWidth: 0,
-            userDefaults: mockUserDefaults
+            userDefaults: mockUserDefaults,
+            isChatBubbleSimpleEnabled: false
         )
 
         trackForMemoryLeaks(section)

--- a/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationMessageCell/ConversationMessageSnapshotTestCase.swift
@@ -185,7 +185,8 @@ class ConversationMessageSnapshotTestCase: ZMSnapshotTestCase {
             userSession: userSession,
             useInvertedIndices: false,
             contentWidth: width,
-            userDefaults: mockUserDefaults
+            userDefaults: mockUserDefaults,
+            isChatBubbleSimpleEnabled: false
         )
 
         let views = section.cellDescriptionsForTesting.map { $0.instance.makeView(message) }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDesign
 import WireReusableUIComponents
+import WireSyncEngine
 import WireUtilities
 
 extension UIColor {
@@ -129,7 +130,7 @@ final class SpinnerButton: LegacyButton {
     // MARK: - factory method
 
     static func alarmButton() -> SpinnerButton {
-        let cornerRadius: CGFloat = DeveloperFlag.chatBubblesSimple.isOn ?
+        let cornerRadius: CGFloat = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false ?
             ConversationMessageContainerView.bubbleCornerRadius : 6
 
         return SpinnerButton(legacyStyle: .empty, cornerRadius: cornerRadius, fontSpec: .smallSemiboldFont)

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -130,7 +130,7 @@ final class SpinnerButton: LegacyButton {
     // MARK: - factory method
 
     static func alarmButton() -> SpinnerButton {
-        let cornerRadius: CGFloat = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false ?
+        let cornerRadius: CGFloat = ZMUserSession.isChatBubbleEnabled ?
             ConversationMessageContainerView.bubbleCornerRadius : 6
 
         return SpinnerButton(legacyStyle: .empty, cornerRadius: cornerRadius, fontSpec: .smallSemiboldFont)

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+IsChatBubbleSimpleEnabled.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMUserSession+IsChatBubbleSimpleEnabled.swift
@@ -1,0 +1,25 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireSyncEngine
+
+extension ZMUserSession {
+    static var isChatBubbleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
+}

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/ReplyRoundCornersView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/ReplyRoundCornersView.swift
@@ -18,8 +18,8 @@
 
 import UIKit
 import WireDesign
-import WireUtilities
 import WireSyncEngine
+import WireUtilities
 
 final class ReplyRoundCornersView: UIControl {
     // MARK: - Properties

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/ReplyRoundCornersView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/ReplyRoundCornersView.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDesign
 import WireUtilities
+import WireSyncEngine
 
 final class ReplyRoundCornersView: UIControl {
     // MARK: - Properties
@@ -46,7 +47,7 @@ final class ReplyRoundCornersView: UIControl {
     // MARK: Setup Subviews and Constraints
 
     private func setupSubviews() {
-        layer.cornerRadius = if DeveloperFlag.chatBubblesSimple.isOn {
+        layer.cornerRadius = if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             8

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -204,7 +204,7 @@ class ConversationIconBasedCell<CellDescription: ConversationMessageCellDescript
             textLabelTrailingConstraint.constant = trailingTextMargin
         }
     }
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 class ConversationIconBasedCell<CellDescription: ConversationMessageCellDescription>: UIView, UITextViewDelegate {
 
@@ -128,7 +129,7 @@ class ConversationIconBasedCell<CellDescription: ConversationMessageCellDescript
             equalTo: trailingAnchor
         )
 
-        if DeveloperFlag.chatBubblesSimple.isOn, shouldRemoveInnerPaddingForBubbles {
+        if isChatBubbleSimpleEnabled, shouldRemoveInnerPaddingForBubbles {
             containerWidthConstraint = imageContainer.widthAnchor
                 .constraint(equalToConstant: 32.0)
             imageContainerLeadingConstraint = imageContainer.leadingAnchor.constraint(
@@ -195,13 +196,17 @@ class ConversationIconBasedCell<CellDescription: ConversationMessageCellDescript
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         topContentViewTrailingConstraint.constant = trailingTextMargin
-        if DeveloperFlag.chatBubblesSimple.isOn, shouldRemoveInnerPaddingForBubbles {
+        if isChatBubbleSimpleEnabled, shouldRemoveInnerPaddingForBubbles {
             containerWidthConstraint.constant = 32.0
             textLabelTrailingConstraint.constant = 0
         } else {
             containerWidthConstraint.constant = conversationHorizontalMargins.left
             textLabelTrailingConstraint.constant = trailingTextMargin
         }
+    }
+    
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }
 
     // MARK: - UITextViewDelegate

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationIconBasedCell.swift
@@ -129,7 +129,7 @@ class ConversationIconBasedCell<CellDescription: ConversationMessageCellDescript
             equalTo: trailingAnchor
         )
 
-        if isChatBubbleSimpleEnabled, shouldRemoveInnerPaddingForBubbles {
+        if ZMUserSession.isChatBubbleEnabled, shouldRemoveInnerPaddingForBubbles {
             containerWidthConstraint = imageContainer.widthAnchor
                 .constraint(equalToConstant: 32.0)
             imageContainerLeadingConstraint = imageContainer.leadingAnchor.constraint(
@@ -196,17 +196,13 @@ class ConversationIconBasedCell<CellDescription: ConversationMessageCellDescript
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         topContentViewTrailingConstraint.constant = trailingTextMargin
-        if isChatBubbleSimpleEnabled, shouldRemoveInnerPaddingForBubbles {
+        if ZMUserSession.isChatBubbleEnabled, shouldRemoveInnerPaddingForBubbles {
             containerWidthConstraint.constant = 32.0
             textLabelTrailingConstraint.constant = 0
         } else {
             containerWidthConstraint.constant = conversationHorizontalMargins.left
             textLabelTrailingConstraint.constant = trailingTextMargin
         }
-    }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }
 
     // MARK: - UITextViewDelegate

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -132,7 +132,7 @@ final class ConversationMessageToolboxCellDescription: ConversationMessageCellDe
     weak var actionController: ConversationMessageActionController?
 
     let containsHighlightableContent: Bool = false
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     let accessibilityIdentifier: String? = "MessageToolbox"
     let accessibilityLabel: String? = nil

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -274,7 +274,7 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
 
         return NSAttributedString(attachment: attachment)
     }
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -183,7 +183,7 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
             availabilityIndicatorView.bottomAnchor.constraint(equalTo: avatar.bottomAnchor, constant: 3)
         ])
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -274,6 +274,10 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
 
         return NSAttributedString(attachment: attachment)
     }
+    
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 
     // MARK: - Tap gesture of avatar
 
@@ -307,7 +311,7 @@ final class ConversationSenderMessageCellDescription: ConversationMessageCellDes
     weak var actionController: ConversationMessageActionController?
 
     let containsHighlightableContent: Bool = false
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     let accessibilityIdentifier: String? = nil
     var accessibilityLabel: String?
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireDataModel
+import WireSyncEngine
 
 // MARK: - Reaction
 
@@ -49,10 +50,14 @@ final class MessageReactionsCell: UIView, ConversationMessageCell {
 
     private lazy var insets = UIEdgeInsets(
         top: 2,
-        left: DeveloperFlag.chatBubblesSimple.isOn ? 0 : conversationHorizontalMargins.left,
+        left: isChatBubbleSimpleEnabled ? 0 : conversationHorizontalMargins.left,
         bottom: 0,
-        right: DeveloperFlag.chatBubblesSimple.isOn ? 0 : conversationHorizontalMargins.right
+        right: isChatBubbleSimpleEnabled ? 0 : conversationHorizontalMargins.right
     )
+    
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 
     // MARK: - Life cycle
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
@@ -54,7 +54,7 @@ final class MessageReactionsCell: UIView, ConversationMessageCell {
         bottom: 0,
         right: isChatBubbleSimpleEnabled ? 0 : conversationHorizontalMargins.right
     )
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCellDescription.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireDataModel
+import WireSyncEngine
 
 // MARK: - MessageReactionsCellDescription
 
@@ -28,7 +29,7 @@ final class MessageReactionsCellDescription: ConversationMessageCellDescription 
     typealias View = MessageReactionsCell
     let configuration: View.Configuration
 
-    let shouldAlignMessageContentForBubbles = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     init(message: ZMConversationMessage) {
         self.message = message

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
 
@@ -56,7 +57,7 @@ final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubview() {
-        let cornerRadius: CGFloat = if DeveloperFlag.chatBubblesSimple.isOn {
+        let cornerRadius: CGFloat = if isChatBubbleSimpleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -97,7 +98,7 @@ final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -138,6 +139,9 @@ final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
         transferView.bounds
     }
 
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 }
 
 extension ConversationAudioMessageCell: TransferViewDelegate {
@@ -155,7 +159,7 @@ final class ConversationAudioMessageCellDescription: ConversationMessageCellDesc
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationImageMessageCell: UIView, ConversationMessageCell, ContextMenuDelegate {
 
@@ -74,7 +75,7 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
     }
 
     private func configureView() {
-        containerView.layer.cornerRadius = if DeveloperFlag.chatBubblesSimple.isOn {
+        containerView.layer.cornerRadius = if isChatBubbleSimpleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -120,7 +121,7 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
             widthConstraint!,
             heightConstraint!
         ])
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -186,6 +187,10 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
             imageResourceView.layer.borderWidth = UIScreen.hairline
         }
     }
+    
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 }
 
 final class ConversationImageMessageCellDescription: ConversationMessageCellDescription {
@@ -210,7 +215,7 @@ final class ConversationImageMessageCellDescription: ConversationMessageCellDesc
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
 
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     var accessibilityIdentifier: String? {
         configuration.isObfuscated ? "ObfuscatedImageCell" : "ImageCell"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -187,7 +187,7 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
             imageResourceView.layer.borderWidth = UIScreen.hairline
         }
     }
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -196,7 +196,7 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
     private func openInMaps() {
         lastConfiguration?.location.openInMaps(with: mapView.region.span)
     }
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -20,6 +20,7 @@ import MapKit
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationLocationMessageCell: UIView, ConversationMessageCell, ContextMenuDelegate {
 
@@ -74,7 +75,7 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
 
     private func configureViews() {
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.layer.cornerRadius = if DeveloperFlag.chatBubblesSimple.isOn {
+        containerView.layer.cornerRadius = if isChatBubbleSimpleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -114,7 +115,7 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
         addressLabel.translatesAutoresizingMaskIntoConstraints = false
 
         let margins = conversationHorizontalMargins
-        let containerInsets: UIEdgeInsets = DeveloperFlag.chatBubblesSimple.isOn
+        let containerInsets: UIEdgeInsets = isChatBubbleSimpleEnabled
             ? .zero
             : UIEdgeInsets(top: 0, left: margins.left, bottom: 0, right: margins.right)
         containerView.fitIn(view: self, insets: containerInsets)
@@ -195,6 +196,10 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
     private func openInMaps() {
         lastConfiguration?.location.openInMaps(with: mapView.region.span)
     }
+    
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 }
 
 final class ConversationLocationMessageCellDescription: ConversationMessageCellDescription {
@@ -216,7 +221,7 @@ final class ConversationLocationMessageCellDescription: ConversationMessageCellD
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     var accessibilityIdentifier: String? {
         configuration.isObfuscated ? "ObfuscatedLocationCell" : "LocationCell"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationPingCell: ConversationIconBasedCell<ConversationPingCellDescription>, ConversationMessageCell {
 
@@ -157,7 +158,7 @@ final class ConversationPingCellDescription: ConversationMessageCellDescription 
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = false
-    let shouldAlignMessageContentForBubbles = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
 
@@ -56,7 +57,7 @@ final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubview() {
-        let cornerRadius: CGFloat = if DeveloperFlag.chatBubblesSimple.isOn {
+        let cornerRadius: CGFloat = if isChatBubbleSimpleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -98,7 +99,7 @@ final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -154,6 +155,9 @@ final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
         transferView.bounds
     }
 
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 }
 
 extension ConversationVideoMessageCell: TransferViewDelegate {
@@ -170,7 +174,7 @@ final class ConversationVideoMessageCellDescription: ConversationMessageCellDesc
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -312,7 +312,7 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
         // Otherwise, let normal hit testing occur
         return super.hitTest(point, with: event)
     }
-
+    
     private var isChatBubbleSimpleEnabled: Bool {
         // the additional DeveloperFlag check is needed for the snapshot test
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false || DeveloperFlag.chatBubblesSimple.isOn

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -312,7 +312,7 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
         // Otherwise, let normal hit testing occur
         return super.hitTest(point, with: event)
     }
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         // the additional DeveloperFlag check is needed for the snapshot test
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false || DeveloperFlag.chatBubblesSimple.isOn

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
@@ -19,6 +19,7 @@
 import UIKit
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationFileMessageCell: UIView, ConversationMessageCell {
 
@@ -55,7 +56,7 @@ final class ConversationFileMessageCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubview() {
-        let cornerRadius: CGFloat = if DeveloperFlag.chatBubblesSimple.isOn {
+        let cornerRadius: CGFloat = if isChatBubbleSimpleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -97,7 +98,7 @@ final class ConversationFileMessageCell: UIView, ConversationMessageCell {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -138,6 +139,9 @@ final class ConversationFileMessageCell: UIView, ConversationMessageCell {
         fileTransferView.bounds
     }
 
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    }
 }
 
 extension ConversationFileMessageCell: TransferViewDelegate {
@@ -155,7 +159,7 @@ final class ConversationFileMessageCellDescription: ConversationMessageCellDescr
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkAttachmentCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkAttachmentCell.swift
@@ -20,6 +20,7 @@ import UIKit
 import WireCommonComponents
 import WireDataModel
 import WireDesign
+import WireSyncEngine
 
 final class ConversationLinkAttachmentCell: UIView, ConversationMessageCell, HighlightableView, ContextMenuDelegate {
 
@@ -96,7 +97,7 @@ final class ConversationLinkAttachmentCell: UIView, ConversationMessageCell, Hig
             widthConstraint
         ])
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -180,7 +181,7 @@ final class ConversationLinkAttachmentCellDescription: ConversationMessageCellDe
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireDataModel
+import WireSyncEngine
 
 final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell, ContextMenuDelegate {
 
@@ -69,7 +70,7 @@ final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell,
 
     private func configureConstraints() {
         let margins = conversationHorizontalMargins
-        let insets: UIEdgeInsets = DeveloperFlag.chatBubblesSimple.isOn
+        let insets: UIEdgeInsets = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
             ? .zero
             : UIEdgeInsets(top: 0, left: margins.left, bottom: 0, right: margins.right)
         articleView.fitIn(view: self, insets: insets)
@@ -128,7 +129,7 @@ final class ConversationLinkPreviewArticleCellDescription: ConversationMessageCe
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     var accessibilityIdentifier: String? {
         configuration.isObfuscated ? "ObfuscatedLinkPreviewCell" : "LinkPreviewCell"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -22,6 +22,7 @@ import WireCommonComponents
 import WireDataModel
 import WireDesign
 import WireFoundation
+import WireSyncEngine
 
 final class ConversationReplyContentView: UIView {
     typealias FileSharingRestrictions = L10n.Localizable.FeatureConfig.FileSharingRestrictions
@@ -324,7 +325,7 @@ final class ConversationReplyCell: UIView, ConversationMessageCell {
 
     private func configureConstraints() {
         let margins = conversationHorizontalMargins
-        let insets: UIEdgeInsets = DeveloperFlag.chatBubblesSimple.isOn
+        let insets: UIEdgeInsets = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
             ? .zero
             : UIEdgeInsets(top: 0, left: margins.left, bottom: 0, right: margins.right)
         container.fitIn(view: self, insets: insets)
@@ -352,7 +353,7 @@ final class ConversationReplyCellDescription: ConversationMessageCellDescription
 
     let supportsActions = false
     let containsHighlightableContent: Bool = true
-    let shouldAlignMessageContentForBubbles: Bool = DeveloperFlag.chatBubblesSimple.isOn
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -193,9 +193,8 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
 
     private var isChatBubbleSimpleEnabled: Bool {
         // the additional DeveloperFlag check is needed for the snapshot test
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false || DeveloperFlag.chatBubblesSimple.isOn
+        ZMUserSession.isChatBubbleEnabled || DeveloperFlag.chatBubblesSimple.isOn
     }
-
 }
 
 // MARK: - Description
@@ -212,13 +211,16 @@ final class ConversationTextMessageCellDescription: ConversationMessageCellDescr
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
 
-    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil
 
     init(attributedString: NSAttributedString, isObfuscated: Bool) {
-        self.configuration = View.Configuration(attributedText: attributedString, isObfuscated: isObfuscated)
+        self.configuration = View.Configuration(
+            attributedText: attributedString,
+            isObfuscated: isObfuscated
+        )
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -474,7 +474,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             }
         }
 
-        //if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false { //this is crashing
+        // if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false { //this is crashing
         if DeveloperFlag.chatBubblesSimple.isOn {
             addReactions()
             addToolbox()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -112,6 +112,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
 
     private let userSession: UserSession
     private let privateDefaults: PrivateUserDefaults<CollapseKey>
+    private var isChatBubbleSimpleEnabled: Bool = false
 
     /// width of a container view to calculate whether message should be collapsed
     var contentWidth: CGFloat
@@ -128,7 +129,8 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
         userSession: UserSession,
         useInvertedIndices: Bool,
         contentWidth: CGFloat,
-        userDefaults: UserDefaultsProtocol = UserDefaults.standard
+        userDefaults: UserDefaultsProtocol = UserDefaults.standard,
+        isChatBubbleSimpleEnabled: Bool,
     ) {
         self.message = message
         self.context = context
@@ -153,6 +155,10 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
         if let quotedMessage = message.textMessageData?.quoteMessage {
             startObservingChanges(for: quotedMessage)
         }
+
+        // We need to provide isChatBubbleEnabled as Bool on init() because can't use
+        // UserSession.isChatBubbleSimpleEnabled here.It will crash because we are on the background thread.
+        self.isChatBubbleSimpleEnabled = isChatBubbleSimpleEnabled
     }
 
     private var collapseOwnMessagesEnabled: Bool {
@@ -474,8 +480,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             }
         }
 
-        // if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false { //this is crashing
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             addReactions()
             addToolbox()
         } else {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -474,6 +474,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             }
         }
 
+        //if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false { //this is crashing
         if DeveloperFlag.chatBubblesSimple.isOn {
             addReactions()
             addToolbox()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -112,7 +112,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
 
     private let userSession: UserSession
     private let privateDefaults: PrivateUserDefaults<CollapseKey>
-    private var isChatBubbleSimpleEnabled: Bool = false
+    private let isChatBubbleSimpleEnabled: Bool
 
     /// width of a container view to calculate whether message should be collapsed
     var contentWidth: CGFloat
@@ -144,6 +144,10 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
             storage: userDefaults
         )
 
+        // We need to provide isChatBubbleEnabled as Bool on init() because can't use
+        // UserSession.isChatBubbleSimpleEnabled here.It will crash because we are on the background thread.
+        self.isChatBubbleSimpleEnabled = isChatBubbleSimpleEnabled
+
         super.init()
 
         self.isCollapsed = isCollapsedInitialValue()
@@ -155,10 +159,6 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
         if let quotedMessage = message.textMessageData?.quoteMessage {
             startObservingChanges(for: quotedMessage)
         }
-
-        // We need to provide isChatBubbleEnabled as Bool on init() because can't use
-        // UserSession.isChatBubbleSimpleEnabled here.It will crash because we are on the background thread.
-        self.isChatBubbleSimpleEnabled = isChatBubbleSimpleEnabled
     }
 
     private var collapseOwnMessagesEnabled: Bool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -21,6 +21,7 @@ import WireCommonComponents
 import WireDataModel
 import WireDesign
 import WireLinkPreview
+import WireSyncEngine
 
 final class ArticleView: UIView {
 
@@ -72,7 +73,7 @@ final class ArticleView: UIView {
     private func setupViews() {
         accessibilityElements = [imageView, messageLabel, authorLabel]
         backgroundColor = containerColor
-        layer.cornerRadius = if DeveloperFlag.chatBubblesSimple.isOn {
+        layer.cornerRadius = if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             4

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -418,7 +418,7 @@ final class MessageToolboxView: UIView {
             statusContainerView.isHidden = true
         }
     }
-    
+
     private var isChatBubbleSimpleEnabled: Bool {
         ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -208,7 +208,7 @@ final class MessageToolboxView: UIView {
             countdownLabel
         ].forEach(contentStack.addArrangedSubview)
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             [
                 contentStack,
                 messageFailureView
@@ -280,7 +280,7 @@ final class MessageToolboxView: UIView {
             countdownContainer.bottomAnchor.constraint(greaterThanOrEqualTo: countdownView.bottomAnchor)
         ])
 
-        if DeveloperFlag.chatBubblesSimple.isOn {
+        if isChatBubbleSimpleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             separatorView.translatesAutoresizingMaskIntoConstraints = false
@@ -417,6 +417,10 @@ final class MessageToolboxView: UIView {
         case nil:
             statusContainerView.isHidden = true
         }
+    }
+    
+    private var isChatBubbleSimpleEnabled: Bool {
+        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }
 
     // MARK: - Timer

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -105,6 +105,8 @@ final class ConversationTableViewDataSource: NSObject {
 
     private(set) var currentSections: [Section] = []
 
+    private var isChatBubbleSimpleEnabled: Bool = false
+
     /// calculate cell sections
     ///
     /// - Parameter forceRecalculate: true if force recreate cell with context check
@@ -269,7 +271,7 @@ final class ConversationTableViewDataSource: NSObject {
         actionResponder: MessageActionResponder,
         cellDelegate: ConversationMessageCellDelegate,
         userSession: UserSession,
-        getUserByIDUseCase: GetUserByIDUseCaseProtocol
+        getUserByIDUseCase: GetUserByIDUseCaseProtocol,
     ) {
         self.messageActionResponder = actionResponder
         self.conversationCellDelegate = cellDelegate
@@ -277,6 +279,7 @@ final class ConversationTableViewDataSource: NSObject {
         self.tableView = tableView
         self.userSession = userSession
         self.getUserByIDUseCase = getUserByIDUseCase
+        self.isChatBubbleSimpleEnabled = userSession.isChatBubbleSimpleEnabled
         super.init()
 
         tableView.dataSource = self
@@ -350,7 +353,8 @@ final class ConversationTableViewDataSource: NSObject {
             selected: message.isEqual(selectedMessage),
             userSession: userSession,
             useInvertedIndices: true,
-            contentWidth: contentWidth
+            contentWidth: contentWidth,
+            isChatBubbleSimpleEnabled: isChatBubbleSimpleEnabled
         )
         sectionController.cellDelegate = conversationCellDelegate
         sectionController.sectionDelegate = self

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -105,7 +105,7 @@ final class ConversationTableViewDataSource: NSObject {
 
     private(set) var currentSections: [Section] = []
 
-    private var isChatBubbleSimpleEnabled: Bool = false
+    private let isChatBubbleSimpleEnabled: Bool
 
     /// calculate cell sections
     ///


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19699" title="WPB-19699" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19699</a>  [iOS] Update cells to use Feature flag instead of Developer Flag only
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We need to update the code using DeveloperFlags.chatBubblesSimple.isOn for the recently added Feature Flag for Chat Bubbles.

Tha means adapting all the cells using that Developer flag. all adaptations were just changing one line except for ConversationMessageSectionController where implementation was a bit more complex and we needed to modify a bit UserSession adding an extra param for isChatBubblesSimpleEnabled.

### Testing

For Debug versions Chat Bubbles will show if ONE of the flags is ON (FeatureFlag from BE or local Developer Flag).

For Release versions Developer Flag will always be OFF, so Chat Bubbles will only show if Feature Flag from BE is enabled.

The Feature Flag from Backend for this feature is “chatBubbles”, added on V11.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
