### PR TITLE
fix: add option to logout when account is blocked - WPB-20485

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -849,7 +849,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         }
     }
 
-    func logout(account: Account, error: Error? = nil) {
+    public func logout(account: Account, error: Error? = nil) {
         WireLogger.session.debug("Logging out account \(account.userIdentifier)...")
         WireLogger.sessionManager.debug("Logging out account \(account.userIdentifier)...")
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
@@ -127,6 +127,16 @@ final class BlockerViewController: LaunchImageViewController {
         if let sessionManager, let account = sessionManager.accountManager.selectedAccount {
             alert.addAction(
                 UIAlertAction(
+                    title: L10n.Localizable.Self.signOut,
+                    style: .default,
+                    handler: { _ in
+                        sessionManager.logout(account: account)
+                    }
+                )
+            )
+
+            alert.addAction(
+                UIAlertAction(
                     title: Strings.retry,
                     style: .cancel,
                     handler: { _ in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20485" title="WPB-20485" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20485</a>  [iOS] Can't log out if account is blocked
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

If the account was blocked due to session loader error, and that error couldn't be resolved, then the use can't log out if they want to. This PR adds a log out option.


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
