### PR TITLE
fix: own chat bubble text black on dark mode - WPB-20366

### DIFF
--- a/WireUI/Sources/WireDesign/Colors/SemanticColors.swift
+++ b/WireUI/Sources/WireDesign/Colors/SemanticColors.swift
@@ -284,7 +284,7 @@ public enum SemanticColors {
 
     public enum ChatBubble {
         public static let backgroundOtherMessage = UIColor(light: .gray30, dark: .gray100)
-        public static let foregroundOwnMessage = UIColor(light: .white, dark: .white)
+        public static let foregroundOwnMessage = UIColor(light: .white, dark: .black)
         public static let foregroundOtherMessage = UIColor(light: .black, dark: .white)
     }
 }


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

White text on chat bubble when dark mode is enable is hard to see.
We are reverting the change and drawing the text black like before.

❌ White text with chat bubbles & dark mode:
![3aa3c15e-9ee1-4df0-a66f-387c6adea540](https://github.com/user-attachments/assets/46f6812a-7558-4da2-8462-9c04239e092d)
![b2e4a004-8b40-4dd8-9a18-d49406d8dd46](https://github.com/user-attachments/assets/0deebb84-906f-46fa-8427-da89551a0c42)

✅ Black text with chat bubbles & dark mode
<img width="590" height="1278" alt="Simulator Screenshot - iPhone 16 - 2025-09-23 at 12 07 37" src="https://github.com/user-attachments/assets/84955ed8-875b-45cc-a461-7e8ab7aadc60" />


### Testing

1. Open the App
2. Enable dark theme
3. Look at any chat bubble you sent yourself in dark mode
4. Text should be black

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
