### PR TITLE
fix: retry button positioning need to be corrected - WPB-20095

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageSendFailureView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageSendFailureView.swift
@@ -80,7 +80,6 @@ final class MessageSendFailureView: UIView {
             stackView.spacing = 15
             [titleLabel, retryButton].forEach(stackView.addArrangedSubview)
         }
-        stackView.spacing = 8
 
         retryButton.translatesAutoresizingMaskIntoConstraints = false
         retryButton.setTitle(L10n.Localizable.Content.System.FailedtosendMessage.retry, for: .normal)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageSendFailureView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageSendFailureView.swift
@@ -77,6 +77,7 @@ final class MessageSendFailureView: UIView {
             setupViewsWithChatBubble()
         } else {
             stackView.alignment = .leading
+            stackView.spacing = 15
             [titleLabel, retryButton].forEach(stackView.addArrangedSubview)
         }
         stackView.spacing = 8
@@ -90,6 +91,7 @@ final class MessageSendFailureView: UIView {
     }
 
     private func setupViewsWithChatBubble() {
+        stackView.spacing = 8
         buttonContainer.translatesAutoresizingMaskIntoConstraints = false
         buttonContainer.addSubview(retryButton)
         [titleLabel, buttonContainer].forEach(stackView.addArrangedSubview)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageSendFailureView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageSendFailureView.swift
@@ -41,9 +41,16 @@ final class MessageSendFailureView: UIView {
         insets: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
     )
 
+    private var isChatBubbleSimpleEnabled: Bool
+    private var buttonContainer = UIView()
+
     // MARK: - initialization
 
-    override init(frame: CGRect) {
+    init(
+        frame: CGRect = .zero,
+        ischatBubbleSimpleEnabled: Bool = false
+    ) {
+        self.isChatBubbleSimpleEnabled = ischatBubbleSimpleEnabled
         super.init(frame: CGRect.zero)
 
         setupViews()
@@ -58,19 +65,34 @@ final class MessageSendFailureView: UIView {
 
     func setTitle(_ errorMessage: String) {
         titleLabel.attributedText = .markdown(from: errorMessage, style: .errorLabelStyle)
+        if isChatBubbleSimpleEnabled {
+            titleLabel.textAlignment = .right
+        }
     }
 
     private func setupViews() {
         addSubview(stackView)
 
-        stackView.alignment = .leading
-        stackView.spacing = 15
-        [titleLabel, retryButton].forEach(stackView.addArrangedSubview)
+        if isChatBubbleSimpleEnabled {
+            setupViewsWithChatBubble()
+        } else {
+            stackView.alignment = .leading
+            [titleLabel, retryButton].forEach(stackView.addArrangedSubview)
+        }
+        stackView.spacing = 8
+
+        retryButton.translatesAutoresizingMaskIntoConstraints = false
         retryButton.setTitle(L10n.Localizable.Content.System.FailedtosendMessage.retry, for: .normal)
         retryButton.addTarget(self, action: #selector(retryButtonTapped), for: .touchUpInside)
 
         setupConstraints()
         setupAccessibility()
+    }
+
+    private func setupViewsWithChatBubble() {
+        buttonContainer.translatesAutoresizingMaskIntoConstraints = false
+        buttonContainer.addSubview(retryButton)
+        [titleLabel, buttonContainer].forEach(stackView.addArrangedSubview)
     }
 
     private func setupAccessibility() {
@@ -80,12 +102,27 @@ final class MessageSendFailureView: UIView {
 
     private func setupConstraints() {
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
+
+        if isChatBubbleSimpleEnabled {
+            NSLayoutConstraint.activate([
+                stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10.0),
+                stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10.0),
+                stackView.topAnchor.constraint(equalTo: topAnchor),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8.0),
+
+                retryButton.topAnchor.constraint(equalTo: buttonContainer.topAnchor),
+                retryButton.bottomAnchor.constraint(equalTo: buttonContainer.bottomAnchor),
+                retryButton.trailingAnchor.constraint(equalTo: buttonContainer.trailingAnchor),
+                retryButton.leadingAnchor.constraint(greaterThanOrEqualTo: buttonContainer.leadingAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                stackView.topAnchor.constraint(equalTo: topAnchor),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
+        }
     }
 
     // MARK: - Methods

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/Utility/MessageToolboxView.swift
@@ -104,7 +104,14 @@ final class MessageToolboxView: UIView {
     private let timestampSeparatorLabel = UILabel.createSeparatorLabel()
     private let statusSeparatorContainer = UIView()
     private let statusSeparatorLabel = UILabel.createSeparatorLabel()
-    private let messageFailureView = MessageSendFailureView()
+
+    private lazy var messageFailureView: MessageSendFailureView = {
+        let view = MessageSendFailureView(ischatBubbleSimpleEnabled: isChatBubbleSimpleEnabled)
+        view.tapHandler = { [weak self] _ in
+            self?.resendMessage()
+        }
+        return view
+    }()
 
     private lazy var statusLabel: UILabel = {
         let label = UILabel()
@@ -193,10 +200,6 @@ final class MessageToolboxView: UIView {
         countdownContainer = UIView()
         countdownView.translatesAutoresizingMaskIntoConstraints = false
         countdownContainer.addSubview(countdownView)
-
-        messageFailureView.tapHandler = { [weak self] _ in
-            self?.resendMessage()
-        }
 
         [
             detailsLabel,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20095" title="WPB-20095" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20095</a>  [iOS] Retry button positioning need to be corrected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We need to align retry button to right and adjust the padding as mentioned in figma. The multiline error message must be aligned to right
<img width="297" height="356" alt="Screenshot 2025-09-09 at 22 29 55" src="https://github.com/user-attachments/assets/60a6d0af-4022-4296-8fbe-1cdd844dce7b" />


fix: Added padding to MessageSenderFailiureView by checking SimpleChatBubble falg



### Testing

Screenshot before and after changes 
<img width="1179" height="2556" alt="Screenshot 2025-09-09 at 22 33 27" src="https://github.com/user-attachments/assets/97dd02f1-ee3e-434a-afd8-8c29e644c1b7" />
<img width="1179" height="2556" alt="Screenshot 2025-09-09 at 22 16 41" src="https://github.com/user-attachments/assets/b03ab282-e9c0-45e4-9f6d-f40a2c7827fe" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
