### PR TITLE
fix: Update the Poll Button Color - WPB-19731

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Poll/ConversationButtonMessageCell.swift
@@ -94,12 +94,13 @@ final class ConversationButtonMessageCell: UIView, ConversationMessageCell {
 
     func configure(with object: Configuration, animated: Bool) {
         config = object
-        guard let userSession = config?.userSession else {
+        guard let userSession = config?.userSession,
+              accentColorChangeHandler == nil else {
             return
         }
         accentColorChangeHandler = AccentColorChangeHandler
-            .addObserver(userSession: userSession) { [unowned self] color in
-                updateBackgroundColor(color: color)
+            .addObserver(userSession: userSession) { [weak self] color in
+                self?.updateBackgroundColor(color: color)
             }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19731" title="WPB-19731" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19731</a>  Update the Poll Button Color view when the accentColor changed from different clients(web,iOS)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Improved the code by adding accent color change observer only once and changed unowned self of handler to weak self for app not to crash.

### Testing
Whenever accent color is changed in webclient, poll buttons must update respectively
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
