### PR TITLE
fix: set accent color for .selected IconButton state - WPB-19908

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
@@ -55,11 +55,13 @@ extension IconButton {
             accessibilityId: "sendButton",
             backgroundColor: [
                 UIControl.State.normal.rawValue: UIColor.accent(),
+                UIControl.State.selected.rawValue: UIColor.accent(),
                 UIControl.State.highlighted.rawValue: UIColor.accentDarken,
                 UIControl.State.disabled.rawValue: SemanticColors.Button.backgroundSendDisabled
             ],
             iconColor: [
                 UIControl.State.normal.rawValue: sendButtonIconColor,
+                UIControl.State.selected.rawValue: sendButtonIconColor,
                 UIControl.State.highlighted.rawValue: sendButtonIconColor,
                 UIControl.State.disabled.rawValue: sendButtonIconColor
             ]


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

**I wasn't able to reproduce the issue, this PR is to make sure most usual button states have a background color defined so no default color is used. If you think the issue might be because of another reason or you think we don't need this update on Button state, don't hesitate to contact me**

---

Sometimes the send button from a chat is showing with the wrong background color, as if there was no color assign to the state and maybe using a default iOS color.

When checking the code the state ".selected" has no color assign and it could be that at some point the button is on that state.

### Testing

This is how it should show:
<img width="388" height="128" alt="Captura de pantalla 2025-09-04 a las 13 42 24" src="https://github.com/user-attachments/assets/cd07b4e0-60c1-4022-b241-c79fbfdd8a6d" />

This is how sometimes is showing up:
<img width="595" height="550" alt="image-20250901-133314" src="https://github.com/user-attachments/assets/3f1fa2be-3d8c-4e79-a5fb-bb0026e5c3be" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
