### PR TITLE
fix(backup-performance): message creation - WPB-20905

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -772,7 +772,8 @@ public final class ClientSessionComponent {
     public private(set) lazy var conversationProtobufMessageProcessor = ConversationProtobufMessageProcessor(
         messageLocalStore: messageLocalStore,
         conversationLocalStore: conversationLocalStore,
-        userLocalStore: userLocalStore
+        userLocalStore: userLocalStore,
+        isProcessingBackup: false
     )
 
     private lazy var oneOnOneResolver = OneOnOneResolver(

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
@@ -241,12 +241,21 @@ public struct ConversationProtobufMessageProcessor: ConversationProtobufMessageP
     ) async throws {
         let (assetClientMessage, isNew): (ZMAssetClientMessage, Bool)
         do {
-            (assetClientMessage, isNew) = try await messageLocalStore.fetchOrCreateAssetClientMessage(
-                id: message.messageID,
-                conversation: conversation,
-                sender: (sender.id, sender.domain, sender.clientID),
-                date: date
-            )
+            if isProcessingBackup {
+                (assetClientMessage, isNew) = (try await messageLocalStore.createAssetClientMessage(
+                    id: message.messageID,
+                    conversation: conversation,
+                    sender: (sender.id, sender.domain, sender.clientID),
+                    date: date
+                ), true)
+            } else {
+                (assetClientMessage, isNew) = try await messageLocalStore.fetchOrCreateAssetClientMessage(
+                    id: message.messageID,
+                    conversation: conversation,
+                    sender: (sender.id, sender.domain, sender.clientID),
+                    date: date
+                )
+            }
         } catch let MessageLocalStore.Failure.invalidInsertion(reason: reason) {
             return WireLogger.eventProcessing.warn(
                 "failed to process asset message, dropping. Reason: \(reason)",

--- a/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
+++ b/WireDomain/Sources/WireDomain/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessor.swift
@@ -26,15 +26,18 @@ public struct ConversationProtobufMessageProcessor: ConversationProtobufMessageP
     let messageLocalStore: any MessageLocalStoreProtocol
     let conversationLocalStore: any ConversationLocalStoreProtocol
     let userLocalStore: any UserLocalStoreProtocol
+    let isProcessingBackup: Bool
 
     public init(
         messageLocalStore: any MessageLocalStoreProtocol,
         conversationLocalStore: any ConversationLocalStoreProtocol,
-        userLocalStore: any UserLocalStoreProtocol
+        userLocalStore: any UserLocalStoreProtocol,
+        isProcessingBackup: Bool
     ) {
         self.messageLocalStore = messageLocalStore
         self.conversationLocalStore = conversationLocalStore
         self.userLocalStore = userLocalStore
+        self.isProcessingBackup = isProcessingBackup
     }
 
     public func processProtobufMessage(
@@ -270,12 +273,21 @@ public struct ConversationProtobufMessageProcessor: ConversationProtobufMessageP
     ) async throws {
         let (clientMessage, isNew): (ZMClientMessage, isNew: Bool)
         do {
-            (clientMessage, isNew) = try await messageLocalStore.fetchOrCreateClientMessage(
-                id: message.messageID,
-                conversation: conversation,
-                sender: (sender.id, sender.domain, sender.clientID),
-                date: date
-            )
+            if isProcessingBackup {
+                (clientMessage, isNew) = (try await messageLocalStore.createClientMessage(
+                    id: message.messageID,
+                    conversation: conversation,
+                    sender: sender,
+                    date: date
+                ), true)
+            } else {
+                (clientMessage, isNew) = try await messageLocalStore.fetchOrCreateClientMessage(
+                    id: message.messageID,
+                    conversation: conversation,
+                    sender: (sender.id, sender.domain, sender.clientID),
+                    date: date
+                )
+            }
         } catch let MessageLocalStore.Failure.invalidInsertion(reason: reason) {
             return WireLogger.eventProcessing.warn(
                 "failed to process message, dropping. Reason: \(reason)",

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -171,6 +171,23 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
 
     }
 
+    public func createClientMessage(
+        id: String,
+        conversation: ZMConversation,
+        sender: (id: UUID, domain: String, clientID: String?),
+        date: Date
+    ) async throws -> ZMClientMessage {
+
+        try await createClientMessage(
+            id: id,
+            messageType: .default,
+            conversation: conversation,
+            sender: sender,
+            date: date
+        ) as! ZMClientMessage
+
+    }
+    
     public func fetchOrCreateAssetClientMessage(
         id: String,
         conversation: ZMConversation,
@@ -401,17 +418,11 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
     ) async throws -> (ZMOTRMessage, isNew: Bool) {
         try await context.perform { [self] in
 
-            if let clearedTime = conversation.clearedTimeStamp, clearedTime.compare(date) != .orderedAscending {
-                throw Failure.invalidInsertion(reason: "message is older than cleared time")
-            }
-
-            guard conversation.conversationType != .`self` else {
-                throw Failure.invalidInsertion(reason: "message cannot be sent to self")
-            }
-
-            guard let nonce = UUID(uuidString: id) else {
-                throw Failure.invalidInsertion(reason: "invalid nonce")
-            }
+            let nonce = try validateClientMessage(
+                id: id,
+                conversation: conversation,
+                date: date
+            )
 
             let clientMessage = messageType == .asset ?
                 ZMAssetClientMessage.fetch(
@@ -428,21 +439,11 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             if let clientMessage {
                 return (clientMessage, false)
             } else {
-                let newClientMessage = messageType == .asset ?
-                    ZMAssetClientMessage(
-                        nonce: nonce,
-                        managedObjectContext: context
-                    ) :
-                    ZMClientMessage(
-                        nonce: nonce,
-                        managedObjectContext: context
-                    )
-
-                setupNewClientMessage(
-                    newClientMessage,
+                let newClientMessage = createValidatedClientMessage(
+                    nonce: nonce,
+                    messageType: messageType,
                     conversation: conversation,
-                    senderID: sender.id,
-                    clientID: sender.clientID,
+                    sender: sender,
                     date: date
                 )
 
@@ -450,7 +451,80 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             }
         }
     }
+    
+    private func createClientMessage(
+        id: String,
+        messageType: ClientMessageType,
+        conversation: ZMConversation,
+        sender: (id: UUID, domain: String, clientID: String?),
+        date: Date
+    ) async throws -> ZMOTRMessage {
+        try await context.perform { [self] in
+            
+            let nonce = try validateClientMessage(
+                id: id,
+                conversation: conversation,
+                date: date
+            )
+            
+            return createValidatedClientMessage(
+                nonce: nonce,
+                messageType: messageType,
+                conversation: conversation,
+                sender: sender,
+                date: date
+            )
+        }
+    }
+    
+    private func createValidatedClientMessage(
+        nonce: UUID,
+        messageType: ClientMessageType,
+        conversation: ZMConversation,
+        sender: (id: UUID, domain: String, clientID: String?),
+        date: Date
+    ) -> ZMOTRMessage {
+        let clientMessage = messageType == .asset ?
+            ZMAssetClientMessage(
+                nonce: nonce,
+                managedObjectContext: context
+            ) :
+            ZMClientMessage(
+                nonce: nonce,
+                managedObjectContext: context
+            )
 
+        setupNewClientMessage(
+            clientMessage,
+            conversation: conversation,
+            senderID: sender.id,
+            clientID: sender.clientID,
+            date: date
+        )
+        
+        return clientMessage
+    }
+    
+    private func validateClientMessage(
+        id: String,
+        conversation: ZMConversation,
+        date: Date
+    ) throws -> UUID {
+        if let clearedTime = conversation.clearedTimeStamp, clearedTime.compare(date) != .orderedAscending {
+            throw Failure.invalidInsertion(reason: "message is older than cleared time")
+        }
+
+        guard conversation.conversationType != .`self` else {
+            throw Failure.invalidInsertion(reason: "message cannot be sent to self")
+        }
+
+        guard let nonce = UUID(uuidString: id) else {
+            throw Failure.invalidInsertion(reason: "invalid nonce")
+        }
+
+        return nonce
+    }
+    
     private func setupNewClientMessage(
         _ message: ZMOTRMessage,
         conversation: ZMConversation,

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -204,6 +204,23 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
         ) as! (ZMAssetClientMessage, Bool)
 
     }
+    
+    public func createAssetClientMessage(
+        id: String,
+        conversation: ZMConversation,
+        sender: (id: UUID, domain: String, clientID: String?),
+        date: Date
+    ) async throws -> ZMAssetClientMessage {
+        
+        try await createClientMessage(
+            id: id,
+            messageType: .asset,
+            conversation: conversation,
+            sender: sender,
+            date: date
+        ) as! ZMAssetClientMessage
+        
+    }
 
     public func addClientMessage(
         _ clientMessage: ZMClientMessage,

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -187,7 +187,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
         ) as! ZMClientMessage
 
     }
-    
+
     public func fetchOrCreateAssetClientMessage(
         id: String,
         conversation: ZMConversation,
@@ -204,14 +204,14 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
         ) as! (ZMAssetClientMessage, Bool)
 
     }
-    
+
     public func createAssetClientMessage(
         id: String,
         conversation: ZMConversation,
         sender: (id: UUID, domain: String, clientID: String?),
         date: Date
     ) async throws -> ZMAssetClientMessage {
-        
+
         try await createClientMessage(
             id: id,
             messageType: .asset,
@@ -219,7 +219,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             sender: sender,
             date: date
         ) as! ZMAssetClientMessage
-        
+
     }
 
     public func addClientMessage(
@@ -468,7 +468,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             }
         }
     }
-    
+
     private func createClientMessage(
         id: String,
         messageType: ClientMessageType,
@@ -477,13 +477,13 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
         date: Date
     ) async throws -> ZMOTRMessage {
         try await context.perform { [self] in
-            
+
             let nonce = try validateClientMessage(
                 id: id,
                 conversation: conversation,
                 date: date
             )
-            
+
             return createValidatedClientMessage(
                 nonce: nonce,
                 messageType: messageType,
@@ -493,7 +493,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             )
         }
     }
-    
+
     private func createValidatedClientMessage(
         nonce: UUID,
         messageType: ClientMessageType,
@@ -518,10 +518,10 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             clientID: sender.clientID,
             date: date
         )
-        
+
         return clientMessage
     }
-    
+
     private func validateClientMessage(
         id: String,
         conversation: ZMConversation,
@@ -541,7 +541,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
 
         return nonce
     }
-    
+
     private func setupNewClientMessage(
         _ message: ZMOTRMessage,
         conversation: ZMConversation,

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -56,7 +56,13 @@ public protocol MessageLocalStoreProtocol {
         date: Date
     ) async throws -> (ZMClientMessage, isNew: Bool)
     
-    // TODO: Add doc comment
+    /// Creates a `ZMClientMessage` locally.
+    /// - Parameters:
+    ///     - id: The message ID.
+    ///     - conversation: The conversation the message is related to.
+    ///     - sender: The message sender info.
+    ///     - date: The date the message was received.
+
     func createClientMessage(
         id: String,
         conversation: ZMConversation,
@@ -78,7 +84,13 @@ public protocol MessageLocalStoreProtocol {
         date: Date
     ) async throws -> (ZMAssetClientMessage, isNew: Bool)
     
-    // TODO: Add doc comment
+    /// Creates a `ZMAssetClientMessage` locally.
+    /// - Parameters:
+    ///     - id: The message ID.
+    ///     - conversation: The conversation the message is related to.
+    ///     - sender: The message sender info.
+    ///     - date: The date the message was received.
+
     func createAssetClientMessage(
         id: String,
         conversation: ZMConversation,

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -55,7 +55,7 @@ public protocol MessageLocalStoreProtocol {
         sender: (id: UUID, domain: String, clientID: String?),
         date: Date
     ) async throws -> (ZMClientMessage, isNew: Bool)
-    
+
     /// Creates a `ZMClientMessage` locally.
     /// - Parameters:
     ///     - id: The message ID.
@@ -83,7 +83,7 @@ public protocol MessageLocalStoreProtocol {
         sender: (id: UUID, domain: String, clientID: String?),
         date: Date
     ) async throws -> (ZMAssetClientMessage, isNew: Bool)
-    
+
     /// Creates a `ZMAssetClientMessage` locally.
     /// - Parameters:
     ///     - id: The message ID.
@@ -97,7 +97,7 @@ public protocol MessageLocalStoreProtocol {
         sender: (id: UUID, domain: String, clientID: String?),
         date: Date
     ) async throws -> ZMAssetClientMessage
-    
+
     /// Adds a `ZMClientMessage` to a given conversation.
     /// - Parameters:
     ///     - clientMessage: The client message.

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -77,7 +77,15 @@ public protocol MessageLocalStoreProtocol {
         sender: (id: UUID, domain: String, clientID: String?),
         date: Date
     ) async throws -> (ZMAssetClientMessage, isNew: Bool)
-
+    
+    // TODO: Add doc comment
+    func createAssetClientMessage(
+        id: String,
+        conversation: ZMConversation,
+        sender: (id: UUID, domain: String, clientID: String?),
+        date: Date
+    ) async throws -> ZMAssetClientMessage
+    
     /// Adds a `ZMClientMessage` to a given conversation.
     /// - Parameters:
     ///     - clientMessage: The client message.

--- a/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/Protocols/MessageLocalStoreProtocol.swift
@@ -55,6 +55,14 @@ public protocol MessageLocalStoreProtocol {
         sender: (id: UUID, domain: String, clientID: String?),
         date: Date
     ) async throws -> (ZMClientMessage, isNew: Bool)
+    
+    // TODO: Add doc comment
+    func createClientMessage(
+        id: String,
+        conversation: ZMConversation,
+        sender: (id: UUID, domain: String, clientID: String?),
+        date: Date
+    ) async throws -> ZMClientMessage
 
     /// Fetches or creates a `ZMAssetClientMessage` locally.
     /// - Parameters:

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2547,6 +2547,29 @@ public class MockMessageLocalStoreProtocol: MessageLocalStoreProtocol {
         }
     }
 
+    // MARK: - createClientMessage
+
+    public var createClientMessageIdConversationSenderDate_Invocations: [(id: String, conversation: ZMConversation, sender: (id: UUID, domain: String, clientID: String?), date: Date)] = []
+    public var createClientMessageIdConversationSenderDate_MockError: Error?
+    public var createClientMessageIdConversationSenderDate_MockMethod: ((String, ZMConversation, (id: UUID, domain: String, clientID: String?), Date) async throws -> ZMClientMessage)?
+    public var createClientMessageIdConversationSenderDate_MockValue: ZMClientMessage?
+
+    public func createClientMessage(id: String, conversation: ZMConversation, sender: (id: UUID, domain: String, clientID: String?), date: Date) async throws -> ZMClientMessage {
+        createClientMessageIdConversationSenderDate_Invocations.append((id: id, conversation: conversation, sender: sender, date: date))
+
+        if let error = createClientMessageIdConversationSenderDate_MockError {
+            throw error
+        }
+
+        if let mock = createClientMessageIdConversationSenderDate_MockMethod {
+            return try await mock(id, conversation, sender, date)
+        } else if let mock = createClientMessageIdConversationSenderDate_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `createClientMessageIdConversationSenderDate`")
+        }
+    }
+
     // MARK: - fetchOrCreateAssetClientMessage
 
     public var fetchOrCreateAssetClientMessageIdConversationSenderDate_Invocations: [(id: String, conversation: ZMConversation, sender: (id: UUID, domain: String, clientID: String?), date: Date)] = []
@@ -2567,6 +2590,29 @@ public class MockMessageLocalStoreProtocol: MessageLocalStoreProtocol {
             return mock
         } else {
             fatalError("no mock for `fetchOrCreateAssetClientMessageIdConversationSenderDate`")
+        }
+    }
+
+    // MARK: - createAssetClientMessage
+
+    public var createAssetClientMessageIdConversationSenderDate_Invocations: [(id: String, conversation: ZMConversation, sender: (id: UUID, domain: String, clientID: String?), date: Date)] = []
+    public var createAssetClientMessageIdConversationSenderDate_MockError: Error?
+    public var createAssetClientMessageIdConversationSenderDate_MockMethod: ((String, ZMConversation, (id: UUID, domain: String, clientID: String?), Date) async throws -> ZMAssetClientMessage)?
+    public var createAssetClientMessageIdConversationSenderDate_MockValue: ZMAssetClientMessage?
+
+    public func createAssetClientMessage(id: String, conversation: ZMConversation, sender: (id: UUID, domain: String, clientID: String?), date: Date) async throws -> ZMAssetClientMessage {
+        createAssetClientMessageIdConversationSenderDate_Invocations.append((id: id, conversation: conversation, sender: sender, date: date))
+
+        if let error = createAssetClientMessageIdConversationSenderDate_MockError {
+            throw error
+        }
+
+        if let mock = createAssetClientMessageIdConversationSenderDate_MockMethod {
+            return try await mock(id, conversation, sender, date)
+        } else if let mock = createAssetClientMessageIdConversationSenderDate_MockValue {
+            return mock
+        } else {
+            fatalError("no mock for `createAssetClientMessageIdConversationSenderDate`")
         }
     }
 

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
@@ -53,7 +53,8 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
         sut = ConversationProtobufMessageProcessor(
             messageLocalStore: messageLocalStore,
             conversationLocalStore: conversationLocalStore,
-            userLocalStore: userLocalStore
+            userLocalStore: userLocalStore,
+            isProcessingBackup: false
         )
     }
 
@@ -107,7 +108,7 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
             1
         )
     }
-
+    
     func testProcessEvent_It_Invokes_Local_Store_Add_Message_Confirmation_Method() async throws {
         // Given
         let conversation = await context.perform { [self] in
@@ -177,6 +178,55 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
         XCTAssertEqual(invocation.userID.uuid, Scaffolding.userID.id)
         XCTAssertEqual(invocation.userID.domain, Scaffolding.userID.domain)
     }
+    
+    func testProcessEvent_InvokesCreateClientMessage_WhenProcessingBackupMessage() async throws {
+        // Given
+
+        let sut = ConversationProtobufMessageProcessor(
+            messageLocalStore: messageLocalStore,
+            conversationLocalStore: conversationLocalStore,
+            userLocalStore: userLocalStore,
+            isProcessingBackup: true
+        )
+        
+        let (conversation, clientMessage) = await context.perform { [self] in
+            let conversation = modelHelper.createGroupConversation(in: context)
+            let clientMessage = ZMClientMessage(context: context)
+
+            return (conversation, clientMessage)
+        }
+
+        messageLocalStore.createClientMessageIdConversationSenderDate_MockValue = clientMessage
+        messageLocalStore
+            .addClientMessageIsNewMessageGenericMessageConversationSenderIDSenderDomain_MockMethod =
+            { _, _, _, _, _, _ in
+            }
+
+        let genericMessage = try XCTUnwrap(GenericMessage.validatedMessage(from: Scaffolding.base64EncodedString))
+
+        // When
+
+        try await sut.processProtobufMessage(
+            genericMessage,
+            conversation: conversation,
+            conversationID: Scaffolding.conversationID,
+            senderID: Scaffolding.userID,
+            senderClientID: "",
+            date: Scaffolding.eventDate,
+            eventMessage: ""
+        )
+
+        // Then
+
+        XCTAssertEqual(messageLocalStore.createClientMessageIdConversationSenderDate_Invocations.count, 1)
+        XCTAssertEqual(messageLocalStore.fetchOrCreateClientMessageIdConversationSenderDate_Invocations.count, 0)
+        XCTAssertEqual(
+            messageLocalStore.addClientMessageIsNewMessageGenericMessageConversationSenderIDSenderDomain_Invocations
+                .count,
+            1
+        )
+    }
+
 
     private enum Scaffolding {
         static let eventDate = Date()

--- a/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Event Processing/ConversationEventProcessor/ConversationProtobufMessageProcessorTests.swift
@@ -108,7 +108,7 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
             1
         )
     }
-    
+
     func testProcessEvent_It_Invokes_Local_Store_Add_Message_Confirmation_Method() async throws {
         // Given
         let conversation = await context.perform { [self] in
@@ -178,7 +178,7 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
         XCTAssertEqual(invocation.userID.uuid, Scaffolding.userID.id)
         XCTAssertEqual(invocation.userID.domain, Scaffolding.userID.domain)
     }
-    
+
     func testProcessEvent_InvokesCreateClientMessage_WhenProcessingBackupMessage() async throws {
         // Given
 
@@ -188,7 +188,7 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
             userLocalStore: userLocalStore,
             isProcessingBackup: true
         )
-        
+
         let (conversation, clientMessage) = await context.perform { [self] in
             let conversation = modelHelper.createGroupConversation(in: context)
             let clientMessage = ZMClientMessage(context: context)
@@ -226,7 +226,6 @@ final class ConversationProtobufMessageProcessorTests: XCTestCase {
             1
         )
     }
-
 
     private enum Scaffolding {
         static let eventDate = Date()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -398,7 +398,8 @@ extension SettingsCellDescriptorFactory {
             processor: ConversationProtobufMessageProcessor(
                 context: context,
                 localDomain: localDomain,
-                isFederationEnabled: isFederationEnabled
+                isFederationEnabled: isFederationEnabled,
+                isProcessingBackup: true
             )
         )
         let userSession = sessionManager.activeUserSession!
@@ -533,7 +534,8 @@ private extension ConversationProtobufMessageProcessor {
     init(
         context: NSManagedObjectContext,
         localDomain: String?,
-        isFederationEnabled: Bool
+        isFederationEnabled: Bool,
+        isProcessingBackup: Bool
     ) {
         let messageLocalStore = MessageLocalStore(context: context)
         self.init(
@@ -548,7 +550,8 @@ private extension ConversationProtobufMessageProcessor {
             userLocalStore: UserLocalStore(
                 context: context,
                 messageLocalStore: messageLocalStore
-            )
+            ),
+            isProcessingBackup: isProcessingBackup
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20905" title="WPB-20905" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20905</a>  [iOS] Backup performance :: creating messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Using the time profiler with a backup sample of ~15k messages, I observed that 34% of the time importing a backup is spent doing a fetch request to fetch messages we’re importing. (in `MessageLocalStore.fetchOrCreateClientMessage`) 

However, since we’re already checking if messages exist before creating them (as part of backup import), we don’t need to try to fetch them, we just need to create them.

### Solution

Add methods:
- `MessageLocalStore.createClientMessage`
- `MessageLocalStore.createAssetClientMessage`
 
And use these when processing messages from the backup in `ConversationProtobuMessageProcessor.processProtobufMessage`

### Result 

Measured the performance of importing a backup of ~15k messages, using a baseline build with no performance improvements and another build with the improvements from this PR (https://github.com/wireapp/wire-ios/pull/3694) + the current PR.


| Metric                           | Baseline  | Optimized | Times Faster         |
| -------------------------------- | --------- | --------- | -------------------- |
| **Total time**                   | 8.90 min  | 3.81 min  | **≈ 2.34×**          |
| **Page processing** (1k messages)             | 33.37 s   | 14.28 s   | **≈ 2.34×**          |
| **Message processing** (individual average)          | 19.81 ms  | 13.33 ms  | **≈ 1.49×**          |
| **Restoring last read**          | 183.6 s   | 12.23 s   | **≈ 15.0×**          |

**Note:** The change from this PR (https://github.com/wireapp/wire-ios/pull/3694) was between **1,2 - 1,31** times faster 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

