### PR TITLE
fix: voiceover not reading message content - WPB-17370

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -95,7 +95,6 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
-        setupAccessibility()
     }
 
     @available(*, unavailable)
@@ -173,11 +172,11 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
         } else {
             messageTextView.accessibilityIdentifier = "Message"
         }
-        accessibilityLabel = messageTextView.attributedText.string
 
         container?.isBubble = isChatBubbleSimpleEnabled
         updateContainerStyle()
         addAccentColorChangeObserver(userSession: object.userSession)
+        setupAccessibility(accessibilityLabel: messageTextView.attributedText.string)
     }
 
     private func addAccentColorChangeObserver(userSession: UserSession?) {
@@ -241,11 +240,12 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
         }
     }
 
-    private func setupAccessibility() {
+    private func setupAccessibility(accessibilityLabel: String) {
         typealias Conversation = L10n.Accessibility.Conversation
 
         isAccessibilityElement = false
         container?.isAccessibilityElement = true
+        container?.accessibilityLabel = accessibilityLabel
         container?.accessibilityHint = "\(Conversation.MessageInfo.hint), \(Conversation.MessageOptions.hint)"
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17370" title="WPB-17370" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17370</a>  [iOS] VoiceOver not reading message content 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Issue: On the iOS version of the app, VoiceOver does not read or detect the message content in conversations. While it correctly reads other elements such as the timestamp and direct reply content, it consistently skips the actual message body.
Solution: Accessibility is added to cell itself but we are adding message text to container view. We have already disabled Cell's Accessibility by setting isAccessibilityElement to false, hence setting accessibilityLabel will not have any effect, hence removed it. Now we are setting accessibility label of container view to message text. 

### Testing

VoiceOver should read the full content of each message aloud when focused.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
