### PR TITLE
fix(backup-performance): fetching / updating conversations - WPB-20804

### DIFF
--- a/WireBackup/Sources/WireBackup/Protocols/BackupLocalStoreProtocol.swift
+++ b/WireBackup/Sources/WireBackup/Protocols/BackupLocalStoreProtocol.swift
@@ -52,7 +52,7 @@ public protocol BackupLocalStoreProtocol: Sendable {
     /// Returns all messages stored in the local database, including deleted ones.
     func fetchAllMessages() -> AsyncThrowingStream<MessageBackupModel, any Error>
 
-    /// Adds a message from the backup file to the local data store.
-    func addMessage(_ message: MessageBackupModel) async throws
+    /// Adds a batch of messages from the backup file to the local data store.
+    func addMessages(_ backupMessages: [MessageBackupModel]) async throws
 
 }

--- a/WireBackup/Sources/WireBackup/UseCases/ImportBackupUseCase.swift
+++ b/WireBackup/Sources/WireBackup/UseCases/ImportBackupUseCase.swift
@@ -20,6 +20,8 @@ public import Foundation
 public import WireLogging
 public import WireFoundation
 
+@preconcurrency import KaliumBackup
+
 public struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
 
     let url: URL
@@ -112,15 +114,15 @@ public struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
                     // messages
                     let storedMessageIDs = try await backupLocalStore.fetchAllMessageIDs()
                     while messagesPager.hasMorePages() {
-                        let backupMessages = messagesPager.nextPage()
-                        for current in 0 ..< backupMessages.size {
-                            guard let backupMessage = backupMessages.get(index: current) else { continue }
 
-                            if !storedMessageIDs.contains(backupMessage.id),
-                               let message = MessageBackupModel(backupMessage) {
-                                try await backupLocalStore.addMessage(message)
-                            }
-                        }
+                        // Map messages
+                        let backupMessages = mapBackupMessages(
+                            fromPage: messagesPager.nextPage(),
+                            storedMessageIDs: storedMessageIDs
+                        )
+
+                        try await backupLocalStore.addMessages(backupMessages)
+
                         try Task.checkCancellation()
                         current += 1
                         reportProgress(current, Int(exactly: total) ?? 1)
@@ -146,6 +148,24 @@ public struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
                 task.cancel()
             }
         }
+    }
+
+    private func mapBackupMessages(
+        fromPage page: KotlinArray<BackupMessage>,
+        storedMessageIDs: Set<String>
+    ) -> [MessageBackupModel] {
+        var backupMessages: [MessageBackupModel] = []
+
+        for current in 0 ..< page.size {
+            guard let backupMessage = page.get(index: current) else { continue }
+
+            if !storedMessageIDs.contains(backupMessage.id),
+               let message = MessageBackupModel(backupMessage) {
+                backupMessages.append(message)
+            }
+        }
+
+        return backupMessages
     }
 
 }

--- a/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
+++ b/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
@@ -104,7 +104,7 @@ final class CreateAndImportBackupUseCaseTests: XCTestCase {
 
         XCTAssertEqual(importEvents.last, .done)
         XCTAssertEqual(backupLocalStoreMock.addUserUserUserBackupModelVoidReceivedInvocations, [user])
-        XCTAssertEqual(backupLocalStoreMock.addMessageMessageMessageBackupModelVoidReceivedInvocations, [message])
+        XCTAssertEqual(backupLocalStoreMock.addMessagesBackupMessagesMessageBackupModelVoidReceivedInvocations, [[message]])
 
     }
 

--- a/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
+++ b/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
@@ -104,7 +104,10 @@ final class CreateAndImportBackupUseCaseTests: XCTestCase {
 
         XCTAssertEqual(importEvents.last, .done)
         XCTAssertEqual(backupLocalStoreMock.addUserUserUserBackupModelVoidReceivedInvocations, [user])
-        XCTAssertEqual(backupLocalStoreMock.addMessagesBackupMessagesMessageBackupModelVoidReceivedInvocations, [[message]])
+        XCTAssertEqual(
+            backupLocalStoreMock.addMessagesBackupMessagesMessageBackupModelVoidReceivedInvocations,
+            [[message]]
+        )
 
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -63,31 +63,63 @@ extension BackupLocalStore {
         }
     }
 
-    func addMessage(_ backupMessage: MessageBackupModel) async throws {
-        let conversationID = backupMessage.conversationID
-        let (conversation, lastReadServerTimeStamp) = await context.perform {
-            let conversation = ZMConversation.fetch(with: conversationID.id, domain: conversationID.domain, in: context)
-            return (conversation, conversation?.lastReadServerTimeStamp)
-        }
-        guard
-            let conversation,
-            let nonce = UUID(transportString: backupMessage.id),
-            let genericMessage = GenericMessage(nonce: nonce, messageContent: backupMessage.content)
-        else { return }
+    func addMessages(_ backupMessages: [MessageBackupModel]) async throws {
 
-        try await processor.processProtobufMessage(
-            genericMessage,
-            conversation: conversation,
-            conversationID: conversationID,
-            senderID: backupMessage.senderUserID,
-            senderClientID: backupMessage.senderClientID,
-            date: backupMessage.creationDate,
-            eventMessage: ""
+        // Fetch conversations and last read timestamps related to backup messages
+        let conversationsAndTimestampsByID = await fetchConversationsAndTimestampByID(
+            conversationIDs: Set(backupMessages.map(\.conversationID))
         )
 
-        // restore `lastReadServerTimeStamp`, messages imported from backups shouldn't be marked as unread
+        // Process all messages
+        for backupMessage in backupMessages {
+            guard
+                let tuple = conversationsAndTimestampsByID[backupMessage.conversationID],
+                let nonce = UUID(transportString: backupMessage.id),
+                let genericMessage = GenericMessage(nonce: nonce, messageContent: backupMessage.content)
+            else { continue }
+
+            try await processor.processProtobufMessage(
+                genericMessage,
+                conversation: tuple.conversation,
+                conversationID: backupMessage.conversationID,
+                senderID: backupMessage.senderUserID,
+                senderClientID: backupMessage.senderClientID,
+                date: backupMessage.creationDate,
+                eventMessage: ""
+            )
+
+        }
+
+        // Restore `lastReadServerTimeStamp`, messages imported from backups shouldn't be marked as unread
         await context.perform {
-            conversation.lastReadServerTimeStamp = lastReadServerTimeStamp ?? .now
+            conversationsAndTimestampsByID.forEach { entry in
+                entry.value.conversation.lastReadServerTimeStamp = entry.value.date
+            }
+        }
+    }
+
+    private func fetchConversationsAndTimestampByID(
+        conversationIDs: Set<WireFoundation.QualifiedID>
+    ) async -> [WireFoundation.QualifiedID: (conversation: ZMConversation, date: Date)] {
+        await context.perform {
+            var dictionary: [
+                WireFoundation.QualifiedID: (conversation: ZMConversation, date: Date)
+            ] = [:]
+
+            conversationIDs.forEach { conversationID in
+                if let conversation = ZMConversation.fetch(
+                    with: conversationID.id,
+                    domain: conversationID.domain,
+                    in: context
+                ) {
+                    dictionary[conversationID] = (
+                        conversation,
+                        conversation.lastReadServerTimeStamp ?? Date()
+                    )
+                }
+            }
+
+            return dictionary
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20804" title="WPB-20804" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20804</a>  [iOS] Backup performance :: Updating `lastReadServerTimeStamp`
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue 

Using Xcode’s Instruments, I was able to measure backup restoration performance. Upon analyzing two samples of an import (one with 4k messages and another with 10k) I found out that **38%** of the time is spent on `[ZMConversation setLastReadServerTimeStamp:]`. Calling this method triggers a recalculation of unread messages that involves performing a fetch request, which is expensive. 

### Cause

For each message being restored:
- The conversation is being fetched (1st expensive operation)
- The `lastReadTimeStamp` is being set (2nd expensive operation)

### Solution

For each batch of messages, fetch a batch of conversations first. Then, process the messages using the cached conversations. Then update the timestamp for each conversation.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

