### PR TITLE
chore: log requests & errors when using the wire cells nodes - WPB-20490

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -18,6 +18,7 @@
 
 import CellsSDK
 import Foundation
+import WireLogging
 import WireMessagingDomain
 
 enum WireCellsNodesAPIError: Error {
@@ -203,6 +204,7 @@ final class RestAPI: Sendable {
         let config = CellsSDKAPIConfiguration()
         config.basePath = serverURL.absoluteString
         config.customHeaders = ["Authorization": "Bearer \(try await accessTokenProvider.accessToken().token)"]
+        config.interceptor = LoggingIntercepter()
 
         return config
     }
@@ -248,5 +250,51 @@ private extension TreeNodeType {
         case .any:
             self = .unknown
         }
+    }
+}
+
+private struct LoggingIntercepter: OpenAPIInterceptor {
+
+    let interceptor = DefaultOpenAPIInterceptor()
+
+    func intercept(
+        urlRequest: URLRequest,
+        urlSession: any URLSessionProtocol,
+        requestBuilder: RequestBuilder<some Any>,
+        completion: @escaping (Result<URLRequest, any Error>) -> Void
+    ) {
+        WireLogger.wireCells.log(urlRequest)
+
+        interceptor.intercept(
+            urlRequest: urlRequest,
+            urlSession: urlSession,
+            requestBuilder: requestBuilder,
+            completion: completion
+        )
+    }
+
+    func retry(
+        urlRequest: URLRequest,
+        urlSession: any URLSessionProtocol,
+        requestBuilder: RequestBuilder<some Any>,
+        data: Data?,
+        response: URLResponse?,
+        error: any Error,
+        completion: @escaping (OpenAPIInterceptorRetry) -> Void
+    ) {
+        WireLogger.wireCells.warn("Wire cells node API request failed: \(error)")
+        if let response = response as? HTTPURLResponse {
+            WireLogger.wireCells.log(response: response)
+        }
+
+        interceptor.retry(
+            urlRequest: urlRequest,
+            urlSession: urlSession,
+            requestBuilder: requestBuilder,
+            data: data,
+            response: response,
+            error: error,
+            completion: completion
+        )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20490" title="WPB-20490" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20490</a>  [iOS] Add logging for CellsSDK requests/errors
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds logging when using the wire cells rest API. It is added to:

- all requests
- error responses

@netbe Please confirm it is reasonable to use the existing logging methods on requests & responses. I can't think of a reason why not.

### Testing

- Run the app connected to a debugger.
- Navigate to a cells enabled conversation.
- Navigate to the Files view.
- Check that a request is logged.
- Repeat with internet off.
- Check that an error is logged.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
