### PR TITLE
fix: send message button flaky color - WPB-19908

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -219,7 +219,7 @@ class IconButton: ButtonWithLargerHitArea {
     ///   - state: UIControl state
     ///   - renderingMode: Default rendering mode is AlwaysTemplate
     ///   - force: force update
-    func setIcon(
+    private func setIcon(
         _ iconType: StyleKitIcon?,
         iconSize: CGFloat,
         for state: UIControl.State,

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/IconButton.swift
@@ -72,6 +72,7 @@ class IconButton: ButtonWithLargerHitArea {
 
     private var iconColorsByState: [UIControl.State.RawValue: UIColor] = [:]
     private var borderColorByState: [UIControl.State.RawValue: UIColor] = [:]
+    private var backgroundColorByState: [UIControl.State.RawValue: UIColor] = [:]
     private var iconDefinitionsByState: [UIControl.State.RawValue: IconDefinition] = [:]
     private var priorState: UIControl.State?
 
@@ -195,11 +196,8 @@ class IconButton: ButtonWithLargerHitArea {
         _ color: UIColor,
         for state: UIControl.State
     ) {
-        setBackgroundImage(UIImage.singlePixelImage(with: color), for: state)
-
-        if adjustBackgroundImageWhenHighlighted, state.contains(.normal) {
-            setBackgroundImage(UIImage.singlePixelImage(with: color.mix(UIColor.black, amount: 0.4)), for: .highlighted)
-        }
+        backgroundColorByState[state.rawValue] = color
+        updateBackgroundImageColor()
     }
 
     func setIcon(
@@ -294,12 +292,29 @@ class IconButton: ButtonWithLargerHitArea {
         borderColorByState[state.rawValue] ?? borderColorByState[UIControl.State.normal.rawValue]
     }
 
+    func backgroundColor(for state: UIControl.State) -> UIColor? {
+        backgroundColorByState[state.rawValue] ?? backgroundColorByState[UIControl.State.normal.rawValue]
+    }
+
     private func updateBorderColor() {
         layer.borderColor = borderColor(for: state)?.cgColor
     }
 
     func updateTintColor() {
         tintColor = iconColor(for: state)
+    }
+
+    private func updateBackgroundImageColor() {
+        if let color = backgroundColor(for: state)?.resolvedColor(with: traitCollection) {
+            setBackgroundImage(UIImage.singlePixelImage(with: color), for: state)
+
+            if adjustBackgroundImageWhenHighlighted, state.contains(.normal) {
+                setBackgroundImage(
+                    UIImage.singlePixelImage(with: color.mix(UIColor.black, amount: 0.4)),
+                    for: .highlighted
+                )
+            }
+        }
     }
 
     private func updateCircularCornerRadius() {
@@ -331,6 +346,7 @@ class IconButton: ButtonWithLargerHitArea {
         // Update for new state (selected, highlighted, disabled) here if needed
         updateTintColor()
         updateBorderColor()
+        updateBackgroundImageColor()
     }
 
     func icon(for state: UIControl.State) -> StyleKitIcon? {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+NavigationBar.swift
@@ -36,7 +36,7 @@ extension ConversationViewController {
     private var videoCallButton: UIButton {
         let button = UIButton(type: .system)
         button.setImage(UIImage(resource: .videoCall), for: .normal)
-        button.tintColor = IconColors.foregroundDefault
+        button.tintColor = IconColors.foregroundDefault.resolvedColor(with: traitCollection)
 
         button.accessibilityIdentifier = "videoCallBarButton"
         button.accessibilityTraits.insert(.startsMediaSession)
@@ -47,9 +47,9 @@ extension ConversationViewController {
         }
         button.addAction(videoCallAction, for: .touchUpInside)
 
-        button.backgroundColor = ButtonColors.backgroundBarItem
+        button.backgroundColor = ButtonColors.backgroundBarItem.resolvedColor(with: traitCollection)
         button.layer.borderWidth = 1
-        button.layer.borderColor = ButtonColors.borderBarItem.cgColor
+        button.layer.borderColor = ButtonColors.borderBarItem.resolvedColor(with: traitCollection).cgColor
         button.layer.cornerRadius = 12
 
         // Enable large content viewer

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
@@ -50,7 +50,7 @@ extension IconButton {
 
         let sendButtonIconColor = SemanticColors.Icon.foregroundDefaultWhite
 
-        return IconButton(
+        return .init(
             icon: .send,
             accessibilityId: "sendButton",
             backgroundColor: [

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/ProfileHeaderViewController.swift
@@ -395,12 +395,27 @@ final class ProfileHeaderViewController: UIViewController {
     }
 
     private func updateColors() {
-        qrCodeButton.setBorderColor(ColorTheme.Strokes.outline, for: .normal)
-        qrCodeButton.setBackgroundImageColor(ColorTheme.Backgrounds.surfaceVariant, for: .normal)
-        qrCodeButton.setIconColor(ColorTheme.Buttons.Secondary.onEnabled, for: .normal)
+        qrCodeButton.setBorderColor(
+            ColorTheme.Strokes.outline.resolvedColor(with: traitCollection),
+            for: .normal
+        )
+        qrCodeButton.setBackgroundImageColor(
+            ColorTheme.Backgrounds.surfaceVariant.resolvedColor(with: traitCollection),
+            for: .normal
+        )
+        qrCodeButton.setIconColor(
+            ColorTheme.Buttons.Secondary.onEnabled.resolvedColor(with: traitCollection),
+            for: .normal
+        )
 
-        qrCodeButton.setBorderColor(ColorTheme.Strokes.outline, for: .highlighted)
-        qrCodeButton.setBackgroundImageColor(ColorTheme.Backgrounds.background, for: .highlighted)
+        qrCodeButton.setBorderColor(
+            ColorTheme.Strokes.outline.resolvedColor(with: traitCollection),
+            for: .highlighted
+        )
+        qrCodeButton.setBackgroundImageColor(
+            ColorTheme.Backgrounds.background.resolvedColor(with: traitCollection),
+            for: .highlighted
+        )
     }
 
     private func qrCodeButtonTapped() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19908" title="WPB-19908" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19908</a>  [iOS] Send message button flaky colors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Send Button color on dark mode was not showing the correct color (accent color)

Screenshots with **incorrect** color:
<img width="393" height="852" alt="Simulator Screenshot - iPhone 16 - 2025-09-05 at 14 01 49" src="https://github.com/user-attachments/assets/95b2c480-07f0-41ce-97cb-f80ece820b12" />
<img width="393" height="852" alt="Simulator Screenshot - iPhone 16 - 2025-09-08 at 09 51 29" src="https://github.com/user-attachments/assets/dbe040fb-0206-4779-9103-23a0875e318d" />

Video with the **correct** color:

https://github.com/user-attachments/assets/f558053a-44d1-4c8e-a2c0-5f2e37f6308e

### Testing

- Open any conversation
- Type some text on the text input
- Send color should show using Accent color (profile user color)

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
