### PR TITLE
fix: Offline message error message width to small - WPB-19912

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -251,7 +251,7 @@ final class MessageToolboxView: UIView {
             contentStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             messageFailureView.leadingAnchor.constraint(equalTo: leadingAnchor),
             messageFailureView.trailingAnchor.constraint(
-                equalTo: trailingAnchor
+                lessThanOrEqualTo: trailingAnchor
             )
         ]
 
@@ -363,13 +363,9 @@ final class MessageToolboxView: UIView {
 
         case let .sendFailure(detailsString):
             hideAndCleanStatusLabel()
-            statusSeparatorContainer.isHidden = true
-            countdownContainer.isHidden = true
-            countdownLabel.isHidden = true
-            timestampSeparatorContainer.isHidden = false
+            setAllContentHidden()
             messageFailureView.isHidden = false
             messageFailureView.setTitle(detailsString)
-            editedLabel.isHidden = true
 
         case let .details(timestamp, state, countdown):
             detailsLabel.text = timestamp

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -251,7 +251,7 @@ final class MessageToolboxView: UIView {
             contentStack.trailingAnchor.constraint(equalTo: trailingAnchor),
             messageFailureView.leadingAnchor.constraint(equalTo: leadingAnchor),
             messageFailureView.trailingAnchor.constraint(
-                lessThanOrEqualTo: trailingAnchor
+                equalTo: trailingAnchor
             )
         ]
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19912" title="WPB-19912" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19912</a>  [iOS] Offline message error message width to small
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…showing messageFailureView"

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Hided Content stack containing detailsLabel, timestampSeparatorContainer, editedLabel,statusContainerView,  statusSeparatorContainer, countdownContainer, countdownLabel when showing messageFailureView

### Testing

Please find before and after screenshots

<img width="1170" height="2532" alt="Image_20250901_152230_359" src="https://github.com/user-attachments/assets/2a075a7c-b673-4619-9efa-3a5f6ee70e44" />
<img width="1179" height="2556" alt="Screenshot 2025-09-02 at 17 42 34" src="https://github.com/user-attachments/assets/f2915476-697b-4d8b-a8aa-64a062010014" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
