### PR TITLE
feat: cells image previews in conversations - WPB-16312

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeNetworkModel.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeNetworkModel.swift
@@ -17,6 +17,7 @@
 //
 
 import CellsSDK
+import UniformTypeIdentifiers
 import WireFoundation
 package import WireMessagingDomain
 package import Foundation
@@ -143,9 +144,7 @@ package extension RestNode {
             contentHash: contentHash,
             mimeType: contentType,
             previews: previews?.compactMap { preview -> PreviewDTO? in
-                guard let urlString = preview.preSignedGET?.url else { return nil }
-                guard let url = URL(string: urlString) else { return nil }
-                return PreviewDTO(url: url, dimension: preview.dimension ?? 0)
+                PreviewDTO(preview)
             } ?? [],
             ownerUserId: userMetadata?
                 .first(where: { $0.namespace == "usermeta-owner-uuid" })?
@@ -163,6 +162,27 @@ package extension RestNode {
 package struct PreviewDTO: Equatable, Hashable, Sendable {
     package let url: URL
     package let dimension: Int?
+
+    init(url: URL, dimension: Int?) {
+        self.url = url
+        self.dimension = dimension
+    }
+
+    init?(_ value: RestFilePreview) {
+        guard
+            let urlString = value.preSignedGET?.url,
+            let contentType = value.contentType,
+            let url = URL(string: urlString),
+            let type = UTType(contentType),
+            type.conforms(to: .image) else
+        {
+            return nil
+        }
+
+        self.url = url
+        self.dimension = value.dimension
+    }
+
 }
 
 package extension PreviewDTO {

--- a/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeNetworkModel.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeNetworkModel.swift
@@ -173,7 +173,7 @@ package struct PreviewDTO: Equatable, Hashable, Sendable {
             let urlString = value.preSignedGET?.url,
             let contentType = value.contentType,
             let url = URL(string: urlString),
-            let type = UTType(contentType),
+            let type = UTType(mimeType: contentType),
             type.conforms(to: .image) else
         {
             return nil

--- a/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeNetworkModel.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/Model/WireCellsNodeNetworkModel.swift
@@ -174,8 +174,7 @@ package struct PreviewDTO: Equatable, Hashable, Sendable {
             let contentType = value.contentType,
             let url = URL(string: urlString),
             let type = UTType(mimeType: contentType),
-            type.conforms(to: .image) else
-        {
+            type.conforms(to: .image) else {
             return nil
         }
 

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/NodesAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/NodesAPI.swift
@@ -99,9 +99,7 @@ package final actor NodesAPI: NodesAPIProtocol, WireCellsNodesRepositoryProtocol
 
     package func getPreviews(nodeID: UUID) async throws -> [WireCellsNodePreview] {
         let dto = try await restAPI.getNode(uuid: nodeID)
-        return dto.previews.map {
-            WireCellsNodePreview(url: $0.url, dimension: $0.dimension ?? 0)
-        }
+        return dto.previews.compactMap { $0.toModel() }
     }
 
     package func getNode(nodeID: UUID) async throws -> WireCellsNode {

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsFileCategory.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsFileCategory.swift
@@ -1,0 +1,45 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package import UniformTypeIdentifiers
+
+package enum WireCellsFileCategory {
+
+    case image
+    case video
+    case audio
+    case document
+
+    package init(_ fileType: UTType?) {
+        guard let fileType else {
+            self = .document
+            return
+        }
+
+        if fileType.conforms(to: .image) {
+            self = .image
+        } else if fileType.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
+            self = .audio
+        } else if fileType.conforms(to: .audiovisualContent) {
+            self = .video
+        } else {
+            self = .document
+        }
+    }
+
+}

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
@@ -24,7 +24,7 @@ public struct WireCellsMessageAttachment: Hashable, Sendable {
     public enum Metadata: Hashable, Sendable {
 
         /// Image metadata, containing width and height in pixels.
-        case image(width: Int, height: Int)
+        case image(width: Int?, height: Int?)
 
         /// Video metadata, containing width and height in pixels, and duration in milliseconds.
         case video(width: Int?, height: Int?, duration: Int?)
@@ -33,6 +33,26 @@ public struct WireCellsMessageAttachment: Hashable, Sendable {
         ///
         /// - note: Currently, normalized loudness is not sent.
         case audio(duration: Int?, normalizedLoudness: Data?)
+
+        package var dimension: CGSize? {
+            switch self {
+            case let .image(width, height), let .video(width, height, _):
+                guard let width, let height else { return nil }
+
+                return CGSize(width: Double(width), height: Double(height))
+            default:
+                return nil
+            }
+        }
+
+        package var duration: Int? {
+            switch self {
+            case let .video(_, _, duration), let .audio(duration, _):
+                return duration
+            default:
+                return nil
+            }
+        }
 
     }
 

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
@@ -54,6 +54,15 @@ public struct WireCellsMessageAttachment: Hashable, Sendable {
             }
         }
 
+        package var normalizedLoudness: Data? {
+            switch self {
+            case let .audio(_, normalizedLoudness):
+                return normalizedLoudness
+            default:
+                return nil
+            }
+        }
+
     }
 
     /// The `nodeID` of the attachment.

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsMessageAttachment.swift
@@ -48,18 +48,18 @@ public struct WireCellsMessageAttachment: Hashable, Sendable {
         package var duration: Int? {
             switch self {
             case let .video(_, _, duration), let .audio(duration, _):
-                return duration
+                duration
             default:
-                return nil
+                nil
             }
         }
 
         package var normalizedLoudness: Data? {
             switch self {
             case let .audio(_, normalizedLoudness):
-                return normalizedLoudness
+                normalizedLoudness
             default:
-                return nil
+                nil
             }
         }
 

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/UploadDraftUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/UploadDraftUseCase.swift
@@ -143,15 +143,16 @@ package struct UploadDraftUseCase: WireCellsUploadDraftUseCaseProtocol, WireCell
     }
 
     private func metadata(for fileURL: URL, fileType: UTType?) async throws -> WireCellsDraft.Metadata? {
-        guard let fileType else { return nil }
+        let category = WireCellsFileCategory(fileType)
 
-        if fileType.conforms(to: .image) {
+        switch category {
+        case .image:
             return try await metadataRepository.imageMetadata(fileURL: fileURL)
-        } else if fileType.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
-            return try await metadataRepository.audioMetadata(fileURL: fileURL)
-        } else if fileType.conforms(to: .audiovisualContent) {
+        case .video:
             return try await metadataRepository.videoMetadata(fileURL: fileURL)
-        } else {
+        case .audio:
+            return try await metadataRepository.audioMetadata(fileURL: fileURL)
+        case .document:
             return nil
         }
     }

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -128,3 +128,4 @@
 
 // MARK: - Conversation
 "conversation.message.attachment.notAvailable" = "File not available";
+"conversation.message.attachment.previewNotAvailable" = "Unable to display preview";

--- a/WireMessaging/Sources/WireMessagingUI/Utilities/Error+Convenience.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Utilities/Error+Convenience.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+extension Error {
+
+    /// Returns `true` if self is a URLError(.cancelled) otherwise `false`.
+    var isURLErrorCancelled: Bool {
+        (self as? URLError)?.code == .cancelled
+    }
+
+}

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsCarousel/AttachmentsCarouselViewModel.swift
@@ -135,18 +135,16 @@ private extension AttachmentsCarouselItem {
 private extension AttachmentsCarouselItem.Kind {
 
     init(_ value: UTType?, thumbnail: UIImage?) {
-        guard let value else {
-            self = .document
-            return
-        }
+        let category = WireCellsFileCategory(value)
 
-        if value.conforms(to: .image) {
+        switch category {
+        case .image:
             self = .image(thumbnail: thumbnail)
-        } else if value.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
-            self = .audio(samples: []) // FIXME: [WPB-19268] Set audio sample data
-        } else if value.conforms(to: .audiovisualContent) {
+        case .video:
             self = .video(thumbnail: thumbnail)
-        } else {
+        case .audio:
+            self = .audio(samples: []) // FIXME: [WPB-19268] Set audio sample data
+        case .document:
             self = .document
         }
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -42,7 +42,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isAssetDownloadError: viewModel.isAssetDownloadError,
                     canShowNoPreviewMessage: false
                 )
                 .frame(width: 74, height: 74)
@@ -50,7 +50,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isAssetDownloadError: viewModel.isAssetDownloadError,
                     canShowNoPreviewMessage: true
                 )
                 .aspectRatio(viewModel.previewAspectRatio, contentMode: .fit)
@@ -67,7 +67,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     headerText: viewModel.headerText,
                     labelText: viewModel.fileName,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isError: viewModel.isAssetDownloadError,
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
@@ -77,7 +77,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     headerText: viewModel.headerText,
                     labelText: viewModel.fileName,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isError: viewModel.isAssetDownloadError,
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
@@ -87,7 +87,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     headerText: viewModel.headerText,
                     labelText: viewModel.fileName,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isError: viewModel.isAssetDownloadError,
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
@@ -97,7 +97,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     headerText: viewModel.headerText,
                     labelText: viewModel.fileName,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isError: viewModel.isAssetDownloadError,
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
@@ -107,7 +107,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     headerText: viewModel.headerText,
                     labelText: viewModel.fileName,
                     progress: viewModel.progress,
-                    isError: viewModel.isError,
+                    isError: viewModel.isAssetDownloadError,
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -43,7 +43,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
                     isError: viewModel.isError,
-                    noPreviewMessage: nil
+                    canShowNoPreviewMessage: false
                 )
                 .frame(width: 74, height: 74)
             case (.image, .large):
@@ -51,7 +51,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
                     isError: viewModel.isError,
-                    noPreviewMessage: L10n.Localizable.Conversation.Message.Attachment.previewNotAvailable
+                    canShowNoPreviewMessage: true
                 )
                 .aspectRatio(viewModel.previewAspectRatio, contentMode: .fit)
                 .frame(

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -31,28 +31,25 @@ struct WireCellsAttachmentsPreviewItemView: View {
     }
 
     var body: some View {
-        Group {
+        HStack {
             switch viewModel.kind {
             case .smallImage:
-                WireCellsDocumentAttachmentPreview(
-                    headerIcon: Image(viewModel.icon),
-                    headerText: viewModel.headerText,
-                    labelText: viewModel.fileName,
+                WireCellsImageConversationAttachmentPreview(
+                    thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
                     isError: viewModel.isError,
+                    noPreviewMessage: nil
                 )
-                .frame(height: 74)
-                .frame(idealWidth: 288)
+                .frame(width: 74, height: 74)
             case .largeImage(let aspectRatio, let maxWidth):
-                WireCellsDocumentAttachmentPreview(
-                    headerIcon: Image(viewModel.icon),
-                    headerText: viewModel.headerText,
-                    labelText: viewModel.fileName,
+                WireCellsImageConversationAttachmentPreview(
+                    thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
                     isError: viewModel.isError,
+                    noPreviewMessage: L10n.Localizable.Conversation.Message.Attachment.previewNotAvailable
                 )
-                .frame(height: 74)
-                .frame(idealWidth: 288)
+                .aspectRatio(aspectRatio, contentMode: .fit)
+                .frame(idealWidth: 288, maxWidth: maxWidth)
             case .smallVideo:
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
@@ -105,6 +102,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 .frame(idealWidth: 288)
             }
         }
+        .contentShape(Rectangle()) // Constrains the tappable content area of the view.
         .onAppear(perform: refresh)
         .onTapGesture(perform: open)
         .quickLookPreview($viewModel.viewingURL)

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -37,8 +37,8 @@ struct WireCellsAttachmentsPreviewItemView: View {
 
     var body: some View {
         HStack {
-            switch viewModel.fileCategory {
-            case .image where viewModel.displaySmall:
+            switch (viewModel.fileCategory, viewModel.displayStyle) {
+            case (.image, .small):
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
@@ -46,7 +46,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     noPreviewMessage: nil
                 )
                 .frame(width: 74, height: 74)
-            case .image where viewModel.displayLarge:
+            case (.image, .large):
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
@@ -61,7 +61,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                         Constants.maxImageHeight * viewModel.previewAspectRatio
                     )
                 )
-            case .video where viewModel.displaySmall:
+            case (.video, .small):
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -71,7 +71,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .video where viewModel.displayLarge:
+            case (.video, .large):
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -81,7 +81,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .document where viewModel.displaySmall:
+            case (.document, .small):
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -91,7 +91,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .document where viewModel.displayLarge:
+            case (.document, .large):
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -101,7 +101,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .audio:
+            case (.audio, .small), (.audio, .large):
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -111,8 +111,6 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            default:
-                unsupportedPreview()
             }
         }
         .contentShape(Rectangle()) // Constrains the tappable content area of the view.
@@ -127,11 +125,6 @@ struct WireCellsAttachmentsPreviewItemView: View {
 
     private func open() {
         Task { await viewModel.open() }
-    }
-
-    private func unsupportedPreview() -> some View {
-        assertionFailure("Unsupported file category")
-        return EmptyView()
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -31,15 +31,80 @@ struct WireCellsAttachmentsPreviewItemView: View {
     }
 
     var body: some View {
-        WireCellsDocumentAttachmentPreview(
-            headerIcon: Image(viewModel.icon),
-            headerText: viewModel.headerText,
-            labelText: viewModel.fileName,
-            progress: viewModel.progress,
-            isError: viewModel.isError,
-        )
-        .frame(height: 74)
-        .frame(idealWidth: 288)
+        Group {
+            switch viewModel.kind {
+            case .smallImage:
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            case .largeImage(let aspectRatio, let maxWidth):
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            case .smallVideo:
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            case .largeVideo(let aspectRatio):
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            case .smallDocument:
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            case .largeDocument:
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            case .audio:
+                WireCellsDocumentAttachmentPreview(
+                    headerIcon: Image(viewModel.icon),
+                    headerText: viewModel.headerText,
+                    labelText: viewModel.fileName,
+                    progress: viewModel.progress,
+                    isError: viewModel.isError,
+                )
+                .frame(height: 74)
+                .frame(idealWidth: 288)
+            }
+        }
         .onAppear(perform: refresh)
         .onTapGesture(perform: open)
         .quickLookPreview($viewModel.viewingURL)

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -24,6 +24,11 @@ import WireMessagingDomain
 import WireMessagingDomainSupport
 
 struct WireCellsAttachmentsPreviewItemView: View {
+
+    private enum Constants {
+        static let maxImageHeight: Double = 400
+    }
+
     @StateObject private var viewModel: WireCellsAttachmentsPreviewItemViewModel
 
     init(viewModel: @autoclosure @escaping () -> WireCellsAttachmentsPreviewItemViewModel) {
@@ -41,7 +46,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     noPreviewMessage: nil
                 )
                 .frame(width: 74, height: 74)
-            case let .largeImage(aspectRatio, maxWidth):
+            case let .largeImage(aspectRatio, imageWidth):
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
@@ -49,7 +54,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     noPreviewMessage: L10n.Localizable.Conversation.Message.Attachment.previewNotAvailable
                 )
                 .aspectRatio(aspectRatio, contentMode: .fit)
-                .frame(idealWidth: 288, maxWidth: maxWidth)
+                .frame(idealWidth: min(288, imageWidth, Constants.maxImageHeight * aspectRatio))
             case .smallVideo:
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -37,8 +37,8 @@ struct WireCellsAttachmentsPreviewItemView: View {
 
     var body: some View {
         HStack {
-            switch viewModel.kind {
-            case .smallImage:
+            switch viewModel.fileCategory {
+            case .image where viewModel.displaySmall:
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
@@ -46,16 +46,22 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     noPreviewMessage: nil
                 )
                 .frame(width: 74, height: 74)
-            case let .largeImage(aspectRatio, imageWidth):
+            case .image where viewModel.displayLarge:
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
                     isError: viewModel.isError,
                     noPreviewMessage: L10n.Localizable.Conversation.Message.Attachment.previewNotAvailable
                 )
-                .aspectRatio(aspectRatio, contentMode: .fit)
-                .frame(idealWidth: min(288, imageWidth, Constants.maxImageHeight * aspectRatio))
-            case .smallVideo:
+                .aspectRatio(viewModel.previewAspectRatio, contentMode: .fit)
+                .frame(
+                    idealWidth: min(
+                        288,
+                        viewModel.previewWidth ?? .infinity,
+                        Constants.maxImageHeight * viewModel.previewAspectRatio
+                    )
+                )
+            case .video where viewModel.displaySmall:
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -65,7 +71,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case let .largeVideo(aspectRatio):
+            case .video where viewModel.displayLarge:
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -75,7 +81,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .smallDocument:
+            case .document where viewModel.displaySmall:
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -85,7 +91,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .largeDocument:
+            case .document where viewModel.displayLarge:
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
@@ -105,6 +111,8 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
+            default:
+                unsupportedPreview()
             }
         }
         .contentShape(Rectangle()) // Constrains the tappable content area of the view.
@@ -119,6 +127,11 @@ struct WireCellsAttachmentsPreviewItemView: View {
 
     private func open() {
         Task { await viewModel.open() }
+    }
+
+    private func unsupportedPreview() -> some View {
+        assertionFailure("Unsupported file category")
+        return EmptyView()
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -41,7 +41,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     noPreviewMessage: nil
                 )
                 .frame(width: 74, height: 74)
-            case .largeImage(let aspectRatio, let maxWidth):
+            case let .largeImage(aspectRatio, maxWidth):
                 WireCellsImageConversationAttachmentPreview(
                     thumbnailURL: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
@@ -60,7 +60,7 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 )
                 .frame(height: 74)
                 .frame(idealWidth: 288)
-            case .largeVideo(let aspectRatio):
+            case let .largeVideo(aspectRatio):
                 WireCellsDocumentAttachmentPreview(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -115,7 +115,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         }
     }
 
-    var isError: Bool {
+    var isAssetDownloadError: Bool {
         switch asset?.downloadState {
         case .failed:
             true

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -62,8 +62,8 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         self.displayStyle = displayStyle
         self.isDeleted = false
 
-        localAssetRepository.observeAsset(nodeID: nodeID).sink { [self] asset in
-            self.asset = asset
+        localAssetRepository.observeAsset(nodeID: nodeID).sink { [weak self] asset in
+            self?.asset = asset
         }.store(in: &cancellables)
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -28,7 +28,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     enum Kind {
         case smallImage
-        case largeImage(aspectRatio: Double, maxWidth: Double)
+        case largeImage(aspectRatio: Double, imageWidth: Double)
         case smallVideo
         case largeVideo(aspectRatio: Double)
         case smallDocument
@@ -79,9 +79,9 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
                 .smallImage
             } else {
                 if let size, size.width > 0, size.height > 0 {
-                    .largeImage(aspectRatio: size.width / size.height, maxWidth: size.width)
+                    .largeImage(aspectRatio: size.width / size.height, imageWidth: size.width)
                 } else {
-                    .largeImage(aspectRatio: 1, maxWidth: 200)
+                    .largeImage(aspectRatio: 1, imageWidth: 288)
                 }
             }
         case let .video(size, _):

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -26,9 +26,21 @@ import WireMessagingDomain
 @MainActor
 final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
+    enum Kind {
+        case smallImage
+        case largeImage(aspectRatio: Double, maxWidth: Double)
+        case smallVideo
+        case largeVideo(aspectRatio: Double)
+        case smallDocument
+        case largeDocument
+        case audio
+    }
+
+    private let initialMetadata: WireCellsMessageAttachment.Metadata?
     private let fetchNodeUseCase: WireCellsFetchNodeUseCase
     private let getAssetUseCase: WireCellsGetAssetUseCase
     private let lastOpenRequest: WireCellsLastOpenRequest
+    private let isSmall: Bool
     private var cancellables = Set<AnyCancellable>()
 
     let alignment: HorizontalAlignment
@@ -39,21 +51,58 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     init(
         item: WireCellsAttachmentsPreviewViewItem,
+        initialMetadata: WireCellsMessageAttachment.Metadata?,
         alignment: HorizontalAlignment,
         fetchNodeUseCase: WireCellsFetchNodeUseCase,
         getAssetUseCase: WireCellsGetAssetUseCase,
         localAssetRepository: any WireCellsLocalAssetRepositoryProtocol,
-        lastOpenRequest: WireCellsLastOpenRequest
+        lastOpenRequest: WireCellsLastOpenRequest,
+        isSmall: Bool
     ) {
         self.item = item
+        self.initialMetadata = initialMetadata
         self.alignment = alignment
         self.fetchNodeUseCase = fetchNodeUseCase
         self.getAssetUseCase = getAssetUseCase
         self.lastOpenRequest = lastOpenRequest
+        self.isSmall = isSmall
 
         localAssetRepository.observeAsset(nodeID: item.nodeID).sink { [self] asset in
             self.asset = asset
         }.store(in: &cancellables)
+    }
+
+    var kind: Kind {
+        switch item.kind {
+        case let .image(size):
+            if isSmall {
+                .smallImage
+            } else {
+                if let size, size.width > 0, size.height > 0 {
+                    .largeImage(aspectRatio: size.width / size.height, maxWidth: size.width)
+                } else {
+                    .largeImage(aspectRatio: 1, maxWidth: 200)
+                }
+            }
+        case let .video(size, _):
+            if isSmall {
+                .smallVideo
+            } else {
+                if let size, size.width > 0, size.height > 0 {
+                    .largeVideo(aspectRatio: size.width / size.height)
+                } else {
+                    .largeVideo(aspectRatio: 16/9)
+                }
+            }
+        case .document:
+            if isSmall {
+                .smallDocument
+            } else {
+                .largeDocument
+            }
+        case .audio:
+            .audio
+        }
     }
 
     var headerText: String {
@@ -71,6 +120,10 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     var icon: ImageResource {
         item.isDeleted ? .fileIconNotAvailable : item.fileIcon.resource
+    }
+
+    var imagePreviewURL: URL? {
+        item.imagePreviewURL
     }
 
     var progress: Double {
@@ -97,7 +150,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         do {
             for try await node in fetchNodeUseCase.invoke(nodeID: item.nodeID) {
                 if let node {
-                    item = WireCellsAttachmentsPreviewViewItem(node)
+                    item = WireCellsAttachmentsPreviewViewItem(node, initialMetadata: initialMetadata)
                 } else {
                     item = WireCellsAttachmentsPreviewViewItem(
                         nodeID: item.nodeID,
@@ -105,7 +158,9 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
                         fileName: item.fileName,
                         fileExtension: item.fileExtension,
                         fileSize: item.fileSize,
-                        isDeleted: true
+                        isDeleted: true,
+                        imagePreviewURL: item.imagePreviewURL,
+                        kind: item.kind
                     )
                 }
             }
@@ -143,20 +198,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
 private extension WireCellsAttachmentsPreviewViewItem {
 
-    init(_ value: WireCellsMessageAttachment, isDeleted: Bool) {
-        let url = value.initialName.flatMap { URL(string: $0) }
-        let fileType = value.contentType.flatMap { UTType(mimeType: $0) }
-        let fileExtension = url?.pathExtension
-
-        self.nodeID = value.nodeID
-        self.fileIcon = .make(type: fileType, fileExtension: fileExtension)
-        self.fileName = url?.deletingPathExtension().lastPathComponent
-        self.fileExtension = fileExtension
-        self.fileSize = value.initialSize
-        self.isDeleted = isDeleted
-    }
-
-    init(_ value: WireCellsNode) {
+    init(_ value: WireCellsNode, initialMetadata: WireCellsMessageAttachment.Metadata?) {
         let url = URL(string: value.path)
         let fileType = value.mimeType.flatMap { UTType(mimeType: $0) }
         let fileExtension = url?.pathExtension
@@ -167,6 +209,8 @@ private extension WireCellsAttachmentsPreviewViewItem {
         self.fileExtension = fileExtension
         self.fileSize = value.size.map { Int($0) }
         self.isDeleted = value.isRecycled
+        self.imagePreviewURL = value.previews.sorted(by: { $0.dimension < $1.dimension }).last?.url
+        self.kind = Kind(fileType: fileType, initialMetadata: initialMetadata)
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -36,7 +36,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         case audio
     }
 
-    private let initialMetadata: WireCellsMessageAttachment.Metadata?
+    private let attachment: WireCellsMessageAttachment
     private let fetchNodeUseCase: WireCellsFetchNodeUseCase
     private let getAssetUseCase: WireCellsGetAssetUseCase
     private let lastOpenRequest: WireCellsLastOpenRequest
@@ -51,7 +51,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     init(
         item: WireCellsAttachmentsPreviewViewItem,
-        initialMetadata: WireCellsMessageAttachment.Metadata?,
+        attachment: WireCellsMessageAttachment,
         alignment: HorizontalAlignment,
         fetchNodeUseCase: WireCellsFetchNodeUseCase,
         getAssetUseCase: WireCellsGetAssetUseCase,
@@ -60,7 +60,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         isSmall: Bool
     ) {
         self.item = item
-        self.initialMetadata = initialMetadata
+        self.attachment = attachment
         self.alignment = alignment
         self.fetchNodeUseCase = fetchNodeUseCase
         self.getAssetUseCase = getAssetUseCase
@@ -150,7 +150,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         do {
             for try await node in fetchNodeUseCase.invoke(nodeID: item.nodeID) {
                 if let node {
-                    item = WireCellsAttachmentsPreviewViewItem(node, initialMetadata: initialMetadata)
+                    item = WireCellsAttachmentsPreviewViewItem(node, initialMetadata: attachment.initialMetadata)
                 } else {
                     item = WireCellsAttachmentsPreviewViewItem(
                         nodeID: item.nodeID,

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -26,14 +26,19 @@ import WireMessagingDomain
 @MainActor
 final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
+    enum DisplayStyle {
+        case small
+        case large
+    }
+
     private let attachment: WireCellsMessageAttachment
     private let fetchNodeUseCase: WireCellsFetchNodeUseCase
     private let getAssetUseCase: WireCellsGetAssetUseCase
     private let lastOpenRequest: WireCellsLastOpenRequest
-    private let isSmall: Bool
     private var cancellables = Set<AnyCancellable>()
 
     let alignment: HorizontalAlignment
+    let displayStyle: DisplayStyle
 
     @Published var viewingURL: URL?
     @Published private var asset: WireCellsLocalAsset?
@@ -47,14 +52,14 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         getAssetUseCase: WireCellsGetAssetUseCase,
         localAssetRepository: any WireCellsLocalAssetRepositoryProtocol,
         lastOpenRequest: WireCellsLastOpenRequest,
-        isSmall: Bool
+        displayStyle: DisplayStyle
     ) {
         self.attachment = attachment
         self.alignment = alignment
         self.fetchNodeUseCase = fetchNodeUseCase
         self.getAssetUseCase = getAssetUseCase
         self.lastOpenRequest = lastOpenRequest
-        self.isSmall = isSmall
+        self.displayStyle = displayStyle
         self.isDeleted = false
 
         localAssetRepository.observeAsset(nodeID: nodeID).sink { [self] asset in
@@ -93,14 +98,6 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
             let fileExtension = pathURL?.pathExtension
             return FileIcon.make(type: fileType, fileExtension: fileExtension).resource
         }
-    }
-
-    var displaySmall: Bool {
-        isSmall
-    }
-
-    var displayLarge: Bool {
-        !isSmall
     }
 
     var imagePreviewURL: URL? {

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -202,30 +202,3 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
     }
 
 }
-
-enum WireCellsFileCategory {
-
-    case image
-    case video
-    case audio
-    case document
-
-    init(_ fileType: UTType?) {
-        guard let fileType else {
-            self = .document
-            return
-        }
-
-        if fileType.conforms(to: .image) {
-            self = .image
-        } else if fileType.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
-            self = .audio
-        } else if fileType.conforms(to: .audiovisualContent) {
-            self = .video
-        } else {
-            self = .document
-        }
-    }
-
-}
-

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -91,7 +91,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
                 if let size, size.width > 0, size.height > 0 {
                     .largeVideo(aspectRatio: size.width / size.height)
                 } else {
-                    .largeVideo(aspectRatio: 16/9)
+                    .largeVideo(aspectRatio: 16 / 9)
                 }
             }
         case .document:

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -133,9 +133,9 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
                 self.node = node
 
                 if let node {
-                    self.isDeleted = node.isRecycled
+                    isDeleted = node.isRecycled
                 } else {
-                    self.isDeleted = true
+                    isDeleted = true
                 }
             }
         } catch {

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -45,9 +45,11 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     let alignment: HorizontalAlignment
 
-    @Published private var item: WireCellsAttachmentsPreviewViewItem
+    @Published private var item_: WireCellsAttachmentsPreviewViewItem
     @Published var viewingURL: URL?
     @Published private var asset: WireCellsLocalAsset?
+    @Published private var node: WireCellsNode?
+    @Published private var isDeleted: Bool
 
     init(
         item: WireCellsAttachmentsPreviewViewItem,
@@ -59,71 +61,96 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         lastOpenRequest: WireCellsLastOpenRequest,
         isSmall: Bool
     ) {
-        self.item = item
+        self.item_ = item
         self.attachment = attachment
         self.alignment = alignment
         self.fetchNodeUseCase = fetchNodeUseCase
         self.getAssetUseCase = getAssetUseCase
         self.lastOpenRequest = lastOpenRequest
         self.isSmall = isSmall
+        self.isDeleted = false
 
         localAssetRepository.observeAsset(nodeID: item.nodeID).sink { [self] asset in
             self.asset = asset
         }.store(in: &cancellables)
     }
 
-    var kind: Kind {
-        switch item.kind {
-        case let .image(size):
-            if isSmall {
-                .smallImage
-            } else {
-                if let size, size.width > 0, size.height > 0 {
-                    .largeImage(aspectRatio: size.width / size.height, imageWidth: size.width)
-                } else {
-                    .largeImage(aspectRatio: 1, imageWidth: 288)
-                }
-            }
-        case let .video(size, _):
-            if isSmall {
-                .smallVideo
-            } else {
-                if let size, size.width > 0, size.height > 0 {
-                    .largeVideo(aspectRatio: size.width / size.height)
-                } else {
-                    .largeVideo(aspectRatio: 16 / 9)
-                }
-            }
-        case .document:
-            if isSmall {
-                .smallDocument
-            } else {
-                .largeDocument
-            }
-        case .audio:
-            .audio
-        }
+//    var kind: Kind {
+//        switch item.kind {
+//        case let .image(size):
+//            if isSmall {
+//                .smallImage
+//            } else {
+//                if let size, size.width > 0, size.height > 0 {
+//                    .largeImage(aspectRatio: size.width / size.height, imageWidth: size.width)
+//                } else {
+//                    .largeImage(aspectRatio: 1, imageWidth: 288)
+//                }
+//            }
+//        case let .video(size, _):
+//            if isSmall {
+//                .smallVideo
+//            } else {
+//                if let size, size.width > 0, size.height > 0 {
+//                    .largeVideo(aspectRatio: size.width / size.height)
+//                } else {
+//                    .largeVideo(aspectRatio: 16 / 9)
+//                }
+//            }
+//        case .document:
+//            if isSmall {
+//                .smallDocument
+//            } else {
+//                .largeDocument
+//            }
+//        case .audio:
+//            .audio
+//        }
+//    }
+
+    var fileCategory: WireCellsFileCategory {
+        let fileType = contentType.flatMap { UTType(mimeType: $0) }
+        return WireCellsFileCategory(fileType)
     }
 
     var headerText: String {
-        if item.isDeleted {
+        if isDeleted {
             return ""
         } else {
-            let fileSize = (item.fileSize?.formatted(.byteCount(style: .decimal)) as String?).map { "(\($0))" }
-            return [item.fileExtension?.uppercased(), fileSize].compactMap(\.self).joined(separator: " ")
+            let fileSizeString = fileSize.map { "(\($0))" }
+            let fileExtension = pathURL?.pathExtension.uppercased()
+            return [fileExtension, fileSize].compactMap(\.self).joined(separator: " ")
         }
     }
 
     var fileName: String {
-        item.isDeleted ? L10n.Localizable.Conversation.Message.Attachment.notAvailable : item.fileName ?? ""
+        if isDeleted {
+            L10n.Localizable.Conversation.Message.Attachment.notAvailable
+        } else {
+            pathURL?.deletingPathExtension().lastPathComponent ?? ""
+        }
     }
 
     var icon: ImageResource {
-        item.isDeleted ? .fileIconNotAvailable : item.fileIcon.resource
+        if isDeleted {
+            return .fileIconNotAvailable
+        } else {
+            let fileType = contentType.flatMap { UTType(mimeType: $0) }
+            let fileExtension = pathURL?.pathExtension
+            return FileIcon.make(type: fileType, fileExtension: fileExtension).resource
+        }
+    }
+
+    var displaySmall: Bool {
+        isSmall
+    }
+
+    var displayLarge: Bool {
+        !isSmall
     }
 
     var imagePreviewURL: URL? {
-        item.imagePreviewURL
+        node?.previews.sorted(by: { $0.dimension < $1.dimension }).last?.url
     }
 
     var progress: Double {
@@ -148,46 +175,72 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     func refresh() async {
         do {
-            for try await node in fetchNodeUseCase.invoke(nodeID: item.nodeID) {
+            for try await node in fetchNodeUseCase.invoke(nodeID: nodeID) {
+                self.node = node
+
                 if let node {
-                    item = WireCellsAttachmentsPreviewViewItem(node, initialMetadata: attachment.initialMetadata)
+                    self.isDeleted = node.isRecycled
                 } else {
-                    item = WireCellsAttachmentsPreviewViewItem(
-                        nodeID: item.nodeID,
-                        fileIcon: item.fileIcon,
-                        fileName: item.fileName,
-                        fileExtension: item.fileExtension,
-                        fileSize: item.fileSize,
-                        isDeleted: true,
-                        imagePreviewURL: item.imagePreviewURL,
-                        kind: item.kind
-                    )
+                    self.isDeleted = true
                 }
             }
         } catch {
-            WireLogger.wireCells.info("Failed to refresh node with ID: \(item.nodeID), error: \(error)")
+            WireLogger.wireCells.info("Failed to refresh node with ID: \(nodeID), error: \(error)")
         }
     }
 
     func open() async {
-        guard !item.isDeleted, !isDownloading else { return }
+        guard !isDeleted, !isDownloading else { return }
 
-        lastOpenRequest.nodeID = item.nodeID
+        lastOpenRequest.nodeID = nodeID
 
         do {
-            let url = try await getAssetUseCase.invoke(nodeID: item.nodeID)
-            if lastOpenRequest.nodeID == item.nodeID {
+            let url = try await getAssetUseCase.invoke(nodeID: nodeID)
+            if lastOpenRequest.nodeID == nodeID {
                 viewingURL = url
             }
         } catch {
-            WireLogger.wireCells.error("Failed to open file with node ID: \(item.nodeID), error: \(error)")
+            WireLogger.wireCells.error("Failed to open file with node ID: \(nodeID), error: \(error)")
         }
+    }
+
+    private var previewSize: CGSize? {
+        guard let size = attachment.initialMetadata?.dimension, size.width > 0, size.height > 0 else {
+            return nil
+        }
+
+        return size
+    }
+
+    var previewAspectRatio: Double {
+        guard let size = previewSize else { return 1 }
+
+        return size.width / size.height
+    }
+
+    var previewWidth: Double? {
+        previewSize?.width as? Double // Explicit conversion necessary due to compiler bug
     }
 
     // MARK: - Private
 
+    private var nodeID: UUID {
+        node?.id ?? attachment.nodeID
+    }
+
+    private var pathURL: URL? {
+        let path = node?.path ?? attachment.initialName
+        return path.flatMap { URL(string: $0) }
+
+    }
+
+    private var contentType: String? {
+        node?.mimeType ?? attachment.contentType
+    }
+
     private var fileSize: String? {
-        item.fileSize.map { Int($0).formatted(.byteCount(style: .decimal)) }
+        let fileSize = node?.size.map { Int($0) } ?? attachment.initialSize
+        return fileSize.map { $0.formatted(.byteCount(style: .decimal)) }
     }
 
     private var isDownloading: Bool {
@@ -214,3 +267,30 @@ private extension WireCellsAttachmentsPreviewViewItem {
     }
 
 }
+
+enum WireCellsFileCategory {
+
+    case image
+    case video
+    case audio
+    case document
+
+    init(_ fileType: UTType?) {
+        guard let fileType else {
+            self = .document
+            return
+        }
+
+        if fileType.conforms(to: .image) {
+            self = .image
+        } else if fileType.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
+            self = .audio
+        } else if fileType.conforms(to: .audiovisualContent) {
+            self = .video
+        } else {
+            self = .document
+        }
+    }
+
+}
+

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -26,16 +26,6 @@ import WireMessagingDomain
 @MainActor
 final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
-    enum Kind {
-        case smallImage
-        case largeImage(aspectRatio: Double, imageWidth: Double)
-        case smallVideo
-        case largeVideo(aspectRatio: Double)
-        case smallDocument
-        case largeDocument
-        case audio
-    }
-
     private let attachment: WireCellsMessageAttachment
     private let fetchNodeUseCase: WireCellsFetchNodeUseCase
     private let getAssetUseCase: WireCellsGetAssetUseCase
@@ -45,14 +35,12 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     let alignment: HorizontalAlignment
 
-    @Published private var item_: WireCellsAttachmentsPreviewViewItem
     @Published var viewingURL: URL?
     @Published private var asset: WireCellsLocalAsset?
     @Published private var node: WireCellsNode?
     @Published private var isDeleted: Bool
 
     init(
-        item: WireCellsAttachmentsPreviewViewItem,
         attachment: WireCellsMessageAttachment,
         alignment: HorizontalAlignment,
         fetchNodeUseCase: WireCellsFetchNodeUseCase,
@@ -61,7 +49,6 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         lastOpenRequest: WireCellsLastOpenRequest,
         isSmall: Bool
     ) {
-        self.item_ = item
         self.attachment = attachment
         self.alignment = alignment
         self.fetchNodeUseCase = fetchNodeUseCase
@@ -70,43 +57,10 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         self.isSmall = isSmall
         self.isDeleted = false
 
-        localAssetRepository.observeAsset(nodeID: item.nodeID).sink { [self] asset in
+        localAssetRepository.observeAsset(nodeID: nodeID).sink { [self] asset in
             self.asset = asset
         }.store(in: &cancellables)
     }
-
-//    var kind: Kind {
-//        switch item.kind {
-//        case let .image(size):
-//            if isSmall {
-//                .smallImage
-//            } else {
-//                if let size, size.width > 0, size.height > 0 {
-//                    .largeImage(aspectRatio: size.width / size.height, imageWidth: size.width)
-//                } else {
-//                    .largeImage(aspectRatio: 1, imageWidth: 288)
-//                }
-//            }
-//        case let .video(size, _):
-//            if isSmall {
-//                .smallVideo
-//            } else {
-//                if let size, size.width > 0, size.height > 0 {
-//                    .largeVideo(aspectRatio: size.width / size.height)
-//                } else {
-//                    .largeVideo(aspectRatio: 16 / 9)
-//                }
-//            }
-//        case .document:
-//            if isSmall {
-//                .smallDocument
-//            } else {
-//                .largeDocument
-//            }
-//        case .audio:
-//            .audio
-//        }
-//    }
 
     var fileCategory: WireCellsFileCategory {
         let fileType = contentType.flatMap { UTType(mimeType: $0) }
@@ -119,7 +73,7 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         } else {
             let fileSizeString = fileSize.map { "(\($0))" }
             let fileExtension = pathURL?.pathExtension.uppercased()
-            return [fileExtension, fileSize].compactMap(\.self).joined(separator: " ")
+            return [fileExtension, fileSizeString].compactMap(\.self).joined(separator: " ")
         }
     }
 
@@ -245,25 +199,6 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
 
     private var isDownloading: Bool {
         asset?.downloadState.isDownloading == true
-    }
-
-}
-
-private extension WireCellsAttachmentsPreviewViewItem {
-
-    init(_ value: WireCellsNode, initialMetadata: WireCellsMessageAttachment.Metadata?) {
-        let url = URL(string: value.path)
-        let fileType = value.mimeType.flatMap { UTType(mimeType: $0) }
-        let fileExtension = url?.pathExtension
-
-        self.nodeID = value.id
-        self.fileIcon = .make(type: fileType, fileExtension: value.path)
-        self.fileName = url?.deletingPathExtension().lastPathComponent
-        self.fileExtension = fileExtension
-        self.fileSize = value.size.map { Int($0) }
-        self.isDeleted = value.isRecycled
-        self.imagePreviewURL = value.previews.sorted(by: { $0.dimension < $1.dimension }).last?.url
-        self.kind = Kind(fileType: fileType, initialMetadata: initialMetadata)
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
@@ -32,7 +32,7 @@ package struct WireCellsAttachmentsPreviewView: View {
     }
 
     package var body: some View {
-        FlowLayout {
+        FlowLayout(alignment: viewModel.alignment) {
             ForEach(Array(viewModel.items.enumerated()), id: \.element) { index, _ in
                 itemRow(index: index)
             }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewView.swift
@@ -33,7 +33,7 @@ package struct WireCellsAttachmentsPreviewView: View {
 
     package var body: some View {
         FlowLayout(alignment: viewModel.alignment) {
-            ForEach(Array(viewModel.items.enumerated()), id: \.element) { index, _ in
+            ForEach(Array(viewModel.attachments.enumerated()), id: \.element) { index, _ in
                 itemRow(index: index)
             }
         }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
@@ -58,7 +58,7 @@ package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
             getAssetUseCase: getAssetUseCase,
             localAssetRepository: localAssetRepository,
             lastOpenRequest: lastOpenRequest,
-            isSmall: attachments.count > 1
+            displayStyle: attachments.count > 1 ? .small : .large
         )
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
@@ -95,7 +95,7 @@ package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
     func itemViewModel(index: Int) -> WireCellsAttachmentsPreviewItemViewModel {
         WireCellsAttachmentsPreviewItemViewModel(
             item: items[index],
-            initialMetadata: attachments[index].initialMetadata,
+            attachment: attachments[index],
             alignment: alignment,
             fetchNodeUseCase: fetchNodeUseCase,
             getAssetUseCase: getAssetUseCase,

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
@@ -27,6 +27,13 @@ import WireMessagingDomainSupport
 /// An item in the `WireCellsAttachmentsPreviewView`.
 struct WireCellsAttachmentsPreviewViewItem: Identifiable, Hashable {
 
+    enum Kind: Hashable {
+        case image(size: CGSize?)
+        case video(size: CGSize?, duration: Int?)
+        case audio(duration: Int?, normalizedLoudness: Data?)
+        case document
+    }
+
     var id: UUID { nodeID }
 
     /// Identifier of this item on the wire cells backend.
@@ -45,6 +52,12 @@ struct WireCellsAttachmentsPreviewViewItem: Identifiable, Hashable {
 
     /// Whether the item is deleted or in the recycle bin.
     let isDeleted: Bool
+
+    /// A remove URL for a preview image of the attachment, if available.
+    let imagePreviewURL: URL?
+
+    /// The kind of attachment.
+    let kind: Kind
 
 }
 
@@ -82,11 +95,13 @@ package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
     func itemViewModel(index: Int) -> WireCellsAttachmentsPreviewItemViewModel {
         WireCellsAttachmentsPreviewItemViewModel(
             item: items[index],
+            initialMetadata: attachments[index].initialMetadata,
             alignment: alignment,
             fetchNodeUseCase: fetchNodeUseCase,
             getAssetUseCase: getAssetUseCase,
             localAssetRepository: localAssetRepository,
-            lastOpenRequest: lastOpenRequest
+            lastOpenRequest: lastOpenRequest,
+            isSmall: attachments.count > 1
         )
     }
 
@@ -105,6 +120,29 @@ private extension WireCellsAttachmentsPreviewViewItem {
         self.fileExtension = fileExtension
         self.fileSize = value.initialSize
         self.isDeleted = isDeleted
+        self.imagePreviewURL = nil
+        self.kind = Kind(fileType: fileType, initialMetadata: value.initialMetadata)
+    }
+
+}
+
+extension WireCellsAttachmentsPreviewViewItem.Kind {
+
+    init(fileType: UTType?, initialMetadata: WireCellsMessageAttachment.Metadata?) {
+        guard let fileType else {
+            self = .document
+            return
+        }
+
+        if fileType.conforms(to: .image) {
+            self = .image(size: initialMetadata?.dimension)
+        } else if fileType.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
+            self = .audio(duration: initialMetadata?.duration, normalizedLoudness: initialMetadata?.normalizedLoudness)
+        } else if fileType.conforms(to: .audiovisualContent) {
+            self = .video(size: initialMetadata?.dimension, duration: initialMetadata?.duration)
+        } else {
+            self = .document
+        }
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewViewModel.swift
@@ -19,59 +19,19 @@
 import Combine
 import Foundation
 package import SwiftUI
-import UniformTypeIdentifiers
-import WireLogging
 package import WireMessagingDomain
 import WireMessagingDomainSupport
-
-/// An item in the `WireCellsAttachmentsPreviewView`.
-struct WireCellsAttachmentsPreviewViewItem: Identifiable, Hashable {
-
-    enum Kind: Hashable {
-        case image(size: CGSize?)
-        case video(size: CGSize?, duration: Int?)
-        case audio(duration: Int?, normalizedLoudness: Data?)
-        case document
-    }
-
-    var id: UUID { nodeID }
-
-    /// Identifier of this item on the wire cells backend.
-    let nodeID: UUID
-
-    /// Icon representing the file type of this attachment.
-    let fileIcon: FileIcon
-
-    /// The name of the file, if available.
-    let fileName: String?
-
-    let fileExtension: String?
-
-    /// The size in bytes of the attachment.
-    let fileSize: Int?
-
-    /// Whether the item is deleted or in the recycle bin.
-    let isDeleted: Bool
-
-    /// A remove URL for a preview image of the attachment, if available.
-    let imagePreviewURL: URL?
-
-    /// The kind of attachment.
-    let kind: Kind
-
-}
 
 @MainActor
 package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
 
-    private let attachments: [WireCellsMessageAttachment]
     private let fetchNodeUseCase: WireCellsFetchNodeUseCase
     private let getAssetUseCase: WireCellsGetAssetUseCase
     private let localAssetRepository: any WireCellsLocalAssetRepositoryProtocol
     private let lastOpenRequest: WireCellsLastOpenRequest
 
+    let attachments: [WireCellsMessageAttachment]
     let alignment: HorizontalAlignment
-    @Published var items: [WireCellsAttachmentsPreviewViewItem]
 
     package init(
         attachments: [WireCellsMessageAttachment],
@@ -87,14 +47,11 @@ package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
         self.getAssetUseCase = getAssetUseCase
         self.localAssetRepository = localAssetRepository
         self.lastOpenRequest = lastOpenRequest
-
-        self.items = attachments.map { WireCellsAttachmentsPreviewViewItem($0, isDeleted: false) }
     }
 
     /// Returns a `WireCellsAttachmentsPreviewView` for the item at the given index.
     func itemViewModel(index: Int) -> WireCellsAttachmentsPreviewItemViewModel {
         WireCellsAttachmentsPreviewItemViewModel(
-            item: items[index],
             attachment: attachments[index],
             alignment: alignment,
             fetchNodeUseCase: fetchNodeUseCase,
@@ -103,46 +60,6 @@ package final class WireCellsAttachmentsPreviewViewModel: ObservableObject {
             lastOpenRequest: lastOpenRequest,
             isSmall: attachments.count > 1
         )
-    }
-
-}
-
-private extension WireCellsAttachmentsPreviewViewItem {
-
-    init(_ value: WireCellsMessageAttachment, isDeleted: Bool) {
-        let url = value.initialName.flatMap { URL(string: $0) }
-        let fileType = value.contentType.flatMap { UTType(mimeType: $0) }
-        let fileExtension = url?.pathExtension
-
-        self.nodeID = value.nodeID
-        self.fileIcon = .make(type: fileType, fileExtension: fileExtension)
-        self.fileName = url?.deletingPathExtension().lastPathComponent
-        self.fileExtension = fileExtension
-        self.fileSize = value.initialSize
-        self.isDeleted = isDeleted
-        self.imagePreviewURL = nil
-        self.kind = Kind(fileType: fileType, initialMetadata: value.initialMetadata)
-    }
-
-}
-
-extension WireCellsAttachmentsPreviewViewItem.Kind {
-
-    init(fileType: UTType?, initialMetadata: WireCellsMessageAttachment.Metadata?) {
-        guard let fileType else {
-            self = .document
-            return
-        }
-
-        if fileType.conforms(to: .image) {
-            self = .image(size: initialMetadata?.dimension)
-        } else if fileType.conforms(to: .audio) { // `audio` must come before `.audiovisualContent`
-            self = .audio(duration: initialMetadata?.duration, normalizedLoudness: initialMetadata?.normalizedLoudness)
-        } else if fileType.conforms(to: .audiovisualContent) {
-            self = .video(size: initialMetadata?.dimension, duration: initialMetadata?.duration)
-        } else {
-            self = .document
-        }
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
@@ -25,13 +25,13 @@ struct WireCellsImageConversationAttachmentPreview: View {
     let thumbnailURL: URL?
     let progress: Double?
     let isError: Bool
-    let noPreviewMessage: String?
+    let canShowNoPreviewMessage: Bool
 
-    init(thumbnailURL: URL?, progress: Double?, isError: Bool, noPreviewMessage: String?) {
+    init(thumbnailURL: URL?, progress: Double?, isError: Bool, canShowNoPreviewMessage: Bool) {
         self.thumbnailURL = thumbnailURL
         self.progress = progress
         self.isError = isError
-        self.noPreviewMessage = noPreviewMessage
+        self.canShowNoPreviewMessage = canShowNoPreviewMessage
     }
 
     var body: some View {
@@ -75,8 +75,8 @@ struct WireCellsImageConversationAttachmentPreview: View {
     // MARK: Helpers
 
     @ViewBuilder private var noPreviewMessageView: some View {
-        if let noPreviewMessage {
-            Text(noPreviewMessage)
+        if canShowNoPreviewMessage {
+            Text(L10n.Localizable.Conversation.Message.Attachment.previewNotAvailable)
                 .wireTextStyle(.subline1)
                 .foregroundColor(ColorTheme.Backgrounds.surface.color)
                 .multilineTextAlignment(.center)
@@ -95,7 +95,7 @@ struct WireCellsImageConversationAttachmentPreview: View {
         thumbnailURL: nil,
         progress: 0.5,
         isError: false,
-        noPreviewMessage: "No preview available"
+        canShowNoPreviewMessage: true
     )
     .environment(\.wireTextStyleMapping, WireTextStyleMapping())
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
@@ -24,26 +24,26 @@ struct WireCellsImageConversationAttachmentPreview: View {
 
     let thumbnailURL: URL?
     let progress: Double?
-    let isError: Bool
+    let isAssetDownloadError: Bool
     let canShowNoPreviewMessage: Bool
 
-    init(thumbnailURL: URL?, progress: Double?, isError: Bool, canShowNoPreviewMessage: Bool) {
+    init(thumbnailURL: URL?, progress: Double?, isAssetDownloadError: Bool, canShowNoPreviewMessage: Bool) {
         self.thumbnailURL = thumbnailURL
         self.progress = progress
-        self.isError = isError
+        self.isAssetDownloadError = isAssetDownloadError
         self.canShowNoPreviewMessage = canShowNoPreviewMessage
     }
 
     var body: some View {
         WireCellsAttachmentPreview(
             progress: progress,
-            progressColor: isError ? ColorTheme.Base.error.color : ColorTheme.Base.primary.color
+            progressColor: isAssetDownloadError ? ColorTheme.Base.error.color : ColorTheme.Base.primary.color
         ) {
             ZStack {
                 if let thumbnailURL {
                     AsyncImage(url: thumbnailURL, scale: UIScreen.main.scale) { phase in
                         switch phase {
-                        case .empty where !isError:
+                        case .empty where !isAssetDownloadError:
                             ProgressView()
                                 .tint(ColorTheme.Backgrounds.surface.color)
                         case let .success(image):
@@ -53,7 +53,7 @@ struct WireCellsImageConversationAttachmentPreview: View {
                                     .scaledToFill()
                                     .frame(width: geometry.size.width, height: geometry.size.height)
                             }
-                        case let .failure(error) where !error.isURLErrorCancelled && !isError:
+                        case let .failure(error) where !error.isURLErrorCancelled && !isAssetDownloadError:
                             noPreviewMessageView
                         default:
                             EmptyView()
@@ -63,7 +63,7 @@ struct WireCellsImageConversationAttachmentPreview: View {
                     noPreviewMessageView
                 }
 
-                if isError {
+                if isAssetDownloadError {
                     WireCellsAttachmentPreviewErrorCircle()
                 }
             }
@@ -94,7 +94,7 @@ struct WireCellsImageConversationAttachmentPreview: View {
     WireCellsImageConversationAttachmentPreview(
         thumbnailURL: nil,
         progress: 0.5,
-        isError: false,
+        isAssetDownloadError: false,
         canShowNoPreviewMessage: true
     )
     .environment(\.wireTextStyleMapping, WireTextStyleMapping())

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
@@ -46,14 +46,14 @@ struct WireCellsImageConversationAttachmentPreview: View {
                         case .empty where !isError:
                             ProgressView()
                                 .tint(ColorTheme.Backgrounds.surface.color)
-                        case .success(let image):
+                        case let .success(image):
                             GeometryReader { geometry in
                                 image
                                     .resizable()
                                     .scaledToFill()
                                     .frame(width: geometry.size.width, height: geometry.size.height)
                             }
-                        case .failure(let error) where !error.isURLErrorCancelled:
+                        case let .failure(error) where !error.isURLErrorCancelled:
                             noPreviewMessageView
                         default:
                             EmptyView()
@@ -74,8 +74,7 @@ struct WireCellsImageConversationAttachmentPreview: View {
 
     // MARK: Helpers
 
-    @ViewBuilder
-    private var noPreviewMessageView: some View {
+    @ViewBuilder private var noPreviewMessageView: some View {
         if let noPreviewMessage {
             Text(noPreviewMessage)
                 .wireTextStyle(.subline1)

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
@@ -1,0 +1,88 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WireDesign
+import WireFoundation
+
+struct WireCellsImageConversationAttachmentPreview: View {
+
+    let thumbnailURL: URL?
+    let progress: Double?
+    let isError: Bool
+    let noPreviewMessage: String?
+
+    init(thumbnailURL: URL?, progress: Double?, isError: Bool, noPreviewMessage: String?) {
+        self.thumbnailURL = thumbnailURL
+        self.progress = progress
+        self.isError = isError
+        self.noPreviewMessage = noPreviewMessage
+    }
+
+    var body: some View {
+        WireCellsAttachmentPreview(
+            progress: progress,
+            progressColor: isError ? ColorTheme.Base.error.color : ColorTheme.Base.primary.color
+        ) {
+            ZStack {
+                AsyncImage(url: thumbnailURL, scale: UIScreen.main.scale) { phase in
+                    switch phase {
+                    case .empty where !isError && thumbnailURL != nil:
+                        ProgressView()
+                            .tint(ColorTheme.Backgrounds.surface.color)
+                    case .success(let image):
+                        GeometryReader { geometry in
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: geometry.size.width, height: geometry.size.height)
+                        }
+                    default:
+                        if let noPreviewMessage, !isError {
+                            Text(noPreviewMessage)
+                                .wireTextStyle(.subline1)
+                                .foregroundColor(ColorTheme.Backgrounds.surface.color)
+                                .multilineTextAlignment(.center)
+                                .padding()
+                        } else {
+                            EmptyView()
+                        }
+                    }
+                }
+
+                if isError {
+                    WireCellsAttachmentPreviewErrorCircle()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(ColorTheme.Backdrop.background.color)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    WireCellsImageConversationAttachmentPreview(
+        thumbnailURL: nil,
+        progress: 0.5,
+        isError: false,
+        noPreviewMessage: "No preview available"
+    )
+    .environment(\.wireTextStyleMapping, WireTextStyleMapping())
+}

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
@@ -53,7 +53,7 @@ struct WireCellsImageConversationAttachmentPreview: View {
                                     .scaledToFill()
                                     .frame(width: geometry.size.width, height: geometry.size.height)
                             }
-                        case let .failure(error) where !error.isURLErrorCancelled:
+                        case let .failure(error) where !error.isURLErrorCancelled && !isError:
                             noPreviewMessageView
                         default:
                             EmptyView()

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/ConversationPreviews/WireCellsImageConversationAttachmentPreview.swift
@@ -40,29 +40,27 @@ struct WireCellsImageConversationAttachmentPreview: View {
             progressColor: isError ? ColorTheme.Base.error.color : ColorTheme.Base.primary.color
         ) {
             ZStack {
-                AsyncImage(url: thumbnailURL, scale: UIScreen.main.scale) { phase in
-                    switch phase {
-                    case .empty where !isError && thumbnailURL != nil:
-                        ProgressView()
-                            .tint(ColorTheme.Backgrounds.surface.color)
-                    case .success(let image):
-                        GeometryReader { geometry in
-                            image
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: geometry.size.width, height: geometry.size.height)
-                        }
-                    default:
-                        if let noPreviewMessage, !isError {
-                            Text(noPreviewMessage)
-                                .wireTextStyle(.subline1)
-                                .foregroundColor(ColorTheme.Backgrounds.surface.color)
-                                .multilineTextAlignment(.center)
-                                .padding()
-                        } else {
+                if let thumbnailURL {
+                    AsyncImage(url: thumbnailURL, scale: UIScreen.main.scale) { phase in
+                        switch phase {
+                        case .empty where !isError:
+                            ProgressView()
+                                .tint(ColorTheme.Backgrounds.surface.color)
+                        case .success(let image):
+                            GeometryReader { geometry in
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: geometry.size.width, height: geometry.size.height)
+                            }
+                        case .failure(let error) where !error.isURLErrorCancelled:
+                            noPreviewMessageView
+                        default:
                             EmptyView()
                         }
                     }
+                } else {
+                    noPreviewMessageView
                 }
 
                 if isError {
@@ -73,6 +71,22 @@ struct WireCellsImageConversationAttachmentPreview: View {
             .background(ColorTheme.Backdrop.background.color)
         }
     }
+
+    // MARK: Helpers
+
+    @ViewBuilder
+    private var noPreviewMessageView: some View {
+        if let noPreviewMessage {
+            Text(noPreviewMessage)
+                .wireTextStyle(.subline1)
+                .foregroundColor(ColorTheme.Backgrounds.surface.color)
+                .multilineTextAlignment(.center)
+                .padding()
+        } else {
+            EmptyView()
+        }
+    }
+
 }
 
 // MARK: - Preview

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesItemViewModel.swift
@@ -60,8 +60,8 @@ final class FilesItemViewModel: ObservableObject {
         self.icon = item.icon
         self.localAssetRepository = localAssetRepository
 
-        localAssetRepository.observeAsset(nodeID: nodeID).sink { [self] asset in
-            self.asset = asset
+        localAssetRepository.observeAsset(nodeID: nodeID).sink { [weak self] asset in
+            self?.asset = asset
         }.store(in: &cancellables)
     }
 

--- a/wire-ios-data-model/Source/Model/Message/MultipartMessageData.swift
+++ b/wire-ios-data-model/Source/Model/Message/MultipartMessageData.swift
@@ -22,11 +22,27 @@ import GenericMessageProtocol
 // TODO: [WPB-16311] This is currently just a stub and needs to be implemented properly.
 public final class MultipartMessageData: NSObject {
 
+    public enum Metadata {
+
+        /// Image metadata, containing width and height in pixels.
+        case image(width: Int?, height: Int?)
+
+        /// Video metadata, containing width and height in pixels, and duration in milliseconds.
+        case video(width: Int?, height: Int?, duration: Int?)
+
+        /// Audio metadata, containing duration in milliseconds and normalized loudness data.
+        ///
+        /// - note: Currently, normalized loudness is not sent.
+        case audio(duration: Int?, normalizedLoudness: Data?)
+
+    }
+
     public struct Attachment {
         public let nodeID: UUID
         public let contentType: String?
         public let initialName: String?
         public let initialSize: Int?
+        public let initialMetadata: Metadata?
     }
 
     public let attachments: [Attachment]
@@ -41,7 +57,33 @@ public final class MultipartMessageData: NSObject {
                 nodeID: nodeID,
                 contentType: asset.hasContentType ? asset.contentType : nil,
                 initialName: asset.hasInitialName ? URL(string: asset.initialName)?.lastPathComponent : nil,
-                initialSize: asset.hasInitialSize ? Int(attachment.cellAsset.initialSize) : nil
+                initialSize: asset.hasInitialSize ? Int(attachment.cellAsset.initialSize) : nil,
+                initialMetadata:  asset.initialMetaData?.metadata
+            )
+        }
+    }
+
+}
+
+private extension CellAsset.OneOf_InitialMetaData {
+
+    var metadata: MultipartMessageData.Metadata {
+        switch self {
+        case let .image(image):
+            return .image(
+                width: image.hasWidth ? Int(image.width) : nil,
+                height: image.hasHeight ? Int(image.height) : nil
+            )
+        case let .video(video):
+            return .video(
+                width: video.hasWidth ? Int(video.width) : nil,
+                height: video.hasHeight ? Int(video.height) : nil,
+                duration: video.hasDurationInMillis ? Int(video.durationInMillis) : nil
+            )
+        case let .audio(audio):
+            return .audio(
+                duration: audio.hasDurationInMillis ? Int(audio.durationInMillis) : nil,
+                normalizedLoudness: audio.hasNormalizedLoudness ? audio.normalizedLoudness : nil
             )
         }
     }

--- a/wire-ios-data-model/Source/Model/Message/MultipartMessageData.swift
+++ b/wire-ios-data-model/Source/Model/Message/MultipartMessageData.swift
@@ -58,7 +58,7 @@ public final class MultipartMessageData: NSObject {
                 contentType: asset.hasContentType ? asset.contentType : nil,
                 initialName: asset.hasInitialName ? URL(string: asset.initialName)?.lastPathComponent : nil,
                 initialSize: asset.hasInitialSize ? Int(attachment.cellAsset.initialSize) : nil,
-                initialMetadata:  asset.initialMetaData?.metadata
+                initialMetadata: asset.initialMetaData?.metadata
             )
         }
     }
@@ -70,18 +70,18 @@ private extension CellAsset.OneOf_InitialMetaData {
     var metadata: MultipartMessageData.Metadata {
         switch self {
         case let .image(image):
-            return .image(
+            .image(
                 width: image.hasWidth ? Int(image.width) : nil,
                 height: image.hasHeight ? Int(image.height) : nil
             )
         case let .video(video):
-            return .video(
+            .video(
                 width: video.hasWidth ? Int(video.width) : nil,
                 height: video.hasHeight ? Int(video.height) : nil,
                 duration: video.hasDurationInMillis ? Int(video.durationInMillis) : nil
             )
         case let .audio(audio):
-            return .audio(
+            .audio(
                 duration: audio.hasDurationInMillis ? Int(audio.durationInMillis) : nil,
                 normalizedLoudness: audio.hasNormalizedLoudness ? audio.normalizedLoudness : nil
             )

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationMultipartMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationMultipartMessageCell.swift
@@ -60,7 +60,16 @@ final class ConversationMultipartMessageCellDescription: ConversationMessageCell
                 contentType: $0.contentType,
                 initialName: $0.initialName,
                 initialSize: $0.initialSize,
-                initialMetadata: nil
+                initialMetadata: $0.initialMetadata.map { metadata in
+                    switch metadata {
+                    case .image(width: let width, height: let height):
+                        .image(width: width, height: height)
+                    case .video(width: let width, height: let height, duration: let duration):
+                        .video(width: width, height: height, duration: duration)
+                    case .audio(duration: let duration, normalizedLoudness: let normalizedLoudness):
+                        .audio(duration: duration, normalizedLoudness: normalizedLoudness)
+                    }
+                }
             )
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationMultipartMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Rich Content/ConversationMultipartMessageCell.swift
@@ -62,11 +62,11 @@ final class ConversationMultipartMessageCellDescription: ConversationMessageCell
                 initialSize: $0.initialSize,
                 initialMetadata: $0.initialMetadata.map { metadata in
                     switch metadata {
-                    case .image(width: let width, height: let height):
+                    case let .image(width: width, height: height):
                         .image(width: width, height: height)
-                    case .video(width: let width, height: let height, duration: let duration):
+                    case let .video(width: width, height: height, duration: duration):
                         .video(width: width, height: height, duration: duration)
-                    case .audio(duration: let duration, normalizedLoudness: let normalizedLoudness):
+                    case let .audio(duration: duration, normalizedLoudness: normalizedLoudness):
                         .audio(duration: duration, normalizedLoudness: normalizedLoudness)
                     }
                 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16312" title="WPB-16312" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16312</a>  [iOS] Small image previews in a conversation message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR introduces small and large image previews into wire cells conversations. This required adding some missing plumbing to ensure that file metadata is forwarded from multipart protobuf messages to the view layer.

<img width="642" height="1389" alt="IMG_0408" src="https://github.com/user-attachments/assets/40d72519-4cb7-40d0-95f2-12ad247250ae" />

### Testing

1. Navigate to a cells enabled conversation
2. Send various files which include images. 
3. Test that the image previews look OK. For some formats no image preview will be available (heic).
4. Test both messages with single attachment (large image preview) and multiple attachments (small image preview)
5. Test that tapping on the previews opens the correct files.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
