### PR TITLE
fix: Other users avatar has wrong color on dark mode - WPB-20661

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationTitleView/ConversationTitleView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationTitleView/ConversationTitleView.swift
@@ -70,7 +70,7 @@ public class ConversationTitleView: UIView {
         let design = AccountImageViewDesign()
         accountImageView.imageBorderWidth = design.borderWidth
         accountImageView.imageBorderColor = design.borderColor
-        accountImageView.initialsTextColor = .white
+        accountImageView.initialsTextColor = SemanticColors.Button.textPrimaryEnabled
 
         dropdownImage.tintColor = ColorTheme.Backgrounds.onSurfaceVariant
 

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/ConversationTitleViewSnapshotTests/testInitialsAvatarForOneOnOnesWithSubtitle.dark.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/ConversationTitleViewSnapshotTests/testInitialsAvatarForOneOnOnesWithSubtitle.dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c8b5a621e0b0c4782f4b9a229aa1d207f6f93864661b30080b447d040fc858a1
-size 10218
+oid sha256:7986b9b0bd2ca729829ac99d8a53546361b03fa16fb4e81b98efd266e280166d
+size 10230


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20661" title="WPB-20661" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20661</a>  [iOS]Other users avatar has wrong color on dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Issue: Conversation Account image icon label color is not updated to black in dark mode

Solution: Update it
### Testing

Conversation account image label color should be black

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
