### PR TITLE
fix: request loop on supported-protocols - WPB-20151

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/User/UserLocalStore.swift
@@ -125,6 +125,7 @@ public final class UserLocalStore: UserLocalStoreProtocol {
         await context.perform { [context] in
             let selfUser = ZMUser.selfUser(in: context)
             selfUser.supportedProtocols = supportedProtocols
+            context.saveOrRollback()
         }
     }
 

--- a/WireDomain/Sources/WireDomain/UseCases/CalculateSupportedProtocolsUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/CalculateSupportedProtocolsUseCase.swift
@@ -55,7 +55,7 @@ public struct CalculateSupportedProtocolsUseCase: CalculateSupportedProtocolsUse
         let currentSelfUserSupportedProtocols = await userLocalStore.fetchSelfUserSupportedProtocols()
 
         logger.debug(
-            "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady)"
+            "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady), currentSelfUserSupportedProtocols: \(currentSelfUserSupportedProtocols)"
         )
 
         var result = Set<WireNetwork.MessageProtocol>()
@@ -63,11 +63,6 @@ public struct CalculateSupportedProtocolsUseCase: CalculateSupportedProtocolsUse
         /// All clients are proteus ready so we support it if the backend does.
         if remoteProtocols.contains(.proteus) {
             result.insert(.proteus)
-        }
-
-        // SelfUser supports mls (other client) at the moment, so we should not remove it
-        if currentSelfUserSupportedProtocols.contains(.mls) {
-            result.insert(.mls)
         }
 
         /// We support mls if the backend does and all MLS clients are ready.
@@ -93,6 +88,11 @@ public struct CalculateSupportedProtocolsUseCase: CalculateSupportedProtocolsUse
         /// Even if proteus isn't supported, migration is pending or still ongoing.
         if remoteProtocols == [.mls], !allClientsMLSReady, migrationState.isOne(of: .notStarted, .ongoing) {
             result = [.proteus]
+        }
+        
+        // SelfUser supports mls (other client) at the moment, so we should not remove it
+        if currentSelfUserSupportedProtocols.contains(.mls) {
+            result.insert(.mls)
         }
 
         logger.debug("calculated supported protocols: \(result)")

--- a/WireDomain/Sources/WireDomain/UseCases/CalculateSupportedProtocolsUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/CalculateSupportedProtocolsUseCase.swift
@@ -89,7 +89,7 @@ public struct CalculateSupportedProtocolsUseCase: CalculateSupportedProtocolsUse
         if remoteProtocols == [.mls], !allClientsMLSReady, migrationState.isOne(of: .notStarted, .ongoing) {
             result = [.proteus]
         }
-        
+
         // SelfUser supports mls (other client) at the moment, so we should not remove it
         if currentSelfUserSupportedProtocols.contains(.mls) {
             result.insert(.mls)

--- a/WireDomain/Tests/WireDomainTests/UseCases/CalculateSupportedProtocolsUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/CalculateSupportedProtocolsUseCaseTests.swift
@@ -219,7 +219,7 @@ final class CalculateSupportedProtocolsUseCaseTests: XCTestCase {
             XCTAssertEqual(testCase.supportedProtocols, supportedProtocols)
         }
     }
-    
+
     func test_CalculateSupportedProtocols_IfSelfClientSupportMLS_NoOverride() async throws {
         // Given
         await setup(remoteSupportedProtocols: [.mls])
@@ -231,7 +231,7 @@ final class CalculateSupportedProtocolsUseCaseTests: XCTestCase {
             (migrationState: Scaffolding.MigrationState, supportedProtocols: Set<WireNetwork.MessageProtocol>)
         ] =
             [
-                (migrationState: .notStarted, supportedProtocols: [.proteus, .mls]),
+                (migrationState: .notStarted, supportedProtocols: [.proteus, .mls])
             ]
 
         for testCase in testCases {

--- a/WireDomain/Tests/WireDomainTests/UseCases/CalculateSupportedProtocolsUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/CalculateSupportedProtocolsUseCaseTests.swift
@@ -219,6 +219,29 @@ final class CalculateSupportedProtocolsUseCaseTests: XCTestCase {
             XCTAssertEqual(testCase.supportedProtocols, supportedProtocols)
         }
     }
+    
+    func test_CalculateSupportedProtocols_IfSelfClientSupportMLS_NoOverride() async throws {
+        // Given
+        await setup(remoteSupportedProtocols: [.mls])
+
+        userClientsLocalStore.allSelfUserClientsAreActiveMLSClients_MockValue = false
+        let selfProtocols = [WireDataModel.MessageProtocol.proteus, WireDataModel.MessageProtocol.mls]
+        userLocalStore.fetchSelfUserSupportedProtocols_MockValue = Set(selfProtocols)
+        let testCases: [
+            (migrationState: Scaffolding.MigrationState, supportedProtocols: Set<WireNetwork.MessageProtocol>)
+        ] =
+            [
+                (migrationState: .notStarted, supportedProtocols: [.proteus, .mls]),
+            ]
+
+        for testCase in testCases {
+            await setup(migrationState: testCase.migrationState)
+            // When
+            let supportedProtocols = await sut.invoke()
+            // Then
+            XCTAssertEqual(testCase.supportedProtocols, supportedProtocols)
+        }
+    }
 
     func test_CalculateSupportedProtocols_NotAllActiveMLSClients_RemoteMLS() async throws {
         // Given

--- a/wire-ios-sync-engine/Source/Services/LegacySupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/LegacySupportedProtocolsService.swift
@@ -106,7 +106,7 @@ public final class LegacySupportedProtocolsService: LegacySupportedProtocolsServ
         if currentSelfUserSupportedProtocols.contains(.mls) {
             result.insert(.mls)
         }
-        
+
         logger.debug("calculated supported protocols: \(result) - legacy")
 
         return result

--- a/wire-ios-sync-engine/Source/Services/LegacySupportedProtocolsService.swift
+++ b/wire-ios-sync-engine/Source/Services/LegacySupportedProtocolsService.swift
@@ -67,7 +67,7 @@ public final class LegacySupportedProtocolsService: LegacySupportedProtocolsServ
 
         logger
             .debug(
-                "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady) - legacy"
+                "remote protocols: \(remoteProtocols), migration state: \(migrationState), allClientsMLSReady: \(allClientsMLSReady), currentSelfUserSupportedProtocols: \(currentSelfUserSupportedProtocols) - legacy"
             )
 
         var result = Set<MessageProtocol>()
@@ -75,11 +75,6 @@ public final class LegacySupportedProtocolsService: LegacySupportedProtocolsServ
         // All clients are proteus ready so we support it if the backend does.
         if remoteProtocols.contains(.proteus) {
             result.insert(.proteus)
-        }
-
-        // SelfUser supports mls (other client) at the moment, so we should not remove it
-        if currentSelfUserSupportedProtocols.contains(.mls) {
-            result.insert(.mls)
         }
 
         // All clients are mls ready so we support it if the backend does.
@@ -107,6 +102,11 @@ public final class LegacySupportedProtocolsService: LegacySupportedProtocolsServ
             result = [.proteus]
         }
 
+        // SelfUser supports mls (other client) at the moment, so we should not remove it
+        if currentSelfUserSupportedProtocols.contains(.mls) {
+            result.insert(.mls)
+        }
+        
         logger.debug("calculated supported protocols: \(result) - legacy")
 
         return result

--- a/wire-ios-sync-engine/Source/Use cases/LegacyResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/LegacyResolveOneOnOneConversationsUseCase.swift
@@ -43,7 +43,7 @@ struct LegacyResolveOneOnOneConversationsUseCase: LegacyResolveOneOnOneConversat
             let selfUser = ZMUser.selfUser(in: context)
             return selfUser.supportedProtocols
         }
-
+        WireLogger.supportedProtocols.debug("old: \(oldProtocols)")
         let newProtocols = await calculateSupportedProtocols()
         if oldProtocols != newProtocols {
             var action = PushSupportedProtocolsAction(supportedProtocols: newProtocols)
@@ -52,6 +52,7 @@ struct LegacyResolveOneOnOneConversationsUseCase: LegacyResolveOneOnOneConversat
             await context.perform {
                 let selfUser = ZMUser.selfUser(in: context)
                 selfUser.supportedProtocols = newProtocols
+                context.saveOrRollback()
             }
         }
 

--- a/wire-ios-sync-engine/Source/Use cases/LegacyResolveOneOnOneConversationsUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/LegacyResolveOneOnOneConversationsUseCase.swift
@@ -43,7 +43,7 @@ struct LegacyResolveOneOnOneConversationsUseCase: LegacyResolveOneOnOneConversat
             let selfUser = ZMUser.selfUser(in: context)
             return selfUser.supportedProtocols
         }
-        WireLogger.supportedProtocols.debug("old: \(oldProtocols)")
+
         let newProtocols = await calculateSupportedProtocols()
         if oldProtocols != newProtocols {
             var action = PushSupportedProtocolsAction(supportedProtocols: newProtocols)

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -550,6 +550,66 @@ public class MockIsE2EICertificateEnrollmentRequiredProtocol: IsE2EICertificateE
 
 }
 
+public class MockLegacyResolveOneOnOneConversationsUseCaseProtocol: LegacyResolveOneOnOneConversationsUseCaseProtocol {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - invoke
+
+    public var invoke_Invocations: [Void] = []
+    public var invoke_MockError: Error?
+    public var invoke_MockMethod: (() async throws -> Bool)?
+    public var invoke_MockValue: Bool?
+
+    @discardableResult
+    public func invoke() async throws -> Bool {
+        invoke_Invocations.append(())
+
+        if let error = invoke_MockError {
+            throw error
+        }
+
+        if let mock = invoke_MockMethod {
+            return try await mock()
+        } else if let mock = invoke_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `invoke`")
+        }
+    }
+
+}
+
+public class MockLegacySupportedProtocolsServiceInterface: LegacySupportedProtocolsServiceInterface {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - calculateSupportedProtocols
+
+    public var calculateSupportedProtocols_Invocations: [Void] = []
+    public var calculateSupportedProtocols_MockMethod: (() -> Set<WireDataModel.MessageProtocol>)?
+    public var calculateSupportedProtocols_MockValue: Set<WireDataModel.MessageProtocol>?
+
+    public func calculateSupportedProtocols() -> Set<WireDataModel.MessageProtocol> {
+        calculateSupportedProtocols_Invocations.append(())
+
+        if let mock = calculateSupportedProtocols_MockMethod {
+            return mock()
+        } else if let mock = calculateSupportedProtocols_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `calculateSupportedProtocols`")
+        }
+    }
+
+}
+
 public class MockPasteboard: Pasteboard {
 
     // MARK: - Life cycle
@@ -656,39 +716,6 @@ public class MockRemoveUserClientUseCaseProtocol: RemoveUserClientUseCaseProtoco
         }
 
         try await mock(clientId, password)
-    }
-
-}
-
-public class MockLegacyResolveOneOnOneConversationsUseCaseProtocol: LegacyResolveOneOnOneConversationsUseCaseProtocol {
-
-    // MARK: - Life cycle
-
-    public init() {}
-
-
-    // MARK: - invoke
-
-    public var invoke_Invocations: [Void] = []
-    public var invoke_MockError: Error?
-    public var invoke_MockMethod: (() async throws -> Bool)?
-    public var invoke_MockValue: Bool?
-
-    @discardableResult
-    public func invoke() async throws -> Bool {
-        invoke_Invocations.append(())
-
-        if let error = invoke_MockError {
-            throw error
-        }
-
-        if let mock = invoke_MockMethod {
-            return try await mock()
-        } else if let mock = invoke_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `invoke`")
-        }
     }
 
 }
@@ -1163,33 +1190,6 @@ public class MockStopCertificateEnrollmentSnoozerUseCaseProtocol: StopCertificat
         }
 
         mock()
-    }
-
-}
-
-public class MockLegacySupportedProtocolsServiceInterface: LegacySupportedProtocolsServiceInterface {
-
-    // MARK: - Life cycle
-
-    public init() {}
-
-
-    // MARK: - calculateSupportedProtocols
-
-    public var calculateSupportedProtocols_Invocations: [Void] = []
-    public var calculateSupportedProtocols_MockMethod: (() -> Set<WireDataModel.MessageProtocol>)?
-    public var calculateSupportedProtocols_MockValue: Set<WireDataModel.MessageProtocol>?
-
-    public func calculateSupportedProtocols() -> Set<WireDataModel.MessageProtocol> {
-        calculateSupportedProtocols_Invocations.append(())
-
-        if let mock = calculateSupportedProtocols_MockMethod {
-            return mock()
-        } else if let mock = calculateSupportedProtocols_MockValue {
-            return mock
-        } else {
-            fatalError("no mock for `calculateSupportedProtocols`")
-        }
     }
 
 }

--- a/wire-ios-sync-engine/Tests/Source/Services/LegacySupportedProtocolsServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Services/LegacySupportedProtocolsServiceTests.swift
@@ -307,19 +307,19 @@ final class LegacySupportedProtocolsServiceTests: XCTestCase {
             XCTAssertEqual(sut.calculateSupportedProtocols(), [.mls])
         }
     }
-    
+
     func test_CalculateSupportedProtocols_IfSelfClientSupportMLS_NoOverride() async throws {
-        
+
         try syncContext.performAndWait {
             // Given
             try mock(allActiveMLSClients: false)
             mock(remoteSupportedProtocols: [.mls])
             ZMUser.selfUser(in: syncContext).supportedProtocols = [.proteus, .mls]
-            
+
             mock(migrationState: .notStarted)
-            
+
             // When / then
-            
+
             XCTAssertEqual(sut.calculateSupportedProtocols(), [.mls, .proteus])
         }
     }

--- a/wire-ios-sync-engine/Tests/Source/Services/LegacySupportedProtocolsServiceTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Services/LegacySupportedProtocolsServiceTests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 @testable import WireSyncEngine
 
-final class SupportedProtocolsServiceTests: XCTestCase {
+final class LegacySupportedProtocolsServiceTests: XCTestCase {
 
     private var coreDataStackHelper: CoreDataStackHelper!
     private var mockCoreDataStack: CoreDataStack!
@@ -305,6 +305,22 @@ final class SupportedProtocolsServiceTests: XCTestCase {
 
             mock(migrationState: .finalised)
             XCTAssertEqual(sut.calculateSupportedProtocols(), [.mls])
+        }
+    }
+    
+    func test_CalculateSupportedProtocols_IfSelfClientSupportMLS_NoOverride() async throws {
+        
+        try syncContext.performAndWait {
+            // Given
+            try mock(allActiveMLSClients: false)
+            mock(remoteSupportedProtocols: [.mls])
+            ZMUser.selfUser(in: syncContext).supportedProtocols = [.proteus, .mls]
+            
+            mock(migrationState: .notStarted)
+            
+            // When / then
+            
+            XCTAssertEqual(sut.calculateSupportedProtocols(), [.mls, .proteus])
         }
     }
 }

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 		EE2DE5EC29263C5100F42F4C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2DE5EB29263C5100F42F4C /* Logger.swift */; };
 		EE38DDEE280437E500D4983D /* BlacklistReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE38DDED280437E500D4983D /* BlacklistReason.swift */; };
 		EE3BA1802CA6DC8C009D182C /* UnauthenticatedSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3BA17F2CA6DC8C009D182C /* UnauthenticatedSessionDelegate.swift */; };
-		EE3E43F62BF62BB9001A43A1 /* SupportedProtocolsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E43F52BF62BB9001A43A1 /* SupportedProtocolsServiceTests.swift */; };
+		EE3E43F62BF62BB9001A43A1 /* LegacySupportedProtocolsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E43F52BF62BB9001A43A1 /* LegacySupportedProtocolsServiceTests.swift */; };
 		EE3E43F92BF62BF6001A43A1 /* SelfSupportedProtocolsRequestStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E43F82BF62BF6001A43A1 /* SelfSupportedProtocolsRequestStrategyTests.swift */; };
 		EE419B58256FEA3D004618E2 /* ZMUserSession.Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE419B57256FEA3D004618E2 /* ZMUserSession.Configuration.swift */; };
 		EE458B0B27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE458B0A27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift */; };
@@ -1078,7 +1078,7 @@
 		EE2DE5EB29263C5100F42F4C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		EE38DDED280437E500D4983D /* BlacklistReason.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlacklistReason.swift; sourceTree = "<group>"; };
 		EE3BA17F2CA6DC8C009D182C /* UnauthenticatedSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnauthenticatedSessionDelegate.swift; sourceTree = "<group>"; };
-		EE3E43F52BF62BB9001A43A1 /* SupportedProtocolsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportedProtocolsServiceTests.swift; sourceTree = "<group>"; };
+		EE3E43F52BF62BB9001A43A1 /* LegacySupportedProtocolsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacySupportedProtocolsServiceTests.swift; sourceTree = "<group>"; };
 		EE3E43F82BF62BF6001A43A1 /* SelfSupportedProtocolsRequestStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSupportedProtocolsRequestStrategyTests.swift; sourceTree = "<group>"; };
 		EE419B57256FEA3D004618E2 /* ZMUserSession.Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMUserSession.Configuration.swift; sourceTree = "<group>"; };
 		EE458B0A27CCD58800F04038 /* ZMOperationLoop+APIVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMOperationLoop+APIVersion.swift"; sourceTree = "<group>"; };
@@ -2322,7 +2322,7 @@
 		EE3E43F72BF62BC4001A43A1 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				EE3E43F52BF62BB9001A43A1 /* SupportedProtocolsServiceTests.swift */,
+				EE3E43F52BF62BB9001A43A1 /* LegacySupportedProtocolsServiceTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2810,7 +2810,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EE3E43F62BF62BB9001A43A1 /* SupportedProtocolsServiceTests.swift in Sources */,
+				EE3E43F62BF62BB9001A43A1 /* LegacySupportedProtocolsServiceTests.swift in Sources */,
 				5E8EE1FC20FDCCE200DB1F9B /* CompanyLoginRequestDetectorTests.swift in Sources */,
 				F991CE161CB55512004D8465 /* ZMUser+Testing.m in Sources */,
 				5E2C354D21A806A80034F1EE /* MockBackgroundActivityManager.swift in Sources */,


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Following https://github.com/wireapp/wire-ios/pull/3628, a request loop occurs on pushing the supporting-protocols because the calculation is still wrong.


```
  if remoteProtocols == [.mls], !allClientsMLSReady, migrationState.isOne(of: .notStarted, .ongoing) {
            result = [.proteus]
        }
```
this overrides the fact that the self client supports mls.

**Solution:**

move after this previous check:

```
 // SelfUser supports mls (other client) at the moment, so we should not remove it
        if currentSelfUserSupportedProtocols.contains(.mls) {
            result.insert(.mls)
        }
```

### Testing

See tests
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
