### PR TITLE
feat: show un-established mls groups - WPB-21161

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ConversationPredicateFactory.swift
@@ -188,14 +188,8 @@ public final class ConversationPredicateFactory: NSObject {
 
         // MLS
         let isMLS = NSPredicate(format: "\(ZMConversation.messageProtocolKey) == \(MessageProtocol.mls.int16Value)")
-        let isMLSStatusReady = NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.ready.rawValue)")
-        let isMLSStatusPendingJoinAfterReset =
-            NSPredicate(format: "\(ZMConversation.mlsStatusKey) == \(MLSGroupStatus.pendingJoinAfterReset.rawValue)")
 
-        let isValidMLSStatus = NSPredicate.any(of: [isMLSStatusReady, isMLSStatusPendingJoinAfterReset])
-        let isMLSAndReady = NSPredicate.all(of: [isMLS, isValidMLSStatus])
-
-        return .any(of: [isProteus, isMixed, isMLSAndReady])
+        return .any(of: [isProteus, isMixed, isMLS])
     }
 
     private func isValidConversation() -> NSPredicate {

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Predicates.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests+Predicates.swift
@@ -38,7 +38,7 @@ class ZMConversationTests_Predicates: ZMConversationTestsBase {
         }
     }
 
-    func test_itDoesntReturnMlsConversations_withMlsStatusNotReady() {
+    func test_itReturnsMlsConversations_withMlsStatusNotReady() {
         syncMOC.performAndWait {
             // given
             let conversation = ZMConversation.insertNewObject(in: syncMOC)
@@ -50,7 +50,7 @@ class ZMConversationTests_Predicates: ZMConversationTestsBase {
             let sut = ConversationPredicateFactory().predicateForConversationsIncludingArchived()
 
             // then
-            XCTAssertFalse(sut.evaluate(with: conversation))
+            XCTAssertTrue(sut.evaluate(with: conversation))
         }
     }
 }

--- a/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/ConversationListObserverTests.swift
@@ -848,7 +848,7 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
             managedObjectContext: uiMOC
         )
 
-        XCTAssertEqual(conversationList.items.count, 0)
+        XCTAssertEqual(conversationList.items.count, 1)
 
         // when
         conversation.mlsStatus = .ready
@@ -859,9 +859,9 @@ class ConversationListObserverTests: NotificationDispatcherTestBase {
 
         XCTAssertEqual(testObserver.changes.count, 1)
         let change = try XCTUnwrap(testObserver.changes.first)
-        XCTAssertEqual(change.insertedIndexes, IndexSet(integer: 0))
+        XCTAssertEqual(change.insertedIndexes, IndexSet())
         XCTAssertEqual(change.deletedIndexes, IndexSet())
-        XCTAssertEqual(change.updatedIndexes, IndexSet())
+        XCTAssertEqual(change.updatedIndexes, IndexSet(integer: 0))
         XCTAssertEqual(movedIndexes(change), [])
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21161" title="WPB-21161" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21161</a>  [iOS]  Display unestablished channels in conversation list
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Soon it'll be possible that a team admin can manage channels from the team admin panel despite not being part of the channel themself. This means that the responsibility to establish the mls group and add participants falls on the participants. For performance reasons, the group will be established by the user who first tries to send a message in the group.

Currently, clients don't show conversations with unestablished mls groups to the user. This PR changes this, so that the user will see conversations in which the underlying mls group is not yet established, so that they have the opportunity to try send a message and then establish the group.

### Testing
N/A

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
