### PR TITLE
fix: Bubble width for video and voice memos to small - WPB-19913

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationAudioMessageCell.swift
@@ -160,6 +160,7 @@ final class ConversationAudioMessageCellDescription: ConversationMessageCellDesc
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
     lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    let isBubbleHasMaximumWidth: Bool = true
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationVideoMessageCell.swift
@@ -175,6 +175,7 @@ final class ConversationVideoMessageCellDescription: ConversationMessageCellDesc
     let supportsActions: Bool = true
     let containsHighlightableContent: Bool = true
     lazy var shouldAlignMessageContentForBubbles: Bool = ZMUserSession.shared()?.isChatBubbleSimpleEnabled ?? false
+    let isBubbleHasMaximumWidth: Bool = true
 
     weak var message: ZMConversationMessage? {
         didSet {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -164,6 +164,9 @@ protocol ConversationMessageCellDescription: AnyObject {
     /// Boolean to check if isCellAlreadyAligned
     var isCellAlreadyAligned: Bool { get }
 
+    /// Boolean to check if isBubbleHasMaximumWidth
+    var isBubbleHasMaximumWidth: Bool { get }
+
     /// The message that is displayed.
     var message: ZMConversationMessage? { get set }
 
@@ -209,6 +212,10 @@ extension ConversationMessageCellDescription {
     }
 
     var isCellAlreadyAligned: Bool {
+        false
+    }
+
+    var isBubbleHasMaximumWidth: Bool {
         false
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCellTableViewAdapter.swift
@@ -55,7 +55,6 @@ final class ConversationMessageCellTableViewAdapter<
     private var existingHorizontalConstraints: [NSLayoutConstraint] = []
     private var ownMessagesHorizontalConstraints: [NSLayoutConstraint] = []
     private var othersMessagesHorizontalConstraints: [NSLayoutConstraint] = []
-    private var othersMessagesLeadingConstraint: NSLayoutConstraint!
 
     private var longPressGesture: UILongPressGestureRecognizer!
     private var doubleTapGesture: UITapGestureRecognizer!
@@ -81,29 +80,6 @@ final class ConversationMessageCellTableViewAdapter<
         bottom.priority = UILayoutPriority(999)
 
         self.existingHorizontalConstraints = [leading, trailing]
-        self.ownMessagesHorizontalConstraints = [
-            cellView.leadingAnchor
-                .constraint(
-                    greaterThanOrEqualTo: contentView.leadingAnchor,
-                    constant: conversationHorizontalMargins.chatBubbleMinimumLeading
-                ),
-            cellView.trailingAnchor.constraint(
-                equalTo: contentView.trailingAnchor,
-                constant: -conversationHorizontalMargins.right
-            )
-        ]
-
-        self.othersMessagesLeadingConstraint = cellView.leadingAnchor.constraint(
-            equalTo: contentView.leadingAnchor,
-            constant: conversationHorizontalMargins.left
-        )
-        self.othersMessagesHorizontalConstraints = [
-            othersMessagesLeadingConstraint,
-            cellView.trailingAnchor.constraint(
-                lessThanOrEqualTo: contentView.trailingAnchor,
-                constant: -conversationHorizontalMargins.chatBubbleMinimumTrailing
-            )
-        ]
 
         NSLayoutConstraint.activate([
             top,
@@ -134,12 +110,62 @@ final class ConversationMessageCellTableViewAdapter<
         cellView.accessibilityIdentifier = cellDescription?.accessibilityIdentifier
         top.constant = cellDescription?.topMargin ?? 0
         bottom.constant = cellDescription?.bottomMargin ?? 0
+        configureChatBubbleConstraints()
+    }
 
+    private func configureChatBubbleConstraints() {
         // Deactivate all horizontal constraints before applying new ones.
         NSLayoutConstraint.deactivate(
             ownMessagesHorizontalConstraints +
                 othersMessagesHorizontalConstraints
         )
+        let othersMessagesLeadingConstraint = cellView.leadingAnchor.constraint(
+            equalTo: contentView.leadingAnchor,
+            constant: isCellAlreadyAligned() ? 0 : conversationHorizontalMargins.left
+        )
+
+        if isBubbleHasMaximumWidth() {
+            ownMessagesHorizontalConstraints = [
+                cellView.leadingAnchor
+                    .constraint(
+                        equalTo: contentView.leadingAnchor,
+                        constant: conversationHorizontalMargins.chatBubbleMinimumLeading
+                    ),
+                cellView.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor,
+                    constant: -conversationHorizontalMargins.right
+                )
+            ]
+
+            othersMessagesHorizontalConstraints = [
+                othersMessagesLeadingConstraint,
+                cellView.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor,
+                    constant: -conversationHorizontalMargins.chatBubbleMinimumTrailing
+                )
+            ]
+
+        } else {
+            ownMessagesHorizontalConstraints = [
+                cellView.leadingAnchor
+                    .constraint(
+                        greaterThanOrEqualTo: contentView.leadingAnchor,
+                        constant: conversationHorizontalMargins.chatBubbleMinimumLeading
+                    ),
+                cellView.trailingAnchor.constraint(
+                    equalTo: contentView.trailingAnchor,
+                    constant: -conversationHorizontalMargins.right
+                )
+            ]
+
+            othersMessagesHorizontalConstraints = [
+                othersMessagesLeadingConstraint,
+                cellView.trailingAnchor.constraint(
+                    lessThanOrEqualTo: contentView.trailingAnchor,
+                    constant: -conversationHorizontalMargins.chatBubbleMinimumTrailing
+                )
+            ]
+        }
 
         if cellDescription?.shouldAlignMessageContentForBubbles == true {
             if cellDescription?.message?.isSentBySelfUser == true {
@@ -147,8 +173,6 @@ final class ConversationMessageCellTableViewAdapter<
                 NSLayoutConstraint.activate(ownMessagesHorizontalConstraints)
             } else {
                 // Left-align the bubble content
-                let otherMessageLeadingConstant = isCellAlreadyAligned() ? 0 : conversationHorizontalMargins.left
-                othersMessagesLeadingConstraint.constant = otherMessageLeadingConstant
                 NSLayoutConstraint.activate(othersMessagesHorizontalConstraints)
             }
         } else {
@@ -160,6 +184,11 @@ final class ConversationMessageCellTableViewAdapter<
     private func isCellAlreadyAligned() -> Bool {
         guard let cellDescription else { return false }
         return cellDescription.isCellAlreadyAligned
+    }
+
+    private func isBubbleHasMaximumWidth() -> Bool {
+        guard let cellDescription else { return false }
+        return cellDescription.isBubbleHasMaximumWidth
     }
 
     private func setupExistingLayout() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19913" title="WPB-19913" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19913</a>  [iOS] Bubble width for video and voice memos to small
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Set Bubble width max for video and voice messages

<!--do not remove the jira markers to link tickets automatically -->


### Issue

- Requirement is to make Bubble width maximum for Audio and Video Messages
- Added a new flag  isBubbleHasMaximumWidth in cellDescription and assigned true only for audio and video type cells
- By checking above flag in ConversationMessageCellTableViewAdapter adjusted the constraints
- Refactored code to make it more understandable

### Testing

Attaching before and after screenshots
<img width="912" height="1556" alt="aa883bbf-2bee-47f5-a6e1-752e7ae4aad7" src="https://github.com/user-attachments/assets/0012ce11-a197-499c-a2e4-2f11824c19d0" />
<img width="1179" height="2556" alt="Screenshot 2025-09-05 at 15 40 11" src="https://github.com/user-attachments/assets/3b743a64-b368-476a-80d0-3fb7f91ed7b6" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
