### PR TITLE
fix: create folder button not enabled - WPB-19888

### DIFF
--- a/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
+++ b/WireUI/Sources/WireMoveToFolderUI/Views/FolderPicker/FolderPicker.swift
@@ -23,6 +23,7 @@ import WireReusableUIComponents
 public struct FolderPicker: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var viewModel: FolderPickerViewModel
+    @StateObject private var createFolderViewModel: CreateFolderViewModel
     private let createFolderUseCase: any CreateConversationFolderUseCaseProtocol
     private let isContextMenuAllowed: Bool
     let conversationName: String
@@ -37,6 +38,9 @@ public struct FolderPicker: View {
         self.createFolderUseCase = createFolderUseCase
         self.isContextMenuAllowed = isContextMenuAllowed
         self.conversationName = conversationName
+        self._createFolderViewModel = StateObject(
+            wrappedValue: CreateFolderViewModel(useCase: createFolderUseCase)
+        )
     }
 
     public var body: some View {
@@ -65,7 +69,7 @@ public struct FolderPicker: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink {
                         CreateFolder(
-                            viewModel: CreateFolderViewModel(useCase: createFolderUseCase),
+                            viewModel: createFolderViewModel,
                             conversationName: conversationName,
                             onFolderCreated: { [weak viewModel] createdFolder in
                                 guard let viewModel else { return }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19888" title="WPB-19888" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19888</a>  [iOS/iPad] Intermittently "create" button doesn't get enabled to create folder after entering the name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When opening FolderPicker, they were at least 2 instance creations of CreateFolderViewModel. This was causing that sometimes "Create" folder button was not enabled when it should because default value for "canCreate" is false and not all instances were updated when textview text was updated.

To fix this issue CreateFolderViewModel was added as @StateObject and instanciated only once on FolderPicker.init().
This way we make sure there is only one instance of CreatefolderViewModel.

The issue is not consistenly reproducable but when debugging you CreateFolderViewModel.init() you can clearly see the difference between before and after the change (before 2-3 calls to .init(), now only 1 call)

### Testing

Is not consistenly reproducable but the steps to replicate should be:
- Long press on a chat and choose "Move to..." from context menu
- Tap + on top right of page window
- Enter folder name, delete it, enter it again... > Observe create button enabled or not

At some point before it was broken and button was disabled even when textview had text. Now should be fix.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
