### PR TITLE
chore: disable consumable-notifications - WPB-19761

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -56,7 +56,7 @@ extension UserClientRequestFactory {
 
         let isConsumableNotificationsEnabled = featureConfigRepository
             .fetchConsumableNotifications()
-            .status == .enabled
+            .status == .enabled && DeveloperFlag.consumableNotifications.isEnabled
 
         if isConsumableNotificationsEnabled, apiVersion >= .v9 {
             capabilities.append("consumable-notifications")
@@ -193,7 +193,7 @@ extension UserClientRequestFactory {
 
         let isConsumableNotificationsEnabled = featureConfigRepository
             .fetchConsumableNotifications()
-            .status == .enabled
+            .status == .enabled && DeveloperFlag.consumableNotifications.isOn
 
         var capabilities = ["legalhold-implicit-consent"]
         if isConsumableNotificationsEnabled {

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestFactory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserClientRequestFactory.swift
@@ -56,7 +56,7 @@ extension UserClientRequestFactory {
 
         let isConsumableNotificationsEnabled = featureConfigRepository
             .fetchConsumableNotifications()
-            .status == .enabled && DeveloperFlag.consumableNotifications.isEnabled
+            .status == .enabled && DeveloperFlag.consumableNotifications.isOn
 
         if isConsumableNotificationsEnabled, apiVersion >= .v9 {
             capabilities.append("consumable-notifications")

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -640,7 +640,7 @@ public final class ZMUserSession: NSObject {
         let featureConfigRepository = clientSessionComponent.featureConfigRepository
         guard await featureConfigRepository.isFeatureEnabled(
             .consumableNotifications
-        ) else { return }
+        ), DeveloperFlag.consumableNotifications.isOn else { return }
 
         guard !journal[.isConsumableNotificationsEnabled] else { return }
 

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -74,7 +74,7 @@ final class UserClientRequestFactoryTests: MessagingTest {
             }
         }
         DeveloperFlag.consumableNotifications.enable(true, storage: .temporary())
-        
+
         try testThatItCreatesRegistrationRequestCorrectly(
             credentials: credentials,
             usingProteusService: true,

--- a/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/E2EE/UserClientRequestFactoryTests.swift
@@ -73,7 +73,8 @@ final class UserClientRequestFactoryTests: MessagingTest {
                 $0.status = .enabled
             }
         }
-
+        DeveloperFlag.consumableNotifications.enable(true, storage: .temporary())
+        
         try testThatItCreatesRegistrationRequestCorrectly(
             credentials: credentials,
             usingProteusService: true,
@@ -184,7 +185,7 @@ final class UserClientRequestFactoryTests: MessagingTest {
 
         let isConsumableNotificationsEnabled = syncMOC.performAndWait {
             Feature.fetch(name: .consumableNotifications, context: syncMOC)?.status == .enabled
-        }
+        } && DeveloperFlag.consumableNotifications.isOn
 
         if apiVersion >= .v9, isConsumableNotificationsEnabled {
             XCTAssertEqual(payload.capabilities, ["legalhold-implicit-consent", "consumable-notifications"])

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -41,6 +41,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case channelsHistory
     case chatBubbles
     case chatBubblesSimple
+    case consumableNotifications
 
     public var description: String {
         switch self {
@@ -100,6 +101,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .chatBubblesSimple:
             "Turn on the simplified version of chat bubbles"
+
+        case .consumableNotifications:
+            "Turn on to enable consumable notifications"
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19761" title="WPB-19761" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19761</a>  Manage release iOS 4.5
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Disable async notifications for the release 4.5. 

Adds a DeveloperFlag on the migrator and the capabalities so neither new or existing clients can use it

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
