### PR TITLE
fix: mls reset sending - WPB-20693 🍒

### DIFF
--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -52,7 +52,7 @@ jobs:
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: false
           
-          subjectPattern: ^(.*) - (WPB-\d+)$
+          subjectPattern: ^(.*) - (WPB-\d+)( 🍒)$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessor.swift
@@ -88,7 +88,7 @@ struct ConversationMLSResetEventProcessor: ConversationMLSResetEventProcessorPro
                     conversation: localConversation
                 )
             } else {
-                await conversationLocalStore.storeMLSConversationPendingJoin(
+                await conversationLocalStore.storeMLSConversationPendingJoinAfterReset(
                     newMLSGroupID: newMLSGroupID,
                     conversation: localConversation
                 )

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore+Status.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore+Status.swift
@@ -112,9 +112,13 @@ extension ConversationLocalStore {
             conversationExists = false
         }
 
-        let newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
+        var newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
 
         await context.perform { [self] in
+            if localConversation.mlsStatus == .pendingJoinAfterReset {
+                // don't override the mlsStatus, this will be handle in re-establish group when needed
+                newStatus = .pendingJoinAfterReset
+            }
             localConversation.mlsStatus = newStatus
             context.saveOrRollback()
         }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -118,12 +118,12 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         }
     }
 
-    public func storeMLSConversationPendingJoin(
+    public func storeMLSConversationPendingJoinAfterReset(
         newMLSGroupID: MLSGroupID,
         conversation: ZMConversation
     ) async {
         await context.perform {
-            conversation.mlsStatus = .pendingJoin
+            conversation.mlsStatus = .pendingJoinAfterReset
             conversation.mlsGroupID = newMLSGroupID
         }
     }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -388,7 +388,7 @@ public protocol ConversationLocalStoreProtocol {
     /// - Parameters:
     ///   - newMLSGroupID: The new generated MLS group ID
     ///   - conversation: The conversation to update the properties for.
-    func storeMLSConversationPendingJoin(
+    func storeMLSConversationPendingJoinAfterReset(
         newMLSGroupID: MLSGroupID,
         conversation: ZMConversation
     ) async

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -1191,7 +1191,7 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
     public var storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations: [(newMLSGroupID: MLSGroupID, conversation: ZMConversation)] = []
     public var storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod: ((MLSGroupID, ZMConversation) async -> Void)?
 
-    public func storeMLSConversationPendingJoin(newMLSGroupID: MLSGroupID, conversation: ZMConversation) async {
+    public func storeMLSConversationPendingJoinAfterReset(newMLSGroupID: MLSGroupID, conversation: ZMConversation) async {
         storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.append((newMLSGroupID: newMLSGroupID, conversation: conversation))
 
         guard let mock = storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod else {

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -1186,16 +1186,16 @@ public class MockConversationLocalStoreProtocol: ConversationLocalStoreProtocol 
         await mock(mlsGroupID, conversation)
     }
 
-    // MARK: - storeMLSConversationPendingJoin
+    // MARK: - storeMLSConversationPendingJoinAfterReset
 
-    public var storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations: [(newMLSGroupID: MLSGroupID, conversation: ZMConversation)] = []
-    public var storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod: ((MLSGroupID, ZMConversation) async -> Void)?
+    public var storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_Invocations: [(newMLSGroupID: MLSGroupID, conversation: ZMConversation)] = []
+    public var storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_MockMethod: ((MLSGroupID, ZMConversation) async -> Void)?
 
     public func storeMLSConversationPendingJoinAfterReset(newMLSGroupID: MLSGroupID, conversation: ZMConversation) async {
-        storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.append((newMLSGroupID: newMLSGroupID, conversation: conversation))
+        storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_Invocations.append((newMLSGroupID: newMLSGroupID, conversation: conversation))
 
-        guard let mock = storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod else {
-            fatalError("no mock for `storeMLSConversationPendingJoinNewMLSGroupIDConversation`")
+        guard let mock = storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_MockMethod else {
+            fatalError("no mock for `storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation`")
         }
 
         await mock(newMLSGroupID, conversation)

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
@@ -57,7 +57,7 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
         mlsService.wipeGroup_MockMethod = { _ in }
         mlsService.conversationExistsGroupID_MockValue = false
         conversationLocalStore.fetchConversationIdDomain_MockValue = conversation
-        conversationLocalStore.storeMLSConversationPendingJoinNewMLSGroupIDConversation_MockMethod = { _, _ in }
+        conversationLocalStore.storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_MockMethod = { _, _ in }
         conversationLocalStore.storeMLSConversationEstablishedMlsGroupIDConversation_MockMethod = { _, _ in }
 
         mockResetLockRepository.removeResetInitiatedConversationID_MockMethod = { _ in }

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
@@ -100,10 +100,10 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
             }
 
         XCTAssertEqual(
-            conversationLocalStore.storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.count,
+            conversationLocalStore.storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_Invocations.count,
             1
         )
-        conversationLocalStore.storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations
+        conversationLocalStore.storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_Invocations
             .forEach {
                 XCTAssertEqual(
                     $0.newMLSGroupID,
@@ -132,7 +132,7 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
             }
 
         XCTAssertEqual(
-            conversationLocalStore.storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.count,
+            conversationLocalStore.storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_Invocations.count,
             0
         )
         XCTAssertEqual(
@@ -162,7 +162,7 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
         XCTAssertEqual(mockResetLockRepository.removeResetInitiatedConversationID_Invocations.count, 1)
         XCTAssertEqual(mlsService.wipeGroup_Invocations.count, 0)
         XCTAssertEqual(
-            conversationLocalStore.storeMLSConversationPendingJoinNewMLSGroupIDConversation_Invocations.count,
+            conversationLocalStore.storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_Invocations.count,
             0
         )
         XCTAssertEqual(mlsService.wipeGroup_Invocations.count, 0)

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationMLSResetEventProcessorTests.swift
@@ -57,7 +57,8 @@ final class ConversationMLSResetEventProcessorTests: XCTestCase {
         mlsService.wipeGroup_MockMethod = { _ in }
         mlsService.conversationExistsGroupID_MockValue = false
         conversationLocalStore.fetchConversationIdDomain_MockValue = conversation
-        conversationLocalStore.storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_MockMethod = { _, _ in }
+        conversationLocalStore
+            .storeMLSConversationPendingJoinAfterResetNewMLSGroupIDConversation_MockMethod = { _, _ in }
         conversationLocalStore.storeMLSConversationEstablishedMlsGroupIDConversation_MockMethod = { _, _ in }
 
         mockResetLockRepository.removeResetInitiatedConversationID_MockMethod = { _ in }

--- a/wire-ios-data-model/Source/MLS/MLSGroupStatus.swift
+++ b/wire-ios-data-model/Source/MLS/MLSGroupStatus.swift
@@ -31,4 +31,8 @@ public enum MLSGroupStatus: Int16 {
     /// The group has become out-of-sync and needs to be rejoined.
 
     case outOfSync
+
+    /// The group is pending to be established or joined via external commit after MLS group was reset
+
+    case pendingJoinAfterReset
 }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -371,9 +371,9 @@ public final class MLSService: MLSServiceInterface {
                 let selfUser = ZMUser.selfUser(in: context)
                 return MLSUser(from: selfUser, localDomain: self.localDomain)
             }
-
-            let usersWithSelfUser = users + [mlsSelfUser]
-            try await addMembersToConversation(with: usersWithSelfUser, for: groupID)
+            // make sure we have the selfUser but only once
+            let usersWithSelfUser = Set(users + [mlsSelfUser])
+            try await addMembersToConversation(with: Array(usersWithSelfUser), for: groupID)
             return ciphersuite
         } catch {
             try await wipeGroup(groupID)
@@ -808,6 +808,7 @@ public final class MLSService: MLSServiceInterface {
         guard let context else {
             return
         }
+
         let conversation = await context.perform {
             ZMConversation.fetch(with: groupID, in: context)
         }
@@ -913,6 +914,48 @@ public final class MLSService: MLSServiceInterface {
         _ = await context.perform { [context] in
             context.saveOrRollback()
         }
+    }
+
+    public func reEstablishPendingGroup(groupID: MLSGroupID) async throws {
+        guard let context else { return }
+
+        let conversationInfo = fetchConversationInfo(with: groupID, in: context)
+
+        guard let conversationInfo else {
+            throw MLSServiceError.conversationNotFound
+        }
+
+        try await actionsProvider.syncConversation(
+            qualifiedID: conversationInfo.qualifiedID,
+            context: context.notificationContext
+        )
+
+        let (conversation, epoch, lastGroupID) = await context.perform {
+            let conversation = ZMConversation.fetch(
+                with: conversationInfo.qualifiedID.uuid,
+                domain: conversationInfo.qualifiedID.domain,
+                in: context
+            )
+            return (conversation, conversation?.epoch, conversation?.mlsGroupID)
+        }
+
+        guard let conversation, let lastGroupID, let epoch else {
+            throw MLSServiceError.conversationNotFound
+        }
+
+        let conversationExists = try await conversationExists(
+            groupID: lastGroupID
+        )
+
+        let shouldEstablishGroup = epoch == 0 && !conversationExists
+
+        if shouldEstablishGroup {
+            try await internalEstablishPendingGroup(groupID: lastGroupID, pendingGroup: conversation, context: context)
+        } else {
+            try await joinByExternalCommit(groupID: lastGroupID)
+        }
+
+        await save(context)
     }
 
     // MARK: - Out-of-sync conversations
@@ -2015,7 +2058,7 @@ extension MLSService: EpochObserver {}
 
 // MARK: - Helper types
 
-public struct MLSUser: Equatable {
+public struct MLSUser: Equatable, Hashable {
 
     public let id: UUID
     public let domain: String

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -482,6 +482,13 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
 
     func startProteusToMLSMigration() async throws
 
+    /// Re-establish pending group
+    ///
+    /// Syncs the conversation metadata and join by external commit
+    /// or establish the group by adding all mls clients depending on the epoch
+    /// - Parameter groupID: the mls GroupID of the conversation to re-establish
+    func reEstablishPendingGroup(groupID: MLSGroupID) async throws
+
     // MARK: - Sync delegate
 
     /// Set the MLS sync delegate.

--- a/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
@@ -189,7 +189,11 @@ public final class ConversationPredicateFactory: NSObject {
         // MLS
         let isMLS = NSPredicate(format: "\(ZMConversation.messageProtocolKey) == \(MessageProtocol.mls.int16Value)")
         let isMLSStatusReady = NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.ready.rawValue)")
-        let isMLSAndReady = NSPredicate.all(of: [isMLS, isMLSStatusReady])
+        let isMLSStatusPendingJoinAfterReset =
+            NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.pendingJoinAfterReset.rawValue)")
+
+        let isValidMLSStatus = NSPredicate.any(of: [isMLSStatusReady, isMLSStatusPendingJoinAfterReset])
+        let isMLSAndReady = NSPredicate.all(of: [isMLS, isValidMLSStatus])
 
         return .any(of: [isProteus, isMixed, isMLSAndReady])
     }

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4820,6 +4820,26 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock()
     }
 
+    // MARK: - reEstablishPendingGroup
+
+    public var reEstablishPendingGroupGroupID_Invocations: [MLSGroupID] = []
+    public var reEstablishPendingGroupGroupID_MockError: Error?
+    public var reEstablishPendingGroupGroupID_MockMethod: ((MLSGroupID) async throws -> Void)?
+
+    public func reEstablishPendingGroup(groupID: MLSGroupID) async throws {
+        reEstablishPendingGroupGroupID_Invocations.append(groupID)
+
+        if let error = reEstablishPendingGroupGroupID_MockError {
+            throw error
+        }
+
+        guard let mock = reEstablishPendingGroupGroupID_MockMethod else {
+            fatalError("no mock for `reEstablishPendingGroupGroupID`")
+        }
+
+        try await mock(groupID)
+    }
+
     // MARK: - setSyncDelegate
 
     public var setSyncDelegate_Invocations: [any MLSSyncDelegate] = []

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -571,6 +571,87 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         XCTAssertTrue(mockAddMembersCalled)
     }
 
+    private func internalTestReEstablishGroup(epoch: UInt64) async throws {
+        // GIVEN
+        let groupID = MLSGroupID(Data([1, 2, 3]))
+        let conversation = await uiMOC.perform {
+            let conversation = self.createConversation(
+                outOfSync: false,
+                currentEpoch: epoch,
+                groupID: groupID
+            ).conversation
+            conversation.mlsStatus = .pendingJoinAfterReset
+            return conversation
+        }
+
+        let mlsSelfUser = await uiMOC.perform {
+            MLSUser(from: self.selfUser, localDomain: self.localDomain)
+        }
+        let groupInfo = Data()
+        mockActionsProvider
+            .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockMethod = { _, _, _, _ in
+                groupInfo
+            }
+        mockMLSActionExecutor.mockJoinGroup = { mlsGroupID, mlsGroupInfo in
+            XCTAssertEqual(mlsGroupID, groupID)
+            XCTAssertEqual(mlsGroupInfo, groupInfo)
+        }
+        mockMLSActionExecutor.mockCommitPendingProposals = { mlsGroupID in
+            XCTAssertEqual(mlsGroupID, groupID)
+        }
+        mockMLSActionExecutor.mockUpdateKeyMaterial = { mlsGroupID in
+            XCTAssertEqual(mlsGroupID, groupID)
+        }
+
+        mockActionsProvider.syncConversationQualifiedIDContext_MockMethod = { _, _ in }
+
+        // WHEN
+        try await sut.reEstablishPendingGroup(groupID: groupID)
+
+        // THEN
+        try XCTAssertCount(mockActionsProvider.syncConversationQualifiedIDContext_Invocations, count: 1)
+        await uiMOC.perform {
+            XCTAssertEqual(conversation.mlsStatus, .ready)
+        }
+    }
+
+    func test_reEstablishGroup_joinViaExternalCommit() async throws {
+        // GIVEN
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
+
+        // WHEN
+        try await internalTestReEstablishGroup(epoch: 1)
+
+        // THEN
+        try XCTAssertCount(
+            mockActionsProvider.fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations,
+            count: 1
+        )
+        XCTAssertEqual(mockMLSActionExecutor.mockAddMembersCount, 0)
+        XCTAssertEqual(mockMLSActionExecutor.mockJoinGroupCount, 1)
+    }
+
+    func test_reEstablishGroup_establishGroup() async throws {
+        // GIVEN
+        mockCoreCryptoContext.createConversationConversationIdCreatorCredentialTypeConfig_MockMethod = { _, _, _ in }
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
+        mockActionsProvider.claimKeyPackagesUserIDDomainCiphersuiteExcludedSelfClientIDIn_MockValue = [KeyPackage(
+            client: "123e",
+            domain: "qwer",
+            keyPackage: "qwer",
+            keyPackageRef: "asdf",
+            userID: UUID()
+        )]
+        mockMLSActionExecutor.mockAddMembers = { _, _ in }
+
+        // WHEN
+        try await internalTestReEstablishGroup(epoch: 0)
+
+        // THEN
+        XCTAssertEqual(mockMLSActionExecutor.mockAddMembersCount, 1)
+        XCTAssertEqual(mockMLSActionExecutor.mockJoinGroupCount, 0)
+    }
+
     func test_EstablishGroup_WipesGroupOnError() async throws {
         // Given
         let groupID = MLSGroupID(Data([1, 2, 3]))
@@ -613,8 +694,15 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         mockCoreCryptoContext.conversationExistsConversationId_MockValue = true
 
         // When
-        await assertItThrows(error: MLSService.MLSAddMembersError.failedToClaimKeyPackages(users: usersIncludingSelf)) {
+
+        do {
             try await _ = sut.establishGroup(for: groupID, with: users)
+        } catch {
+            if case let MLSService.MLSAddMembersError.failedToClaimKeyPackages(users) = error {
+                XCTAssertEqual(Set(usersIncludingSelf), Set(users))
+            } else {
+                XCTFail("unexepected error  \(error)")
+            }
         }
 
         // Then

--- a/wire-ios-data-model/Tests/MLS/MockMLSActionExecutor.swift
+++ b/wire-ios-data-model/Tests/MLS/MockMLSActionExecutor.swift
@@ -55,6 +55,12 @@ final class MockMLSActionExecutor: MLSActionExecutorProtocol {
 
     // MARK: - Add members
 
+    private var mockAddMembersCount_ = 0
+    var mockAddMembersCount: Int {
+        get { serialQueue.sync { mockAddMembersCount_ } }
+        set { serialQueue.sync { mockAddMembersCount_ = newValue } }
+    }
+
     typealias AddMembersMock = ([WireDataModel.KeyPackage], MLSGroupID) async throws -> Void
     private var _mockAddMembers: AddMembersMock?
     var mockAddMembers: AddMembersMock? {
@@ -67,6 +73,7 @@ final class MockMLSActionExecutor: MLSActionExecutorProtocol {
             fatalError("no mock for `addMembers`")
         }
 
+        mockAddMembersCount_ += 1
         return try await mock(keyPackages, groupID)
     }
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -372,10 +372,11 @@ public final class MessageSender: MessageSenderInterface {
     }
 
     private func attemptToSendWithMLS(message: any SendableMessage, apiVersion: APIVersion) async throws {
-        let (conversationID, groupID, mlsService) = await context.perform { (
+        let (conversationID, groupID, mlsService, mlsStatus) = await context.perform { (
             message.conversation?.qualifiedID,
             message.conversation?.mlsGroupID,
-            self.context.mlsService
+            self.context.mlsService,
+            message.conversation?.mlsStatus
         ) }
 
         guard let conversationID else {
@@ -389,6 +390,10 @@ public final class MessageSender: MessageSenderInterface {
         }
 
         do {
+            if mlsStatus?.isOne(of: .pendingJoinAfterReset, .pendingJoin) == true {
+                try await mlsService.reEstablishPendingGroup(groupID: groupID)
+            }
+
             try await mlsService.commitPendingProposals(in: groupID)
             let encryptedData = try await encryptMlsMessage(message, groupID: groupID)
 

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -463,6 +463,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: 0)
         let messageSendingStatus = Payload.MLSMessageSendingStatus(
@@ -494,6 +495,7 @@ final class MessageSenderTests: MessagingTestBase {
         try await messageSender.sendMessage(message: message)
 
         // then test completes
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageSucceeds_thenCommitPendingProposalsInGroup() async throws {
@@ -501,6 +503,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: 0)
         let messageSendingStatus = Payload.MLSMessageSendingStatus(
@@ -533,6 +536,7 @@ final class MessageSenderTests: MessagingTestBase {
 
         // then
         XCTAssertEqual([Arrangement.Scaffolding.groupID], arrangement.mlsService.commitPendingProposalsIn_Invocations)
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageFailsWithPermanentError_thenThrowError() async throws {
@@ -540,6 +544,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let response = ZMTransportResponse(payload: nil, httpStatus: 403, transportSessionError: nil, apiVersion: 0)
         let networkError = NetworkError.errorDecodingResponse(response)
@@ -573,6 +578,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let networkError = SendMLSMessageFailure.mlsMissingSenderClient(message: "test")
         let message = GenericMessageEntity(
@@ -605,6 +611,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let networkError = SendMLSMessageFailure.mlsInvalidLeafNodeIndex(message: "Test")
         let message = GenericMessageEntity(
@@ -632,6 +639,7 @@ final class MessageSenderTests: MessagingTestBase {
         let invocation = arrangement.initiateResetMLSConversationUseCase.invokeGroupIDEpoch_Invocations.first
         XCTAssertEqual(invocation?.epoch, 0)
         XCTAssertEqual(invocation?.groupID, Arrangement.Scaffolding.groupID)
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageFailsWithResetMLSConversationError_AndFeatureFlagIsOff_JustThrows() async throws {
@@ -639,6 +647,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let networkError = SendMLSMessageFailure.mlsInvalidLeafNodeIndex(message: "Test")
         let message = GenericMessageEntity(
@@ -666,6 +675,7 @@ final class MessageSenderTests: MessagingTestBase {
         }
 
         XCTAssertEqual(arrangement.initiateResetMLSConversationUseCase.invokeGroupIDEpoch_Invocations.count, 0)
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
     func testThatWhenSendingMlsMessageWithoutMlsService_thenThrowError() async throws {
@@ -673,6 +683,7 @@ final class MessageSenderTests: MessagingTestBase {
         await syncMOC.performGrouped {
             self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let message = GenericMessageEntity(
             message: GenericMessage(content: Text(content: "Hello World")),
@@ -697,6 +708,7 @@ final class MessageSenderTests: MessagingTestBase {
         // given
         await syncMOC.performGrouped {
             self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
         }
         let message = GenericMessageEntity(
             message: GenericMessage(content: Text(content: "Hello World")),
@@ -705,7 +717,7 @@ final class MessageSenderTests: MessagingTestBase {
             completionHandler: nil
         )
 
-        let (_, messageSender) = Arrangement(coreDataStack: coreDataStack)
+        let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
             .withIncrementalSyncObserverCompleting()
             .withMessageDependencyResolverReturning(result: .success(()))
             .withApiVersionResolving(to: .v5)
@@ -716,6 +728,45 @@ final class MessageSenderTests: MessagingTestBase {
         await assertItThrows(error: MessageSendError.missingGroupID) {
             try await messageSender.sendMessage(message: message)
         }
+
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
+    }
+
+    func testThatWhenSendingMlsMessageOnAPendingJoinConversation_CallsReEstablishPendingJoin() async throws {
+        // given
+        await syncMOC.performGrouped {
+            self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
+            self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .pendingJoinAfterReset
+        }
+        let message = GenericMessageEntity(
+            message: GenericMessage(content: Text(content: "Hello World")),
+            context: syncMOC,
+            conversation: groupConversation,
+            completionHandler: nil
+        )
+        let response = ZMTransportResponse(payload: nil, httpStatus: 200, transportSessionError: nil, apiVersion: 0)
+        let messageSendingStatus = Payload.MLSMessageSendingStatus(
+            time: Date(),
+            events: [],
+            failedToSend: nil
+        )
+
+        let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withIncrementalSyncObserverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(()))
+            .withApiVersionResolving(to: .v5)
+            .withMLServiceConfigured()
+            .withSendMlsMessage(returning: .success((messageSendingStatus, response)))
+            .arrange()
+        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
+        arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
+            message + [000]
+        }
+
+        try await messageSender.sendMessage(message: message)
+
+        XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 1)
     }
 
     // MARK: - Helpers
@@ -795,7 +846,7 @@ final class MessageSenderTests: MessagingTestBase {
                 status: .enabled,
                 config: .init(mlsConversationReset: true)
             )
-
+            mlsService.reEstablishPendingGroupGroupID_MockMethod = { _ in }
         }
 
         func withApiVersionResolving(to apiVersion: APIVersion?) -> Arrangement {

--- a/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Processing/Helpers/MLSEventProcessor.swift
@@ -153,11 +153,15 @@ public class MLSEventProcessor: MLSEventProcessing {
                 .error("failed to check if conversation \(mlsGroupID.safeForLoggingDescription) exists: \(error)")
             conversationExists = false
         }
-        let newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
+        var newStatus: MLSGroupStatus = conversationExists ? .ready : .pendingJoin
 
         await context.perform {
             let previousStatus = conversation.mlsStatus
 
+            if previousStatus == .pendingJoinAfterReset {
+                // never override pendingJoinAferReset, this will be handle in re-establish group
+                newStatus = .pendingJoinAfterReset
+            }
             conversation.mlsStatus = newStatus
             context.saveOrRollback()
             Flow.createGroup.checkpoint(description: "saved ZMConversation for MLS")

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsView.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsView.swift
@@ -27,7 +27,7 @@ struct DeveloperDebugActionsView: View {
         List(viewModel.debugItems) { debugItem in
             switch debugItem {
             case let .button(buttonItem):
-                Button(action: buttonItem.action) {
+                Button(hapticFeedbackStyle: .success, action: buttonItem.action) {
                     Text(buttonItem.title)
                 }
             case let .toggle(toggleItem):

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -723,10 +723,6 @@ extension ConversationViewController: ZMConversationListObserver {
     func conversationListDidChange(_ changeInfo: ConversationListChangeInfo) {
         updateLeftNavigationBarItems()
         if changeInfo.deletedObjects.contains(conversation) {
-            if conversation.mlsStatus == .pendingJoin {
-                // don't pop if mls reset happened
-                return
-            }
             ZClientViewController.shared?.transitionToList(animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20693" title="WPB-20693" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20693</a>  [iOS] Recover from re-initialized MLS conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cherry-pick from https://github.com/wireapp/wire-ios/pull/3663 (develop) and https://github.com/wireapp/wire-ios/pull/3657 (4.6.3)
