### PR TITLE
fix: nse not displaying notifications after first app launch - WPB-21136

### DIFF
--- a/WireDomain/Sources/WireDomain/Account/BackendEnvironmentStore.swift
+++ b/WireDomain/Sources/WireDomain/Account/BackendEnvironmentStore.swift
@@ -100,6 +100,7 @@ public struct BackendEnvironmentStore {
             if
                 nsError.domain == NSCocoaErrorDomain,
                 nsError.code == NSFileReadNoSuchFileError {
+                // Why do we return nil ?
                 return nil
             }
 

--- a/WireDomain/Sources/WireDomain/Account/BackendEnvironmentStore.swift
+++ b/WireDomain/Sources/WireDomain/Account/BackendEnvironmentStore.swift
@@ -100,7 +100,6 @@ public struct BackendEnvironmentStore {
             if
                 nsError.domain == NSCocoaErrorDomain,
                 nsError.code == NSFileReadNoSuchFileError {
-                // Why do we return nil ?
                 return nil
             }
 

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -93,9 +93,10 @@ final class UserSessionLoader {
 
     @MainActor
     func load(newEnvironment: NewEnvironment?) async throws -> ZMUserSession {
-        // Persist the new environment.
+        // Persist the new environment and metadata
         if let newEnvironment {
             try await storeNewEnvironment(newEnvironment)
+            try backendStore.storeBackendMetadata(newEnvironment.metadata, for: accountID)
         }
 
         // Get the environment for this account.
@@ -129,13 +130,10 @@ final class UserSessionLoader {
             proxyCredentials: proxyCredentials
         )
 
-        let metadata: ResolvedBackendMetadata
-        if let newMetadata = newEnvironment?.metadata {
-            metadata = newMetadata
-            // we store the metadata for NSE
-            try backendStore.storeBackendMetadata(metadata, for: accountID)
+        let metadata: ResolvedBackendMetadata = if let newMetadata = newEnvironment?.metadata {
+            newMetadata
         } else {
-            metadata = try await resolveBackendMetadata(with: networkStack)
+            try await resolveBackendMetadata(with: networkStack)
         }
 
         // Load persistence stack.

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -129,10 +129,13 @@ final class UserSessionLoader {
             proxyCredentials: proxyCredentials
         )
 
-        let metadata: ResolvedBackendMetadata = if let newMetadata = newEnvironment?.metadata {
-            newMetadata
+        let metadata: ResolvedBackendMetadata
+        if let newMetadata = newEnvironment?.metadata {
+            metadata = newMetadata
+            // we store the metadata for NSE
+            try backendStore.storeBackendMetadata(metadata, for: accountID)
         } else {
-            try await resolveBackendMetadata(with: networkStack)
+            metadata = try await resolveBackendMetadata(with: networkStack)
         }
 
         // Load persistence stack.

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -56,6 +56,7 @@ final class NotificationService: UNNotificationServiceExtension {
                 withContentHandler: contentHandler
             )
         } else {
+            WireLogger.notifications.warn("no notification service loaded", attributes: .safePublic)
             contentHandler(.empty)
         }
     }
@@ -106,6 +107,7 @@ final class NotificationService: UNNotificationServiceExtension {
             for: request,
             appContainerURL: appContainerURL
         ) else {
+            WireLogger.notifications.warn("no last known api version", attributes: .safePublic)
             return nil
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21136" title="WPB-21136" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21136</a>  [iOS] Notifications not working on backend apiVersion below 8
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

On a fresh install, after login and accepting notifications permissions, if a user receives a message in background, no notification is shown.

This is due to the fact that the resolvedBackendMetadata is not stored. So when NSE starts and try to fetch the metadata it does not find one. Killing the app and start again fixes the issue as it then stores the metadata.

Solution: Store BackendMetadata on first launch.


Note: this affects custom and default backend.

### Testing

1. install app
2. login on iOS and accept notifications permissions
3. put app in background
4. send a message to iOS device 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
