### PR TITLE
fix: Send button and message text box color doesn't change on changing the accent color from web - WPB-20522

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -208,6 +208,7 @@ final class ConversationInputBarViewController: UIViewController,
     var editingMessage: ZMConversationMessage?
     var quotedMessage: ZMConversationMessage?
     var replyComposingView: ReplyComposingView?
+    private var accentColorChangeHandler: AccentColorChangeHandler?
 
     // MARK: feedback
 
@@ -863,6 +864,16 @@ final class ConversationInputBarViewController: UIViewController,
 
             self?.updateViewsForSelfDeletingMessageChanges()
         }
+        guard accentColorChangeHandler == nil else { return }
+        accentColorChangeHandler = AccentColorChangeHandler
+            .addObserver(userSession: userSession) { [weak self] color in
+                self?.updateBackgroundColor(color: color)
+            }
+    }
+
+    private func updateBackgroundColor(color: ZMAccentColor?) {
+        sendButton.updateSendButtonColor()
+        inputBar.updateTextViewTintColor()
     }
 
     // MARK: - Keyboard Shortcuts

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/InputBar.swift
@@ -633,6 +633,10 @@ final class InputBar: UIView {
         }
     }
 
+    func updateTextViewTintColor() {
+        textView.tintColor = .accent()
+    }
+
     // MARK: – Editing View State
 
     func setInputBarText(_ text: String, mentions: [Mention]) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/IconButton+Factory.swift
@@ -79,14 +79,7 @@ extension IconButton {
         setIcon(icon, size: size, for: .normal)
         accessibilityIdentifier = accessibilityId
         translatesAutoresizingMaskIntoConstraints = false
-
-        for (state, color) in backgroundColor {
-            setBackgroundImageColor(color, for: .init(rawValue: state))
-        }
-
-        for (state, color) in iconColor {
-            setIconColor(color, for: .init(rawValue: state))
-        }
+        updateIconAndBackgroundColor(backgroundColor: backgroundColor, iconColor: iconColor)
 
         borderWidth = 0
 
@@ -96,4 +89,34 @@ extension IconButton {
         }
     }
 
+    private func updateIconAndBackgroundColor(
+        backgroundColor: [UIControl.State.RawValue: UIColor],
+        iconColor: [UIControl.State.RawValue: UIColor]
+    ) {
+        for (state, color) in backgroundColor {
+            setBackgroundImageColor(color, for: .init(rawValue: state))
+        }
+
+        for (state, color) in iconColor {
+            setIconColor(color, for: .init(rawValue: state))
+        }
+    }
+
+    func updateSendButtonColor() {
+        let sendButtonIconColor = SemanticColors.Icon.foregroundDefaultWhite
+        let backgroundColor = [
+            UIControl.State.normal.rawValue: UIColor.accent(),
+            UIControl.State.highlighted.rawValue: UIColor.accentDarken,
+            UIControl.State.disabled.rawValue: SemanticColors.Button.backgroundSendDisabled
+        ]
+        let iconColor = [
+            UIControl.State.normal.rawValue: sendButtonIconColor,
+            UIControl.State.highlighted.rawValue: sendButtonIconColor,
+            UIControl.State.disabled.rawValue: sendButtonIconColor
+        ]
+        updateIconAndBackgroundColor(
+            backgroundColor: backgroundColor,
+            iconColor: iconColor
+        )
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20522" title="WPB-20522" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20522</a>  [iOS] Send button and message text box color doesn't change on changing the accent color from web
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Steps to replicate:
- Make sure you have both device and web logged in with same user
- Change the accent color from web and observe the background and sent button > Send button color doesn't change

Solution: Added observer using accentColorChangeHandler and updated colors whenever we receive new color
### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
