### PR TITLE
fix: Adjusted reactions cell view maximum width if chatbubblesflag is on - WPB-19738

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
@@ -117,7 +117,8 @@ final class MessageReactionsCell: UIView, ConversationMessageCell {
         withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
         verticalFittingPriority: UILayoutPriority
     ) -> CGSize {
-        let insetsWidth = conversationHorizontalMargins.left + conversationHorizontalMargins.right + (isChatBubbleSimpleEnabled ? 48 : 0)
+        let insetsWidth = conversationHorizontalMargins.left + conversationHorizontalMargins
+            .right + (isChatBubbleSimpleEnabled ? 48 : 0)
         reactionsView.widthForCalculations = targetSize.width - insetsWidth
         reactionsView.setNeedsLayout()
         reactionsView.layoutIfNeeded()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/Reactions/MessageReactionsCell.swift
@@ -117,7 +117,7 @@ final class MessageReactionsCell: UIView, ConversationMessageCell {
         withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
         verticalFittingPriority: UILayoutPriority
     ) -> CGSize {
-        let insetsWidth = insets.left + insets.right
+        let insetsWidth = conversationHorizontalMargins.left + conversationHorizontalMargins.right + (isChatBubbleSimpleEnabled ? 48 : 0)
         reactionsView.widthForCalculations = targetSize.width - insetsWidth
         reactionsView.setNeedsLayout()
         reactionsView.layoutIfNeeded()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19738" title="WPB-19738" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19738</a>  [iOS] More reactions to a message doesn't show up
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Adjusted reactions cell view maximum width if chatbubblesflag is on

### Testing

Please find the screenshots before and after 
<img width="1179" height="2556" alt="Screenshot 2025-08-29 at 15 52 45" src="https://github.com/user-attachments/assets/ad713204-be26-4220-b597-a7a4f8a2dd1a" />
<img width="1179" height="2556" alt="Screenshot 2025-08-29 at 15 54 08" src="https://github.com/user-attachments/assets/43f12735-7cb7-4669-9292-b3fe4376f6a2" />


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
