### PR TITLE
fix: mls reset sending - WPB-20693

### DIFF
--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessor.swift
@@ -88,7 +88,7 @@ struct ConversationMLSResetEventProcessor: ConversationMLSResetEventProcessorPro
                     conversation: localConversation
                 )
             } else {
-                await conversationLocalStore.storeMLSConversationPendingJoin(
+                await conversationLocalStore.storeMLSConversationPendingJoinAfterReset(
                     newMLSGroupID: newMLSGroupID,
                     conversation: localConversation
                 )

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore+Status.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore+Status.swift
@@ -111,11 +111,12 @@ extension ConversationLocalStore {
         } catch {
             conversationExists = false
         }
-        
+
         var newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
 
         await context.perform { [self] in
             if localConversation.mlsStatus == .pendingJoinAfterReset {
+                // don't override the mlsStatus, this will be handle in re-establish group when needed
                 newStatus = .pendingJoinAfterReset
             }
             localConversation.mlsStatus = newStatus

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore+Status.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore+Status.swift
@@ -111,10 +111,13 @@ extension ConversationLocalStore {
         } catch {
             conversationExists = false
         }
-
-        let newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
+        
+        var newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
 
         await context.perform { [self] in
+            if localConversation.mlsStatus == .pendingJoinAfterReset {
+                newStatus = .pendingJoinAfterReset
+            }
             localConversation.mlsStatus = newStatus
             context.saveOrRollback()
         }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -118,12 +118,12 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         }
     }
 
-    public func storeMLSConversationPendingJoin(
+    public func storeMLSConversationPendingJoinAfterReset(
         newMLSGroupID: MLSGroupID,
         conversation: ZMConversation
     ) async {
         await context.perform {
-            conversation.mlsStatus = .pendingJoin
+            conversation.mlsStatus = .pendingJoinAfterReset
             conversation.mlsGroupID = newMLSGroupID
         }
     }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -388,7 +388,7 @@ public protocol ConversationLocalStoreProtocol {
     /// - Parameters:
     ///   - newMLSGroupID: The new generated MLS group ID
     ///   - conversation: The conversation to update the properties for.
-    func storeMLSConversationPendingJoin(
+    func storeMLSConversationPendingJoinAfterReset(
         newMLSGroupID: MLSGroupID,
         conversation: ZMConversation
     ) async

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -1191,7 +1191,7 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
     public var storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations: [(newMLSGroupID: MLSGroupID, conversation: ZMConversation)] = []
     public var storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod: ((MLSGroupID, ZMConversation) async -> Void)?
 
-    public func storeMLSConversationPendingJoin(newMLSGroupID: MLSGroupID, conversation: ZMConversation) async {
+    public func storeMLSConversationPendingJoinAfterReset(newMLSGroupID: MLSGroupID, conversation: ZMConversation) async {
         storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.append((newMLSGroupID: newMLSGroupID, conversation: conversation))
 
         guard let mock = storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod else {

--- a/wire-ios-data-model/Source/MLS/MLSGroupStatus.swift
+++ b/wire-ios-data-model/Source/MLS/MLSGroupStatus.swift
@@ -19,7 +19,7 @@
 /// Represents the status of an MLS group.
 
 public enum MLSGroupStatus: Int16 {
-    
+
     /// The group is pending to be joined via external commit.
 
     case pendingJoin
@@ -31,7 +31,7 @@ public enum MLSGroupStatus: Int16 {
     /// The group has become out-of-sync and needs to be rejoined.
 
     case outOfSync
-    
+
     /// The group is pending to be established or joined via external commit after MLS group was reset
 
     case pendingJoinAfterReset

--- a/wire-ios-data-model/Source/MLS/MLSGroupStatus.swift
+++ b/wire-ios-data-model/Source/MLS/MLSGroupStatus.swift
@@ -19,7 +19,7 @@
 /// Represents the status of an MLS group.
 
 public enum MLSGroupStatus: Int16 {
-
+    
     /// The group is pending to be joined via external commit.
 
     case pendingJoin
@@ -31,4 +31,8 @@ public enum MLSGroupStatus: Int16 {
     /// The group has become out-of-sync and needs to be rejoined.
 
     case outOfSync
+    
+    /// The group is pending to be established or joined via external commit after MLS group was reset
+
+    case pendingJoinAfterReset
 }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -931,27 +931,27 @@ public final class MLSService: MLSServiceInterface {
             context: context.notificationContext
         )
         
-        let (conversation, epoch) = await context.perform {
+        let (conversation, epoch, lastGroupID) = await context.perform {
             let conversation = ZMConversation.fetch(with: conversationInfo.qualifiedID.uuid,
                                                     domain: conversationInfo.qualifiedID.domain,
                                                     in: context)
-            return (conversation, conversation?.epoch)
+            return (conversation, conversation?.epoch, conversation?.mlsGroupID)
         }
         
-        guard let conversation else {
+        guard let conversation, let lastGroupID, let epoch else {
             throw MLSServiceError.conversationNotFound
         }
         
         let conversationExists = try await self.conversationExists(
-            groupID: groupID
+            groupID: lastGroupID
         )
 
         let shouldEstablishGroup = epoch == 0 && !conversationExists
 
-        if epoch == 0 {
-            try await internalEstablishPendingGroup(groupID: groupID, pendingGroup: conversation, context: context)
+        if shouldEstablishGroup {
+            try await internalEstablishPendingGroup(groupID: lastGroupID, pendingGroup: conversation, context: context)
         } else {
-            try await joinByExternalCommit(groupID: groupID)
+            try await joinByExternalCommit(groupID: lastGroupID)
         }
         
         await save(context)

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -817,7 +817,6 @@ public final class MLSService: MLSServiceInterface {
             throw MLSServiceError.conversationNotFound
         }
 
-        
         try await internalEstablishPendingGroup(
             groupID: groupID,
             pendingGroup: conversation,
@@ -917,32 +916,34 @@ public final class MLSService: MLSServiceInterface {
         }
     }
 
-    public func reEstablishPendingGroup( groupID: MLSGroupID) async throws {
+    public func reEstablishPendingGroup(groupID: MLSGroupID) async throws {
         guard let context else { return }
-        
+
         let conversationInfo = fetchConversationInfo(with: groupID, in: context)
-        
+
         guard let conversationInfo else {
             throw MLSServiceError.conversationNotFound
         }
-        
+
         try await actionsProvider.syncConversation(
             qualifiedID: conversationInfo.qualifiedID,
             context: context.notificationContext
         )
-        
+
         let (conversation, epoch, lastGroupID) = await context.perform {
-            let conversation = ZMConversation.fetch(with: conversationInfo.qualifiedID.uuid,
-                                                    domain: conversationInfo.qualifiedID.domain,
-                                                    in: context)
+            let conversation = ZMConversation.fetch(
+                with: conversationInfo.qualifiedID.uuid,
+                domain: conversationInfo.qualifiedID.domain,
+                in: context
+            )
             return (conversation, conversation?.epoch, conversation?.mlsGroupID)
         }
-        
+
         guard let conversation, let lastGroupID, let epoch else {
             throw MLSServiceError.conversationNotFound
         }
-        
-        let conversationExists = try await self.conversationExists(
+
+        let conversationExists = try await conversationExists(
             groupID: lastGroupID
         )
 
@@ -953,10 +954,10 @@ public final class MLSService: MLSServiceInterface {
         } else {
             try await joinByExternalCommit(groupID: lastGroupID)
         }
-        
+
         await save(context)
     }
-    
+
     // MARK: - Out-of-sync conversations
 
     public func repairOutOfSyncConversations() async throws {

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -371,9 +371,9 @@ public final class MLSService: MLSServiceInterface {
                 let selfUser = ZMUser.selfUser(in: context)
                 return MLSUser(from: selfUser, localDomain: self.localDomain)
             }
-
-            let usersWithSelfUser = users + [mlsSelfUser]
-            try await addMembersToConversation(with: usersWithSelfUser, for: groupID)
+            // make sure we have the selfUser but only once
+            let usersWithSelfUser = Set(users + [mlsSelfUser])
+            try await addMembersToConversation(with: Array(usersWithSelfUser), for: groupID)
             return ciphersuite
         } catch {
             try await wipeGroup(groupID)
@@ -2058,7 +2058,7 @@ extension MLSService: EpochObserver {}
 
 // MARK: - Helper types
 
-public struct MLSUser: Equatable {
+public struct MLSUser: Equatable, Hashable {
 
     public let id: UUID
     public let domain: String

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -916,7 +916,7 @@ public final class MLSService: MLSServiceInterface {
         }
     }
 
-    public func reEstablishPendingGroup(groupID: MLSGroupID) async throws {
+    public func reestablishPendingGroup(groupID: MLSGroupID) async throws {
         guard let context else { return }
 
         let conversationInfo = fetchConversationInfo(with: groupID, in: context)

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -808,6 +808,7 @@ public final class MLSService: MLSServiceInterface {
         guard let context else {
             return
         }
+
         let conversation = await context.perform {
             ZMConversation.fetch(with: groupID, in: context)
         }
@@ -816,6 +817,7 @@ public final class MLSService: MLSServiceInterface {
             throw MLSServiceError.conversationNotFound
         }
 
+        
         try await internalEstablishPendingGroup(
             groupID: groupID,
             pendingGroup: conversation,
@@ -915,6 +917,46 @@ public final class MLSService: MLSServiceInterface {
         }
     }
 
+    public func reEstablishPendingGroup( groupID: MLSGroupID) async throws {
+        guard let context else { return }
+        
+        let conversationInfo = fetchConversationInfo(with: groupID, in: context)
+        
+        guard let conversationInfo else {
+            throw MLSServiceError.conversationNotFound
+        }
+        
+        try await actionsProvider.syncConversation(
+            qualifiedID: conversationInfo.qualifiedID,
+            context: context.notificationContext
+        )
+        
+        let (conversation, epoch) = await context.perform {
+            let conversation = ZMConversation.fetch(with: conversationInfo.qualifiedID.uuid,
+                                                    domain: conversationInfo.qualifiedID.domain,
+                                                    in: context)
+            return (conversation, conversation?.epoch)
+        }
+        
+        guard let conversation else {
+            throw MLSServiceError.conversationNotFound
+        }
+        
+        let conversationExists = try await self.conversationExists(
+            groupID: groupID
+        )
+
+        let shouldEstablishGroup = epoch == 0 && !conversationExists
+
+        if epoch == 0 {
+            try await internalEstablishPendingGroup(groupID: groupID, pendingGroup: conversation, context: context)
+        } else {
+            try await joinByExternalCommit(groupID: groupID)
+        }
+        
+        await save(context)
+    }
+    
     // MARK: - Out-of-sync conversations
 
     public func repairOutOfSyncConversations() async throws {

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -916,7 +916,7 @@ public final class MLSService: MLSServiceInterface {
         }
     }
 
-    public func reestablishPendingGroup(groupID: MLSGroupID) async throws {
+    public func reEstablishPendingGroup(groupID: MLSGroupID) async throws {
         guard let context else { return }
 
         let conversationInfo = fetchConversationInfo(with: groupID, in: context)

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -481,14 +481,14 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// documentation](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/746488003/Proteus+to+MLS+Migration)
 
     func startProteusToMLSMigration() async throws
-    
+
     /// Restablish pending group
     ///
     /// Syncs the conversation metadata and join by external commit
     /// or establish the group by adding all mls clients depending on the epoch
     /// - Parameter groupID: the mls GroupID of the conversation to re-establish
     func reEstablishPendingGroup(groupID: MLSGroupID) async throws
-    
+
     // MARK: - Sync delegate
 
     /// Set the MLS sync delegate.
@@ -496,6 +496,6 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// - Parameter delegate: The sync delegate to set.
 
     func setSyncDelegate(_ delegate: any MLSSyncDelegate)
-    
+
     func setResetBrokenMLSConversationDelegate(_ delegate: any ResetBrokenMLSConversationDelegate)
 }

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -482,7 +482,7 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
 
     func startProteusToMLSMigration() async throws
 
-    /// Restablish pending group
+    /// Re-establish pending group
     ///
     /// Syncs the conversation metadata and join by external commit
     /// or establish the group by adding all mls clients depending on the epoch

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -481,7 +481,14 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// documentation](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/746488003/Proteus+to+MLS+Migration)
 
     func startProteusToMLSMigration() async throws
-
+    
+    /// Restablish pending group
+    ///
+    /// Syncs the conversation metadata and join by external commit
+    /// or establish the group by adding all mls clients depending on the epoch
+    /// - Parameter groupID: the mls GroupID of the conversation to re-establish
+    func reEstablishPendingGroup(groupID: MLSGroupID) async throws
+    
     // MARK: - Sync delegate
 
     /// Set the MLS sync delegate.
@@ -489,6 +496,6 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
     /// - Parameter delegate: The sync delegate to set.
 
     func setSyncDelegate(_ delegate: any MLSSyncDelegate)
-
+    
     func setResetBrokenMLSConversationDelegate(_ delegate: any ResetBrokenMLSConversationDelegate)
 }

--- a/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
@@ -189,9 +189,10 @@ public final class ConversationPredicateFactory: NSObject {
         // MLS
         let isMLS = NSPredicate(format: "\(ZMConversation.messageProtocolKey) == \(MessageProtocol.mls.int16Value)")
         let isMLSStatusReady = NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.ready.rawValue)")
-        let isMLSStatusPendingJoinAfterReset = NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.pendingJoinAfterReset.rawValue)")
-        
-        let isValidMLSStatus = NSPredicate.any(of: [isMLSStatusReady , isMLSStatusPendingJoinAfterReset])
+        let isMLSStatusPendingJoinAfterReset =
+            NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.pendingJoinAfterReset.rawValue)")
+
+        let isValidMLSStatus = NSPredicate.any(of: [isMLSStatusReady, isMLSStatusPendingJoinAfterReset])
         let isMLSAndReady = NSPredicate.all(of: [isMLS, isValidMLSStatus])
 
         return .any(of: [isProteus, isMixed, isMLSAndReady])

--- a/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
@@ -189,7 +189,10 @@ public final class ConversationPredicateFactory: NSObject {
         // MLS
         let isMLS = NSPredicate(format: "\(ZMConversation.messageProtocolKey) == \(MessageProtocol.mls.int16Value)")
         let isMLSStatusReady = NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.ready.rawValue)")
-        let isMLSAndReady = NSPredicate.all(of: [isMLS, isMLSStatusReady])
+        let isMLSStatusPendingJoinAfterReset = NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.pendingJoinAfterReset.rawValue)")
+        
+        let isValidMLSStatus = NSPredicate.any(of: [isMLSStatusReady , isMLSStatusPendingJoinAfterReset])
+        let isMLSAndReady = NSPredicate.all(of: [isMLS, isValidMLSStatus])
 
         return .any(of: [isProteus, isMixed, isMLSAndReady])
     }

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4783,6 +4783,26 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock()
     }
 
+    // MARK: - reEstablishPendingGroup
+
+    public var reEstablishPendingGroupGroupID_Invocations: [MLSGroupID] = []
+    public var reEstablishPendingGroupGroupID_MockError: Error?
+    public var reEstablishPendingGroupGroupID_MockMethod: ((MLSGroupID) async throws -> Void)?
+
+    public func reEstablishPendingGroup(groupID: MLSGroupID) async throws {
+        reEstablishPendingGroupGroupID_Invocations.append(groupID)
+
+        if let error = reEstablishPendingGroupGroupID_MockError {
+            throw error
+        }
+
+        guard let mock = reEstablishPendingGroupGroupID_MockMethod else {
+            fatalError("no mock for `reEstablishPendingGroupGroupID`")
+        }
+
+        try await mock(groupID)
+    }
+
     // MARK: - setSyncDelegate
 
     public var setSyncDelegate_Invocations: [any MLSSyncDelegate] = []

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -705,7 +705,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             }
         }
 
-
         // Then
         XCTAssertEqual(mockCreateConversationCount, 1)
         XCTAssertEqual(mockCoreCryptoContext.wipeConversationConversationId_Invocations.count, 1)

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -600,7 +600,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         // WHEN
         try await sut.reEstablishPendingGroup(groupID: groupID)
 
-
         // THEN
         try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
         try XCTAssertCount(
@@ -642,7 +641,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         // WHEN
         try await sut.reEstablishPendingGroup(groupID: groupID)
 
-
         // THEN
         try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
         try XCTAssertCount(
@@ -653,7 +651,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             XCTAssertEqual(conversation.mlsStatus, .ready)
         }
     }
-
 
     func test_EstablishGroup_WipesGroupOnError() async throws {
         // Given

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -571,6 +571,90 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertTrue(mockAddMembersCalled)
     }
 
+    func test_reEstablishGroup_establishGroup() async throws {
+        // GIVEN
+        let groupID = MLSGroupID(Data([1, 2, 3]))
+        let conversation = await uiMOC.perform { self.createConversation(
+            outOfSync: false,
+            currentEpoch: 0,
+            groupID: groupID
+        ).conversation }
+        await uiMOC.perform {
+            XCTAssertEqual(conversation.mlsStatus, .pendingJoin)
+        }
+        let mlsSelfUser = await uiMOC.perform {
+            MLSUser(from: self.selfUser, localDomain: self.localDomain)
+        }
+        let groupInfo = Data()
+        mockActionsProvider
+            .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockMethod = { _, _, _, _ in
+                groupInfo
+            }
+        mockMLSActionExecutor.mockJoinGroup = { mlsGroupID, mlsGroupInfo in
+            XCTAssertEqual(mlsGroupID, groupID)
+            XCTAssertEqual(mlsGroupInfo, groupInfo)
+        }
+        mockActionsProvider.syncConversationQualifiedIDContext_MockMethod = { _, _ in }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
+
+        // WHEN
+        try await sut.reEstablishPendingGroup(groupID: groupID)
+
+
+        // THEN
+        try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
+        try XCTAssertCount(
+            mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations,
+            count: 1
+        )
+        await uiMOC.perform {
+            XCTAssertEqual(conversation.mlsStatus, .ready)
+        }
+    }
+
+    func test_reEstablishGroup_joinViaExternalCommit() async throws {
+        // GIVEN
+        let groupID = MLSGroupID(Data([1, 2, 3]))
+        let conversation = await uiMOC.perform { self.createConversation(
+            outOfSync: false,
+            currentEpoch: 1,
+            groupID: groupID
+        ).conversation }
+
+        await uiMOC.perform {
+            XCTAssertEqual(conversation.mlsStatus, .pendingJoin)
+        }
+        let mlsSelfUser = await uiMOC.perform {
+            MLSUser(from: self.selfUser, localDomain: self.localDomain)
+        }
+        let groupInfo = Data()
+        mockActionsProvider
+            .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockMethod = { _, _, _, _ in
+                groupInfo
+            }
+        mockMLSActionExecutor.mockJoinGroup = { mlsGroupID, mlsGroupInfo in
+            XCTAssertEqual(mlsGroupID, groupID)
+            XCTAssertEqual(mlsGroupInfo, groupInfo)
+        }
+        mockActionsProvider.syncConversationQualifiedIDContext_MockMethod = { _, _ in }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
+
+        // WHEN
+        try await sut.reEstablishPendingGroup(groupID: groupID)
+
+
+        // THEN
+        try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
+        try XCTAssertCount(
+            mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations,
+            count: 1
+        )
+        await uiMOC.perform {
+            XCTAssertEqual(conversation.mlsStatus, .ready)
+        }
+    }
+
+
     func test_EstablishGroup_WipesGroupOnError() async throws {
         // Given
         let groupID = MLSGroupID(Data([1, 2, 3]))

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -694,9 +694,17 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // When
-        await assertItThrows(error: MLSService.MLSAddMembersError.failedToClaimKeyPackages(users: usersIncludingSelf)) {
+
+        do {
             try await _ = sut.establishGroup(for: groupID, with: users)
+        } catch {
+            if case let MLSService.MLSAddMembersError.failedToClaimKeyPackages(users) = error {
+                XCTAssertEqual(Set(usersIncludingSelf), Set(users))
+            } else {
+                XCTFail("unexepected error  \(error)")
+            }
         }
+
 
         // Then
         XCTAssertEqual(mockCreateConversationCount, 1)

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -576,10 +576,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         let groupID = MLSGroupID(Data([1, 2, 3]))
         let conversation = await uiMOC.perform {
             let conversation = self.createConversation(
-            outOfSync: false,
-            currentEpoch: epoch,
-            groupID: groupID
-        ).conversation
+                outOfSync: false,
+                currentEpoch: epoch,
+                groupID: groupID
+            ).conversation
             conversation.mlsStatus = .pendingJoinAfterReset
             return conversation
         }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -574,15 +574,16 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
     private func internalTestReEstablishGroup(epoch: UInt64) async throws {
         // GIVEN
         let groupID = MLSGroupID(Data([1, 2, 3]))
-        let conversation = await uiMOC.perform { self.createConversation(
+        let conversation = await uiMOC.perform {
+            let conversation = self.createConversation(
             outOfSync: false,
             currentEpoch: epoch,
             groupID: groupID
-        ).conversation }
-
-        await uiMOC.perform {
-            XCTAssertEqual(conversation.mlsStatus, .pendingJoin)
+        ).conversation
+            conversation.mlsStatus = .pendingJoinAfterReset
+            return conversation
         }
+
         let mlsSelfUser = await uiMOC.perform {
             MLSUser(from: self.selfUser, localDomain: self.localDomain)
         }

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -571,14 +571,15 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertTrue(mockAddMembersCalled)
     }
 
-    func test_reEstablishGroup_establishGroup() async throws {
+    private func internalTestReEstablishGroup(epoch: UInt64) async throws {
         // GIVEN
         let groupID = MLSGroupID(Data([1, 2, 3]))
         let conversation = await uiMOC.perform { self.createConversation(
             outOfSync: false,
-            currentEpoch: 0,
+            currentEpoch: epoch,
             groupID: groupID
         ).conversation }
+
         await uiMOC.perform {
             XCTAssertEqual(conversation.mlsStatus, .pendingJoin)
         }
@@ -594,18 +595,20 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             XCTAssertEqual(mlsGroupID, groupID)
             XCTAssertEqual(mlsGroupInfo, groupInfo)
         }
+        mockMLSActionExecutor.mockCommitPendingProposals = { mlsGroupID in
+            XCTAssertEqual(mlsGroupID, groupID)
+        }
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { mlsGroupID in
+            XCTAssertEqual(mlsGroupID, groupID)
+        }
+
         mockActionsProvider.syncConversationQualifiedIDContext_MockMethod = { _, _ in }
-        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // WHEN
         try await sut.reEstablishPendingGroup(groupID: groupID)
 
         // THEN
         try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
-        try XCTAssertCount(
-            mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations,
-            count: 1
-        )
         await uiMOC.perform {
             XCTAssertEqual(conversation.mlsStatus, .ready)
         }
@@ -613,43 +616,39 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_reEstablishGroup_joinViaExternalCommit() async throws {
         // GIVEN
-        let groupID = MLSGroupID(Data([1, 2, 3]))
-        let conversation = await uiMOC.perform { self.createConversation(
-            outOfSync: false,
-            currentEpoch: 1,
-            groupID: groupID
-        ).conversation }
-
-        await uiMOC.perform {
-            XCTAssertEqual(conversation.mlsStatus, .pendingJoin)
-        }
-        let mlsSelfUser = await uiMOC.perform {
-            MLSUser(from: self.selfUser, localDomain: self.localDomain)
-        }
-        let groupInfo = Data()
-        mockActionsProvider
-            .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockMethod = { _, _, _, _ in
-                groupInfo
-            }
-        mockMLSActionExecutor.mockJoinGroup = { mlsGroupID, mlsGroupInfo in
-            XCTAssertEqual(mlsGroupID, groupID)
-            XCTAssertEqual(mlsGroupInfo, groupInfo)
-        }
-        mockActionsProvider.syncConversationQualifiedIDContext_MockMethod = { _, _ in }
         mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // WHEN
-        try await sut.reEstablishPendingGroup(groupID: groupID)
+        try await internalTestReEstablishGroup(epoch: 1)
 
         // THEN
-        try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
         try XCTAssertCount(
             mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations,
             count: 1
         )
-        await uiMOC.perform {
-            XCTAssertEqual(conversation.mlsStatus, .ready)
-        }
+        XCTAssertEqual(mockMLSActionExecutor.mockAddMembersCount, 0)
+        XCTAssertEqual(mockMLSActionExecutor.mockJoinGroupCount, 1)
+    }
+
+    func test_reEstablishGroup_establishGroup() async throws {
+        // GIVEN
+        mockCoreCryptoContext.createConversationConversationIdCreatorCredentialTypeConfig_MockMethod = { _, _, _ in }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
+        mockActionsProvider.claimKeyPackagesUserIDDomainCiphersuiteExcludedSelfClientIDIn_MockValue = [KeyPackage(
+            client: "123e",
+            domain: "qwer",
+            keyPackage: "qwer",
+            keyPackageRef: "asdf",
+            userID: UUID()
+        )]
+        mockMLSActionExecutor.mockAddMembers = { _, _ in }
+
+        // WHEN
+        try await internalTestReEstablishGroup(epoch: 0)
+
+        // THEN
+        XCTAssertEqual(mockMLSActionExecutor.mockAddMembersCount, 1)
+        XCTAssertEqual(mockMLSActionExecutor.mockJoinGroupCount, 0)
     }
 
     func test_EstablishGroup_WipesGroupOnError() async throws {

--- a/wire-ios-data-model/Tests/MLS/MockMLSActionExecutor.swift
+++ b/wire-ios-data-model/Tests/MLS/MockMLSActionExecutor.swift
@@ -55,6 +55,12 @@ final class MockMLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Add members
 
+    private var mockAddMembersCount_ = 0
+    var mockAddMembersCount: Int {
+        get { serialQueue.sync { mockAddMembersCount_ } }
+        set { serialQueue.sync { mockAddMembersCount_ = newValue } }
+    }
+
     typealias AddMembersMock = ([WireDataModel.KeyPackage], MLSGroupID) async throws -> Void
     private var _mockAddMembers: AddMembersMock?
     var mockAddMembers: AddMembersMock? {
@@ -67,6 +73,7 @@ final class MockMLSActionExecutor: MLSActionExecutorProtocol {
             fatalError("no mock for `addMembers`")
         }
 
+        mockAddMembersCount_ += 1
         return try await mock(keyPackages, groupID)
     }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -389,10 +389,11 @@ public final class MessageSender: MessageSenderInterface {
             throw MessageSendError.missingMlsService
         }
 
-        if mlsStatus == .pendingJoin {
-            try await mlsService.reEstablishGroup(groupID: groupID)
-        }
         do {
+            if mlsStatus == .pendingJoin {
+                try await mlsService.reEstablishPendingGroup(groupID: groupID)
+            }
+
             try await mlsService.commitPendingProposals(in: groupID)
             let encryptedData = try await encryptMlsMessage(message, groupID: groupID)
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -372,10 +372,11 @@ public final class MessageSender: MessageSenderInterface {
     }
 
     private func attemptToSendWithMLS(message: any SendableMessage, apiVersion: APIVersion) async throws {
-        let (conversationID, groupID, mlsService) = await context.perform { (
+        let (conversationID, groupID, mlsService, mlsStatus) = await context.perform { (
             message.conversation?.qualifiedID,
             message.conversation?.mlsGroupID,
-            self.context.mlsService
+            self.context.mlsService,
+            message.conversation?.mlsStatus
         ) }
 
         guard let conversationID else {
@@ -388,6 +389,9 @@ public final class MessageSender: MessageSenderInterface {
             throw MessageSendError.missingMlsService
         }
 
+        if mlsStatus == .pendingJoin {
+            try await mlsService.reEstablishGroup(groupID: groupID)
+        }
         do {
             try await mlsService.commitPendingProposals(in: groupID)
             let encryptedData = try await encryptMlsMessage(message, groupID: groupID)

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -390,7 +390,7 @@ public final class MessageSender: MessageSenderInterface {
         }
 
         do {
-            if mlsStatus == .pendingJoin {
+            if mlsStatus?.isOne(of: .pendingJoinAfterReset, .pendingJoin) == true {
                 try await mlsService.reEstablishPendingGroup(groupID: groupID)
             }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -728,7 +728,7 @@ final class MessageSenderTests: MessagingTestBase {
         await assertItThrows(error: MessageSendError.missingGroupID) {
             try await messageSender.sendMessage(message: message)
         }
-        
+
         XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -737,7 +737,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
-            self.groupConversation.mlsStatus = .pendingJoin
+            self.groupConversation.mlsStatus = .pendingJoinAfterReset
         }
         let message = GenericMessageEntity(
             message: GenericMessage(content: Text(content: "Hello World")),

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -718,6 +718,44 @@ final class MessageSenderTests: MessagingTestBase {
         }
     }
 
+    func testThatWhenSendingMlsMessageOnAPendingJoinConversation_CallsReEstablishPendingJoin() async throws {
+        // given
+        await syncMOC.performGrouped {
+            self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
+            self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .pendingJoin
+        }
+        let message = GenericMessageEntity(
+            message: GenericMessage(content: Text(content: "Hello World")),
+            context: syncMOC,
+            conversation: groupConversation,
+            completionHandler: nil
+        )
+        let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: 0)
+        let messageSendingStatus = Payload.MLSMessageSendingStatus(
+            time: Date(),
+            events: [],
+            failedToSend: nil
+        )
+
+        let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withIncrementalSyncObserverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(()))
+            .withApiVersionResolving(to: .v5)
+            .withMLServiceConfigured()
+            .withSendMlsMessage(returning: .success((messageSendingStatus, response)))
+            .arrange()
+        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
+        arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
+            message + [000]
+        }
+        arrangement.mlsService.reEstablishPendingGroupGroupID_MockMethod = { _ in }
+
+        try await messageSender.sendMessage(message: message)
+
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 1)
+    }
+
     // MARK: - Helpers
 
     private func broadcastMessage() async -> GenericMessageEntity {

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -463,6 +463,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: 0)
         let messageSendingStatus = Payload.MLSMessageSendingStatus(
@@ -494,6 +495,7 @@ final class MessageSenderTests: MessagingTestBase {
         try await messageSender.sendMessage(message: message)
 
         // then test completes
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageSucceeds_thenCommitPendingProposalsInGroup() async throws {
@@ -501,6 +503,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: 0)
         let messageSendingStatus = Payload.MLSMessageSendingStatus(
@@ -533,6 +536,7 @@ final class MessageSenderTests: MessagingTestBase {
 
         // then
         XCTAssertEqual([Arrangement.Scaffolding.groupID], arrangement.mlsService.commitPendingProposalsIn_Invocations)
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageFailsWithPermanentError_thenThrowError() async throws {
@@ -540,6 +544,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let response = ZMTransportResponse(payload: nil, httpStatus: 403, transportSessionError: nil, apiVersion: 0)
         let networkError = NetworkError.errorDecodingResponse(response)
@@ -573,6 +578,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let networkError = SendMLSMessageFailure.mlsMissingSenderClient(message: "test")
         let message = GenericMessageEntity(
@@ -605,6 +611,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let networkError = SendMLSMessageFailure.mlsInvalidLeafNodeIndex(message: "Test")
         let message = GenericMessageEntity(
@@ -632,6 +639,7 @@ final class MessageSenderTests: MessagingTestBase {
         let invocation = arrangement.initiateResetMLSConversationUseCase.invokeGroupIDEpoch_Invocations.first
         XCTAssertEqual(invocation?.epoch, 0)
         XCTAssertEqual(invocation?.groupID, Arrangement.Scaffolding.groupID)
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageFailsWithResetMLSConversationError_AndFeatureFlagIsOff_JustThrows() async throws {
@@ -639,6 +647,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let networkError = SendMLSMessageFailure.mlsInvalidLeafNodeIndex(message: "Test")
         let message = GenericMessageEntity(
@@ -666,6 +675,7 @@ final class MessageSenderTests: MessagingTestBase {
         }
 
         XCTAssertEqual(arrangement.initiateResetMLSConversationUseCase.invokeGroupIDEpoch_Invocations.count, 0)
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageWithoutMlsService_thenThrowError() async throws {
@@ -673,6 +683,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let message = GenericMessageEntity(
             message: GenericMessage(content: Text(content: "Hello World")),
@@ -697,6 +708,7 @@ final class MessageSenderTests: MessagingTestBase {
         // given
         await syncMOC.performGrouped {
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let message = GenericMessageEntity(
             message: GenericMessage(content: Text(content: "Hello World")),
@@ -705,7 +717,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil
         )
 
-        let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+        let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
             .withIncrementalSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(()))
             .withApiVersionResolving(to: .v5)
@@ -716,6 +728,8 @@ final class MessageSenderTests: MessagingTestBase {
         await assertItThrows(error: MessageSendError.missingGroupID) {
             try await messageSender.sendMessage(message: message)
         }
+        
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageOnAPendingJoinConversation_CallsReEstablishPendingJoin() async throws {
@@ -749,7 +763,6 @@ final class MessageSenderTests: MessagingTestBase {
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
-        arrangement.mlsService.reEstablishPendingGroupGroupID_MockMethod = { _ in }
 
         try await messageSender.sendMessage(message: message)
 
@@ -833,7 +846,7 @@ final class MessageSenderTests: MessagingTestBase {
                 status: .enabled,
                 config: .init(mlsConversationReset: true)
             )
-
+            mlsService.reEstablishPendingGroupGroupID_MockMethod = { _ in }
         }
 
         func withApiVersionResolving(to apiVersion: APIVersion?) -> Arrangement {

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -153,11 +153,14 @@ public class MLSEventProcessor: MLSEventProcessing {
                 .error("failed to check if conversation \(mlsGroupID.safeForLoggingDescription) exists: \(error)")
             conversationExists = false
         }
-        let newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
+        var newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
 
         await context.perform {
             let previousStatus = conversation.mlsStatus
-
+            // double check
+            if previousStatus == .pendingJoinAfterReset {
+                newStatus = .pendingJoinAfterReset
+            }
             conversation.mlsStatus = newStatus
             context.saveOrRollback()
             Flow.createGroup.checkpoint(description: "saved ZMConversation for MLS")

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -157,8 +157,9 @@ public class MLSEventProcessor: MLSEventProcessing {
 
         await context.perform {
             let previousStatus = conversation.mlsStatus
-            // double check
+
             if previousStatus == .pendingJoinAfterReset {
+                // never override pendingJoinAferReset, this will be handle in re-establish group
                 newStatus = .pendingJoinAfterReset
             }
             conversation.mlsStatus = newStatus

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsView.swift
@@ -27,7 +27,7 @@ struct DeveloperDebugActionsView: View {
         List(viewModel.debugItems) { debugItem in
             switch debugItem {
             case let .button(buttonItem):
-                Button(action: buttonItem.action) {
+                Button(hapticFeedbackStyle: .success, action: buttonItem.action) {
                     Text(buttonItem.title)
                 }
             case let .toggle(toggleItem):

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -723,10 +723,6 @@ extension ConversationViewController: ZMConversationListObserver {
     func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
         updateLeftNavigationBarItems()
         if changeInfo.deletedObjects.contains(conversation) {
-            if conversation.mlsStatus == .pendingJoin {
-                // don't pop if mls reset happened
-                return
-            }
             ZClientViewController.shared?.transitionToList(animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20693" title="WPB-20693" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20693</a>  [iOS] Recover from re-initialized MLS conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When on a conversation view where the conversation gets mls reset on another user's client, it's not possible to recover from sending a message.

### Solution

* Reestablish the session for pendingJoin conversation while sending a message.
* **[EDIT]:** adding new status pendingJoinAfterReset so in case the mls reset is not complete even when not on the conversation view, it's possible to fix the conversation in sending a message
  * Include in conversation's list conversations with pendingJoinAfterReset

### Testing

See ticket
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
