### PR TITLE
fix: deadlock on incrementalSync - WPB-21010

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -20,6 +20,7 @@ import Combine
 import Foundation
 import WireLogging
 import WireNetwork
+import WireSystem
 
 public struct IncrementalSync: IncrementalSyncProtocol {
 
@@ -123,10 +124,24 @@ public struct IncrementalSync: IncrementalSyncProtocol {
                 logger.debug("handling live event stream", attributes: .incrementalSyncV2)
                 syncStateSubject.send(.liveSyncing(.ongoing))
 
-                await processLiveEvents(
-                    liveEventStream: liveEventStream,
-                    processedEnvelopeIDs: processedEnvelopeIDs
-                )
+                do {
+                    // because we might be interrupted when in background, we wrap the sync in an expiringActivity that
+                    // will
+                    // cancel the task - not keeping any db operation (sqlite file opened) in suspend mode
+                    try await withExpiringActivity(reason: "processLiveStream IncrementalSync") {
+                        await processLiveEvents(
+                            liveEventStream: liveEventStream,
+                            processedEnvelopeIDs: processedEnvelopeIDs
+                        )
+                    }
+                } catch {
+                    // if we expire, close everything
+                    WireLogger.sync.debug(
+                        "Error while processing live stream, close push channel",
+                        attributes: .incrementalSyncV2
+                    )
+                    await pushChannel.close()
+                }
 
                 logger.debug("live event stream did finish", attributes: .incrementalSyncV2)
                 syncStateSubject.send(.liveSyncing(.finished))

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSync.swift
@@ -126,8 +126,7 @@ public struct IncrementalSync: IncrementalSyncProtocol {
 
                 do {
                     // because we might be interrupted when in background, we wrap the sync in an expiringActivity that
-                    // will
-                    // cancel the task - not keeping any db operation (sqlite file opened) in suspend mode
+                    // will cancel the task - not keeping any db operation (sqlite file opened) in suspend mode
                     try await withExpiringActivity(reason: "processLiveStream IncrementalSync") {
                         await processLiveEvents(
                             liveEventStream: liveEventStream,

--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
@@ -146,6 +146,9 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
         await mlsGroupRepairAgent.repairConversations()
 
         let task = Task { @Sendable [self] in
+            logger.debug("handling live event stream", attributes: logAttributes)
+            syncStateSubject.send(.liveSyncing(.ongoing))
+
             do {
                 // because we might be interrupted when in background, we wrap the sync in an expiringActivity that will
                 // cancel the task (not keeping any file lock in suspend mode)
@@ -156,13 +159,16 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
                         syncMarker: syncMarker
                     )
 
-                    WireLogger.sync.debug("Live stream ended, close push channel")
+                    WireLogger.sync.debug("Live stream ended, close push channel", attributes: logAttributes)
                     await pushChannel.close()
                     await pushChannelState.markAsClosed()
                 }
             } catch {
                 // if we expire, close everything
-                WireLogger.sync.debug("Error while processing live stream, close push channel")
+                WireLogger.sync.debug(
+                    "Error while processing live stream, close push channel",
+                    attributes: logAttributes
+                )
                 await pushChannel.close()
                 await pushChannelState.markAsClosed()
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21010" title="WPB-21010" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21010</a>  [iOS] crash deadlock on IncrementalSync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

We still have reports with deadlock on last release 4.7.0. Looking at the stacktrace, we can see the incrementalSync running.

Make sure the incrementalSync is closed when the app is suspended.


Note: the submodule is updated, because I forgot to update the ref after merging wire-ios-build-assets on last PR -> https://github.com/wireapp/wire-ios/pull/3727

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
