### PR TITLE
fix: Update the ChatBubble background color when the accentColor changed from different clients - WPB-20325

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -145,7 +145,15 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
         accessibilityLabel = messageTextView.attributedText.string
 
         container?.isBubble = isChatBubbleSimpleEnabled
+        updateContainerStyle()
         configureTextColor(forOwnMessage: message?.isSentBySelfUser ?? false)
+    }
+    
+    private func updateContainerStyle() {
+        guard let message, isChatBubbleSimpleEnabled else { return }
+        let isOwnMessage = message.isSentBySelfUser
+        let userColor = message.senderUser?.accentColor ?? .clear
+        container?.bubbleStyle = isOwnMessage ? .ownMessage(userColor: userColor) : .otherMessage
     }
 
     func textView(_ textView: LinkInteractionTextView, open url: URL) -> Bool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -148,7 +148,7 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
         updateContainerStyle()
         configureTextColor(forOwnMessage: message?.isSentBySelfUser ?? false)
     }
-    
+
     private func updateContainerStyle() {
         guard let message, isChatBubbleSimpleEnabled else { return }
         let isOwnMessage = message.isSentBySelfUser


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20325" title="WPB-20325" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20325</a>  Update the ChatBubble background color when the accentColor changed from different clients(web,iOS)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

ChatBubble background color in iOS is not updated  immediately when the accent Color is changed from different client (ex:Web ). It is only updated after refresh of the page

Update container background color inside configure function of cell. Wheneve accent color is changed from any client configure function is triggered, so updated background color here

### Testing

Change user accesnt color from web and that must be in sync with iOS client. Visually iOS client chat bubble color must immediately change
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
