### PR TITLE
fix: tapping buttons in composite messages (e.g. polls) - WPB-19793

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/Composite/CompositeMessageItemContent.swift
+++ b/wire-ios-data-model/Source/Model/Message/Composite/CompositeMessageItemContent.swift
@@ -19,7 +19,7 @@
 import Foundation
 import GenericMessageProtocol
 
-class CompositeMessageItemContent: NSObject {
+final class CompositeMessageItemContent: NSObject {
     private let parentMessage: ZMClientMessage
     private let item: Composite.Item
 
@@ -116,19 +116,18 @@ extension CompositeMessageItemContent: ButtonMessageData {
     }
 
     func touchAction() {
-        guard let moc = parentMessage.managedObjectContext,
-              let buttonId = button?.id,
-              let messageId = parentMessage.nonce,
-              !hasSelectedButton else { return }
+        guard let context = parentMessage.managedObjectContext else { return }
 
-        moc.performGroupedBlock { [weak self] in
-            guard let self else { return }
+        context.performGroupedBlock { [weak self] in
+            guard let self, let messageId = parentMessage.nonce, let buttonId = button?.id,
+                  !hasSelectedButton else { return }
+
             let buttonState = buttonState ??
-                ButtonState.insert(with: buttonId, message: parentMessage, inContext: moc)
+                ButtonState.insert(with: buttonId, message: parentMessage, inContext: context)
             parentMessage.buttonStates?.resetExpired()
             guard parentMessage.isSenderInConversation else {
                 buttonState.isExpired = true
-                moc.saveOrRollback()
+                context.saveOrRollback()
                 return
             }
 
@@ -139,7 +138,7 @@ extension CompositeMessageItemContent: ButtonMessageData {
                 Logging.messageProcessing.warn("Failed to append button action. Reason: \(error.localizedDescription)")
             }
 
-            moc.saveOrRollback()
+            context.saveOrRollback()
         }
     }
 }

--- a/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wire-ios-mono.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "41982a3656a71c768319979febd796c6fd111d5c",
-          "version": "1.5.0"
+          "revision": "309a47b2b1d9b5e991f36961c983ecec72275be3",
+          "version": "1.6.1"
         }
       },
       {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -189,9 +189,16 @@ final class ConversationTableViewDataSource: NSObject {
 
                     // Re-set messages from Main thread to section controller to not have crash with later interactions
                     // with data
+
+                    // Fix for tapping composite message buttons [WPB-19793]:
+                    // This workaround forces replacing `message` instance in `CompositeMessageItem` with an instance
+                    // originating from the main context.
+                    var recreateCellDescriptions = false
+
                     if let managedID = (sectionController.message as? ZMMessage)?.objectID,
                        let mainThreadMessage = try? mainThreadContext.existingObject(with: managedID) as? ZMMessage {
                         sectionController.updateMessage(mainThreadMessage)
+                        recreateCellDescriptions = mainThreadMessage.isComposite
                     } else {
                         WireLogger.conversation
                             .debug(
@@ -201,7 +208,7 @@ final class ConversationTableViewDataSource: NSObject {
 
                     sectionController.selfUser = selfUserOnMainThread
 
-                    if sectionController.context != context || forceRecalculate {
+                    if sectionController.context != context || forceRecalculate || recreateCellDescriptions {
                         sectionController.recreateCellDescriptions(in: context)
                     }
 

--- a/wire-ios/Wire-iOS/Wire-Info.plist
+++ b/wire-ios/Wire-iOS/Wire-Info.plist
@@ -79,8 +79,6 @@
 	<string>$(FORCE_ENCRYPTION_AT_REST_ENABLED)</string>
 	<key>GenerateLinkPreviewEnabled</key>
 	<string>${GENERATE_LINK_PREVIEW_ENABLED}</string>
-	<key>OpenLinksExternally</key>
-	<string>${OPEN_LINKS_EXTERNALLY}</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
 	<key>ITSEncryptionExportComplianceCode</key>
@@ -126,6 +124,8 @@
 	<string>Allow Wire to store pictures you take in the photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Allow Wire to access pictures stored in photo library.</string>
+	<key>OpenLinksExternally</key>
+	<string>${OPEN_LINKS_EXTERNALLY}</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>RedactedScript-Regular.ttf</string>
@@ -137,6 +137,8 @@
 		<string>remote-notification</string>
 		<string>fetch</string>
 	</array>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19793" title="WPB-19793" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-19793</a>  [iOS] Selecting option in poll option doesn't work
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Manual cherry-pick of #3696

A performance improvement #2921 earlier this year broke composite messages.
Some dangling Core Data objects from a temporary background context remain in the view/model hierarchy.
So when a button of a composite message is tapped, it cannot be handled properly.

This PR adds a workaround which forces the recreation of conversation message views if the message is a composite message.

### Testing

Create a poll in a Proteus conversation and try to vote.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
