### PR TITLE
fix: update HorizontalMargin when chat bubbles enable - WPB-20399

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/UITraitEnvironment+LayoutMargins.swift
@@ -17,12 +17,14 @@
 //
 
 import UIKit
+import WireSyncEngine
 
 struct HorizontalMargins {
     var left: CGFloat
     var right: CGFloat
     var chatBubbleMinimumLeading: CGFloat
     var chatBubbleMinimumTrailing: CGFloat
+    private let shouldAlign: Bool = ZMUserSession.isChatBubbleEnabled
 
     init(left: CGFloat, right: CGFloat, chatBubbleMinimumLeading: CGFloat, chatBubbleMinimumTrailing: CGFloat) {
         self.left = left
@@ -34,8 +36,8 @@ struct HorizontalMargins {
     init(userInterfaceSizeClass: UIUserInterfaceSizeClass) {
         switch userInterfaceSizeClass {
         case .regular:
-            self.left = 96
-            self.right = 96
+            self.left = shouldAlign ? 56 : 96
+            self.right = shouldAlign ? 16 : 96
             self.chatBubbleMinimumLeading = 136.0
             self.chatBubbleMinimumTrailing = 136.0
         default:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20399" title="WPB-20399" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20399</a>  [iPad] Update paddings left and right for chat bubbles
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When chat bubbles were enable left and right padding on conversation view was wrong.
Not it is adjust correctly on both own & others messages.

Screenshot with wrong padding:
<img width="1032" height="1376" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-09-18 at 12 58 35" src="https://github.com/user-attachments/assets/cd56d35e-eacb-4e71-a925-c48020bd8753" />

Screenshot with corrected padding:
<img width="1032" height="1376" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-09-18 at 18 23 27" src="https://github.com/user-attachments/assets/a2d70afa-f452-4670-98d3-8f6f235d0902" />


### Testing

Open a chat on iPad and check paddings from own and others messages.
Test also without chat bubbles (even is the change on the code should not affect)
Test in iPhone just to make sure no change on small screens.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
