### PR TITLE
fix: Update the Poll Button Color view when the accentColor changed - WPB-19731

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
+++ b/wire-ios/Wire-iOS/Sources/Components/Buttons/SpinnerButton.swift
@@ -103,6 +103,10 @@ final class SpinnerButton: LegacyButton {
         setTitleColor(.white, for: .disabled)
 
         setTitleColor(UIColor.from(scheme: .textDimmed, variant: variant), for: .highlighted)
+
+        setBorderColor(UIColor.accent(), for: .normal)
+        setBorderColor(UIColor.accentDarken, for: .highlighted)
+        setBorderColor(UIColor.from(scheme: .textDimmed, variant: variant), for: .disabled)
     }
 
     /// custom empty style with accent color for disabled state.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19731" title="WPB-19731" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19731</a>  Update the Poll Button Color view when the accentColor changed from different clients(web,iOS)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Issue: Border color is not updated correctly
Solution : Added code to update border color

### Testing

Border color must also update in iOS client whenever we change accent color from web client

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
