### PR TITLE
fix: remove unnecessary call to updateDelegates - WPB-19740

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -75,14 +75,11 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
     private let useInvertedIndices: Bool
 
     /// The object that controls actions for the cell.
-    var actionController: ConversationMessageActionController? {
-        didSet { updateDelegates() }
-    }
+    var actionController: ConversationMessageActionController?
 
     /// The message that is being presented.
-    var message: ConversationMessage {
+    private(set) var message: ConversationMessage {
         didSet {
-            updateDelegates()
             changeObservers.removeAll()
             startObservingChanges(for: message)
         }
@@ -91,9 +88,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
     var selfUser: any UserType
 
     /// The delegate for cells injected by the list adapter.
-    weak var cellDelegate: ConversationMessageCellDelegate? {
-        didSet { updateDelegates() }
-    }
+    weak var cellDelegate: ConversationMessageCellDelegate?
 
     /// The object that receives informations from the section.
     weak var sectionDelegate: ConversationMessageSectionControllerDelegate?
@@ -500,7 +495,8 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
         self.cellDescriptions = cellDescriptions
     }
 
-    private func updateDelegates() {
+    func updateMessage(_ message: ConversationMessage) {
+        self.message = message
         actionController?.message = message
         cellDescriptions.forEach { cellDescription in
             cellDescription.message = message
@@ -512,7 +508,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
     func recreateCellDescriptions(in context: ConversationMessageContext) {
         self.context = context
         createCellDescriptions(in: context)
-        updateDelegates()
+        updateMessage(message)
     }
 
     func isBurstTimestampVisible(in context: ConversationMessageContext) -> Bool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -189,7 +189,7 @@ final class ConversationTableViewDataSource: NSObject {
                     // with data
                     if let managedID = (sectionController.message as? ZMMessage)?.objectID,
                        let mainThreadMessage = try? mainThreadContext.existingObject(with: managedID) as? ZMMessage {
-                        sectionController.message = mainThreadMessage
+                        sectionController.updateMessage(mainThreadMessage)
                     } else {
                         WireLogger.conversation
                             .debug(


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

On ConversationMessageSectionController we had a function updateDelegates() that was trying (sometimes) to update the message from the background thread. This was causing a crash.

Now we've updated the function so the naming is correct (updateMessage), it's getting the message as a parameter and i also remove the calls from the background thread that were not necessary and were causing the crash.

### Testing

- Open group chat and make keyboard up
- Try to minimise the keyboard

Expected - App shouldn’t crash

Also test with different type cells (text, self deleting, file, image, etc.) and in 1 to 1 chats.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
