### PR TITLE
fix: Unable to tap user avatar to show profile - WPB-19923

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -312,7 +312,7 @@ final class ConversationSenderMessageCellDescription: ConversationMessageCellDes
 
     let containsHighlightableContent: Bool = false
     lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    lazy var isCellAlreadyAligned: Bool = true
+    let isCellAlreadyAligned: Bool = true
 
     let accessibilityIdentifier: String? = nil
     var accessibilityLabel: String?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -313,7 +313,7 @@ final class ConversationSenderMessageCellDescription: ConversationMessageCellDes
     let containsHighlightableContent: Bool = false
     lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
     lazy var isAlreadyAlignedInsideCell: Bool = true
-    
+
     let accessibilityIdentifier: String? = nil
     var accessibilityLabel: String?
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -160,7 +160,7 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
         ]
 
         let chatBubbleConstraints = [
-            avatar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
+            avatar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20.0),
             authorLabel.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: 12),
             authorLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         ]
@@ -312,7 +312,7 @@ final class ConversationSenderMessageCellDescription: ConversationMessageCellDes
 
     let containsHighlightableContent: Bool = false
     lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
-    lazy var isAlreadyAlignedInsideCell: Bool = true
+    lazy var isCellAlreadyAligned: Bool = true
 
     let accessibilityIdentifier: String? = nil
     var accessibilityLabel: String?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSenderMessageDetailsCell.swift
@@ -160,7 +160,7 @@ final class ConversationSenderMessageDetailsCell: UIView, ConversationMessageCel
         ]
 
         let chatBubbleConstraints = [
-            avatar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: -(24 + 12)),
+            avatar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
             authorLabel.leadingAnchor.constraint(equalTo: avatar.trailingAnchor, constant: 12),
             authorLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         ]
@@ -312,6 +312,8 @@ final class ConversationSenderMessageCellDescription: ConversationMessageCellDes
 
     let containsHighlightableContent: Bool = false
     lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    lazy var isAlreadyAlignedInsideCell: Bool = true
+    
     let accessibilityIdentifier: String? = nil
     var accessibilityLabel: String?
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -160,7 +160,7 @@ protocol ConversationMessageCellDescription: AnyObject {
 
     /// Boolean to check for aligning message content for Bubbles
     var shouldAlignMessageContentForBubbles: Bool { get }
-    
+
     /// Boolean to check if isAlreadyAlignedinsideCell
     var isCellAlreadyAligned: Bool { get }
 
@@ -207,7 +207,7 @@ extension ConversationMessageCellDescription {
     var shouldAlignMessageContentForBubbles: Bool {
         false
     }
-    
+
     var isCellAlreadyAligned: Bool {
         false
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -161,7 +161,7 @@ protocol ConversationMessageCellDescription: AnyObject {
     /// Boolean to check for aligning message content for Bubbles
     var shouldAlignMessageContentForBubbles: Bool { get }
 
-    /// Boolean to check if isAlreadyAlignedinsideCell
+    /// Boolean to check if isCellAlreadyAligned
     var isCellAlreadyAligned: Bool { get }
 
     /// The message that is displayed.

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -160,6 +160,9 @@ protocol ConversationMessageCellDescription: AnyObject {
 
     /// Boolean to check for aligning message content for Bubbles
     var shouldAlignMessageContentForBubbles: Bool { get }
+    
+    /// Boolean to check if isAlreadyAlignedinsideCell
+    var isCellAlreadyAligned: Bool { get }
 
     /// The message that is displayed.
     var message: ZMConversationMessage? { get set }
@@ -202,6 +205,10 @@ extension ConversationMessageCellDescription {
     }
 
     var shouldAlignMessageContentForBubbles: Bool {
+        false
+    }
+    
+    var isCellAlreadyAligned: Bool {
         false
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -55,6 +55,7 @@ final class ConversationMessageCellTableViewAdapter<
     private var existingHorizontalConstraints: [NSLayoutConstraint] = []
     private var ownMessagesHorizontalConstraints: [NSLayoutConstraint] = []
     private var othersMessagesHorizontalConstraints: [NSLayoutConstraint] = []
+    private var othersMessagesLeadingConstraint: NSLayoutConstraint!
 
     private var longPressGesture: UILongPressGestureRecognizer!
     private var doubleTapGesture: UITapGestureRecognizer!
@@ -91,11 +92,13 @@ final class ConversationMessageCellTableViewAdapter<
                 constant: -conversationHorizontalMargins.right
             )
         ]
+        
+        self.othersMessagesLeadingConstraint = cellView.leadingAnchor.constraint(
+                   equalTo: contentView.leadingAnchor,
+                   constant: conversationHorizontalMargins.left
+               )
         self.othersMessagesHorizontalConstraints = [
-            cellView.leadingAnchor.constraint(
-                equalTo: contentView.leadingAnchor,
-                constant: conversationHorizontalMargins.left
-            ),
+            othersMessagesLeadingConstraint,
             cellView.trailingAnchor.constraint(
                 lessThanOrEqualTo: contentView.trailingAnchor,
                 constant: -conversationHorizontalMargins.chatBubbleMinimumTrailing
@@ -144,12 +147,19 @@ final class ConversationMessageCellTableViewAdapter<
                 NSLayoutConstraint.activate(ownMessagesHorizontalConstraints)
             } else {
                 // Left-align the bubble content
+                let otherMessageLeadingConstant = isCellAlreadyAligned() ? 0 : conversationHorizontalMargins.left
+                othersMessagesLeadingConstraint.constant = otherMessageLeadingConstant
                 NSLayoutConstraint.activate(othersMessagesHorizontalConstraints)
             }
         } else {
             setupExistingLayout()
         }
         setNeedsLayout()
+    }
+    
+    private func isCellAlreadyAligned() -> Bool {
+        guard let cellDescription else { return false }
+        return cellDescription.isCellAlreadyAligned
     }
 
     private func setupExistingLayout() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -92,11 +92,11 @@ final class ConversationMessageCellTableViewAdapter<
                 constant: -conversationHorizontalMargins.right
             )
         ]
-        
+
         self.othersMessagesLeadingConstraint = cellView.leadingAnchor.constraint(
-                   equalTo: contentView.leadingAnchor,
-                   constant: conversationHorizontalMargins.left
-               )
+            equalTo: contentView.leadingAnchor,
+            constant: conversationHorizontalMargins.left
+        )
         self.othersMessagesHorizontalConstraints = [
             othersMessagesLeadingConstraint,
             cellView.trailingAnchor.constraint(
@@ -156,7 +156,7 @@ final class ConversationMessageCellTableViewAdapter<
         }
         setNeedsLayout()
     }
-    
+
     private func isCellAlreadyAligned() -> Bool {
         guard let cellDescription else { return false }
         return cellDescription.isCellAlreadyAligned


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19923" title="WPB-19923" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19923</a>  [iOS] Unable to tap user avatar to show profile
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Problem is with ConversationSenderMessageDetailsCell: tappedOnAvatar is never called

avatar.leadingAnchor.constraint(equalTo: leadingAnchor, constant: -(24 + 12)) pushes the avatar 36 points to the left, outside the frame of its superview. Even if the avatar is visually displayed (because the cell's clipsToBounds property might be false), the touch system will ignore any taps that occur outside the parent's frame.

So aligned it with in ConversationSenderMessageDetailsCell and added flag isAlreadyAlignedInsideCell so that again it is not aligned in ConversationMessageCellTableViewAdapter

### Testing

Avatar must be tappable now like before

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
