### PR TITLE
feat: improve network error alerts - WPB-20669

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Resources/Localization/de.lproj/Localizable.strings
@@ -33,14 +33,14 @@
 "login.sso.title" = "Anmelden";
 "login.sso.expiration_message" = "Ihre Session ist abgelaufen. Melden Sie sich mit Ihrem Unternehmenskonto an, um fortzufahren.";
 "login.sso.input_code.title" = "SSO Zugangscode";
-"login.sso.input_code.placeholder" = "SSO Zugangscode eingeben";
+"login.sso.input_code.placeholder" = "SSO-Code eingeben";
 "login.sso.submit" = "Anmeldung für Unternehmen";
 
 "logout.button.title" = "Abmelden";
 "logout.alert.title" = "Abmelden";
-"logout.alert.message" = "Entscheiden Sie, ob Sie Ihre Gesprächshistorie behalten oder unwiderruflich von diesem Gerät löschen wollen.";
-"logout.alert.delete_data_button" = "Abmelden und Historie löschen";
-"logout.alert.keep_data_button" = "Abmelden und Historie behalten";
+"logout.alert.message" = "Entscheiden Sie, ob Sie Ihren Gesprächsverlauf behalten oder unwiderruflich von diesem Gerät löschen möchten.";
+"logout.alert.delete_data_button" = "Abmelden und Verlauf löschen";
+"logout.alert.keep_data_button" = "Abmelden und Verlauf behalten";
 "logout.alert.cancel" = "Abbrechen";
 
 "create_account_or_team.title" = "Sie haben kein Benutzerkonto? ";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Accessibility.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Accessibility.strings
@@ -21,7 +21,7 @@
 
 // MARK: Conversation Files View
 "conversation.wireCells.files.close" = "Dateien schließen";
-"conversation.wireCells.files.loadMore.title" = "Load more";
+"conversation.wireCells.files.loadMore.title" = "Weitere Objekte laden";
 "conversation.wireCells.files.noData.title" = "Es gibt noch keine Dateien oder Ordner";
 "conversation.wireCells.files.noData.message" = "Hier finden Sie alle Dateien und Ordner, die in dieser Unterhaltung geteilt wurden.";
 "conversation.wireCells.files.pendingCells.title" = "Files are being prepared";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 // MARK: Conversation Files View
 "conversation.wireCells.files.navigationTitle" = "Dokumente";
 "conversation.wireCells.files.item.subtitle" = "%@ von %@";
-"conversation.wireCells.files.loadMore.title" = "Load more";
+"conversation.wireCells.files.loadMore.title" = "Weitere Objekte laden";
 "conversation.wireCells.files.item.menu.open" = "Öffnen";
 "conversation.wireCells.files.item.menu.download" = "Herunterladen";
 "conversation.wireCells.files.item.menu.rename" = "Umbenennen";

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1094,6 +1094,16 @@ public final class SessionManager: NSObject, SessionManagerType {
                     error: .clientIsObsolete
                 )
                 return nil
+            } catch let error as URLError {
+                WireLogger.sessionManager.error(
+                    "failed to load user session due to url error code: \(error.errorCode)",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .networkError(code: error.errorCode)
+                )
+                return nil
             } catch let error as SafeForLoggingStringConvertible {
                 WireLogger.sessionManager.error(
                     "failed to load user session: \(error.safeForLoggingDescription)",
@@ -2078,6 +2088,7 @@ public extension SessionManager {
         case buildIsBlacklisted
         case backendIsObsolete
         case clientIsObsolete
+        case networkError(code: Int)
         case genericError
 
     }

--- a/wire-ios-sync-engine/Source/UserSession/BlacklistReason.swift
+++ b/wire-ios-sync-engine/Source/UserSession/BlacklistReason.swift
@@ -37,17 +37,17 @@ public enum BlacklistReason: Equatable {
     public static func == (lhs: BlacklistReason, rhs: BlacklistReason) -> Bool {
         switch (lhs, rhs) {
         case (.appVersionBlacklisted, .appVersionBlacklisted):
-            return true
+            true
         case (.clientAPIVersionObsolete, .clientAPIVersionObsolete):
-            return true
+            true
         case (.backendAPIVersionObsolete, .backendAPIVersionObsolete):
-            return true
+            true
         case let (.networkError(lhsCode), .networkError(rhsCode)):
-            return lhsCode == rhsCode
+            lhsCode == rhsCode
         case (.genericError, .genericError):
-            return true
+            true
         default:
-            return false
+            false
         }
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/BlacklistReason.swift
+++ b/wire-ios-sync-engine/Source/UserSession/BlacklistReason.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public enum BlacklistReason {
+public enum BlacklistReason: Equatable {
     /// The app version is too old to be supported or has been explicitly blacklisted
     case appVersionBlacklisted
 
@@ -28,7 +28,27 @@ public enum BlacklistReason {
     /// The API versions supported by the backend are too old in comparison to the ones supported by the client
     case backendAPIVersionObsolete
 
+    /// The session failed to load due to network issues.
+    case networkError(code: Int)
+
     /// Some reason that the session couldn't be loaded.
     case genericError
+
+    public static func == (lhs: BlacklistReason, rhs: BlacklistReason) -> Bool {
+        switch (lhs, rhs) {
+        case (.appVersionBlacklisted, .appVersionBlacklisted):
+            return true
+        case (.clientAPIVersionObsolete, .clientAPIVersionObsolete):
+            return true
+        case (.backendAPIVersionObsolete, .backendAPIVersionObsolete):
+            return true
+        case let (.networkError(lhsCode), .networkError(rhsCode)):
+            return lhsCode == rhsCode
+        case (.genericError, .genericError):
+            return true
+        default:
+            return false
+        }
+    }
 
 }

--- a/wire-ios/Wire-iOS Share Extension/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS Share Extension/Resources/Localization/de.lproj/Localizable.strings
@@ -84,4 +84,4 @@
 "share_extension.error.update_required.obsolete_backend" = "Ihr Wire-Server muss aktualisiert werden. Bitte informieren Sie Ihren Systemadministrator.";
 
 "share_extension.error.open_app.title" = "App öffnen";
-"share_extension.error.open_app.message" = "Öffnen Sie Ihr Benutzerkonto in Wire und versuchen Sie es erneut.";
+"share_extension.error.open_app.message" = "Öffnen Sie dieses Konto in der App und versuchen Sie es erneut.";

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -1204,12 +1204,20 @@ internal enum L10n {
           internal static let message = L10n.tr("Localizable", "account_blocked.generic_error.alert.message", fallback: "Please contact support if the error persists.")
           /// Retry
           internal static let retry = L10n.tr("Localizable", "account_blocked.generic_error.alert.retry", fallback: "Retry")
-          /// Send debug logs
-          internal static let sendLogs = L10n.tr("Localizable", "account_blocked.generic_error.alert.send_logs", fallback: "Send debug logs")
+          /// Send Debug Report
+          internal static let sendLogs = L10n.tr("Localizable", "account_blocked.generic_error.alert.send_logs", fallback: "Send Debug Report")
           /// Switch accounts
           internal static let switchAccounts = L10n.tr("Localizable", "account_blocked.generic_error.alert.switch_accounts", fallback: "Switch accounts")
           /// Something went wrong
           internal static let title = L10n.tr("Localizable", "account_blocked.generic_error.alert.title", fallback: "Something went wrong")
+        }
+      }
+      internal enum NetworkError {
+        internal enum Alert {
+          /// Please check your internet connection and try again.
+          internal static let message = L10n.tr("Localizable", "account_blocked.network_error.alert.message", fallback: "Please check your internet connection and try again.")
+          /// Network issue
+          internal static let title = L10n.tr("Localizable", "account_blocked.network_error.alert.title", fallback: "Network issue")
         }
       }
     }

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -2148,8 +2148,10 @@ to reset this device and log in again";
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Something went wrong";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "حدث خطأ";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Noget gik galt";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Zertifikatsdetails";
 "device.details.certificate_details.copy_to_clipboard" = "In Zwischenablage kopieren";
 
+"account_blocked.network_error.alert.title" = "Netzwerkproblem";
+"account_blocked.network_error.alert.message" = "Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.";
 "account_blocked.generic_error.alert.title" = "Ein Fehler ist aufgetreten";
-"account_blocked.generic_error.alert.message" = "Bitte kontaktiere den Support, falls dieser Fehler weiterhin auftritt.";
+"account_blocked.generic_error.alert.message" = "Bitte kontaktieren Sie den Support, falls dieser Fehler weiterhin auftritt.";
 "account_blocked.generic_error.alert.switch_accounts" = "Konto wechseln";
 "account_blocked.generic_error.alert.send_logs" = "Fehlerbericht senden";
 "account_blocked.generic_error.alert.retry" = "Wiederholen";

--- a/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Algo salió mal";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Midagi läks valesti";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Jokin meni pieleen";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Une erreur est survenue";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Qualcosa è andato storto";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "何か問題があります";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Kažkas atsitiko";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Er is iets mis gegaan";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Coś poszło nie tak";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Detalhes do Certificado";
 "device.details.certificate_details.copy_to_clipboard" = "Copiar para Área de Transferência";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Algo deu errado";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Tentar novamente";

--- a/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Сведения о сертификате";
 "device.details.certificate_details.copy_to_clipboard" = "Скопировать в буфер обмена";
 
+"account_blocked.network_error.alert.title" = "Проблема с сетью";
+"account_blocked.network_error.alert.message" = "Проверьте подключение к интернету и повторите попытку.";
 "account_blocked.generic_error.alert.title" = "Что-то пошло не так";
 "account_blocked.generic_error.alert.message" = "Если ошибка повторяется, обратитесь в службу поддержки.";
 "account_blocked.generic_error.alert.switch_accounts" = "Сменить аккаунт";
-"account_blocked.generic_error.alert.send_logs" = "Отправить журнал отладки";
+"account_blocked.generic_error.alert.send_logs" = "Отправить отладочный отчет";
 "account_blocked.generic_error.alert.retry" = "Повторить";

--- a/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Nekaj je šlo narobe";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Bir şeyler yanlış gitti";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "Щось пішло не так";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "证书详情";
 "device.details.certificate_details.copy_to_clipboard" = "复制到剪贴板";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "好像出了点问题。";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "重试";

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -2146,8 +2146,10 @@
 "device.details.certificate_details.title" = "Certificate Details";
 "device.details.certificate_details.copy_to_clipboard" = "Copy to Clipboard";
 
+"account_blocked.network_error.alert.title" = "Network issue";
+"account_blocked.network_error.alert.message" = "Please check your internet connection and try again.";
 "account_blocked.generic_error.alert.title" = "出了點問題";
 "account_blocked.generic_error.alert.message" = "Please contact support if the error persists.";
 "account_blocked.generic_error.alert.switch_accounts" = "Switch accounts";
-"account_blocked.generic_error.alert.send_logs" = "Send debug logs";
+"account_blocked.generic_error.alert.send_logs" = "Send Debug Report";
 "account_blocked.generic_error.alert.retry" = "Retry";

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -270,6 +270,8 @@ extension AppStateCalculator: SessionManagerDelegate {
             transition(to: .blacklisted(reason: .backendAPIVersionObsolete))
         case .clientIsObsolete:
             transition(to: .blacklisted(reason: .clientAPIVersionObsolete))
+        case let .networkError(code):
+            transition(to: .blacklisted(reason: .networkError(code: code)))
         case .genericError:
             transition(to: .blacklisted(reason: .genericError))
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlacklistReason+BlockerViewControllerContext.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlacklistReason+BlockerViewControllerContext.swift
@@ -28,6 +28,8 @@ extension BlacklistReason {
             .backendObsolete
         case .clientAPIVersionObsolete:
             .clientObsolete
+        case let .networkError(code: code):
+            .networkError(code: code)
         case .genericError:
             .genericError
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
@@ -86,10 +86,11 @@ final class BlockerViewController: LaunchImageViewController {
     }
 
     private func showNetworkErrorMessage(code: Int) {
+        typealias Strings = L10n.Localizable.AccountBlocked.NetworkError.Alert
         showErrorMessage(
-            title: "Network issue",
-            message: "Please check your internet connection and try again.",
-            debugLogMessage: "Account failed to load due to network error code: \(code)"
+            title: Strings.title,
+            message: Strings.message,
+            debugLogMessage: "Account failed to load due to network error (code: \(code))"
         )
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
@@ -29,6 +29,7 @@ enum BlockerViewControllerContext {
     case backendObsolete
     case clientObsolete
     case pendingCertificateEnroll
+    case networkError(code: Int)
     case genericError
 }
 
@@ -77,16 +78,39 @@ final class BlockerViewController: LaunchImageViewController {
             showDatabaseFailureMessage()
         case .pendingCertificateEnroll:
             showGetCertificateMessage()
+        case let .networkError(code):
+            showNetworkErrorMessage(code: code)
         case .genericError:
             showGenericErrorMessage()
         }
     }
 
+    private func showNetworkErrorMessage(code: Int) {
+        showErrorMessage(
+            title: "Network issue",
+            message: "Please check your internet connection and try again.",
+            debugLogMessage: "Account failed to load due to network error code: \(code)"
+        )
+    }
+
     private func showGenericErrorMessage() {
         typealias Strings = L10n.Localizable.AccountBlocked.GenericError.Alert
-        let alert = UIAlertController(
+        showErrorMessage(
             title: Strings.title,
             message: Strings.message,
+            debugLogMessage: "Account failed to load"
+        )
+    }
+
+    private func showErrorMessage(
+        title: String,
+        message: String,
+        debugLogMessage: String
+    ) {
+        typealias Strings = L10n.Localizable.AccountBlocked.GenericError.Alert
+        let alert = UIAlertController(
+            title: title,
+            message: message,
             preferredStyle: .alert
         )
 
@@ -110,7 +134,7 @@ final class BlockerViewController: LaunchImageViewController {
                     return
                 }
                 DebugLogSender.sendLogsByEmail(
-                    message: "My account failed to load.",
+                    message: debugLogMessage,
                     shareWithAVS: false,
                     presentingViewController: self,
                     fallbackActivityPopoverConfiguration: .sourceView(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20669" title="WPB-20669" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20669</a>  [iOS] Improve error alert when session loading fails due to poor network
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
In this PR:
- catch url errors when failing to load a session
- show an error alert indicating a network issue occurred

### Testing
1. Have network issues (e.g very poor network)
2. Try to launch the app
3. Assert you see a failure with an alert indicating a network issue may be the cause.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
