### PR TITLE
fix: calling actions view moves down - WPB-20193

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingActionsInfoViewController/CallingActionsInfoViewController.swift
@@ -20,6 +20,10 @@ import UIKit
 import WireDataModel
 import WireDesign
 
+protocol CallingActionsInfoViewControllerDelegate: AnyObject {
+    func actionsViewHeightChanged(to height: CGFloat)
+}
+
 final class CallingActionsInfoViewController: UIViewController, UICollectionViewDelegateFlowLayout {
     private let participantsHeaderHeight: CGFloat = 42
     private let cellHeight: CGFloat = 56
@@ -35,8 +39,9 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
         color: SemanticColors.Label.textSectionHeader
     )
     private(set) var actionsViewHeightConstraint: NSLayoutConstraint!
-    var isIncomingCall: Bool = false
 
+    weak var delegate: CallingActionsInfoViewControllerDelegate?
+    var isIncomingCall: Bool = false
     let actionsView = CallingActionsView()
 
     var participants: CallParticipantsList {
@@ -69,6 +74,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateRows()
+        updateActionViewHeight()
     }
 
     func setCallingActionsViewDelegate(actionsDelegate: CallingActionsViewDelegate?) {
@@ -112,7 +118,7 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     private func createConstraints() {
-        actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: 128.0)
+        actionsViewHeightConstraint = actionsView.heightAnchor.constraint(equalToConstant: calculateHeightConstant())
 
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
@@ -145,16 +151,24 @@ final class CallingActionsInfoViewController: UIViewController, UICollectionView
     }
 
     func updateActionViewHeight() {
-        actionsViewHeightConstraint.constant = calculateHeightConstant()
+        let height = calculateHeightConstant()
+        actionsViewHeightConstraint.constant = height
+        delegate?.actionsViewHeightChanged(to: height)
         actionsView.verticalStackView.alignment = determineStackViewAlignment()
     }
 
     private func calculateHeightConstant() -> CGFloat {
-        if UIDevice.current.twoDimensionOrientation.isLandscape {
+        var baseHeight: CGFloat = if UIDevice.current.twoDimensionOrientation.isLandscape {
             128
         } else {
-            (isIncomingCall ? 250 : 128) + view.safeAreaInsets.bottom
+            isIncomingCall ? 250 : 128
         }
+
+        if !securityLevelView.isHidden {
+            baseHeight += SecurityLevelView.securityLevelViewHeight
+        }
+
+        return baseHeight + view.safeAreaInsets.bottom
     }
 
     private func determineStackViewAlignment() -> UIStackView.Alignment {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Calling/BottomSheetContainerViewController/CallingBottomSheetViewController.swift
@@ -84,6 +84,8 @@ final class CallingBottomSheetViewController: BottomSheetContainerViewController
         callingActionsInfoViewController
             .setCallingActionsViewDelegate(actionsDelegate: visibleVoiceChannelViewController)
         callingActionsInfoViewController.actionsView.bottomSheetScrollingDelegate = self
+        callingActionsInfoViewController.delegate = self
+
         visibleVoiceChannelViewController.configurationObserver = self
         self.participantsObserverToken = voiceChannel.addParticipantObserver(self)
         visibleVoiceChannelViewController.delegate = self
@@ -315,6 +317,19 @@ extension CallingBottomSheetViewController: CallViewControllerDelegate {
     @objc
     func hideCallView() {
         delegate?.activeCallViewControllerDidDisappear(self, for: voiceChannel.conversation)
+    }
+}
+
+extension CallingBottomSheetViewController: CallingActionsInfoViewControllerDelegate {
+
+    func actionsViewHeightChanged(to height: CGFloat) {
+        updateMinimalOffset(height)
+    }
+
+    private func updateMinimalOffset(_ offset: CGFloat) {
+        guard configuration.initialOffset != offset else { return }
+        configuration = BottomSheetConfiguration(height: configuration.height, initialOffset: offset)
+        hideBottomSheet()
     }
 }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
@@ -26,7 +26,7 @@ final class SecurityLevelView: UIView {
 
     // MARK: - Constants
 
-    private static let SecurityLevelViewHeight = 24.0
+    static let securityLevelViewHeight = 24.0
 
     // MARK: - Properties
 
@@ -120,7 +120,7 @@ final class SecurityLevelView: UIView {
             securityLevelLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             securityLevelLabel.topAnchor.constraint(equalTo: topAnchor),
             securityLevelLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
-            securityLevelLabel.heightAnchor.constraint(equalToConstant: SecurityLevelView.SecurityLevelViewHeight),
+            securityLevelLabel.heightAnchor.constraint(equalToConstant: SecurityLevelView.securityLevelViewHeight),
             iconImageView.widthAnchor.constraint(equalToConstant: 11.0),
             iconImageView.heightAnchor.constraint(equalToConstant: 11.0),
             iconImageView.centerYAnchor.constraint(equalTo: centerYAnchor),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20193" title="WPB-20193" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20193</a>  [iOS] Calling UI moves down when minimized then maximized
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

<img width="320" height="659" alt="iOS-after-call-UI-minimized" src="https://github.com/user-attachments/assets/740a7bfe-e3b9-4110-aab6-c96340f2ae6f" />

The call actions view moves outside of the bottom safe area after minimising and maximising the call view.

### Causes

The call actions view is part of the `CallingBottomSheetViewController` which acts as a swipe-able sheet that only shows the call actions by default, and displays the participants list when the user swipes up. This mechanism relies on a constraint that offsets the position of the view.

The offset is based on the call actions view height constraint. When the offset is updated, the height constraint misses the height of the bottom safe area (it evaluates to 0 because the view hasn't been laid out yet).

In addition to this, the height constraint doesn't take into account the `SecurityLevelView` height, which can further lower the calculated offset.

### Solution

- Update the height constraint after ` viewDidLayoutSubviews()` so that the bottom safe area height is factored in
- Inform the `CallingBottomSheetViewController` it needs to update the offset when the call actions view height constraint changes
- Include the `SecurityLevelView` height in the call actions view height constraint

### Testing

- Start / join a call in a classified / unclassified conversation (it needs to have the classification banner)
- Minimise and maximise the call view

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
