### PR TITLE
fix: crash when session expires before updating to 4.6.0 - WPB-20649

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -139,6 +139,9 @@ final class AuthenticationInterfaceBuilder {
                 authenticationType = .new
             }
 
+            // If there's no environment, then it probably means that the user
+            // hasn't yet migrated to multibackend support yet. Fallback to the
+            // legacy environment to allow them to reauthenticate.
             let (rootView, bridge) = wireAuthenticationAssembly(
                 authenticationType: authenticationType,
                 environment: environment ?? BackendEnvironment2(BackendEnvironment.shared),

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -141,7 +141,7 @@ final class AuthenticationInterfaceBuilder {
 
             let (rootView, bridge) = wireAuthenticationAssembly(
                 authenticationType: authenticationType,
-                environment: environment!,
+                environment: environment ?? BackendEnvironment2(BackendEnvironment.shared),
                 registrationAnalyticsTracker: registrationAnalyticsTracker
             )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20649" title="WPB-20649" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20649</a>  [iOS] App crashes when reauth needed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
If your session expired (e.g you've been offline for a couple weeks and your cookie expired) and then you updated to 4.6.0, then each time you open the app it will crash.

This is because of a force unwrap on the environment which was assumed to exist in the reauthentication flow. However, it will be nil if the user hasn't yet loaded the session and migrated toward multibackend support.

The solution is simple: fallback on the legacy environment.

### Testing
1. Log in to a 4.5.0 or below.
2. Let your cookie expire.
3. Update to 4.6.0, crash.
4. Update to 4.6.2 (this fix) -> login screen.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
