### PR TITLE
fix: handle save password bottom sheet - WPB-21181

### DIFF
--- a/wire-ios/WireUITests/Pages/FirstTimePage.swift
+++ b/wire-ios/WireUITests/Pages/FirstTimePage.swift
@@ -75,7 +75,7 @@ class FirstTimePage: PageModel {
     }
 
     private func dismissSavePasswordAlertIfPresent() {
-        if savePasswordSheet.exists {
+        if savePasswordSheet.waitForExistence(timeout: 2) {
             notNowOptionOnSavePasswordSheet.tap()
             _ = savePasswordSheet.waitToDisappear(timeout: 2)
         }

--- a/wire-ios/WireUITests/Pages/FirstTimePage.swift
+++ b/wire-ios/WireUITests/Pages/FirstTimePage.swift
@@ -34,10 +34,19 @@ class FirstTimePage: PageModel {
         app.buttons["OK"]
     }
 
+    var savePasswordSheet: XCUIElement {
+        app.staticTexts["Save Password?"]
+    }
+
+    var notNowOptionOnSavePasswordSheet: XCUIElement {
+        app.buttons["Not Now"]
+    }
+
     var handler: (XCTestCase, any NSObjectProtocol)?
 
     // Tap OK button on first time using Wire popup
     func acceptFirstTimeAlert() -> FirstTimePage {
+        dismissSavePasswordAlertIfPresent()
         okButton.tap()
         return self
     }
@@ -63,5 +72,12 @@ class FirstTimePage: PageModel {
                 return true
             }
         self.handler = (testCase, handler)
+    }
+
+    private func dismissSavePasswordAlertIfPresent() {
+        if savePasswordSheet.exists {
+            notNowOptionOnSavePasswordSheet.tap()
+            _ = savePasswordSheet.waitToDisappear(timeout: 2)
+        }
     }
 }

--- a/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
+++ b/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
@@ -55,7 +55,12 @@ class OptionsOnSettingsPage: PageModel {
     func enterPasscode(_ pass: String) throws -> ConversationsPage {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         try springboard.secureTextFields["Passcode field"].tapIfKeyboardNotFocused().typeText(pass)
-        springboard.keyboards.buttons["Done"].tap()
+
+        if springboard.keyboards.buttons["Done"].exists {
+            springboard.keyboards.buttons["Done"].tap()
+        } else {
+            springboard.typeText(XCUIKeyboardKey.return.rawValue)
+        }
         return try ConversationsPage()
     }
 

--- a/wire-ios/WireUITests/XCUIElement+Additions.swift
+++ b/wire-ios/WireUITests/XCUIElement+Additions.swift
@@ -35,4 +35,13 @@ extension XCUIElement {
         }
         return self
     }
+
+    @discardableResult
+    func waitToDisappear(timeout: TimeInterval = 2) -> Bool {
+        let exp = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: self
+        )
+        return XCTWaiter().wait(for: [exp], timeout: timeout) == .completed
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21181" title="WPB-21181" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21181</a>  [iOS] fix: handle save password bottom sheet in UITests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

Due to new save password bottom sheet, test fail as not able to login. Handled the sheet
<img width="991" height="1022" alt="image" src="https://github.com/user-attachments/assets/ef0756f1-4b3e-466b-84c7-eaeae65915f5" />


_Optional: add details about technical approach, solutions etc._

_Optional: reference dependencies to other pull requests etc._

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
