### PR TITLE
fix: don't display soft deleted files in the  Files View - WPB-20460

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -57,7 +57,7 @@ final class RestAPI: Sendable {
                     deleted: StatusFilterDeletedStatus(request.filter.deletionStatus),
                     isDraft: false
                 ),
-                text: request.filter.text.map { LookupFilterTextSearch(searchIn: .baseName, term: $0) },
+                text: LookupFilterTextSearch(searchIn: .baseName, term: "*"),
                 type: TreeNodeType(request.filter.type)
             ),
             flags: [.withPreSignedURLs],

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -57,7 +57,7 @@ final class RestAPI: Sendable {
                     deleted: StatusFilterDeletedStatus(request.filter.deletionStatus),
                     isDraft: false
                 ),
-                text: LookupFilterTextSearch(searchIn: .baseName, term: "*"),
+                text: LookupFilterTextSearch(searchIn: .baseName, term: request.filter.text ?? "*"),
                 type: TreeNodeType(request.filter.type)
             ),
             flags: [.withPreSignedURLs],

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
@@ -105,7 +105,15 @@ package struct WireCellsFetchNodesUseCase: Sendable {
             limit: configuration.pageSize,
             offset: offset
         )
-        let (nodes, nextOffset) = try await repository.getNodes(request)
+        var (nodes, nextOffset) = try await repository.getNodes(request)
+
+        // FIXME: [WPB-16311] Temporary fix to filter out recycled nodes.
+        // This is necessary because the backend doesn't filter out recycled nodes when we have requested specific
+        // nodes. Once we implement showing previews in a conversation this check should move there, if there is no
+        // backend fix.
+        if configuration.deletionStatus == .notDeleted, let nodeIDs = configuration.nodeIDs, nodeIDs.count > 0 {
+            nodes = nodes.filter { !$0.isRecycled }
+        }
 
         return (nodes, nextOffset == nil)
     }

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
@@ -111,7 +111,7 @@ package struct WireCellsFetchNodesUseCase: Sendable {
         // This is necessary because the backend doesn't filter out recycled nodes when we have requested specific
         // nodes. Once we implement showing previews in a conversation this check should move there, if there is no
         // backend fix.
-        if configuration.deletionStatus == .notDeleted, let nodeIDs = configuration.nodeIDs, nodeIDs.count > 0 {
+        if configuration.deletionStatus == .notDeleted, let nodeIDs = configuration.nodeIDs, !nodeIDs.isEmpty {
             nodes = nodes.filter { !$0.isRecycled }
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20460" title="WPB-20460" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20460</a>  [iOS] Recyled files appear in the Files View
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Wire cells has the concept of a recycle bin where files are moved first when they are deleted. From there they can be permanently deleted or restored.

This feature doesn't yet exist on iOS but there is a bug where if a user moves a file to the recycle bin on another platform it is still visible in the files view on iOS. This PR fixes that. 

### Testing

1. Navigate to a wire cells enabled conversation.
2. Send a message with 2 attachments.
3. Open the files view and confirm both attachments are there.
4. On web move one attachment to the recycle bin.
5. Open the files view and confirm the moved attachment is not there.
6. Click on the link to view attachments for a particular message.
7. Confirm that the recycled file is not displayed.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---
