### PR TITLE
fix: consumable notifications migration flag - WPB-19800

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -416,6 +416,7 @@ public final class ClientSessionComponent {
     public func consumableNotificationsMigrator() -> ConsumableNotificationsMigrator {
         ConsumableNotificationsMigrator(
             sync: incrementalSync,
+            featureConfigRepository: featureConfigRepository,
             userClientsAPI: userClientsAPI,
             userClientsLocalStore: userClientsLocalStore,
             apiVersion: apiVersion,

--- a/WireDomain/Sources/WireDomain/Synchronization/ConsumableNotificationsMigrator.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/ConsumableNotificationsMigrator.swift
@@ -28,9 +28,11 @@ public final class ConsumableNotificationsMigrator: ConsumableNotificationsMigra
     let userClientsLocalStore: UserClientsLocalStoreProtocol
     let userClientsAPI: UserClientsAPI
     var journal: JournalProtocol
-
+    let featureConfigRepository: FeatureConfigRepositoryProtocol
+    
     init(
         sync: SyncMigratorProtocol,
+        featureConfigRepository: FeatureConfigRepositoryProtocol,
         userClientsAPI: UserClientsAPI,
         userClientsLocalStore: UserClientsLocalStoreProtocol,
         apiVersion: WireNetwork.APIVersion,
@@ -41,15 +43,22 @@ public final class ConsumableNotificationsMigrator: ConsumableNotificationsMigra
         self.userClientsLocalStore = userClientsLocalStore
         self.journal = journal
         self.userClientsAPI = userClientsAPI
+        self.featureConfigRepository = featureConfigRepository
     }
 
     public enum Failure: Error {
         case apiVersionTooLow
         case missingClient
         case missingClientID
+        case featureConfigNotEnabled
     }
 
     public func migrate() async throws {
+        // 0)
+        guard await featureConfigRepository.isFeatureEnabled(.consumableNotifications) else {
+            throw Failure.featureConfigNotEnabled
+        }
+
         // 1) register consumable notifications capabilities
         guard apiVersion >= .v9 else {
             throw Failure.apiVersionTooLow

--- a/WireDomain/Sources/WireDomain/Synchronization/ConsumableNotificationsMigrator.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/ConsumableNotificationsMigrator.swift
@@ -29,7 +29,7 @@ public final class ConsumableNotificationsMigrator: ConsumableNotificationsMigra
     let userClientsAPI: UserClientsAPI
     var journal: JournalProtocol
     let featureConfigRepository: FeatureConfigRepositoryProtocol
-    
+
     init(
         sync: SyncMigratorProtocol,
         featureConfigRepository: FeatureConfigRepositoryProtocol,

--- a/WireDomain/Tests/WireDomainTests/Synchronization/ConsumableNotificationsMigratorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/ConsumableNotificationsMigratorTests.swift
@@ -27,6 +27,7 @@ final class ConsumableNotificationsMigratorTests: XCTestCase {
     var mockSync: MockSyncMigratorProtocol!
     var mockUserClientsAPI: MockUserClientsAPI!
     var mockLocalStore: MockUserClientsLocalStoreProtocol!
+    var mockFeatureConfigRepository: MockFeatureConfigRepositoryProtocol!
     var journal: JournalProtocol!
 
     enum Scaffolding {
@@ -39,10 +40,14 @@ final class ConsumableNotificationsMigratorTests: XCTestCase {
         mockSync = .init()
         mockUserClientsAPI = .init()
         mockLocalStore = .init()
+        mockFeatureConfigRepository = MockFeatureConfigRepositoryProtocol()
+        mockFeatureConfigRepository.isFeatureEnabled_MockValue = true
+
         journal = Journal(userID: Scaffolding.userID, storage: UserDefaults.temporary())
 
         sut = ConsumableNotificationsMigrator(
             sync: mockSync,
+            featureConfigRepository: mockFeatureConfigRepository,
             userClientsAPI: mockUserClientsAPI,
             userClientsLocalStore: mockLocalStore,
             apiVersion: .v9,
@@ -135,6 +140,7 @@ final class ConsumableNotificationsMigratorTests: XCTestCase {
         // GIVEN
         sut = ConsumableNotificationsMigrator(
             sync: mockSync,
+            featureConfigRepository: mockFeatureConfigRepository,
             userClientsAPI: mockUserClientsAPI,
             userClientsLocalStore: mockLocalStore,
             apiVersion: .v7,
@@ -145,6 +151,18 @@ final class ConsumableNotificationsMigratorTests: XCTestCase {
 
         // WHEN / THEN
         await XCTAssertThrowsErrorAsync(ConsumableNotificationsMigrator.Failure.apiVersionTooLow) {
+            try await self.sut.migrate()
+        }
+    }
+
+    func test_migrate_featureConfigDisabled_throws() async throws {
+        // GIVEN
+        mockFeatureConfigRepository.isFeatureEnabled_MockValue = false
+
+        mockSync.migrateFromIncrementalSyncV1_MockMethod = {}
+
+        // WHEN / THEN
+        await XCTAssertThrowsErrorAsync(ConsumableNotificationsMigrator.Failure.featureConfigNotEnabled) {
             try await self.sut.migrate()
         }
     }

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -211,9 +211,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
 
     func performIncrementalSync() async throws {
 
-        let isConsumableNotificationsEnabled = await featureConfigRepository.isFeatureEnabled(
-            .consumableNotifications
-        ) && journal[.isConsumableNotificationsEnabled]
+        let isConsumableNotificationsEnabled = journal[.isConsumableNotificationsEnabled]
 
         if isSyncV2Enabled {
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -647,7 +647,8 @@ public final class ZMUserSession: NSObject {
         let migrator = clientSessionComponent.consumableNotificationsMigrator()
         do {
             try await migrator.migrate()
-        } catch ConsumableNotificationsMigrator.Failure.apiVersionTooLow, ConsumableNotificationsMigrator.Failure.featureConfigNotEnabled {
+        } catch ConsumableNotificationsMigrator.Failure.apiVersionTooLow,
+            ConsumableNotificationsMigrator.Failure.featureConfigNotEnabled {
             // ignore error
         } catch {
             WireLogger.session.error("Failed to migrate to consumable-notifications: \(String(describing: error))")

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -647,7 +647,7 @@ public final class ZMUserSession: NSObject {
         let migrator = clientSessionComponent.consumableNotificationsMigrator()
         do {
             try await migrator.migrate()
-        } catch ConsumableNotificationsMigrator.Failure.apiVersionTooLow {
+        } catch ConsumableNotificationsMigrator.Failure.apiVersionTooLow, ConsumableNotificationsMigrator.Failure.featureConfigNotEnabled {
             // ignore error
         } catch {
             WireLogger.session.error("Failed to migrate to consumable-notifications: \(String(describing: error))")

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -637,11 +637,6 @@ public final class ZMUserSession: NSObject {
             throw ZMUserSessionError.selfClientNotReady
         }
 
-        let featureConfigRepository = clientSessionComponent.featureConfigRepository
-        guard await featureConfigRepository.isFeatureEnabled(
-            .consumableNotifications
-        ) else { return }
-
         guard !journal[.isConsumableNotificationsEnabled] else { return }
 
         let migrator = clientSessionComponent.consumableNotificationsMigrator()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19800" title="WPB-19800" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19800</a>  [iOS] Fix Edge clients with consumable notifications enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Right now, the few prod clients with consumable notifications on are broken because we check the backend feature config flag on main app incremental sync but not on NSE.

Solution:

Check the flag only on ConsumableNotificationsMigrator meaning that once a client has migrated to the new system it cannot go back. Further checks depend on the journal value.

### Testing

N/A

This should restore prod edge clients with consumable notifications on.


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
