### PR TITLE
fix: remove journal from mail report - WPB-19982

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/LogFilesProvider.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/LogFilesProvider.swift
@@ -141,7 +141,7 @@ struct LogFilesProvider: LogFilesProviding {
         """
 
         if includingJournal {
-            body += "Journal:\n\(journalInfos())"
+            body += "\n\nJournal:\n\(journalInfos())"
         }
 
         if let datadogUserIdentifier = WireAnalytics.Datadog.userIdentifier {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/LogFilesProvider.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Debug Report/LogFilesProvider.swift
@@ -129,7 +129,7 @@ struct LogFilesProvider: LogFilesProviding {
 
     // MARK: - Helpers
 
-    var info: String {
+    func info(includingJournal: Bool = false) -> String {
         let date = Date()
 
         var body = """
@@ -138,10 +138,11 @@ struct LogFilesProvider: LogFilesProviding {
         Device: \(UIDevice.current.zm_model())
         iOS version: \(UIDevice.current.systemVersion)
         Date: \(date.transportString())
-
-        Journal:
-        \(journalInfos())
         """
+
+        if includingJournal {
+            body += "Journal:\n\(journalInfos())"
+        }
 
         if let datadogUserIdentifier = WireAnalytics.Datadog.userIdentifier {
             // display only when enabled
@@ -166,6 +167,7 @@ struct LogFilesProvider: LogFilesProviding {
     private func createInfoFile(at url: URL) throws -> URL {
         let infoFileURL = url.appendingPathComponent("info.txt")
 
+        let info = self.info(includingJournal: true)
         try info.write(
             to: infoFileURL,
             atomically: true,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/MFMailComposeViewController+Logs.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/MFMailComposeViewController+Logs.swift
@@ -27,7 +27,7 @@ extension MFMailComposeViewController {
     func prefilledBody(withMessage message: String = "") -> String {
         var body = """
         --DO NOT EDIT--
-        \(LogFilesProvider().info)
+        \(LogFilesProvider().info())
         ---------------\n
         """
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19982" title="WPB-19982" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19982</a>  [iOS] Implement monitoring for health observability of async notifications
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->



### Issue

Removes journal keys from mail. Keep journal within info.txt within logs.zip

### Testing

**mail:**

![IMG_AE3EC5B16C4D-1](https://github.com/user-attachments/assets/c4779d1b-e52d-40e2-867c-0cba0f1ace1d)

**info.txt:**

![IMG_5357C14FE8DF-1](https://github.com/user-attachments/assets/e8340819-6b46-4b3c-998a-f3f3ac2f3755)
