### PR TITLE
fix: ensure forced self deleting messages is disabled when wire cells ON - WPB-19754

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/SelfDeletingMessages/ZMConversation+SelfDeletingMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/SelfDeletingMessages/ZMConversation+SelfDeletingMessages.swift
@@ -127,7 +127,7 @@ public extension ZMConversation {
         guard let context = managedObjectContext else { return nil }
         return LegacyFeatureRepository(context: context).fetchSelfDeletingMessages()
     }
-    
+
     private var isWireCellsEnabled: Bool {
         guard let context = managedObjectContext else { return false }
         let cellsFeature = LegacyFeatureRepository(context: context).fetchCells()

--- a/wire-ios-data-model/Source/Model/Conversation/SelfDeletingMessages/ZMConversation+SelfDeletingMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/SelfDeletingMessages/ZMConversation+SelfDeletingMessages.swift
@@ -108,7 +108,7 @@ public extension ZMConversation {
     // MARK: - Helpers
 
     private var hasForcedMessageDestructionTimeout: Bool {
-        guard let feature = selfDeletingMessagesFeature else { return false }
+        guard let feature = selfDeletingMessagesFeature, !isWireCellsEnabled else { return false }
         return feature.isForcedOff || feature.isForcedOn
     }
 
@@ -126,6 +126,12 @@ public extension ZMConversation {
     private var selfDeletingMessagesFeature: Feature.SelfDeletingMessages? {
         guard let context = managedObjectContext else { return nil }
         return LegacyFeatureRepository(context: context).fetchSelfDeletingMessages()
+    }
+    
+    private var isWireCellsEnabled: Bool {
+        guard let context = managedObjectContext else { return false }
+        let cellsFeature = LegacyFeatureRepository(context: context).fetchCells()
+        return cellsFeature.status == .enabled
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationProtocol.swift
@@ -78,7 +78,7 @@ extension ZMConversation: InputBarConversation {
     var isSelfDeletingMessageTimeoutForced: Bool {
         guard let context = managedObjectContext else { return false }
         let feature = LegacyFeatureRepository(context: context).fetchSelfDeletingMessages()
-        return feature.config.enforcedTimeoutSeconds > 0
+        return feature.config.enforcedTimeoutSeconds > 0 && !isCellsEnabled
     }
 
     var participants: [UserType] {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-19754" title="WPB-19754" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-19754</a>  [iOS] Disable self-deleting messages in conversations
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR is a follow-up of https://github.com/wireapp/wire-ios/pull/3700 to add missing condition check for when a team admin **forces** self deleting messages in the team settings. 

This PR handles that missing use case.

### Testing

in team settings, force self deleting messages with any duration
on iOS, on that same team account, there should not be any mentions of self deleting messages in the input bar or in the message itself.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
