### PR TITLE
feat: add multibackend support for legacy NSE - WPB-20365

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEFlow.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEFlow.swift
@@ -80,7 +80,7 @@ final class NSEFlow: BootstrapComponent {
         contentHandler: @escaping (UNNotificationContent) -> Void
     ) async throws {
         // Get account.
-        let payload = try await ProcessNotificationRequestUseCase().invoke(request: request)
+        let payload = try ProcessNotificationRequestUseCase().invoke(request: request)
 
         guard let account = accountManager.account(with: payload.userID) else {
             throw Failure.accountNotFound(payload.userID)

--- a/WireDomain/Sources/WireDomain/Notifications/Models/NotificationPayload.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Models/NotificationPayload.swift
@@ -19,7 +19,8 @@
 import Foundation
 
 /// Push notification payload
-struct NotificationPayload: Decodable {
+public struct NotificationPayload: Decodable {
+
     private let data: Payload
 
     private struct Payload: Decodable {
@@ -31,11 +32,11 @@ struct NotificationPayload: Decodable {
         }
     }
 
-    var userID: UUID {
+    public var userID: UUID {
         data.user
     }
 
-    var eventID: UUID {
+    public var eventID: UUID {
         data.data.id
     }
 }

--- a/WireDomain/Sources/WireDomain/Notifications/ProcessNotificationRequestUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/ProcessNotificationRequestUseCase.swift
@@ -20,18 +20,21 @@ import UserNotifications
 import WireLogging
 
 // sourcery: AutoMockable
-protocol ProcessNotificationUseCaseProtocol {
+public protocol ProcessNotificationUseCaseProtocol {
     func invoke(
         request: UNNotificationRequest
-    ) async throws -> NotificationPayload
+    ) throws -> NotificationPayload
 }
 
-struct ProcessNotificationRequestUseCase: ProcessNotificationUseCaseProtocol {
+public struct ProcessNotificationRequestUseCase: ProcessNotificationUseCaseProtocol {
+
     private let logger = WireLogger.notifications
 
-    func invoke(
+    public init() {}
+
+    public func invoke(
         request: UNNotificationRequest
-    ) async throws -> NotificationPayload {
+    ) throws -> NotificationPayload {
         let userInfo = request.content.userInfo
 
         logger.info(

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2822,20 +2822,21 @@ public class MockOneOnOneResolverProtocol: OneOnOneResolverProtocol {
 
 }
 
-class MockProcessNotificationUseCaseProtocol: ProcessNotificationUseCaseProtocol {
+public class MockProcessNotificationUseCaseProtocol: ProcessNotificationUseCaseProtocol {
 
     // MARK: - Life cycle
 
+    public init() {}
 
 
     // MARK: - invoke
 
-    var invokeRequest_Invocations: [UNNotificationRequest] = []
-    var invokeRequest_MockError: Error?
-    var invokeRequest_MockMethod: ((UNNotificationRequest) async throws -> NotificationPayload)?
-    var invokeRequest_MockValue: NotificationPayload?
+    public var invokeRequest_Invocations: [UNNotificationRequest] = []
+    public var invokeRequest_MockError: Error?
+    public var invokeRequest_MockMethod: ((UNNotificationRequest) throws -> NotificationPayload)?
+    public var invokeRequest_MockValue: NotificationPayload?
 
-    func invoke(request: UNNotificationRequest) async throws -> NotificationPayload {
+    public func invoke(request: UNNotificationRequest) throws -> NotificationPayload {
         invokeRequest_Invocations.append(request)
 
         if let error = invokeRequest_MockError {
@@ -2843,7 +2844,7 @@ class MockProcessNotificationUseCaseProtocol: ProcessNotificationUseCaseProtocol
         }
 
         if let mock = invokeRequest_MockMethod {
-            return try await mock(request)
+            return try mock(request)
         } else if let mock = invokeRequest_MockValue {
             return mock
         } else {

--- a/wire-ios-notification-engine/Sources/LegacyNotificationSessionLoader.swift
+++ b/wire-ios-notification-engine/Sources/LegacyNotificationSessionLoader.swift
@@ -22,7 +22,7 @@ import WireDomain
 import WireFoundation
 import WireNetwork
 
-public struct NotificationSessionLoader {
+public struct LegacyNotificationSessionLoader {
 
     public enum Failure: Error {
 

--- a/wire-ios-notification-engine/Sources/LegacyNotificationSessionLoader.swift
+++ b/wire-ios-notification-engine/Sources/LegacyNotificationSessionLoader.swift
@@ -27,6 +27,7 @@ public struct LegacyNotificationSessionLoader {
     public enum Failure: Error {
 
         case mainAppRequired(message: String)
+        case shouldBeUsingNewNSE
         case failedToFetchBackendEnvironment(any Error)
         case failedToFetchProxyCredentials(any Error)
         case persistenceStoresNotFound
@@ -110,9 +111,8 @@ public struct LegacyNotificationSessionLoader {
             throw Failure.buildIsBlacklisted(buildNumber: buildNumber)
         }
 
-        // Return early if needed.
-        guard !shouldEnableSyncV2(metadata: metadata) else {
-            throw Failure.mainAppRequired(message: "sync v2 should be enabled")
+        guard !journal[.isSyncV2Enabled] else {
+            throw Failure.shouldBeUsingNewNSE
         }
 
         guard let selfClientID = await coreDataStack.syncContext.perform({
@@ -241,13 +241,6 @@ public struct LegacyNotificationSessionLoader {
         } catch {
             throw Failure.failedToCheckBuildBlacklist(error)
         }
-    }
-
-    private func shouldEnableSyncV2(metadata: ResolvedBackendMetadata) -> Bool {
-        return false
-        let isAvailable = metadata.apiVersion >= .v8
-        let isAlreadyEnabled = journal[.isSyncV2Enabled]
-        return isAvailable && !isAlreadyEnabled
     }
 
     private func makeNotificationSession(

--- a/wire-ios-notification-engine/Sources/NotificationSessionLoader.swift
+++ b/wire-ios-notification-engine/Sources/NotificationSessionLoader.swift
@@ -1,0 +1,362 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+import WireDomain
+import WireFoundation
+import WireNetwork
+
+public struct NotificationSessionLoader {
+
+    public enum Failure: Error {
+
+        case mainAppRequired(message: String)
+        case failedToFetchBackendEnvironment(any Error)
+        case failedToFetchProxyCredentials(any Error)
+        case persistenceStoresNotFound
+        case failedToStoreMetadata(any Error)
+        case failedToLoadPersistenceStack(any Error)
+        case failedToCheckBuildBlacklist(any Error)
+        case buildIsBlacklisted(buildNumber: String)
+
+    }
+
+    private let account: Account
+    private let appContainerURL: URL
+    private let accountDataURL: URL
+    private let appGroupID: String
+    private let buildNumber: String
+    private let sharedUserDefaults: UserDefaults
+    private let minTLSVersion: String?
+
+    private let accountID: UUID
+    private let backendStore: BackendEnvironmentStore
+    private let journal: Journal
+
+    public init(
+        account: Account,
+        appContainerURL: URL,
+        appGroupID: String,
+        buildNumber: String,
+        sharedUserDefaults: UserDefaults,
+        minTLSVersion: String?
+    ) throws {
+        self.account = account
+        self.appContainerURL = appContainerURL
+        self.appGroupID = appGroupID
+        self.buildNumber = buildNumber
+        self.sharedUserDefaults = sharedUserDefaults
+        self.minTLSVersion = minTLSVersion
+
+        self.accountID = account.userIdentifier
+        self.accountDataURL = AccountURLs(root: appContainerURL).accountData
+        self.backendStore = try BackendEnvironmentStore(directory: accountDataURL)
+        self.journal = Journal(
+            userID: accountID,
+            storage: sharedUserDefaults
+        )
+    }
+
+    public func load() async throws -> NotificationSession {
+        // Get the stored environment for this account.
+        let backendEnvironment = try fetchBackendEnvironment()
+
+        // Retrieve proxy credentials if needed.
+        var proxyCredentials: WireNetwork.ProxyCredentials?
+        if let config = backendEnvironment.config.proxyConfig {
+            proxyCredentials = try await fetchProxyCredentials(for: config)
+        }
+
+        // Set up network stack.
+        let preferredAPIVersion = BackendInfo.preferredAPIVersion.flatMap {
+            WireNetwork.APIVersion(rawValue: UInt($0.rawValue))
+        }
+
+        let networkStack = NetworkStack(
+            backendEnvironment: backendEnvironment,
+            minTLSVersion: .minVersionFrom(minTLSVersion),
+            preferredAPIVersion: preferredAPIVersion,
+            proxyCredentials: proxyCredentials
+        )
+
+        let networkServices = try await networkStack.networkServices
+
+        let metadata = try await resolveBackendMetadata(with: networkStack)
+
+        // Set up persistence stack.
+        let coreDataStack = try await setupPersistenceStack(
+            localDomain: metadata.domain,
+            isFederationEnabled: metadata.isFederationEnabled
+        )
+
+        // Return early if needed.
+        guard try await !isBuildBlacklisted(networkService: networkServices.blacklist) else {
+            throw Failure.buildIsBlacklisted(buildNumber: buildNumber)
+        }
+
+        // Return early if needed.
+        guard !shouldEnableSyncV2(metadata: metadata) else {
+            throw Failure.mainAppRequired(message: "sync v2 should be enabled")
+        }
+
+        guard let selfClientID = await coreDataStack.syncContext.perform({
+            let selfUser = ZMUser.selfUser(in: coreDataStack.syncContext)
+            return selfUser.selfClient()?.remoteIdentifier
+        }) else {
+            throw Failure.mainAppRequired(message: "no self client id")
+        }
+
+        return try await makeNotificationSession(
+            selfClientID: selfClientID,
+            environment: backendEnvironment,
+            proxyCredentials: proxyCredentials,
+            restNetworkService: networkServices.rest,
+            webSocketNetworkService: networkServices.webSocket,
+            backendMetadata: metadata,
+            coreDataStack: coreDataStack
+        )
+    }
+
+    private func fetchBackendEnvironment() throws -> BackendEnvironment2 {
+        do {
+            guard let environment = try backendStore.fetchBackendEnvironment(accountID: accountID) else {
+                throw Failure.mainAppRequired(message: "no backend environment")
+            }
+
+            return environment
+        } catch {
+            throw Failure.failedToFetchBackendEnvironment(error)
+        }
+    }
+
+    private func fetchProxyCredentials(for config: BackendEnvironment2.ProxyConfig) async throws -> WireNetwork
+        .ProxyCredentials? {
+        guard config.needsAuthentication else {
+            return nil
+        }
+
+        let proxyCredentialStore = ProxyCredentialStore()
+
+        do {
+            guard let (username, password) = try await proxyCredentialStore.fetchCredentials(
+                host: config.host,
+                port: config.port
+            ) else {
+                return nil
+            }
+
+            return ProxyCredentials(
+                username: username,
+                password: password
+            )
+        } catch {
+            throw Failure.failedToFetchProxyCredentials(error)
+        }
+    }
+
+    private func resolveBackendMetadata(with networkStack: NetworkStack) async throws -> ResolvedBackendMetadata {
+        // Get the last known metadata.
+        guard let prevMetadata = try backendStore.fetchBackendMetadata(accountID: accountID) else {
+            throw Failure.mainAppRequired(message: "no previous backend metadata")
+        }
+
+        // Get new metadata.
+        let newMetadata = try await networkStack.resolvedBackendMetadata()
+
+        // TODO: [WPB-17732] de-duplicate when implementing NSE
+        if !prevMetadata.isFederationEnabled, newMetadata.isFederationEnabled {
+            // TODO: [WPB-14630] mark federation migration needed
+        }
+
+        if prevMetadata.apiVersion < .v3, newMetadata.apiVersion >= .v3 {
+            // TODO: [WPB-14630] mark access token migration needed
+        }
+
+        // Store new metadata.
+        do {
+            try backendStore.storeBackendMetadata(
+                newMetadata,
+                for: accountID
+            )
+        } catch {
+            throw Failure.failedToStoreMetadata(error)
+        }
+
+        return newMetadata
+    }
+
+    private func setupPersistenceStack(
+        localDomain: String?,
+        isFederationEnabled: Bool
+    ) async throws -> CoreDataStack {
+        let coreDataStack = CoreDataStack(
+            account: account,
+            applicationContainer: appContainerURL,
+            localDomain: localDomain,
+            isFederationEnabled: isFederationEnabled
+        )
+
+        guard coreDataStack.storesExists else {
+            throw Failure.persistenceStoresNotFound
+        }
+
+        guard !coreDataStack.needsMigration  else {
+            throw Failure.mainAppRequired(message: "database migration required")
+        }
+
+        do {
+            try await coreDataStack.load()
+        } catch {
+            throw Failure.failedToLoadPersistenceStack(error)
+        }
+
+        return coreDataStack
+    }
+
+    private func isBuildBlacklisted(networkService: NetworkService) async throws -> Bool {
+        let api = BlacklistAPIBuilder(networkService: networkService).makeAPI()
+        let useCase = IsBuildBlacklistedUseCaseImpl(
+            currentBuildNumber: buildNumber,
+            api: api
+        )
+
+        do {
+            return try await useCase.invoke()
+        } catch {
+            throw Failure.failedToCheckBuildBlacklist(error)
+        }
+    }
+
+    private func shouldEnableSyncV2(metadata: ResolvedBackendMetadata) -> Bool {
+        return false
+        let isAvailable = metadata.apiVersion >= .v8
+        let isAlreadyEnabled = journal[.isSyncV2Enabled]
+        return isAvailable && !isAlreadyEnabled
+    }
+
+    private func makeNotificationSession(
+        selfClientID: String,
+        environment: BackendEnvironment2,
+        proxyCredentials: WireNetwork.ProxyCredentials?,
+        restNetworkService: NetworkService,
+        webSocketNetworkService: NetworkService,
+        backendMetadata: ResolvedBackendMetadata,
+        coreDataStack: CoreDataStack
+    ) async throws -> NotificationSession {
+        let legacyEnvironment = BackendEnvironment(environment)
+        // Don't cache the cookie because if the user logs out and back in again in the main app
+        // process, then the cached cookie will be invalid.
+        let legacyCookieStorage = ZMPersistentCookieStorage(
+            forServerName: legacyEnvironment.backendURL.host!,
+            userIdentifier: accountID,
+            useCache: false
+        )
+        guard legacyCookieStorage.hasAuthenticationCookie else {
+            throw Failure.mainAppRequired(message: "no authentication cookie")
+        }
+        let reachabilityGroup = ZMSDispatchGroup(dispatchGroup: DispatchGroup(), label: "Sharing session reachability")
+        let serverNames = [legacyEnvironment.backendURL, legacyEnvironment.backendWSURL].compactMap(\.host)
+        let reachability = ZMReachability(serverNames: serverNames, group: reachabilityGroup)
+        let transportSession = ZMTransportSession(
+            environment: legacyEnvironment,
+            proxyUsername: proxyCredentials?.username,
+            proxyPassword: proxyCredentials?.password,
+            cookieStorage: legacyCookieStorage,
+            reachability: reachability,
+            initialAccessToken: nil,
+            applicationGroupIdentifier: appGroupID,
+            applicationVersion: buildNumber,
+            minTLSVersion: minTLSVersion,
+            selfClientID: selfClientID,
+            // This flag only concerns the push channel which isn't relevant
+            // in the sharing session.
+            isSyncV2Enabled: false
+        )
+        let cachesDirectory = FileManager.default.cachesURLForAccount(with: accountID, in: appContainerURL)
+        let userAccountDataURL = accountDataURL.appending(path: accountID.uuidString)
+        let saveNotificationPersistence = ContextDidSaveNotificationPersistence(accountContainer: userAccountDataURL)
+        let lastEventIDRepository = LastEventIDRepository(
+            userID: accountID,
+            sharedUserDefaults: sharedUserDefaults
+        )
+        let applicationStatusDirectory = ApplicationStatusDirectory(
+            syncContext: coreDataStack.syncContext,
+            transportSession: transportSession,
+            lastEventIDRepository: lastEventIDRepository
+        )
+        let pushNotificationStrategy = PushNotificationStrategy(
+            syncContext: coreDataStack.syncContext,
+            applicationStatus: applicationStatusDirectory,
+            pushNotificationStatus: applicationStatusDirectory.pushNotificationStatus,
+            lastEventIDRepository: lastEventIDRepository
+        )
+        let requestGeneratorStore = RequestGeneratorStore(strategies: [pushNotificationStrategy])
+        let operationLoop = RequestGeneratingOperationLoop(
+            userContext: coreDataStack.viewContext,
+            syncContext: coreDataStack.syncContext,
+            callBackQueue: .main,
+            requestGeneratorStore: requestGeneratorStore,
+            transportSession: transportSession
+        )
+        let cryptoboxMigrationManager = CryptoboxMigrationManager()
+        guard !cryptoboxMigrationManager.isMigrationNeeded(accountDirectory: userAccountDataURL) else {
+            throw Failure.mainAppRequired(message: "cryptobox migration required")
+        }
+        let earService = EARService(
+            accountID: accountID,
+            sharedUserDefaults: sharedUserDefaults,
+            authenticationContext: AuthenticationContext(storage: LAContextStorage())
+        )
+        let coreCryptoProvider = CoreCryptoProvider(
+            selfUserID: accountID,
+            sharedContainerURL: appContainerURL,
+            accountDirectory: userAccountDataURL,
+            syncContext: coreDataStack.syncContext,
+            cryptoboxMigrationManager: cryptoboxMigrationManager,
+            coreCryptoKeyMigrationManager: CoreCryptoKeyMigrationManager(journal: journal),
+            allowCreation: false,
+            localDomain: backendMetadata.domain
+        )
+        let featureRepository = LegacyFeatureRepository(context: coreDataStack.syncContext)
+        let mlsActionExecutor = MLSActionExecutor(
+            coreCryptoProvider: coreCryptoProvider,
+            featureRepository: featureRepository
+        )
+        let proteusService = ProteusService(coreCryptoProvider: coreCryptoProvider)
+        let mlsDecryptionService = MLSDecryptionService(
+            context: coreDataStack.syncContext,
+            mlsActionExecutor: mlsActionExecutor
+        )
+        return try NotificationSession(
+            coreDataStack: coreDataStack,
+            transportSession: transportSession,
+            cachesDirectory: cachesDirectory,
+            saveNotificationPersistence: saveNotificationPersistence,
+            applicationStatusDirectory: applicationStatusDirectory,
+            operationLoop: operationLoop,
+            accountIdentifier: accountID,
+            pushNotificationStrategy: pushNotificationStrategy,
+            cryptoboxMigrationManager: cryptoboxMigrationManager,
+            earService: earService,
+            proteusService: proteusService,
+            mlsDecryptionService: mlsDecryptionService,
+            lastEventIDRepository: lastEventIDRepository
+        )
+    }
+}

--- a/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697129C2497CAC200C32169 /* PushNotificationStrategy.swift */; };
 		06DE7AB72DE4D8A100D79D99 /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06DE7AB62DE4D8A100D79D99 /* WireDomain.framework */; };
 		06DE7ABF2DE4E39200D79D99 /* WireFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 06DE7ABE2DE4E39200D79D99 /* WireFoundation */; };
-		3431F0872E795487007BA692 /* NotificationSessionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3431F0862E795487007BA692 /* NotificationSessionLoader.swift */; };
+		3431F0872E795487007BA692 /* LegacyNotificationSessionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3431F0862E795487007BA692 /* LegacyNotificationSessionLoader.swift */; };
 		3431F0892E795B90007BA692 /* WireNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 3431F0882E795B90007BA692 /* WireNetwork */; };
 		591B6E262C8B097B009F8A7B /* WireRequestStrategy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE668BC52954BA4C00D939E7 /* WireRequestStrategy.framework */; };
 		591B6E2C2C8B0983009F8A7B /* WireDataModelSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59B170E52BCE70E200575995 /* WireDataModelSupport.framework */; };
@@ -74,7 +74,7 @@
 		06BD1D392487B01C002F82A6 /* project-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "project-debug.xcconfig"; sourceTree = "<group>"; };
 		06BD1D3B2487B01C002F82A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		06DE7AB62DE4D8A100D79D99 /* WireDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3431F0862E795487007BA692 /* NotificationSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSessionLoader.swift; sourceTree = "<group>"; };
+		3431F0862E795487007BA692 /* LegacyNotificationSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyNotificationSessionLoader.swift; sourceTree = "<group>"; };
 		59B170E52BCE70E200575995 /* WireDataModelSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDataModelSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNotificationSessionTests.swift; sourceTree = "<group>"; };
 		EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSessionTests.swift; sourceTree = "<group>"; };
@@ -193,7 +193,7 @@
 				EE32460128229FDF00F2A84A /* AuthenticationStatus.swift */,
 				EE3245FF28229F6B00F2A84A /* ClientRegistrationStatus.swift */,
 				069712952497C1BC00C32169 /* NotificationSession.swift */,
-				3431F0862E795487007BA692 /* NotificationSessionLoader.swift */,
+				3431F0862E795487007BA692 /* LegacyNotificationSessionLoader.swift */,
 				066042A0247FE76C00A5F161 /* Assets.xcassets */,
 				066042A5247FE76C00A5F161 /* Info.plist */,
 			);
@@ -432,7 +432,7 @@
 				EE32460028229F6B00F2A84A /* ClientRegistrationStatus.swift in Sources */,
 				069712912497B96E00C32169 /* OperationLoop.swift in Sources */,
 				EE9AEC982BD159C700F7853F /* WireNotificationEngine.docc in Sources */,
-				3431F0872E795487007BA692 /* NotificationSessionLoader.swift in Sources */,
+				3431F0872E795487007BA692 /* LegacyNotificationSessionLoader.swift in Sources */,
 				0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */,
 				069712992497C2B900C32169 /* AuthenticationStatusProvider.swift in Sources */,
 				069712972497C1BF00C32169 /* NotificationSession.swift in Sources */,

--- a/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-notification-engine/WireNotificationEngine.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0697129C2497CAC200C32169 /* PushNotificationStrategy.swift */; };
 		06DE7AB72DE4D8A100D79D99 /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06DE7AB62DE4D8A100D79D99 /* WireDomain.framework */; };
 		06DE7ABF2DE4E39200D79D99 /* WireFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 06DE7ABE2DE4E39200D79D99 /* WireFoundation */; };
+		3431F0872E795487007BA692 /* NotificationSessionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3431F0862E795487007BA692 /* NotificationSessionLoader.swift */; };
+		3431F0892E795B90007BA692 /* WireNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 3431F0882E795B90007BA692 /* WireNetwork */; };
 		591B6E262C8B097B009F8A7B /* WireRequestStrategy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE668BC52954BA4C00D939E7 /* WireRequestStrategy.framework */; };
 		591B6E2C2C8B0983009F8A7B /* WireDataModelSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59B170E52BCE70E200575995 /* WireDataModelSupport.framework */; };
 		591B6E2F2C8B0988009F8A7B /* WireMockTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEC80B5629B6054A00099727 /* WireMockTransport.framework */; };
@@ -72,6 +74,7 @@
 		06BD1D392487B01C002F82A6 /* project-debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "project-debug.xcconfig"; sourceTree = "<group>"; };
 		06BD1D3B2487B01C002F82A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		06DE7AB62DE4D8A100D79D99 /* WireDomain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDomain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3431F0862E795487007BA692 /* NotificationSessionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSessionLoader.swift; sourceTree = "<group>"; };
 		59B170E52BCE70E200575995 /* WireDataModelSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WireDataModelSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		630A582C29AF9F3E00E26C4D /* BaseNotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNotificationSessionTests.swift; sourceTree = "<group>"; };
 		EE0BA28929D59B1D004E93B5 /* NotificationSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSessionTests.swift; sourceTree = "<group>"; };
@@ -113,6 +116,7 @@
 			files = (
 				06DE7ABF2DE4E39200D79D99 /* WireFoundation in Frameworks */,
 				06DE7AB72DE4D8A100D79D99 /* WireDomain.framework in Frameworks */,
+				3431F0892E795B90007BA692 /* WireNetwork in Frameworks */,
 				591B6E262C8B097B009F8A7B /* WireRequestStrategy.framework in Frameworks */,
 				59537D8D2CFF9FB300920B59 /* WireLogging in Frameworks */,
 			);
@@ -189,6 +193,7 @@
 				EE32460128229FDF00F2A84A /* AuthenticationStatus.swift */,
 				EE3245FF28229F6B00F2A84A /* ClientRegistrationStatus.swift */,
 				069712952497C1BC00C32169 /* NotificationSession.swift */,
+				3431F0862E795487007BA692 /* NotificationSessionLoader.swift */,
 				066042A0247FE76C00A5F161 /* Assets.xcassets */,
 				066042A5247FE76C00A5F161 /* Info.plist */,
 			);
@@ -427,6 +432,7 @@
 				EE32460028229F6B00F2A84A /* ClientRegistrationStatus.swift in Sources */,
 				069712912497B96E00C32169 /* OperationLoop.swift in Sources */,
 				EE9AEC982BD159C700F7853F /* WireNotificationEngine.docc in Sources */,
+				3431F0872E795487007BA692 /* NotificationSessionLoader.swift in Sources */,
 				0697129D2497CAC200C32169 /* PushNotificationStrategy.swift in Sources */,
 				069712992497C2B900C32169 /* AuthenticationStatusProvider.swift in Sources */,
 				069712972497C1BF00C32169 /* NotificationSession.swift in Sources */,
@@ -815,6 +821,10 @@
 		06DE7ABE2DE4E39200D79D99 /* WireFoundation */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WireFoundation;
+		};
+		3431F0882E795B90007BA692 /* WireNetwork */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireNetwork;
 		};
 		59537D8C2CFF9FB300920B59 /* WireLogging */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
@@ -229,7 +229,7 @@ final class LegacyNotificationService: UNNotificationServiceExtension, Notificat
     @MainActor
     private func createSession(accountID: UUID) async throws -> NotificationSession {
         if DeveloperFlag.multibackend.isOn {
-            let loader = try NotificationSessionLoader(
+            let loader = try LegacyNotificationSessionLoader(
                 account: Account(userName: "", userIdentifier: accountID),
                 appContainerURL: appContainerURL,
                 appGroupID: appGroupID,

--- a/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
@@ -48,7 +48,18 @@ final class CallEventHandler: CallEventHandlerProtocol {
 final class LegacyNotificationService: UNNotificationServiceExtension, NotificationSessionDelegate,
     NotificationServiceProtocol {
 
+    enum Failure: Error {
+
+        case failedToCreateSession(message: String)
+
+    }
+
     // MARK: - Properties
+
+    let appGroupID: String
+    let appContainerURL: URL
+    let currentAppVersion: String
+    let currentBuildNumber: String
 
     var callEventHandler: CallEventHandlerProtocol = CallEventHandler()
 
@@ -56,33 +67,26 @@ final class LegacyNotificationService: UNNotificationServiceExtension, Notificat
     private var contentHandler: ((UNNotificationContent) -> Void)?
 
     private lazy var accountManager: AccountManager? = {
-        let sharedContainerURL = FileManager.sharedContainerDirectory(for: appGroupID)
-        let accountURLs = AccountURLs(root: sharedContainerURL)
+        let accountURLs = AccountURLs(root: appContainerURL)
         return try? AccountManager(
             currentAppVersion: currentAppVersion,
             directory: accountURLs.accounts
         )
     }()
 
-    private var currentAppVersion: String {
-        guard let currentAppVersion = Bundle.main.shortVersionString else {
-            fatalError("cannot get current app version identifier")
-        }
-        return currentAppVersion
-    }
-
-    private var appGroupID: String {
-        guard let groupID = Bundle.main.applicationGroupIdentifier else {
-            fatalError("cannot get app group identifier")
-        }
-
-        return groupID
-    }
-
     // MARK: - Life cycle
 
-    override init() {
+    init(
+        appGroupID: String,
+        appContainerURL: URL,
+        currentAppVersion: String,
+        currentBuildNumber: String
+    ) {
         WireLogger.notifications.info("initializing new legacy notification service", attributes: .legacyNSE)
+        self.appGroupID = appGroupID
+        self.appContainerURL = appContainerURL
+        self.currentAppVersion = currentAppVersion
+        self.currentBuildNumber = currentBuildNumber
         super.init()
     }
 
@@ -230,17 +234,30 @@ final class LegacyNotificationService: UNNotificationServiceExtension, Notificat
 
     @MainActor
     private func createSession(accountID: UUID) async throws -> NotificationSession {
-        let session = try await NotificationSession(
-            currentAppVersion: currentAppVersion,
-            applicationGroupIdentifier: appGroupID,
-            accountIdentifier: accountID,
-            environment: BackendEnvironment.shared,
-            sharedUserDefaults: .applicationGroup,
-            minTLSVersion: SecurityFlags.minTLSVersion.stringValue
-        )
-
-        session.delegate = self
-        return session
+        if DeveloperFlag.multibackend.isOn {
+            let loader = try NotificationSessionLoader(
+                account: Account(userName: "", userIdentifier: accountID),
+                appContainerURL: appContainerURL,
+                appGroupID: appGroupID,
+                buildNumber: currentBuildNumber,
+                sharedUserDefaults: .applicationGroup,
+                minTLSVersion: SecurityFlags.minTLSVersion.stringValue
+            )
+            let session = try await loader.load()
+            session.delegate = self
+            return session
+        } else {
+            let session = try await NotificationSession(
+                currentAppVersion: currentAppVersion,
+                applicationGroupIdentifier: appGroupID,
+                accountIdentifier: accountID,
+                environment: BackendEnvironment.shared,
+                sharedUserDefaults: .applicationGroup,
+                minTLSVersion: SecurityFlags.minTLSVersion.stringValue
+            )
+            session.delegate = self
+            return session
+        }
     }
 
     private func totalUnreadCount(_ unreadConversationCount: Int) -> NSNumber? {

--- a/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/LegacyNotificationService.swift
@@ -48,12 +48,6 @@ final class CallEventHandler: CallEventHandlerProtocol {
 final class LegacyNotificationService: UNNotificationServiceExtension, NotificationSessionDelegate,
     NotificationServiceProtocol {
 
-    enum Failure: Error {
-
-        case failedToCreateSession(message: String)
-
-    }
-
     // MARK: - Properties
 
     let appGroupID: String

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -106,10 +106,6 @@ final class NotificationService: UNNotificationServiceExtension {
             for: request,
             appContainerURL: appContainerURL
         ) else {
-            WireLogger.notifications.critical(
-                "api version unknown, can't load service",
-                attributes: .safePublic
-            )
             return nil
         }
 

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -22,6 +22,7 @@ import WireCommonComponents
 import WireDomain
 import WireFoundation
 import WireLogging
+import WireNetwork
 import WireTransport
 import WireUtilities
 
@@ -46,7 +47,7 @@ final class NotificationService: UNNotificationServiceExtension {
         WireLogger.notifications.info("did receive notification request: \(request.debugDescription)")
 
         if notificationService == nil {
-            notificationService = loadNotificationService()
+            notificationService = loadNotificationService(for: request)
         }
 
         if let notificationService {
@@ -63,7 +64,7 @@ final class NotificationService: UNNotificationServiceExtension {
         notificationService?.serviceExtensionTimeWillExpire()
     }
 
-    private func loadNotificationService() -> NotificationServiceProtocol? {
+    private func loadNotificationService(for request: UNNotificationRequest) -> NotificationServiceProtocol? {
         let info = Bundle.appMainBundle.infoDictionary
 
         guard let currentAppVersion = info?["CFBundleShortVersionString"] as? String else {
@@ -101,8 +102,18 @@ final class NotificationService: UNNotificationServiceExtension {
             return nil
         }
 
-        if DeveloperFlag.multibackend.isOn {
-            // Only new extension is supported in multibackend mode.
+        guard let apiVersion = fetchLastKnownAPIVersion(
+            for: request,
+            appContainerURL: appContainerURL
+        ) else {
+            WireLogger.notifications.critical(
+                "api version unknown, can't load service",
+                attributes: .safePublic
+            )
+            return nil
+        }
+
+        if apiVersion >= .v8 {
             WireLogger.notifications.info(
                 "loading new notification service",
                 attributes: .safePublic
@@ -119,42 +130,35 @@ final class NotificationService: UNNotificationServiceExtension {
                 }
             )
         } else {
-            // API version decides which service to use, if we don't have it
-            // yet then we simply supress the notification request.
-            guard let apiVersion = BackendInfo.apiVersion else {
-                WireLogger.notifications.warn(
-                    "no resolved api version, not loading service",
-                    attributes: .safePublic
-                )
-                return nil
-            }
+            WireLogger.notifications.info(
+                "loading legacy notification service",
+                attributes: .safePublic
+            )
+            return LegacyNotificationService(
+                appGroupID: appID,
+                appContainerURL: appContainerURL,
+                currentAppVersion: currentAppVersion,
+                currentBuildNumber: currentBuildNumber
+            )
+        }
+    }
 
-            /// With v8, the new extension is available, but not necessarily
-            /// turned on yet. Regardless, we will use it and later check
-            /// if the new sync is enabled.
-            if apiVersion >= .v8 {
-                WireLogger.notifications.info(
-                    "loading new notification service",
-                    attributes: .safePublic
-                )
-                return NotificationServiceExtension(
-                    currentAppVersion: currentAppVersion,
-                    currentBuildNumber: currentBuildNumber,
-                    appContainerURL: appContainerURL,
-                    sharedUserDefaults: sharedUserDefaults,
-                    cookieEncryptionKey: UserDefaults.cookiesKey(),
-                    minTLSVersion: SecurityFlags.minTLSVersion.stringValue,
-                    preferredAPIVersion: BackendInfo.preferredAPIVersion.map {
-                        UInt($0.rawValue)
-                    }
-                )
-            } else {
-                WireLogger.notifications.info(
-                    "loading legacy notification service",
-                    attributes: .safePublic
-                )
-                return LegacyNotificationService()
-            }
+    private func fetchLastKnownAPIVersion(
+        for request: UNNotificationRequest,
+        appContainerURL: URL
+    ) -> WireNetwork.APIVersion? {
+        do {
+            let payload = try ProcessNotificationRequestUseCase().invoke(request: request)
+            let accountURLs = AccountURLs(root: appContainerURL)
+            let environmentStore = try BackendEnvironmentStore(directory: accountURLs.accountData)
+            let metadata = try environmentStore.fetchBackendMetadata(accountID: payload.userID)
+            return metadata?.apiVersion
+        } catch {
+            WireLogger.notifications.error(
+                "failed to fetch last known api version",
+                attributes: .safePublic
+            )
+            return nil
         }
     }
 

--- a/wire-ios/Wire-iOS Tests/Notification Service Extension/LegacyNotificationServiceTest.swift
+++ b/wire-ios/Wire-iOS Tests/Notification Service Extension/LegacyNotificationServiceTest.swift
@@ -51,7 +51,12 @@ final class LegacyNotificationServiceTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        sut = LegacyNotificationService()
+        sut = LegacyNotificationService(
+            appGroupID: "appGroupID",
+            appContainerURL: .temporaryDirectory,
+            currentAppVersion: "1.2.3",
+            currentBuildNumber: "12345"
+        )
         callEventHandlerMock = CallEventHandlerMock()
         currentUserIdentifier = UUID.create()
         notificationContent = createNotificationContent()

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		061F341B2B1E2ED50099CBAB /* AppAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 061F341A2B1E2ED50099CBAB /* AppAuthCore */; };
 		065A5AE5279B07AC002D4D1E /* Wire Notification Service Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 065A5ADE279B07AC002D4D1E /* Wire Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		16EE08AE2D92E861001B372C /* WireCoreCryptoUniffi in Frameworks */ = {isa = PBXBuildFile; productRef = 16EE08AD2D92E861001B372C /* WireCoreCryptoUniffi */; };
+		3431F08B2E795BD0007BA692 /* WireNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 3431F08A2E795BD0007BA692 /* WireNetwork */; };
 		3438C5592E5C518900D6FB5C /* WireNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 3438C5582E5C518900D6FB5C /* WireNetwork */; };
 		3438C55B2E5C51A700D6FB5C /* WireNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 3438C55A2E5C51A700D6FB5C /* WireNetwork */; };
 		346C755F2E74726600800769 /* WireFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 346C755E2E74726600800769 /* WireFoundation */; };
@@ -921,6 +922,7 @@
 			files = (
 				346C75612E74727000800769 /* WireFoundation in Frameworks */,
 				591B6E212C8B096C009F8A7B /* WireCommonComponents.framework in Frameworks */,
+				3431F08B2E795BD0007BA692 /* WireNetwork in Frameworks */,
 				59537D912CFFA0BA00920B59 /* WireLogging in Frameworks */,
 				EE9A8586298B0A3B00064A9C /* WireNotificationEngine.framework in Frameworks */,
 			);
@@ -2843,6 +2845,10 @@
 		16EE08AD2D92E861001B372C /* WireCoreCryptoUniffi */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WireCoreCryptoUniffi;
+		};
+		3431F08A2E795BD0007BA692 /* WireNetwork */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireNetwork;
 		};
 		3438C5582E5C518900D6FB5C /* WireNetwork */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -39,8 +39,10 @@ class WireUITestCase: XCTestCase {
 
         app = XCUIApplication()
         app.launchArguments = launchArguments
-        app.useWireAuthentication()
-        app.developerFlag(.multibackend, enabled: false)
+        app.setDeveloperFlags([
+            .useWireAuthentication: true,
+            .multibackend: false
+        ])
         app.launch()
 
         // In UI tests it is usually best to stop immediately when a failure occurs

--- a/wire-ios/WireUITests/XCUIApplication+Additions.swift
+++ b/wire-ios/WireUITests/XCUIApplication+Additions.swift
@@ -21,12 +21,12 @@ import XCTest
 
 extension XCUIApplication {
 
-    func useWireAuthentication(_ enabled: Bool = true) {
-        developerFlag(DeveloperFlag.useWireAuthentication, enabled: enabled)
-    }
+    func setDeveloperFlags(_ flags: [DeveloperFlag: Bool]) {
+        let flagsString = flags.map {
+            "\($0.key.rawValue):\($0.value ? "true" : "false")"
+        }.joined(separator: " ")
 
-    func developerFlag(_ developerFlag: DeveloperFlag, enabled: Bool) {
-        launchArguments.append("--developer-flag=\(developerFlag.rawValue):\(enabled ? "true" : "false")")
+        launchArguments.append("--developer-flag=\(flagsString)")
     }
 
     func loginUser(email: String, password: String) throws -> FirstTimePage {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20365" title="WPB-20365" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20365</a>  [iOS] Add multibackend support in legacy NSE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Current multibackend support assumes that sync v2 is available, which is only the case when the api version is 8 or higher. To remove this assumption we must add multibackend support in the legacy NSE (for when the api version is less than 8).

### Testing
1. Set preferred api version 7 or less.
2. Log in with multbackend accounts.
3. Put app in background and receive messages for both accounts.
4. Assert you see notifications for both accounts.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
