### PR TITLE
fix: not uploading asset metadata when required - WPB-20714

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -133,10 +133,8 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             mlsService: mlsService
         )
 
-        let assetAuditLog = featureRepository.fetchAssetAuditLog()
-
         var isCloudDomain = false
-        if let localDomain = metadata.domain, !BackendEnvironment2.isCloudDomain(localDomain) {
+        if let localDomain = metadata.domain, BackendEnvironment2.isCloudDomain(localDomain) {
             isCloudDomain = true
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20714" title="WPB-20714" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-20714</a>  [iOS] Upload asset with additional metadata
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When uploading an asset on a backend that has asset audit log enabled, the asset upload fails with because no metadata was included. The reason is because of a faulty condition that set the flag `isCloudDomain` to true when it should have been false, thus preventing extra metadata upload.

### Testing
1. Log in to Anta with preferred api version v12
2. Upload assets
3. Assert they succeed


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
