### PR TITLE
fix: syntax for semantic lint - WPB-20776

### DIFF
--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -52,7 +52,7 @@ jobs:
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: false
           
-          subjectPattern: ^(.*) - (WPB-\d+)( 🍒)$
+          subjectPattern: ^(.*) - (WPB-\d+)( 🍒)?$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20776" title="WPB-20776" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20776</a>  [iOS] CI semantic lint does not pass for cherry-pick
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fix wrong syntax for semantic titles

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
