### PR TITLE
fix: gif picker leaving blank area in place of keyboard - WPB-20252

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -769,8 +769,8 @@ final class ConversationInputBarViewController: UIViewController,
             let conversation = conversation as? ZMConversation
         else { return }
 
-        presentMLSPrivacyWarningIfNeeded {
-            self.showGiphy(for: conversation)
+        presentMLSPrivacyWarningIfNeeded { [weak self] in
+            self?.showGiphy(for: conversation)
         }
     }
 
@@ -783,7 +783,6 @@ final class ConversationInputBarViewController: UIViewController,
     }
 
     private func showGiphy(for conversation: ZMConversation) {
-        inputBar.textView.resignFirstResponder()
         let giphySearchViewController = GiphySearchViewController(
             searchTerm: "",
             conversation: conversation,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20252" title="WPB-20252" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20252</a>  [iOS][iOS26] White space shows in place of keyboard on opening gif/camera/markers 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The virtual keyboard leaves a blank area when the keyboard is dismissed (by unfocussing the message text field) right before opening the gif picker.
The solution is to remove the unfocussing (resignFirstResponder).

### Testing

On iOS 26, open a conversation and tap into the text message input field so that the virtual keyboard appears.
Then tap on the gif button to open the gif/giphy picker view.
The keyboard should disappear automatically.
Dismiss/cancel the gif picker.
There should be no blank space where the keyboard was.
Instead, the keyboard should be visible again.
