### PR TITLE
fix: unable to switch to multibackend on iPad - WPB-20246

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+SwitchBackend.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+SwitchBackend.swift
@@ -28,7 +28,7 @@ public extension SessionManager {
     typealias CompletedSwitch = (Result<BackendEnvironment, Error>) -> Void
 
     func canSwitchBackend() -> SwitchBackendError? {
-        guard !accountManager.hasAccounts else {
+        guard DeveloperFlag.multibackend.isOn || !accountManager.hasAccounts else {
             return .loggedInAccounts
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20246" title="WPB-20246" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20246</a>  [iOS/iPad] Not able to switch backend on iPad
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
On iPad, when the multibackend flag is enabled and trying to add a second account on a different backend, there is an error alert preventing the switch to a different backend.

The cause is a check to prevent switching when there is an existing account that doesn't get bypassed when the multibackend flag is enabled. It appears that this check is not run on iPhone (there's another check in the WireAuthentication module, but only on iPad.

### Testing
1. Be on iPad, enabled multibackend developer flag
2. Log in to one account
3. Start to add a second account, switch to another backend
4. Assert you can switch and log in to the second account.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
