### PR TITLE
fix: Create button is not get enabled after entering name - WPB-19888

### DIFF
--- a/WireUI/Sources/WireMoveToFolderUI/ViewControllers/FolderPickerHostingController.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/ViewControllers/FolderPickerHostingController.swift
@@ -35,7 +35,6 @@ public final class FolderPickerHostingController: UIHostingController<FolderPick
         self.conversationName = conversationName
         super.init(rootView: FolderPicker(
             viewModel: viewModel,
-            createFolderUseCase: createFolderUseCase,
             isContextMenuAllowed: isContextMenuAllowed,
             conversationName: conversationName
         ))

--- a/WireUI/Sources/WireMoveToFolderUI/ViewModels/FolderPickerViewModel.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/ViewModels/FolderPickerViewModel.swift
@@ -29,16 +29,20 @@ public final class FolderPickerViewModel: ObservableObject {
     private let directory: any FolderDirectoryTypeProtocol
     private let updateConversationFolderUseCase: any UpdateConversationFolderUseCaseProtocol
 
+    public let createFolderViewModel: CreateFolderViewModel
+
     // MARK: - Initialization
 
     public init(
         conversation: Conversation,
         directory: any FolderDirectoryTypeProtocol,
-        updateConversationFolderUseCase: any UpdateConversationFolderUseCaseProtocol
+        updateConversationFolderUseCase: any UpdateConversationFolderUseCaseProtocol,
+        createFolderUseCase: any CreateConversationFolderUseCaseProtocol
     ) {
         self.conversation = conversation
         self.directory = directory
         self.updateConversationFolderUseCase = updateConversationFolderUseCase
+        self.createFolderViewModel = CreateFolderViewModel(useCase: createFolderUseCase)
         loadFolders()
     }
 

--- a/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
@@ -39,8 +39,8 @@ public struct FolderPicker: View {
         self.isContextMenuAllowed = isContextMenuAllowed
         self.conversationName = conversationName
         self._createFolderViewModel = StateObject(
-                   wrappedValue: CreateFolderViewModel(useCase: createFolderUseCase)
-               )
+            wrappedValue: CreateFolderViewModel(useCase: createFolderUseCase)
+        )
     }
 
     public var body: some View {

--- a/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
@@ -23,24 +23,17 @@ import WireReusableUIComponents
 public struct FolderPicker: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var viewModel: FolderPickerViewModel
-    @StateObject private var createFolderViewModel: CreateFolderViewModel
-    private let createFolderUseCase: any CreateConversationFolderUseCaseProtocol
     private let isContextMenuAllowed: Bool
     let conversationName: String
 
     public init(
         viewModel: FolderPickerViewModel,
-        createFolderUseCase: any CreateConversationFolderUseCaseProtocol,
         isContextMenuAllowed: Bool,
         conversationName: String
     ) {
         self.viewModel = viewModel
-        self.createFolderUseCase = createFolderUseCase
         self.isContextMenuAllowed = isContextMenuAllowed
         self.conversationName = conversationName
-        self._createFolderViewModel = StateObject(
-            wrappedValue: CreateFolderViewModel(useCase: createFolderUseCase)
-        )
     }
 
     public var body: some View {
@@ -69,7 +62,7 @@ public struct FolderPicker: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink {
                         CreateFolder(
-                            viewModel: createFolderViewModel,
+                            viewModel: viewModel.createFolderViewModel,
                             conversationName: conversationName,
                             onFolderCreated: { [weak viewModel] createdFolder in
                                 guard let viewModel else { return }
@@ -133,9 +126,9 @@ public struct FolderPicker: View {
                     Folder(identifier: UUID(), name: "Personal")
                 ]
             ),
-            updateConversationFolderUseCase: PreviewMoveConversationToFolderUseCase()
+            updateConversationFolderUseCase: PreviewMoveConversationToFolderUseCase(),
+            createFolderUseCase: PreviewCreateConversationFolderUseCase()
         ),
-        createFolderUseCase: PreviewCreateConversationFolderUseCase(),
         isContextMenuAllowed: true,
         conversationName: "Test"
     )

--- a/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
@@ -23,6 +23,7 @@ import WireReusableUIComponents
 public struct FolderPicker: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var viewModel: FolderPickerViewModel
+    @StateObject private var createFolderViewModel: CreateFolderViewModel
     private let createFolderUseCase: any CreateConversationFolderUseCaseProtocol
     private let isContextMenuAllowed: Bool
     let conversationName: String
@@ -37,6 +38,9 @@ public struct FolderPicker: View {
         self.createFolderUseCase = createFolderUseCase
         self.isContextMenuAllowed = isContextMenuAllowed
         self.conversationName = conversationName
+        self._createFolderViewModel = StateObject(
+                   wrappedValue: CreateFolderViewModel(useCase: createFolderUseCase)
+               )
     }
 
     public var body: some View {
@@ -65,7 +69,7 @@ public struct FolderPicker: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink {
                         CreateFolder(
-                            viewModel: CreateFolderViewModel(useCase: createFolderUseCase),
+                            viewModel: createFolderViewModel,
                             conversationName: conversationName,
                             onFolderCreated: { [weak viewModel] createdFolder in
                                 guard let viewModel else { return }

--- a/WireUI/Tests/WireMoveToFolderUITests/FolderPickerViewModelTests.swift
+++ b/WireUI/Tests/WireMoveToFolderUITests/FolderPickerViewModelTests.swift
@@ -35,6 +35,7 @@ final class FolderPickerViewModelTests: XCTestCase {
     override func setUp() async throws {
         mockDirectory = MockFolderDirectoryTypeProtocol()
         mockUpdateFolderUseCase = MockUpdateConversationFolderUseCase()
+        mockCreateFolderUseCase = MockCreateConversationFolderUseCase()
     }
 
     // MARK: - tearDown
@@ -44,6 +45,7 @@ final class FolderPickerViewModelTests: XCTestCase {
         sut = nil
         mockDirectory = nil
         mockUpdateFolderUseCase = nil
+        mockCreateFolderUseCase = nil
     }
 
     // MARK: - Initialization
@@ -156,7 +158,8 @@ final class FolderPickerViewModelTests: XCTestCase {
         sut = FolderPickerViewModel(
             conversation: conversation,
             directory: mockDirectory,
-            updateConversationFolderUseCase: mockUpdateFolderUseCase, createFolderUseCase: mockCreateFolderUseCase
+            updateConversationFolderUseCase: mockUpdateFolderUseCase,
+            createFolderUseCase: mockCreateFolderUseCase
         )
     }
 }

--- a/WireUI/Tests/WireMoveToFolderUITests/FolderPickerViewModelTests.swift
+++ b/WireUI/Tests/WireMoveToFolderUITests/FolderPickerViewModelTests.swift
@@ -27,6 +27,7 @@ final class FolderPickerViewModelTests: XCTestCase {
     private var sut: FolderPickerViewModel!
     private var mockDirectory: MockFolderDirectoryTypeProtocol!
     private var mockUpdateFolderUseCase: MockUpdateConversationFolderUseCase!
+    private var mockCreateFolderUseCase: MockCreateConversationFolderUseCase!
 
     // MARK: - setUp
 
@@ -155,7 +156,7 @@ final class FolderPickerViewModelTests: XCTestCase {
         sut = FolderPickerViewModel(
             conversation: conversation,
             directory: mockDirectory,
-            updateConversationFolderUseCase: mockUpdateFolderUseCase
+            updateConversationFolderUseCase: mockUpdateFolderUseCase, createFolderUseCase: mockCreateFolderUseCase
         )
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Folders/FolderPickerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Folders/FolderPickerBuilder.swift
@@ -40,7 +40,8 @@ struct FolderPickerBuilder {
         let viewModel = FolderPickerViewModel(
             conversation: Conversation(conversation),
             directory: directoryMapper,
-            updateConversationFolderUseCase: useCase
+            updateConversationFolderUseCase: useCase,
+            createFolderUseCase: createConversationFolderUseCase
         )
 
         return FolderPickerHostingController(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19888" title="WPB-19888" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19888</a>  [iOS/iPad] Intermittently "create" button doesn't get enabled to create folder after entering the name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

…ject

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Create Button is disabled even after entering the Folder name 
<img width="1179" height="2556" alt="Screenshot 2025-09-05 at 17 08 29" src="https://github.com/user-attachments/assets/4717843d-2014-4ffb-9cc8-aca12d43d5f9" />

This is happening because FolderPicker view is creating creating a new, fresh instance of CreateFolderViewModel every time the user taps the navigation link.

Fix: We are creating the createFolderViewModel in the FolderPicker using @StateObject, it ensures that a single, persistent instance is created and then passed to the CreateFolder view. So that CreateFolder View will observe for the changes in same instance of CreateFolderViewModel.

### Testing

Create button must be enabled when user enters  folder name. It must work consistently every time in both iPhone and iPad

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
