### PR TITLE
chore: disable critical flows temporarly - WPB-21303

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -135,10 +135,10 @@ jobs:
         run: |
           bundle exec fastlane generate_env
 
-      - name: "Test new critical flows"
-        if: ${{ inputs.run_critical_flows }}
-        run: |
-          bundle exec fastlane run_uitests
+      # - name: "Test new critical flows"
+      #   if: ${{ inputs.run_critical_flows }}
+      #   run: |
+      #     bundle exec fastlane run_uitests
 
       - name: "Test all selected frameworks"
         if: ${{ inputs.test_dependencies || inputs.all }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21303" title="WPB-21303" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21303</a>  [iOS] maintenance of critical flows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Temporarly disable critical flows since stars and Inbucket are not available