### PR TITLE
feat: disable self deleting messages on cells conv - WPB-19754

### DIFF
--- a/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsTimeoutOptionsCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsTimeoutOptionsCellTests.swift
@@ -85,7 +85,7 @@ final class GroupDetailsTimeoutOptionsCellTests: CoreDataSnapshotTestCase {
             .withUserInterfaceStyle(.dark)
             .verify(matching: cell)
     }
-    
+
     func testThatItDisplaysDisabledCell_WithoutTimeout_Light() {
         // GIVEN & WHEN
         conversation.cellsState = .ready

--- a/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsTimeoutOptionsCellTests.swift
+++ b/wire-ios/Wire-iOS Tests/ConversationDetail/GroupDetailsTimeoutOptionsCellTests.swift
@@ -85,6 +85,26 @@ final class GroupDetailsTimeoutOptionsCellTests: CoreDataSnapshotTestCase {
             .withUserInterfaceStyle(.dark)
             .verify(matching: cell)
     }
+    
+    func testThatItDisplaysDisabledCell_WithoutTimeout_Light() {
+        // GIVEN & WHEN
+        conversation.cellsState = .ready
+        updateTimeout(0)
+
+        // THEN
+        snapshotHelper.verify(matching: cell)
+    }
+
+    func testThatItDisplaysDisabledCell_WithoutTimeout_Dark() {
+        // GIVEN & WHEN
+        conversation.cellsState = .ready
+        updateTimeout(0)
+
+        // THEN
+        snapshotHelper
+            .withUserInterfaceStyle(.dark)
+            .verify(matching: cell)
+    }
 
     private func updateTimeout(_ newValue: TimeInterval) {
         conversation.setMessageDestructionTimeoutValue(.init(rawValue: newValue), for: .groupConversation)

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupDetailsTimeoutOptionsCellTests/testThatItDisplaysDisabledCell_WithoutTimeout_Dark.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupDetailsTimeoutOptionsCellTests/testThatItDisplaysDisabledCell_WithoutTimeout_Dark.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e00c2055167c12bf892676e4a274ba1583d5a538326af60be370017e78306c17
+size 14003

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/GroupDetailsTimeoutOptionsCellTests/testThatItDisplaysDisabledCell_WithoutTimeout_Light.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/GroupDetailsTimeoutOptionsCellTests/testThatItDisplaysDisabledCell_WithoutTimeout_Light.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef0eb8bba5576bc6e1d8fe7851fb5e330fa9e5cf30a2c5e17895ad12ff82e87b
+size 13842

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -2031,6 +2031,8 @@ internal enum L10n {
         internal static func messageTimerOffYou(_ p1: Any) -> String {
           return L10n.tr("Localizable", "content.system.message_timer_off-you", String(describing: p1), fallback: "%@ turned off the message timer")
         }
+        /// Self-deleting messages are disabled for the conversations with Cells
+        internal static let messageTimerUnavailable = L10n.tr("Localizable", "content.system.message_timer_unavailable", fallback: "Self-deleting messages are disabled for the conversations with Cells")
         /// You haven’t used this device for a while. Some messages may not appear here.
         internal static let missingMessages = L10n.tr("Localizable", "content.system.missing_messages", fallback: "You haven’t used this device for a while. Some messages may not appear here.")
         /// Plural format key: "%#@d_new_devices@"

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -602,6 +602,8 @@
 "content.system.message_timer_off" = "%@ turned off the message timer";
 "content.system.message_timer_off-you" = "%@ turned off the message timer";
 
+"content.system.message_timer_unavailable" = "Self-deleting messages are disabled for the conversations with Cells";
+
 "content.system.backends_stop_federating.self_backend" = "**Your backend** stopped federating with **%@**. [Learn more](%@)";
 "content.system.backends_stop_federating.other_backends" = "The backends **%@** and **%@** stopped federating. [Learn more](%@)";
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
@@ -60,10 +60,20 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
         get { titleLabel.text }
         set { updateTitle(newValue) }
     }
+    
+    var titleColor: UIColor {
+        get { titleLabel.textColor }
+        set { updateTitleColor(newValue) }
+    }
 
     var status: String? {
         get { statusLabel.text }
         set { updateStatus(newValue) }
+    }
+    
+    var statusColor: UIColor {
+        get { statusLabel.textColor }
+        set { updateStatusColor(newValue) }
     }
 
     var allowMultilineStatus: Bool = false {
@@ -168,6 +178,10 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
         }
     }
 
+    private func updateTitleColor(_ newValue: UIColor) {
+        titleLabel.textColor = newValue
+    }
+
     private func updateStatus(_ newValue: String?) {
         if let value = newValue {
             statusLabel.text = value
@@ -175,6 +189,10 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
         } else {
             statusLabel.isHidden = true
         }
+    }
+    
+    private func updateStatusColor(_ newValue: UIColor) {
+        statusLabel.textColor = newValue
     }
 
     private func setupAccessibility() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Views/DetailsCollectionViewCell.swift
@@ -60,7 +60,7 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
         get { titleLabel.text }
         set { updateTitle(newValue) }
     }
-    
+
     var titleColor: UIColor {
         get { titleLabel.textColor }
         set { updateTitleColor(newValue) }
@@ -70,7 +70,7 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
         get { statusLabel.text }
         set { updateStatus(newValue) }
     }
-    
+
     var statusColor: UIColor {
         get { statusLabel.textColor }
         set { updateStatusColor(newValue) }
@@ -190,7 +190,7 @@ class DetailsCollectionViewCell: SeparatorCollectionViewCell, DynamicTypeCapable
             statusLabel.isHidden = true
         }
     }
-    
+
     private func updateStatusColor(_ newValue: UIColor) {
         statusLabel.textColor = newValue
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageTimerSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageTimerSystemMessageCellDescription.swift
@@ -37,7 +37,7 @@ final class ConversationMessageTimerSystemMessageCellDescription: ConversationMe
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String?
-    
+
     enum State {
         case updated(message: ZMConversationMessage, data: ZMSystemMessageData, timer: NSNumber, sender: UserType)
         case unavailable
@@ -49,7 +49,7 @@ final class ConversationMessageTimerSystemMessageCellDescription: ConversationMe
             .font: UIFont.mediumFont,
             .foregroundColor: LabelColors.textDefault
         ]
-        
+
         switch state {
         case let .updated(message, _, timer, sender):
             let senderText = message.senderName
@@ -74,9 +74,12 @@ final class ConversationMessageTimerSystemMessageCellDescription: ConversationMe
             }
 
         case .unavailable:
-            updateText = NSAttributedString(string: L10n.Localizable.Content.System.messageTimerUnavailable, attributes: baseAttributes)
+            updateText = NSAttributedString(
+                string: L10n.Localizable.Content.System.messageTimerUnavailable,
+                attributes: baseAttributes
+            )
         }
-        
+
         let icon = StyleKitIcon.hourglass.makeImage(size: 16, color: IconColors.backgroundDefault)
         self.configuration = View.Configuration(icon: icon, attributedText: updateText, showLine: false)
         self.accessibilityLabel = updateText?.string

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageTimerSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageTimerSystemMessageCellDescription.swift
@@ -37,35 +37,46 @@ final class ConversationMessageTimerSystemMessageCellDescription: ConversationMe
 
     let accessibilityIdentifier: String? = nil
     let accessibilityLabel: String?
+    
+    enum State {
+        case updated(message: ZMConversationMessage, data: ZMSystemMessageData, timer: NSNumber, sender: UserType)
+        case unavailable
+    }
 
-    init(message: ZMConversationMessage, data: ZMSystemMessageData, timer: NSNumber, sender: UserType) {
-        let senderText = message.senderName
-        let timeoutValue = MessageDestructionTimeoutValue(rawValue: timer.doubleValue)
-
+    init(state: State) {
         var updateText: NSAttributedString?
         let baseAttributes: [NSAttributedString.Key: AnyObject] = [
             .font: UIFont.mediumFont,
             .foregroundColor: LabelColors.textDefault
         ]
+        
+        switch state {
+        case let .updated(message, _, timer, sender):
+            let senderText = message.senderName
+            let timeoutValue = MessageDestructionTimeoutValue(rawValue: timer.doubleValue)
 
-        if timeoutValue == .none {
-            updateText = NSAttributedString(
-                string: "content.system.message_timer_off".localized(pov: sender.pov, args: senderText),
-                attributes: baseAttributes
-            )
+            if timeoutValue == .none {
+                updateText = NSAttributedString(
+                    string: "content.system.message_timer_off".localized(pov: sender.pov, args: senderText),
+                    attributes: baseAttributes
+                )
 
-        } else if let displayString = timeoutValue.displayString {
-            let timerString = displayString.replacingOccurrences(
-                of: String.breakingSpace,
-                with: String.nonBreakingSpace
-            )
-            updateText = NSAttributedString(
-                string: "content.system.message_timer_changes"
-                    .localized(pov: sender.pov, args: senderText, timerString),
-                attributes: baseAttributes
-            )
+            } else if let displayString = timeoutValue.displayString {
+                let timerString = displayString.replacingOccurrences(
+                    of: String.breakingSpace,
+                    with: String.nonBreakingSpace
+                )
+                updateText = NSAttributedString(
+                    string: "content.system.message_timer_changes"
+                        .localized(pov: sender.pov, args: senderText, timerString),
+                    attributes: baseAttributes
+                )
+            }
+
+        case .unavailable:
+            updateText = NSAttributedString(string: L10n.Localizable.Content.System.messageTimerUnavailable, attributes: baseAttributes)
         }
-
+        
         let icon = StyleKitIcon.hourglass.makeImage(size: 16, color: IconColors.backgroundDefault)
         self.configuration = View.Configuration(icon: icon, attributedText: updateText, showLine: false)
         self.accessibilityLabel = updateText?.string

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -81,10 +81,7 @@ enum ConversationSystemMessageCellDescription {
             }
 
             let timerCell = ConversationMessageTimerSystemMessageCellDescription(
-                message: message,
-                data: systemMessageData,
-                timer: timer,
-                sender: sender
+                state: .updated(message: message, data: systemMessageData, timer: timer, sender: sender)
             )
             return [AnyConversationMessageCellDescription(timerCell)]
 
@@ -191,6 +188,13 @@ enum ConversationSystemMessageCellDescription {
             if conversation.isOpenGroup {
                 let encryptionInfoCell = ConversationEncryptionInfoSystemMessageCellDescription()
                 cells.append(AnyConversationMessageCellDescription(encryptionInfoCell))
+            }
+            
+            if conversation.isCellsEnabled {
+                let timerCell = ConversationMessageTimerSystemMessageCellDescription(
+                    state: .unavailable
+                )
+                cells.append(AnyConversationMessageCellDescription(timerCell))
             }
 
             if conversation.isChannel, let channelHistoryDepth = conversation.channelHistoryDepth {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationSystemMessageCellDescription.swift
@@ -189,7 +189,7 @@ enum ConversationSystemMessageCellDescription {
                 let encryptionInfoCell = ConversationEncryptionInfoSystemMessageCellDescription()
                 cells.append(AnyConversationMessageCellDescription(encryptionInfoCell))
             }
-            
+
             if conversation.isCellsEnabled {
                 let timerCell = ConversationMessageTimerSystemMessageCellDescription(
                     state: .unavailable

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
@@ -72,7 +72,7 @@ extension ZMConversation: InputBarConversation {
     var isSelfDeletingMessageSendingDisabled: Bool {
         guard let context = managedObjectContext else { return false }
         let feature = LegacyFeatureRepository(context: context).fetchSelfDeletingMessages()
-        return feature.status == .disabled
+        return feature.status == .disabled || isCellsEnabled
     }
 
     var isSelfDeletingMessageTimeoutForced: Bool {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -269,7 +269,7 @@ final class ConversationInputBarViewController: UIViewController,
                 locationButton
             ]
         }
-        if !conversation.isSelfDeletingMessageSendingDisabled {
+        if !conversation.isCellsEnabled, !conversation.isSelfDeletingMessageSendingDisabled {
             buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -269,7 +269,7 @@ final class ConversationInputBarViewController: UIViewController,
                 locationButton
             ]
         }
-        if !conversation.isCellsEnabled, !conversation.isSelfDeletingMessageSendingDisabled {
+        if !conversation.isSelfDeletingMessageSendingDisabled {
             buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsTimeoutOptionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsTimeoutOptionsCell.swift
@@ -34,8 +34,12 @@ final class GroupDetailsTimeoutOptionsCell: GroupDetailsDisclosureOptionsCell {
     }
 
     func configure(with conversation: GroupDetailsConversationType) {
-        let timeout = MessageDestructionTimeoutValue(rawValue: conversation.syncedMessageDestructionTimeout)
-        status = timeout.displayString
+        if conversation.isCellsEnabled {
+            setDisabledCell()
+        } else {
+            let timeout = MessageDestructionTimeoutValue(rawValue: conversation.syncedMessageDestructionTimeout)
+            status = timeout.displayString
+        }
     }
 
     override var isHighlighted: Bool {
@@ -44,6 +48,17 @@ final class GroupDetailsTimeoutOptionsCell: GroupDetailsDisclosureOptionsCell {
                 ? SemanticColors.View.backgroundUserCellHightLighted
                 : SemanticColors.View.backgroundUserCell
         }
+    }
+    
+    private func setDisabledCell() {
+        let disabled = MessageDestructionTimeoutValue.none
+        status = disabled.displayString
+        iconColor = UIColor.systemGray
+        titleColor = UIColor.systemGray
+        statusColor = UIColor.systemGray
+        accessoryColor = UIColor.systemGray
+        isUserInteractionEnabled = false
+        alpha = 0.8
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsTimeoutOptionsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Cells/GroupDetailsTimeoutOptionsCell.swift
@@ -49,7 +49,7 @@ final class GroupDetailsTimeoutOptionsCell: GroupDetailsDisclosureOptionsCell {
                 : SemanticColors.View.backgroundUserCell
         }
     }
-    
+
     private func setDisabledCell() {
         let disabled = MessageDestructionTimeoutValue.none
         status = disabled.displayString

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/Sections/GroupOptionsSectionController.swift
@@ -149,7 +149,9 @@ final class GroupOptionsSectionController: GroupDetailsSectionController {
         case .services:
             delegate?.presentServicesOptions(animated: true)
         case .timeout:
-            delegate?.presentTimeoutOptions(animated: true)
+            if !conversation.isCellsEnabled {
+                delegate?.presentTimeoutOptions(animated: true)
+            }
         case .notifications:
             delegate?.presentNotificationsOptions(animated: true)
         case .channelAccess:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19754" title="WPB-19754" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19754</a>  [iOS] Disable self-deleting messages in conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR disables self deleting messages in conversations with cells enabled, specifically:
- remove self deleting button in input bar (for users to set a self deleting message)
- grey out and disable self deleting messages option for conversation admins
- add a system message to let users know self deleting messages are not available

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
