### PR TITLE
fix: failed to upload asset via share extension - WPB-20714

### DIFF
--- a/wire-ios-share-engine/Sources/StrategyFactory.swift
+++ b/wire-ios-share-engine/Sources/StrategyFactory.swift
@@ -65,7 +65,7 @@ final class StrategyFactory {
         self.apiVersion = apiVersion
         self.localDomain = localDomain
 
-        if let localDomain, !BackendEnvironment2.isCloudDomain(localDomain) {
+        if let localDomain, BackendEnvironment2.isCloudDomain(localDomain) {
             self.isCloudDomain = true
         } else {
             self.isCloudDomain = false


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20714" title="WPB-20714" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-20714</a>  [iOS] Upload asset with additional metadata
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

A follow-up to https://github.com/wireapp/wire-ios/pull/3744, this time for the share extension.

### Testing
1. Enable api v12
2. Log in to Anta
3. Send an image via the share extension
4. Assert it succeeds

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
