### PR TITLE
feat: perform metadata migrations - WPB-14360

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
@@ -212,7 +212,11 @@ final class NSEUserScope: Component<NSEUserScopeDependency> {
 
         // TODO: [WPB-19777] deduplicate
         if !prevMetadata.isFederationEnabled, newMetadata.isFederationEnabled {
-            // TODO: [WPB-14630] mark federation migration needed
+            // Now that federation is enabled we'll start storing domains
+            // on entities in the database. We'll therefore need to add
+            // the local domain to all existing entities so they're
+            // fully qualified.
+            journal[.isFederationMigrationRequired] = true
         }
 
         // Store new metadata.

--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
@@ -215,11 +215,6 @@ final class NSEUserScope: Component<NSEUserScopeDependency> {
             // TODO: [WPB-14630] mark federation migration needed
         }
 
-        // TODO: [WPB-19777] deduplicate
-        if prevMetadata.apiVersion < .v3, newMetadata.apiVersion >= .v3 {
-            // TODO: [WPB-14630] mark access token migration needed
-        }
-
         // Store new metadata.
         do {
             try dependency.backendStore.storeBackendMetadata(

--- a/WireDomain/Sources/WireDomain/Utilities/Journal/JournalKey.swift
+++ b/WireDomain/Sources/WireDomain/Utilities/Journal/JournalKey.swift
@@ -81,6 +81,14 @@ public extension JournalKey where Value == Bool {
         defaultValue: false
     )
 
+    /// Whether the local domain needs to be added to entities
+    /// in the database.
+
+    static let isFederationMigrationRequired = Self(
+        "isFederationMigrationRequired",
+        defaultValue: false
+    )
+
 }
 
 public extension JournalKey where Value == Set<String> {

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -185,7 +185,11 @@ public struct SharingSessionLoader {
 
         // TODO: [WPB-17732] de-duplicate when implementing NSE
         if !prevMetadata.isFederationEnabled, newMetadata.isFederationEnabled {
-            // TODO: [WPB-14630] mark federation migration needed
+            // Now that federation is enabled we'll start storing domains
+            // on entities in the database. We'll therefore need to add
+            // the local domain to all existing entities so they're
+            // fully qualified.
+            journal[.isFederationMigrationRequired] = true
         }
 
         // Store new metadata.

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -188,10 +188,6 @@ public struct SharingSessionLoader {
             // TODO: [WPB-14630] mark federation migration needed
         }
 
-        if prevMetadata.apiVersion < .v3, newMetadata.apiVersion >= .v3 {
-            // TODO: [WPB-14630] mark access token migration needed
-        }
-
         // Store new metadata.
         do {
             try backendStore.storeBackendMetadata(

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -296,10 +296,6 @@ final class UserSessionLoader {
             if !prevMetadata.isFederationEnabled, newMetadata.isFederationEnabled {
                 // TODO: [WPB-14630] mark federation migration needed
             }
-
-            if prevMetadata.apiVersion < .v3, newMetadata.apiVersion >= .v3 {
-                // TODO: [WPB-14630] mark access token migration needed
-            }
         }
 
         // Store new metadata.

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -190,7 +190,10 @@ final class UserSessionLoader {
 
         // Perform pending migrations.
         do {
-            try await performPendingMigrations(userSession: userSession)
+            try await performPendingMigrations(
+                userSession: userSession,
+                localDomain: metadata.domain
+            )
         } catch {
             await userSession.close(deleteCookie: false)
             throw error
@@ -282,7 +285,12 @@ final class UserSessionLoader {
         // Get new metadata.
         let newMetadata: ResolvedBackendMetadata
         do {
-            newMetadata = try await networkStack.resolvedBackendMetadata()
+            let metadata = try await networkStack.resolvedBackendMetadata()
+            newMetadata = ResolvedBackendMetadata(
+                apiVersion: metadata.apiVersion,
+                domain: metadata.domain,
+                isFederationEnabled: metadata.isFederationEnabled
+            )
         } catch URLError.notConnectedToInternet, URLError.networkConnectionLost {
             // To allow offline browsing fallback to previous metadata if possible.
             if let prevMetadata {
@@ -598,8 +606,31 @@ final class UserSessionLoader {
         }
     }
 
-    private func performPendingMigrations(userSession: ZMUserSession) async throws {
-        // TODO: [WPB-14630] perform metadata migrations
+    private func performPendingMigrations(
+        userSession: ZMUserSession,
+        localDomain: String
+    ) async throws {
+        if journal[.isFederationMigrationRequired] {
+            WireLogger.session.info(
+                "federation migration is required...",
+                attributes: .safePublic
+            )
+            do {
+                try await CoreDataStack.migrateLocalStorage(
+                    accountIdentifier: accountID,
+                    applicationContainer: sharedContainerURL,
+                    migration: {
+                        try $0.migrateToFederation(localDomain: localDomain)
+                    }
+                )
+                journal[.isFederationMigrationRequired] = false
+            } catch {
+                WireLogger.session.error(
+                    "failed to migrate to federation: \(String(describing: error))",
+                )
+                throw Failure.failedToMigrateToFederation(error)
+            }
+        }
 
         // Perform app version migrations.
         let migrationService = userSession.makeAppVersionMigrationService()
@@ -645,6 +676,7 @@ final class UserSessionLoader {
         case failedToEnabledSyncV2(any Error)
         case buildIsBlacklisted
         case failedToPerformMigration(any Error)
+        case failedToMigrateToFederation(any Error)
         case failedToMigrationToConsumableNotifications(any Error)
 
         var safeForLoggingDescription: String {
@@ -667,6 +699,8 @@ final class UserSessionLoader {
                 "build is blacklisted"
             case .failedToPerformMigration:
                 "failed to perform migration"
+            case .failedToMigrateToFederation:
+                "failed to migrate to federation"
             case .failedToMigrationToConsumableNotifications:
                 "failed to migrate to consumable notifications"
             }

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -294,7 +294,11 @@ final class UserSessionLoader {
 
         if let prevMetadata {
             if !prevMetadata.isFederationEnabled, newMetadata.isFederationEnabled {
-                // TODO: [WPB-14630] mark federation migration needed
+                // Now that federation is enabled we'll start storing domains
+                // on entities in the database. We'll therefore need to add
+                // the local domain to all existing entities so they're
+                // fully qualified.
+                journal[.isFederationMigrationRequired] = true
             }
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14360" title="WPB-14360" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14360</a>  [iOS] Perform backend metadata migrations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When comparing previous backend metadata to new metadata, the difference may require one of two migrations to be performed:
1. If federation is turned on, then the local domain needs to be assigned to all conversations and users in the local database
2. Moving to api v3 or higher then a the access token should be renewed with the self client id.

In this PR:
- when detecting federation being enabled, mark the federation migration as required.
- perform the federation migration after creating the user session
- No need to perform the access token migration: access tokens are only stored in memory, so given there is a self client, a new access token will always be requested with that client id in the lifetime of the app.

### Testing
1. Log in to backend that has federation disabled.
2. Export and inspect the database to assert no domains are stored on `ZMConversation` and `ZMUser`.
3. Enable federation on the backend.
4. Relaunch the app.
5. Export and inspect the database and assert all conversations and users have the local domain set as their domain.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
