### PR TITLE
fix: remove DeveloperFlag cells check - WPB-21157

### DIFF
--- a/wire-ios-data-model/Source/Utilis/Protos/GenericMessage+Helper.swift
+++ b/wire-ios-data-model/Source/Utilis/Protos/GenericMessage+Helper.swift
@@ -238,7 +238,7 @@ public extension GenericMessage {
             if case let .text(data)? = ephemeral.content {
                 return data
             }
-        case let .multipart(data) where DeveloperFlag.wireCells.isOn:
+        case let .multipart(data):
             return data.text
         default:
             return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21157" title="WPB-21157" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21157</a>  [iOS] Text message doesn't show up in conv when files are attached (Developer Flag issue)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When cells feature status == enabled but DeveloperFlag == disabled, the **text message** with files sent doesn't show up in the conv - only the files do. This PR fixes that by removing the no longer relevant Developer flag condition check.

### Testing

have wire cells feature enabled on a conv and developer flag disabled,
text with files should properly be sent and shown in the conv

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
