### PR TITLE
fix: dark theme own messages black text color - WPB-19910

### DIFF
--- a/WireUI/Sources/WireDesign/Colors/SemanticColors.swift
+++ b/WireUI/Sources/WireDesign/Colors/SemanticColors.swift
@@ -284,7 +284,7 @@ public enum SemanticColors {
 
     public enum ChatBubble {
         public static let backgroundOtherMessage = UIColor(light: .gray30, dark: .gray100)
-        public static let foregroundOwnMessage = UIColor(light: .white, dark: .black)
+        public static let foregroundOwnMessage = UIColor(light: .white, dark: .white)
         public static let foregroundOtherMessage = UIColor(light: .black, dark: .white)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19910" title="WPB-19910" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19910</a>  [iOS] Dark theme own messages black text color
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

In dark theme the own messages text color is black an contrast-wise not good readable. Change own font color from black to white

<img width="1179" height="2556" alt="Screenshot 2025-09-01 at 15 01 01" src="https://github.com/user-attachments/assets/03e9b2c7-ae5a-4aaf-97ad-082565cdfa32" />


### Testing

It must be white as shown in attached screenshot
<img width="1179" height="2556" alt="Screenshot 2025-09-01 at 14 58 19" src="https://github.com/user-attachments/assets/e1f12b08-edc0-4981-a2ea-ccb389b1b0a6" />


_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
