### PR TITLE
fix: use ZMUSerSession.isChatBubbleEnabled in all cells - WPB-19740

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/ReplyRoundCornersView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/ReplyRoundCornersView.swift
@@ -47,7 +47,7 @@ final class ReplyRoundCornersView: UIControl {
     // MARK: Setup Subviews and Constraints
 
     private func setupSubviews() {
-        layer.cornerRadius = if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false {
+        layer.cornerRadius = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             8

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageToolboxCell.swift
@@ -132,7 +132,7 @@ final class ConversationMessageToolboxCellDescription: ConversationMessageCellDe
     weak var actionController: ConversationMessageActionController?
 
     let containsHighlightableContent: Bool = false
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     let accessibilityIdentifier: String? = "MessageToolbox"
     let accessibilityLabel: String? = nil

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -183,7 +183,7 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
             availabilityIndicatorView.bottomAnchor.constraint(equalTo: avatar.bottomAnchor, constant: 3)
         ])
 
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -275,10 +275,6 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
         return NSAttributedString(attachment: attachment)
     }
 
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    }
-
     // MARK: - Tap gesture of avatar
 
     @objc
@@ -311,7 +307,7 @@ final class ConversationSenderMessageCellDescription: ConversationMessageCellDes
     weak var actionController: ConversationMessageActionController?
 
     let containsHighlightableContent: Bool = false
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
     let accessibilityIdentifier: String? = nil
     var accessibilityLabel: String?
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
@@ -56,7 +56,7 @@ final class MessageReactionsCell: UIView, ConversationMessageCell {
     )
 
     private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+        ZMUserSession.isChatBubbleEnabled
     }
 
     // MARK: - Life cycle

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCellDescription.swift
@@ -29,7 +29,7 @@ final class MessageReactionsCellDescription: ConversationMessageCellDescription 
     typealias View = MessageReactionsCell
     let configuration: View.Configuration
 
-    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.isChatBubbleEnabled
 
     init(message: ZMConversationMessage) {
         self.message = message

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -57,7 +57,7 @@ final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubview() {
-        let cornerRadius: CGFloat = if isChatBubbleSimpleEnabled {
+        let cornerRadius: CGFloat = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -98,7 +98,7 @@ final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -138,10 +138,6 @@ final class ConversationAudioMessageCell: UIView, ConversationMessageCell {
     var selectionRect: CGRect {
         transferView.bounds
     }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    }
 }
 
 extension ConversationAudioMessageCell: TransferViewDelegate {
@@ -159,7 +155,7 @@ final class ConversationAudioMessageCellDescription: ConversationMessageCellDesc
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationImageMessageCell.swift
@@ -75,7 +75,7 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
     }
 
     private func configureView() {
-        containerView.layer.cornerRadius = if isChatBubbleSimpleEnabled {
+        containerView.layer.cornerRadius = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -121,7 +121,7 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
             widthConstraint!,
             heightConstraint!
         ])
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -187,10 +187,6 @@ final class ConversationImageMessageCell: UIView, ConversationMessageCell, Conte
             imageResourceView.layer.borderWidth = UIScreen.hairline
         }
     }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    }
 }
 
 final class ConversationImageMessageCellDescription: ConversationMessageCellDescription {
@@ -215,7 +211,7 @@ final class ConversationImageMessageCellDescription: ConversationMessageCellDesc
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
 
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     var accessibilityIdentifier: String? {
         configuration.isObfuscated ? "ObfuscatedImageCell" : "ImageCell"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationLocationMessageCell.swift
@@ -75,7 +75,7 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
 
     private func configureViews() {
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.layer.cornerRadius = if isChatBubbleSimpleEnabled {
+        containerView.layer.cornerRadius = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -115,7 +115,7 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
         addressLabel.translatesAutoresizingMaskIntoConstraints = false
 
         let margins = conversationHorizontalMargins
-        let containerInsets: UIEdgeInsets = isChatBubbleSimpleEnabled
+        let containerInsets: UIEdgeInsets = ZMUserSession.isChatBubbleEnabled
             ? .zero
             : UIEdgeInsets(top: 0, left: margins.left, bottom: 0, right: margins.right)
         containerView.fitIn(view: self, insets: containerInsets)
@@ -196,10 +196,6 @@ final class ConversationLocationMessageCell: UIView, ConversationMessageCell, Co
     private func openInMaps() {
         lastConfiguration?.location.openInMaps(with: mapView.region.span)
     }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    }
 }
 
 final class ConversationLocationMessageCellDescription: ConversationMessageCellDescription {
@@ -221,7 +217,7 @@ final class ConversationLocationMessageCellDescription: ConversationMessageCellD
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.isChatBubbleEnabled
 
     var accessibilityIdentifier: String? {
         configuration.isObfuscated ? "ObfuscatedLocationCell" : "LocationCell"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationPingCell.swift
@@ -158,7 +158,7 @@ final class ConversationPingCellDescription: ConversationMessageCellDescription 
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = false
-    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles = ZMUserSession.isChatBubbleEnabled
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -57,7 +57,7 @@ final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubview() {
-        let cornerRadius: CGFloat = if isChatBubbleSimpleEnabled {
+        let cornerRadius: CGFloat = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -99,7 +99,7 @@ final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -154,10 +154,6 @@ final class ConversationVideoMessageCell: UIView, ConversationMessageCell {
     var selectionRect: CGRect {
         transferView.bounds
     }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    }
 }
 
 extension ConversationVideoMessageCell: TransferViewDelegate {
@@ -174,7 +170,7 @@ final class ConversationVideoMessageCellDescription: ConversationMessageCellDesc
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationCollapsedMessageCell.swift
@@ -315,7 +315,7 @@ final class ConversationCollapsedMessageCell: UIView, ConversationMessageCell {
 
     private var isChatBubbleSimpleEnabled: Bool {
         // the additional DeveloperFlag check is needed for the snapshot test
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false || DeveloperFlag.chatBubblesSimple.isOn
+        ZMUserSession.isChatBubbleEnabled || DeveloperFlag.chatBubblesSimple.isOn
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationFileMessageCell.swift
@@ -56,7 +56,7 @@ final class ConversationFileMessageCell: UIView, ConversationMessageCell {
     }
 
     private func configureSubview() {
-        let cornerRadius: CGFloat = if isChatBubbleSimpleEnabled {
+        let cornerRadius: CGFloat = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             12
@@ -98,7 +98,7 @@ final class ConversationFileMessageCell: UIView, ConversationMessageCell {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
         ])
 
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -138,10 +138,6 @@ final class ConversationFileMessageCell: UIView, ConversationMessageCell {
     var selectionRect: CGRect {
         fileTransferView.bounds
     }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    }
 }
 
 extension ConversationFileMessageCell: TransferViewDelegate {
@@ -159,7 +155,7 @@ final class ConversationFileMessageCellDescription: ConversationMessageCellDescr
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkAttachmentCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkAttachmentCell.swift
@@ -97,7 +97,7 @@ final class ConversationLinkAttachmentCell: UIView, ConversationMessageCell, Hig
             widthConstraint
         ])
 
-        if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             NSLayoutConstraint.activate(existingConstraints)
@@ -181,7 +181,7 @@ final class ConversationLinkAttachmentCellDescription: ConversationMessageCellDe
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String? = nil

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationLinkPreviewArticleCell.swift
@@ -70,7 +70,7 @@ final class ConversationLinkPreviewArticleCell: UIView, ConversationMessageCell,
 
     private func configureConstraints() {
         let margins = conversationHorizontalMargins
-        let insets: UIEdgeInsets = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+        let insets: UIEdgeInsets = ZMUserSession.isChatBubbleEnabled
             ? .zero
             : UIEdgeInsets(top: 0, left: margins.left, bottom: 0, right: margins.right)
         articleView.fitIn(view: self, insets: insets)
@@ -129,7 +129,7 @@ final class ConversationLinkPreviewArticleCellDescription: ConversationMessageCe
 
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     var accessibilityIdentifier: String? {
         configuration.isObfuscated ? "ObfuscatedLinkPreviewCell" : "LinkPreviewCell"

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationQuoteCell.swift
@@ -325,7 +325,7 @@ final class ConversationReplyCell: UIView, ConversationMessageCell {
 
     private func configureConstraints() {
         let margins = conversationHorizontalMargins
-        let insets: UIEdgeInsets = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+        let insets: UIEdgeInsets = ZMUserSession.isChatBubbleEnabled
             ? .zero
             : UIEdgeInsets(top: 0, left: margins.left, bottom: 0, right: margins.right)
         container.fitIn(view: self, insets: insets)
@@ -353,7 +353,7 @@ final class ConversationReplyCellDescription: ConversationMessageCellDescription
 
     let supportsActions = false
     let containsHighlightableContent: Bool = true
-    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.isChatBubbleEnabled
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/ArticleView.swift
@@ -73,7 +73,7 @@ final class ArticleView: UIView {
     private func setupViews() {
         accessibilityElements = [imageView, messageLabel, authorLabel]
         backgroundColor = containerColor
-        layer.cornerRadius = if ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false {
+        layer.cornerRadius = if ZMUserSession.isChatBubbleEnabled {
             ConversationMessageContainerView.bubbleCornerRadius
         } else {
             4

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -208,7 +208,7 @@ final class MessageToolboxView: UIView {
             countdownLabel
         ].forEach(contentStack.addArrangedSubview)
 
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             [
                 contentStack,
                 messageFailureView
@@ -280,7 +280,7 @@ final class MessageToolboxView: UIView {
             countdownContainer.bottomAnchor.constraint(greaterThanOrEqualTo: countdownView.bottomAnchor)
         ])
 
-        if isChatBubbleSimpleEnabled {
+        if ZMUserSession.isChatBubbleEnabled {
             NSLayoutConstraint.activate(chatBubbleConstraints)
         } else {
             separatorView.translatesAutoresizingMaskIntoConstraints = false
@@ -417,10 +417,6 @@ final class MessageToolboxView: UIView {
         case nil:
             statusContainerView.isHidden = true
         }
-    }
-
-    private var isChatBubbleSimpleEnabled: Bool {
-        ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     }
 
     // MARK: - Timer


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19740" title="WPB-19740" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19740</a>  [iOS/iPad] App crashes on minimising keyboard on iPad
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

On iPad, when closing the keyboard the app was crashing sometimes. Could be related with certain cells types and the chatBubbles feature flag.

This PR try to fix the issue using the newly ZMUserSession extension to keep the feature flag value in an static var

When testing i think the type of messages that are on the chat are important. I saw the crash related with File type and Self Deletion type, but could be happening with other types.

Now all the cell types use ZMUserSession.isChatBubbleEnabled instead of ZMUserSession.shared()?.isChatBubbleSimpleEnabled

### Testing

Steps to replicate:
- Open group chat and make keyboard up
- Try to minimise the keyboard

App should not be crashing. Test with different types of cells

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
