### PR TITLE
fix: Update the Poll Button Color view when the accentColor changes - WPB-19731

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -135,4 +135,9 @@ final class SpinnerButton: LegacyButton {
 
         return SpinnerButton(legacyStyle: .empty, cornerRadius: cornerRadius, fontSpec: .smallSemiboldFont)
     }
+
+    func updateAlarmButtonColor(color: ZMAccentColor?) {
+        let variant: ColorSchemeVariant = ColorScheme.default.variant
+        updateStyle(variant: variant)
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/ZMButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/ZMButton.swift
@@ -126,7 +126,7 @@ class LegacyButton: ButtonWithLargerHitArea {
         updateStyle(variant: variant)
     }
 
-    private func updateStyle(variant: ColorSchemeVariant) {
+    func updateStyle(variant: ColorSchemeVariant) {
         guard let style = legacyStyle else { return }
 
         switch style {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireDataModel
+import WireSyncEngine
 
 final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
 
@@ -26,6 +27,7 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
     weak var message: ZMConversationMessage?
     weak var delegate: ConversationMessageCellDelegate?
     weak var actionController: ConversationMessageActionController?
+    private var accentColorChangeHandler: AccentColorChangeHandler?
 
     var errorMessage: String? {
         didSet {
@@ -92,6 +94,17 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
 
     func configure(with object: Configuration, animated: Bool) {
         config = object
+        guard let userSession = config?.userSession else {
+            return
+        }
+        accentColorChangeHandler = AccentColorChangeHandler
+            .addObserver(userSession: userSession) { [unowned self] color in
+                updateBackgroundColor(color: color)
+            }
+    }
+
+    private func updateBackgroundColor(color: ZMAccentColor?) {
+        button.updateAlarmButtonColor(color: color)
     }
 
     struct Configuration {
@@ -99,6 +112,7 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
         let state: ButtonMessageState
         let buttonAction: Completion
         let hasError: Bool
+        let userSession: UserSession
     }
 
     override init(frame: CGRect) {
@@ -108,6 +122,11 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
         createConstraints()
 
         button.addTarget(self, action: #selector(buttonTouched(sender:)), for: .touchUpInside)
+
+    }
+
+    deinit {
+        accentColorChangeHandler = nil
     }
 
     @objc
@@ -171,13 +190,15 @@ final class ConversationButtonMessageCellDescription: ConversationMessageCellDes
         text: String?,
         state: ButtonMessageState,
         hasError: Bool,
+        userSession: UserSession,
         buttonAction: @escaping Completion
     ) {
         self.configuration = View.Configuration(
             text: text,
             state: state,
             buttonAction: buttonAction,
-            hasError: hasError
+            hasError: hasError,
+            userSession: userSession
         )
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -125,10 +125,6 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
 
     }
 
-    deinit {
-        accentColorChangeHandler = nil
-    }
-
     @objc
     private func buttonTouched(sender: Any) {
         buttonAction?()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -391,6 +391,7 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
                     text: data.title,
                     state: data.state,
                     hasError: data.isExpired,
+                    userSession: userSession,
                     buttonAction: {
                         data.touchAction()
                     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19731" title="WPB-19731" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19731</a>  Update the Poll Button Color view when the accentColor changed from different clients(web,iOS)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…ver Accent color is changed

<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Issue:** Poll Button color in iOS is not updated immediately when the accent Color is changed from different client (ex:Web ). It is only updated after refresh of the page

**Solution:** Added Observing using AccentColorChangeHandler and updated view whenever Accent color is changed 

### Testing

Change user accent color from web and that must be in sync with iOS client. Visually iOS client Poll Button color must immediately change

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
