### PR TITLE
feat: add skeleton version of `WireCellsAttachmentsPreviewView` - WPB-20750

### DIFF
--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
@@ -1,0 +1,74 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+public import Foundation
+
+/// Data for a single attachment sent with a message
+public struct WireCellsMessageAttachment {
+
+    public enum Metadata {
+
+        /// Image metadata, containing width and height in pixels.
+        case image(width: Int, height: Int)
+
+        /// Video metadata, containing width and height in pixels, and duration in milliseconds.
+        case video(width: Int?, height: Int?, duration: Int?)
+
+        /// Audio metadata, containing duration in milliseconds and normalized loudness data.
+        ///
+        /// - note: Currently, normalized loudness is not sent.
+        case audio(duration: Int?, normalizedLoudness: Data?)
+
+    }
+
+    /// The `nodeID` of the attachment.
+    public let nodeID: UUID
+
+    /// The mime type of the attachment.
+    public let contentType: String?
+
+    /// The full name of the attachment, including cell prefix. E.g. "<conversation-qualified-id>/<file-name>"
+    ///
+    /// - note: This is the initial value when the document was first sent and may no longer be accurate.
+    public let initialName: String?
+
+    /// The initial size of the attachment, in bytes.
+    ///
+    /// - note: This is the initial value when the document was first sent and may no longer be accurate.
+    public let initialSize: Int?
+
+    /// The initial metadata of the attachment, if relevant.
+    ///
+    /// - note: This is the initial value when the document was first sent and may no longer be accurate.
+    public let initialMetadata: Metadata?
+
+    public init(
+        nodeID: UUID,
+        contentType: String?,
+        initialName: String?,
+        initialSize: Int?,
+        initialMetadata: Metadata?
+    ) {
+        self.nodeID = nodeID
+        self.contentType = contentType
+        self.initialName = initialName
+        self.initialSize = initialSize
+        self.initialMetadata = initialMetadata
+    }
+
+}

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
@@ -1,0 +1,50 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package import SwiftUI
+import WireMessagingDomain
+
+/// A collection of attachment previews suitable for displaying in a conversation message.
+package struct WireCellsAttachmentsPreviewView: View {
+
+    @StateObject var viewModel: WireCellsAttachmentsPreviewViewModel
+
+    init(viewModel: @autoclosure @escaping () -> WireCellsAttachmentsPreviewViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel())
+    }
+
+    package var body: some View {
+        Text(verbatim: "\(viewModel.attachments.count) attachments")
+    }
+}
+
+#Preview {
+    WireCellsAttachmentsPreviewView(
+        viewModel: WireCellsAttachmentsPreviewViewModel(
+            attachments: [
+                WireCellsMessageAttachment(
+                    nodeID: UUID(),
+                    contentType: nil,
+                    initialName: nil,
+                    initialSize: nil,
+                    initialMetadata: nil
+                )
+            ]
+        )
+    )
+}

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
@@ -29,7 +29,14 @@ package struct WireCellsAttachmentsPreviewView: View {
     }
 
     package var body: some View {
-        Text(verbatim: "\(viewModel.attachments.count) attachments")
+        VStack {
+            ForEach(viewModel.attachments, id: \.nodeID) { attachment in
+                Text(attachment.initialName ?? "Unnamed")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+            }
+        }
+        .background(Color.red)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
@@ -1,0 +1,30 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+package import WireMessagingDomain
+
+package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
+
+    let attachments: [WireCellsMessageAttachment]
+
+    package init(attachments: [WireCellsMessageAttachment]) {
+        self.attachments = attachments
+    }
+
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20750" title="WPB-20750" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20750</a>  [iOS] Create skeleton of attachments preview view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a new view - `WireCellsAttachmentsPreviewView` and it's associated view model. This view will be used to display a collection of wire cells attachment previews for a given message in a conversation.

Right now this is only a skeleton implementation to allow @jullianm to work on integrating the view while I work on it's implementation.

### Testing

Nothing to test

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

