### PR TITLE
chore: add developer tool for core crypto keys - WPB-20695

### DIFF
--- a/wire-ios-data-model/Source/Core Crypto/CoreCryptoKeyProvider.swift
+++ b/wire-ios-data-model/Source/Core Crypto/CoreCryptoKeyProvider.swift
@@ -21,7 +21,7 @@ import WireFoundation
 import WireLogging
 import WireSystem
 
-enum CoreCryptoKeyProviderDefaults: String, DefaultsKey {
+public enum CoreCryptoKeyProviderDefaults: String, DefaultsKey {
     case uniqueKeyIdentifier
 }
 

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysView.swift
@@ -19,9 +19,10 @@
 import SwiftUI
 
 // MARK: - Views
+
 struct DeveloperCoreCryptoKeysView: View {
     @StateObject var viewModel: DeveloperCoreCryptoKeysViewModel
-    
+
     var body: some View {
         NavigationView {
             List {
@@ -37,7 +38,7 @@ struct DeveloperCoreCryptoKeysView: View {
             .navigationTitle("Core Crypto Keys")
         }
     }
-    
+
     func keysSection(keys: [KeychainItem]) -> some View {
         Section(header: Text("Keychain Items").font(.headline)) {
             ForEach(keys) { item in
@@ -54,10 +55,10 @@ struct DeveloperCoreCryptoKeysView: View {
             }
         }
     }
-    
+
     func uniqueKeyIdSection(uuid: UUID?) -> some View {
         Section(header: Text("Unique Key Identifier").font(.headline)) {
-            if let uuid = uuid {
+            if let uuid {
                 Text(uuid.uuidString)
                     .font(.footnote)
                     .foregroundColor(.secondary)

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysView.swift
@@ -1,0 +1,70 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+
+// MARK: - Views
+struct DeveloperCoreCryptoKeysView: View {
+    @StateObject var viewModel: DeveloperCoreCryptoKeysViewModel
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(viewModel.accounts, id: \.userID) { account in
+                    Section(header: Text(viewModel.nameText(for: account))) {
+                        if !account.keys.isEmpty {
+                            keysSection(keys: account.keys)
+                        }
+                        uniqueKeyIdSection(uuid: account.uniqueKeyID)
+                    }
+                }
+            }
+            .navigationTitle("Core Crypto Keys")
+        }
+    }
+    
+    func keysSection(keys: [KeychainItem]) -> some View {
+        Section(header: Text("Keychain Items").font(.headline)) {
+            ForEach(keys) { item in
+                Text(item.applicationTag ?? "<no tag>")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .swipeActions {
+                        Button(role: .destructive) {
+                            viewModel.deleteKeychainItem(item)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+            }
+        }
+    }
+    
+    func uniqueKeyIdSection(uuid: UUID?) -> some View {
+        Section(header: Text("Unique Key Identifier").font(.headline)) {
+            if let uuid = uuid {
+                Text(uuid.uuidString)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("No UUID stored")
+                    .foregroundColor(.gray)
+            }
+        }
+    }
+}

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysViewModel.swift
@@ -17,9 +17,9 @@
 //
 
 import SwiftUI
-import WireSyncEngine
-import WireFoundation
 import WireCommonComponents
+import WireFoundation
+import WireSyncEngine
 
 struct DebugCoreCryptoAccount: Hashable {
     let userID: UUID
@@ -30,22 +30,23 @@ struct DebugCoreCryptoAccount: Hashable {
 }
 
 // MARK: - ViewModel
+
 class DeveloperCoreCryptoKeysViewModel: ObservableObject {
     @Published var accounts: [DebugCoreCryptoAccount] = []
-    
+
     private let userDefaults = UserDefaults.applicationGroup
     private let keychainHelper = DeveloperKeychainHelper()
     private let accountManager = SessionManager.shared?.accountManager
-    
+
     init() {
         loadAccounts()
     }
-    
+
     func loadAccounts() {
         guard let accountManager else { return }
 
         accounts = accountManager.accounts.compactMap { account in
-            return DebugCoreCryptoAccount(
+            DebugCoreCryptoAccount(
                 userID: account.userIdentifier,
                 username: account.userName,
                 keys: fetchKechainItems(for: account.userIdentifier),
@@ -54,14 +55,14 @@ class DeveloperCoreCryptoKeysViewModel: ObservableObject {
             )
         }
     }
-    
+
     func nameText(for account: DebugCoreCryptoAccount) -> String {
         var text = account.username
-        
+
         if account.isSelected {
             text += " - current account"
         }
-        
+
         return text
     }
 
@@ -69,13 +70,13 @@ class DeveloperCoreCryptoKeysViewModel: ObservableObject {
         keychainHelper.delete(item)
         loadAccounts()
     }
-    
+
     private func fetchKechainItems(for userID: UUID) -> [KeychainItem] {
-        return keychainHelper.fetchAll(matchingSecClass: kSecClassKey).filter {
+        keychainHelper.fetchAll(matchingSecClass: kSecClassKey).filter {
             $0.applicationTag?.contains(userID.uuidString) ?? false
         }
     }
-    
+
     private func fetchUniqueIdentifier(for userID: UUID) -> UUID? {
         let userDefaults = PrivateUserDefaults<CoreCryptoKeyProviderDefaults>(
             userID: userID,

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/CoreCryptoKeys/DeveloperCoreCryptoKeysViewModel.swift
@@ -1,0 +1,87 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WireSyncEngine
+import WireFoundation
+import WireCommonComponents
+
+struct DebugCoreCryptoAccount: Hashable {
+    let userID: UUID
+    let username: String
+    let keys: [KeychainItem]
+    let uniqueKeyID: UUID?
+    let isSelected: Bool
+}
+
+// MARK: - ViewModel
+class DeveloperCoreCryptoKeysViewModel: ObservableObject {
+    @Published var accounts: [DebugCoreCryptoAccount] = []
+    
+    private let userDefaults = UserDefaults.applicationGroup
+    private let keychainHelper = DeveloperKeychainHelper()
+    private let accountManager = SessionManager.shared?.accountManager
+    
+    init() {
+        loadAccounts()
+    }
+    
+    func loadAccounts() {
+        guard let accountManager else { return }
+
+        accounts = accountManager.accounts.compactMap { account in
+            return DebugCoreCryptoAccount(
+                userID: account.userIdentifier,
+                username: account.userName,
+                keys: fetchKechainItems(for: account.userIdentifier),
+                uniqueKeyID: fetchUniqueIdentifier(for: account.userIdentifier),
+                isSelected: accountManager.selectedAccount == account
+            )
+        }
+    }
+    
+    func nameText(for account: DebugCoreCryptoAccount) -> String {
+        var text = account.username
+        
+        if account.isSelected {
+            text += " - current account"
+        }
+        
+        return text
+    }
+
+    func deleteKeychainItem(_ item: KeychainItem) {
+        keychainHelper.delete(item)
+        loadAccounts()
+    }
+    
+    private func fetchKechainItems(for userID: UUID) -> [KeychainItem] {
+        return keychainHelper.fetchAll(matchingSecClass: kSecClassKey).filter {
+            $0.applicationTag?.contains(userID.uuidString) ?? false
+        }
+    }
+    
+    private func fetchUniqueIdentifier(for userID: UUID) -> UUID? {
+        let userDefaults = PrivateUserDefaults<CoreCryptoKeyProviderDefaults>(
+            userID: userID,
+            storage: userDefaults
+        )
+        return userDefaults.getUUID(forKey: CoreCryptoKeyProviderDefaults.uniqueKeyIdentifier)
+    }
+
+}

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -297,6 +297,11 @@ final class DeveloperToolsViewModel: ObservableObject {
                         AnyView(DeveloperKeychainItemsView(
                             viewModel: DeveloperKeychainItemsViewModel()
                         ))
+                    })),
+                    .destination(DestinationItem(title: "Core Crypto Keys", makeView: {
+                        AnyView(DeveloperCoreCryptoKeysView(
+                            viewModel: DeveloperCoreCryptoKeysViewModel()
+                        ))
                     }))
                 ]
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20695" title="WPB-20695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20695</a>  [iOS] Add developer tool to list core crypto keys for each account
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds an item to the developer menu to be able to see a list of core crypto keys saved in the keychain for each account logged in on the device. 

<img width="414" height="896" alt="Screenshot 2025-09-30 at 10 20 10" src="https://github.com/user-attachments/assets/b7d587ca-c896-4383-8a23-11a8c0b33c92" />


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
