### PR TITLE
fix: Down lib upgrade to 2.3.6 - WPB-17582

### DIFF
--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/wireapp/Down",
         "state": {
           "branch": null,
-          "revision": "609219dda243620bedfef9777b70af92a7fe3494",
-          "version": "2.3.5"
+          "revision": "6fe54b29996eeca7a0a887af63330046de9a43a3",
+          "version": "2.3.6"
         }
       },
       {

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -2797,7 +2797,7 @@
 			repositoryURL = "https://github.com/wireapp/Down";
 			requirement = {
 				kind = exactVersion;
-				version = 2.3.5;
+				version = 2.3.6;
 			};
 		};
 		E9FBF3A42C47C23100C65DA8 /* XCRemoteSwiftPackageReference "FLAnimatedImage" */ = {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-17582" title="WPB-17582" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-17582</a>  [iOS] blank list items break the formatting
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Nested list items in markdown text are not rendering correctly when they are empty.
The fix for this issue is available in v2.3.6 of Down and this change is upgraging the Down package to this version.

### Testing

Write a text message in the chat which contains a nested list with an empty item such as this:

```
nested list test
1. Main A
    1. Sub A1
    2. Sub A2
    3.
2. Main B
    1. Sub B1
```

It should be rendered correctly.