### PR TITLE
fix(consumable-notifications): ignore missed notifications in NSE - WPB-20686

### DIFF
--- a/.github/workflows/semantic_commit_lint.yml
+++ b/.github/workflows/semantic_commit_lint.yml
@@ -52,7 +52,7 @@ jobs:
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: false
           
-          subjectPattern: ^(.*) - (WPB-\d+)( 🍒)$
+          subjectPattern: ^(.*) - (WPB-\d+)( 🍒)?$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsV2Sync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsV2Sync.swift
@@ -91,6 +91,8 @@ public struct PullPendingUpdateEventsSyncV2: PullPendingUpdateEventsSyncV2Protoc
                     }
                 case .missedEvents:
                     logger.debug("missedEvents event", attributes: logAttributes)
+                    continuation.finish()
+                    break streamLoop
                 case let .events(envelopes):
                     do {
                         try await processBatch(

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsV2Sync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsV2Sync.swift
@@ -90,7 +90,12 @@ public struct PullPendingUpdateEventsSyncV2: PullPendingUpdateEventsSyncV2Protoc
                         break streamLoop
                     }
                 case .missedEvents:
-                    logger.debug("missedEvents event", attributes: logAttributes)
+                    logger.warn(
+                        "missedEvents event, full sync required, open main app",
+                        attributes: logAttributes,
+                        .safePublic
+                    )
+                    // end the stream gracefully so notifications can be shown
                     continuation.finish()
                     break streamLoop
                 case let .events(envelopes):

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncV2Tests.swift
@@ -181,6 +181,30 @@ class PullPendingUpdateEventsSyncV2Tests: XCTestCase {
         XCTAssertTrue(pushChannel.acknowledgeEventDeliveryTagMultiple_Invocations[4].multiple == false)
     }
 
+
+    func testPull_missedEvents() async throws {
+
+        let upstream = AsyncThrowingStream { continuation in
+            continuation.yield(PushChannelV2.Element.events([Scaffolding.event2]))
+            continuation.yield(PushChannelV2.Element.missedEvents)
+            continuation.yield(PushChannelV2.Element.events([Scaffolding.event3]))
+        }
+
+        let pushChannel = try await internalTestPull(
+            stream: upstream,
+            receivedEventsCount: 1,
+            decryptionCount: 1,
+            storedEventsCount: 1,
+            acknowledgementCount: 1
+        )
+
+        // the missedEvents should break the stream and not process the last event
+        // in reality the event3 will never come before you ack the fullsync
+        // ack the fullsync will be done in main app
+
+        XCTAssertEqual(pushChannel.acknowledgeFullSync_Invocations.count, 0)
+    }
+
     @discardableResult
     func internalTestPull(
         stream: AsyncThrowingStream<PushChannelV2.Element, any Error>,
@@ -205,19 +229,22 @@ class PullPendingUpdateEventsSyncV2Tests: XCTestCase {
         try XCTAssertCount(
             decryptor.decryptEventsInContext_Invocations,
             count: decryptionCount,
+            "decryptionCount mismatch",
             file: file,
-            line: line
+            line: line,
         )
         // check events stored
         try XCTAssertCount(
             updateEventsStore.indexOfLastEventEnvelope_Invocations,
             count: storedEventsCount,
+            "lastEventEnvelopeCount mismatch",
             file: file,
             line: line
         )
         try XCTAssertCount(
             updateEventsStore.persistEventEnvelopeIndex_Invocations,
             count: storedEventsCount,
+            "storedEventsCount mismatch",
             file: file,
             line: line
         )
@@ -226,6 +253,7 @@ class PullPendingUpdateEventsSyncV2Tests: XCTestCase {
         try XCTAssertCount(
             pushChannel.acknowledgeEventDeliveryTagMultiple_Invocations,
             count: acknowledgementCount,
+            "acknowledgementCount mismatch",
             file: file,
             line: line
         )

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncV2Tests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullPendingUpdateEventsSyncV2Tests.swift
@@ -181,7 +181,6 @@ class PullPendingUpdateEventsSyncV2Tests: XCTestCase {
         XCTAssertTrue(pushChannel.acknowledgeEventDeliveryTagMultiple_Invocations[4].multiple == false)
     }
 
-
     func testPull_missedEvents() async throws {
 
         let upstream = AsyncThrowingStream { continuation in
@@ -231,7 +230,7 @@ class PullPendingUpdateEventsSyncV2Tests: XCTestCase {
             count: decryptionCount,
             "decryptionCount mismatch",
             file: file,
-            line: line,
+            line: line
         )
         // check events stored
         try XCTAssertCount(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20686" title="WPB-20686" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20686</a>  [iOS] missed notifications is not ack in NSE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When we receice a missed-notifications event from backend the app must do a `performInitialSyncV2`. This can only be done in mainApp.

If received in NSE, we don't do anything, also the backend won't deliver any new notifications until we acknowledge the missed-notifications event.

As a small improvement:
- log this event even in production
- exit early, and show any notifications required from previous events if needed

### Testing

1. login on lich env, send a message
2. ~put app in background and wait for missing event~
3. look at logs on datadog
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
