### PR TITLE
feat(backup-performance): import messages from backup in batches - WPB-21300

### DIFF
--- a/WireBackup/Sources/WireBackup/Models/BackupMessageModel.swift
+++ b/WireBackup/Sources/WireBackup/Models/BackupMessageModel.swift
@@ -190,6 +190,20 @@ public extension MessageBackupModel.Content {
         )
     }
 
+    var isText: Bool {
+        if case .text = self { return true }
+        return false
+    }
+
+    var isLocation: Bool {
+        if case .location = self { return true }
+        return false
+    }
+
+    var isAsset: Bool {
+        if case .asset = self { return true }
+        return false
+    }
 }
 
 public extension MessageBackupModel.Content.AssetContent.Metadata {

--- a/WireBackup/Sources/WireBackup/Models/BackupMessagesImportFailure.swift
+++ b/WireBackup/Sources/WireBackup/Models/BackupMessagesImportFailure.swift
@@ -16,9 +16,15 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-public extension ZMMessage {
-    @NSManaged var senderID: UUID?
-    @NSManaged var senderDomain: String?
-    @NSManaged var conversationID: UUID?
-    @NSManaged var conversationDomain: String?
+public import Foundation
+
+public enum BackupMessagesImportFailure: LocalizedError {
+    case failedToFetchRelationships
+
+    public var errorDescription: String? {
+        switch self {
+        case .failedToFetchRelationships:
+            "Relationships with senders / conversations could not be fetched."
+        }
+    }
 }

--- a/WireBackup/Sources/WireBackup/Models/BackupMessagesImportResult.swift
+++ b/WireBackup/Sources/WireBackup/Models/BackupMessagesImportResult.swift
@@ -1,0 +1,49 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+public struct BackupMessagesImportResult {
+
+    public let validationCount: ResultCount
+    public let insertionCount: ResultCount
+    public let rehydrationCount: ResultCount
+
+    public init(
+        validationCount: ResultCount,
+        insertionCount: ResultCount,
+        rehydrationCount: ResultCount
+    ) {
+        self.validationCount = validationCount
+        self.insertionCount = insertionCount
+        self.rehydrationCount = rehydrationCount
+    }
+
+}
+
+public extension BackupMessagesImportResult {
+
+    struct ResultCount {
+        public let successCount: Int
+        public let failureCount: Int
+
+        public init(successCount: Int, failureCount: Int) {
+            self.successCount = successCount
+            self.failureCount = failureCount
+        }
+    }
+
+}

--- a/WireBackup/Sources/WireBackup/Protocols/BackupLocalStoreProtocol.swift
+++ b/WireBackup/Sources/WireBackup/Protocols/BackupLocalStoreProtocol.swift
@@ -53,6 +53,8 @@ public protocol BackupLocalStoreProtocol: Sendable {
     func fetchAllMessages() -> AsyncThrowingStream<MessageBackupModel, any Error>
 
     /// Adds a batch of messages from the backup file to the local data store.
-    func addMessages(_ backupMessages: [MessageBackupModel]) async throws
+    func addMessages(_ backupMessages: [MessageBackupModel]) async throws -> BackupMessagesImportResult
 
+    /// Refreshes the managed objects in the view context
+    func refreshViewContext() async throws
 }

--- a/WireBackup/Sources/WireBackup/UseCases/ImportBackupUseCase.swift
+++ b/WireBackup/Sources/WireBackup/UseCases/ImportBackupUseCase.swift
@@ -88,9 +88,15 @@ public struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
                     var current = 0
                     let total = usersPager.totalPages + messagesPager.totalPages
 
+                    logger.info(
+                        "Starting importing users from backup... Pages: \(usersPager.totalPages)",
+                        attributes: .safePublic
+                    )
+
                     // users
                     let storedUserIDs = try await backupLocalStore.fetchAllUserIDs()
                     while usersPager.hasMorePages() {
+                        logger.info("Importing users page \(current)/\(total)", attributes: .safePublic)
                         let backupUsers = usersPager.nextPage()
                         for current in 0 ..< backupUsers.size {
                             guard
@@ -112,26 +118,63 @@ public struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
                     // Any conversation that has been left or deleted will not be restored from the backup in the first
                     // version. All other conversations where the self-user is participant will already be available.
 
+                    logger.info(
+                        "Starting importing messages from backup... Pages: \(messagesPager.totalPages)",
+                        attributes: .safePublic
+                    )
+
                     // messages
+                    var totalSuccessCount = 0
+                    var totalFailureCount = 0
                     let storedMessageIDs = try await backupLocalStore.fetchAllMessageIDs()
                     while messagesPager.hasMorePages() {
+                        logger.info("Importing messages page \(current)/\(total)", attributes: .safePublic)
 
-                        // Map messages
+                        // Map messages from kotlin array to swift array,
+                        // filtering out messages that already exist in DB
                         let backupMessages = mapBackupMessages(
                             fromPage: messagesPager.nextPage(),
                             storedMessageIDs: storedMessageIDs
                         )
 
-                        try await backupLocalStore.addMessages(backupMessages)
+                        do {
+                            let result = try await backupLocalStore.addMessages(backupMessages)
+                            let successCount = result.rehydrationCount.successCount
+                            let failureCount = backupMessages.count - successCount
+                            totalSuccessCount += successCount
+                            totalFailureCount += failureCount
+
+                            logger.info(
+                                "Page (\(current)/\(total)): Imported \(successCount) messages, \(failureCount) failed to import",
+                                attributes: .safePublic
+                            )
+
+                        } catch {
+                            // Catch and log the error but don't stop execution, as we should
+                            // still be able to continue importing the other pages
+                            logger.warn(
+                                "Page (\(current)/\(total)) import error: \(String(describing: error))",
+                                attributes: .safePublic
+                            )
+                        }
 
                         try Task.checkCancellation()
                         current += 1
                         reportProgress(current, Int(exactly: total) ?? 1)
                     }
 
+                    logger.info(
+                        "Imported total of \(totalSuccessCount) messages, \(totalFailureCount) failed to import",
+                        attributes: .safePublic
+                    )
+
+                    try await backupLocalStore.refreshViewContext()
+
                     if total > 0 {
                         syncTrigger()
                     }
+
+                    logger.info("Completed backup import", attributes: .safePublic)
 
                     continuation.yield(.done)
                     continuation.finish()

--- a/WireDomain/Sources/WireDomain/Helpers/AssetTransferStateResolver.swift
+++ b/WireDomain/Sources/WireDomain/Helpers/AssetTransferStateResolver.swift
@@ -1,0 +1,75 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import GenericMessageProtocol
+import WireDataModel
+
+// sourcery: AutoMockable
+public protocol AssetTransferStateResolverProtocol {
+
+    /// Resolves the asset message's transfer state
+    ///
+    /// - Parameters:
+    ///   - assetMessage: message to resolve
+    ///   - genericMessage: the generic message for the asset message
+    ///   - context: the managed object context
+
+    func resolveTransferState(
+        assetMessage: ZMAssetClientMessage,
+        genericMessage: GenericMessage,
+        context: NSManagedObjectContext
+    )
+}
+
+public struct AssetTransferStateResolver: AssetTransferStateResolverProtocol {
+
+    public init() {}
+
+    public func resolveTransferState(
+        assetMessage: ZMAssetClientMessage,
+        genericMessage: GenericMessage,
+        context: NSManagedObjectContext
+    ) {
+        guard let assetData = genericMessage.assetData, let status = assetData.status else {
+            return
+        }
+
+        switch status {
+        case let .uploaded(data) where data.hasAssetID:
+            assetMessage.updateTransferState(
+                .uploaded,
+                synchronize: false
+            )
+
+        case .notUploaded where assetMessage.transferState != .uploaded:
+            switch assetData.notUploaded {
+            case .cancelled:
+                context.delete(assetMessage)
+            case .failed:
+                assetMessage.updateTransferState(
+                    .uploadingFailed,
+                    synchronize: false
+                )
+            }
+
+        default:
+            break
+        }
+    }
+
+}

--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -40,6 +40,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
     // MARK: - Properties
 
     let context: NSManagedObjectContext
+    let assetTransferStateResolver: AssetTransferStateResolverProtocol
 
     // MARK: - Object lifecycle
 
@@ -47,6 +48,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
         context: NSManagedObjectContext
     ) {
         self.context = context
+        self.assetTransferStateResolver = AssetTransferStateResolver()
     }
 
     // MARK: - Public
@@ -241,29 +243,11 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
             // We assume received assets are V3 since backend no longer supports sending V2 assets.
             assetClientMessage.version = 3
 
-            if let assetData = genericMessage.assetData, let status = assetData.status {
-                switch status {
-                case let .uploaded(data) where data.hasAssetID:
-                    assetClientMessage.updateTransferState(
-                        .uploaded,
-                        synchronize: false
-                    )
-
-                case .notUploaded where assetClientMessage.transferState != .uploaded:
-                    switch assetData.notUploaded {
-                    case .cancelled:
-                        context.delete(assetClientMessage)
-                    case .failed:
-                        assetClientMessage.updateTransferState(
-                            .uploadingFailed,
-                            synchronize: false
-                        )
-                    }
-
-                default:
-                    break
-                }
-            }
+            assetTransferStateResolver.resolveTransferState(
+                assetMessage: assetClientMessage,
+                genericMessage: genericMessage,
+                context: context
+            )
 
             finalizeMessageUpdate(
                 message: assetClientMessage,

--- a/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMAssetClientMessage+GenericMessage.swift
@@ -63,6 +63,16 @@ extension ZMAssetClientMessage {
         try mergeWithExistingData(message: message)
     }
 
+    /// Sets the underlying protobuf message data by creating a new `ZMGenericMessageData` object,
+    /// without checking if any generic message data exists to merge with.
+    ///
+    /// - Parameter message: The protobuf message object to be associated with this asset client message.
+    /// - Throws `ProcessingError` if the protobuf data can't be processed.
+
+    public func setNewUnderlyingMessage(_ message: GenericMessage) throws {
+        try createNewGenericMessageData(with: message)
+    }
+
     @discardableResult
     func mergeWithExistingData(message: GenericMessage) throws -> ZMGenericMessageData {
         cachedUnderlyingAssetMessage = nil
@@ -82,6 +92,7 @@ extension ZMAssetClientMessage {
         }
     }
 
+    @discardableResult
     func createNewGenericMessageData(with message: GenericMessage) throws -> ZMGenericMessageData {
         guard let moc = managedObjectContext else {
             throw ProcessingError.missingManagedObjectContext

--- a/wire-ios-data-model/Source/Model/Message/ZMClientMessage+GenericMessage.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMClientMessage+GenericMessage.swift
@@ -19,9 +19,9 @@
 import Foundation
 import GenericMessageProtocol
 
-extension ZMClientMessage {
+public extension ZMClientMessage {
 
-    public var underlyingMessage: GenericMessage? {
+    var underlyingMessage: GenericMessage? {
         guard !isZombieObject else {
             return nil
         }
@@ -54,7 +54,7 @@ extension ZMClientMessage {
     /// - Parameter message: The protobuf message object to be associated with this client message.
     /// - Throws `ProcessingError` if the protobuf data can't be processed.
 
-    public func setUnderlyingMessage(_ message: GenericMessage) throws {
+    func setUnderlyingMessage(_ message: GenericMessage) throws {
         let messageData = try mergeWithExistingData(message)
 
         if nonce == .none, let messageID = messageData.underlyingMessage?.messageID {
@@ -71,12 +71,12 @@ extension ZMClientMessage {
     /// - Parameter message: The protobuf message object to be associated with this asset client message.
     /// - Throws `ProcessingError` if the protobuf data can't be processed.
 
-    public func setNewUnderlyingMessage(_ message: GenericMessage) throws {
+    func setNewUnderlyingMessage(_ message: GenericMessage) throws {
         try createNewGenericMessageData(with: message)
     }
 
     @discardableResult
-    func mergeWithExistingData(_ message: GenericMessage) throws -> ZMGenericMessageData {
+    internal func mergeWithExistingData(_ message: GenericMessage) throws -> ZMGenericMessageData {
         cachedUnderlyingMessage = nil
 
         let existingMessageData = dataSet

--- a/wire-ios-data-model/Source/Model/Message/ZMClientMessage+GenericMessage.swift
+++ b/wire-ios-data-model/Source/Model/Message/ZMClientMessage+GenericMessage.swift
@@ -65,6 +65,16 @@ extension ZMClientMessage {
         setLocallyModifiedKeys([#keyPath(ZMClientMessage.dataSet)])
     }
 
+    /// Sets the underlying protobuf message data by creating a new `ZMGenericMessageData` object,
+    /// without checking if any generic message data exists to merge with.
+    ///
+    /// - Parameter message: The protobuf message object to be associated with this asset client message.
+    /// - Throws `ProcessingError` if the protobuf data can't be processed.
+
+    public func setNewUnderlyingMessage(_ message: GenericMessage) throws {
+        try createNewGenericMessageData(with: message)
+    }
+
     @discardableResult
     func mergeWithExistingData(_ message: GenericMessage) throws -> ZMGenericMessageData {
         cachedUnderlyingMessage = nil
@@ -86,6 +96,7 @@ extension ZMClientMessage {
         return messageData
     }
 
+    @discardableResult
     private func createNewGenericMessageData(with message: GenericMessage) throws -> ZMGenericMessageData {
         guard let moc = managedObjectContext else {
             throw ProcessingError.missingManagedObjectContext

--- a/wire-ios-data-model/Source/Model/QualifiedID.swift
+++ b/wire-ios-data-model/Source/Model/QualifiedID.swift
@@ -64,9 +64,9 @@ public protocol HasQualifiedID {
     var qualifiedID: WireDataModel.QualifiedID? { get }
 }
 
-public extension ZMUser {
+extension ZMUser: HasQualifiedID {
 
-    var qualifiedID: QualifiedID? {
+    public var qualifiedID: QualifiedID? {
         guard
             let context = managedObjectContext,
             let uuid = remoteIdentifier,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -386,7 +386,6 @@
 		882B85752E83ED7E008A50CA /* StaleCoreCryptoKeysTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B85742E83ED7A008A50CA /* StaleCoreCryptoKeysTrackerTests.swift */; };
 		882B86BC2E843D0C008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B86BB2E843D05008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift */; };
 		882B86BE2E8441AA008A50CA /* RemoveCoreCryptoKeysUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B86BD2E84419A008A50CA /* RemoveCoreCryptoKeysUseCase.swift */; };
-		884371642EB8DC50003DA083 /* ZMMessage+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884371632EB8DC49003DA083 /* ZMMessage+Backup.swift */; };
 		884371662EB8E9F3003DA083 /* store2-132-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 884371652EB8E9F3003DA083 /* store2-132-0.wiredatabase */; };
 		A90676E7238EAE8B006417AC /* ParticipantRole.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90676E6238EAE8B006417AC /* ParticipantRole.swift */; };
 		A90676EA238EB05F006417AC /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = A90676E8238EB05E006417AC /* Action.swift */; };
@@ -1154,7 +1153,6 @@
 		882B86BB2E843D05008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveCoreCryptoKeysUseCaseTests.swift; sourceTree = "<group>"; };
 		882B86BD2E84419A008A50CA /* RemoveCoreCryptoKeysUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveCoreCryptoKeysUseCase.swift; sourceTree = "<group>"; };
 		884371622EB8DB58003DA083 /* zmessaging2.132.0.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = zmessaging2.132.0.xcdatamodel; sourceTree = "<group>"; };
-		884371632EB8DC49003DA083 /* ZMMessage+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMMessage+Backup.swift"; sourceTree = "<group>"; };
 		884371652EB8E9F3003DA083 /* store2-132-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-132-0.wiredatabase"; sourceTree = "<group>"; };
 		A90676E6238EAE8B006417AC /* ParticipantRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantRole.swift; sourceTree = "<group>"; };
 		A90676E8238EB05E006417AC /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -17,14 +17,14 @@
 //
 
 import Foundation
-import XCTest
 import WireBackup
-@testable import WireDataModel
 import WireFoundation
+import XCTest
 @testable import Wire
+@testable import WireDataModel
 
 final class BackupLocalStoreMessagesTests: XCTestCase {
-    
+
     private typealias QualifiedID = WireFoundation.QualifiedID
 
     // MARK: - Properties
@@ -34,7 +34,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
     private var senderID: QualifiedID!
     private var conversationID: QualifiedID!
     private var context: NSManagedObjectContext!
-    
+
     // MARK: - Setup & Teardown
 
     override func setUp() async throws {
@@ -58,7 +58,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
 
         sut = BackupLocalStore(contextProvider: coreDataStack)
         context = sut.backupContext
-    
+
         // Create test fixtures
         conversationID = QualifiedID(id: UUID(), domain: "wire.com")
         senderID = QualifiedID(id: UUID(), domain: "wire.com")
@@ -111,11 +111,11 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         XCTAssertEqual(result.rehydrationCount.successCount, 2)
 
         try await context.perform { [senderID, conversationID, fetchMessages] in
-            
+
             // Verify messages in database
             let fetchedMessages = try fetchMessages()
             XCTAssertEqual(fetchedMessages.count, 2)
-        
+
             // Verify relationships
             for message in fetchedMessages {
                 XCTAssertNotNil(message.sender)
@@ -125,7 +125,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
             }
         }
     }
-    
+
     func test_AddMessages_ImportsValidAssetMessages() async throws {
         // GIVEN
         let messages = [
@@ -145,11 +145,11 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
 
         // Verify asset message in database
         try await context.perform { [senderID, conversationID, fetchMessages] in
-            
+
             // Verify messages in database
             let fetchedMessages = try fetchMessages()
             XCTAssertEqual(fetchedMessages.count, 1)
-            
+
             guard let assetMessage = fetchedMessages.first as? ZMAssetClientMessage else {
                 XCTFail("Expected ZMAssetClientMessage")
                 return
@@ -161,7 +161,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
             XCTAssertEqual(assetMessage.visibleInConversation?.remoteIdentifier, conversationID?.id)
             XCTAssertNotNil(assetMessage.underlyingMessage)
         }
-        
+
     }
 
     func test_AddMessages_ImportsValidLocationMessages() async throws {
@@ -182,11 +182,11 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         XCTAssertEqual(result.rehydrationCount.successCount, 1)
 
         try await context.perform { [senderID, conversationID, fetchMessages] in
-            
+
             // Verify message in database
             let fetchedMessages = try fetchMessages()
             XCTAssertEqual(fetchedMessages.count, 1)
-    
+
             guard let message = fetchedMessages.first else { return XCTFail() }
             XCTAssertNotNil(message.sender)
             XCTAssertEqual(message.sender?.remoteIdentifier, senderID?.id)
@@ -255,7 +255,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
 
     func test_AddMessages_ReportsValidationFailure_ForUnsupportedContentType() async throws {
         // GIVEN
-        
+
         // Create a message with text content but manually create the model
         // to simulate unsupported content that doesn't pass validation
         let invalidMessage = MessageBackupModel(
@@ -311,7 +311,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         try await context.perform { [fetchMessages] in
             let fetchedMessages = try fetchMessages()
             XCTAssertEqual(fetchedMessages.count, 1)
-            
+
             guard let message = fetchedMessages.first else {
                 return XCTFail()
             }
@@ -353,7 +353,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
 
     func testThatAddMessagesHandlesLargeBatch() async throws {
         // GIVEN - 1000 messages
-        let messages = (0..<1000).map { _ in
+        let messages = (0 ..< 1000).map { _ in
             makeValidTextMessage(
                 conversationID: conversationID,
                 senderID: senderID
@@ -445,7 +445,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
             content: .text("This message has invalid nonce")
         )
     }
-    
+
     func fetchMessages() throws -> [ZMMessage] {
         let fetchRequest = ZMMessage.fetchRequest()
         let fetchResult = try context!.fetch(fetchRequest) as? [ZMMessage]

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -447,7 +447,7 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
 
     func fetchMessages() throws -> [ZMMessage] {
         let fetchRequest = ZMMessage.fetchRequest()
-        let fetchResult = try context!.fetch(fetchRequest) as? [ZMMessage]
+        let fetchResult = try context.fetch(fetchRequest) as? [ZMMessage]
         return try XCTUnwrap(fetchResult)
     }
 }

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -143,10 +143,9 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         XCTAssertEqual(result.insertionCount.successCount, 1)
         XCTAssertEqual(result.rehydrationCount.successCount, 1)
 
-        // Verify asset message in database
         try await context.perform { [senderID, conversationID, fetchMessages] in
 
-            // Verify messages in database
+            // Verify asset message in database
             let fetchedMessages = try fetchMessages()
             XCTAssertEqual(fetchedMessages.count, 1)
 

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -1,0 +1,454 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import XCTest
+import WireBackup
+@testable import WireDataModel
+import WireFoundation
+@testable import Wire
+
+final class BackupLocalStoreMessagesTests: XCTestCase {
+    
+    private typealias QualifiedID = WireFoundation.QualifiedID
+
+    // MARK: - Properties
+
+    private var sut: BackupLocalStore!
+    private var coreDataStack: CoreDataStack!
+    private var senderID: QualifiedID!
+    private var conversationID: QualifiedID!
+    private var context: NSManagedObjectContext!
+    
+    // MARK: - Setup & Teardown
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Create Core Data stack with temporary SQLite store
+        let account = Account(userName: "", userIdentifier: UUID())
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+
+        coreDataStack = CoreDataStack(
+            account: account,
+            applicationContainer: tempDirectory,
+            inMemoryStore: false,
+            localDomain: "wire.com",
+            isFederationEnabled: true
+        )
+        try await coreDataStack.load()
+
+        sut = BackupLocalStore(contextProvider: coreDataStack)
+        context = sut.backupContext
+    
+        // Create test fixtures
+        conversationID = QualifiedID(id: UUID(), domain: "wire.com")
+        senderID = QualifiedID(id: UUID(), domain: "wire.com")
+
+        try await context.perform { [context, senderID, conversationID] in
+            let sender = ZMUser.insertNewObject(in: context!)
+            sender.remoteIdentifier = senderID?.id
+            sender.domain = senderID?.domain
+            sender.name = "Bob"
+
+            let conversation = ZMConversation.insertNewObject(in: context!)
+            conversation.remoteIdentifier = conversationID?.id
+            conversation.domain = conversationID?.domain
+            conversation.conversationType = .group
+
+            try context!.save()
+        }
+    }
+
+    override func tearDown() {
+        sut = nil
+        coreDataStack = nil
+        context = nil
+        senderID = nil
+        conversationID = nil
+        super.tearDown()
+    }
+
+    // MARK: - Success Cases
+
+    func test_AddMessages_ImportsValidTextMessages() async throws {
+        // GIVEN
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            ),
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 2)
+        XCTAssertEqual(result.insertionCount.successCount, 2)
+        XCTAssertEqual(result.rehydrationCount.successCount, 2)
+
+        try await context.perform { [senderID, conversationID, fetchMessages] in
+            
+            // Verify messages in database
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 2)
+        
+            // Verify relationships
+            for message in fetchedMessages {
+                XCTAssertNotNil(message.sender)
+                XCTAssertEqual(message.sender?.remoteIdentifier, senderID?.id)
+                XCTAssertNotNil(message.visibleInConversation)
+                XCTAssertEqual(message.visibleInConversation?.remoteIdentifier, conversationID?.id)
+            }
+        }
+    }
+    
+    func test_AddMessages_ImportsValidAssetMessages() async throws {
+        // GIVEN
+        let messages = [
+            makeValidAssetMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.insertionCount.successCount, 1)
+        XCTAssertEqual(result.rehydrationCount.successCount, 1)
+
+        // Verify asset message in database
+        try await context.perform { [senderID, conversationID, fetchMessages] in
+            
+            // Verify messages in database
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1)
+            
+            guard let assetMessage = fetchedMessages.first as? ZMAssetClientMessage else {
+                XCTFail("Expected ZMAssetClientMessage")
+                return
+            }
+
+            XCTAssertNotNil(assetMessage.sender)
+            XCTAssertEqual(assetMessage.sender?.remoteIdentifier, senderID?.id)
+            XCTAssertNotNil(assetMessage.visibleInConversation)
+            XCTAssertEqual(assetMessage.visibleInConversation?.remoteIdentifier, conversationID?.id)
+            XCTAssertNotNil(assetMessage.underlyingMessage)
+        }
+        
+    }
+
+    func test_AddMessages_ImportsValidLocationMessages() async throws {
+        // GIVEN
+        let messages = [
+            makeValidLocationMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.insertionCount.successCount, 1)
+        XCTAssertEqual(result.rehydrationCount.successCount, 1)
+
+        try await context.perform { [senderID, conversationID, fetchMessages] in
+            
+            // Verify message in database
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1)
+    
+            guard let message = fetchedMessages.first else { return XCTFail() }
+            XCTAssertNotNil(message.sender)
+            XCTAssertEqual(message.sender?.remoteIdentifier, senderID?.id)
+            XCTAssertNotNil(message.visibleInConversation)
+            XCTAssertEqual(message.visibleInConversation?.remoteIdentifier, conversationID?.id)
+        }
+    }
+
+    func test_AddMessages_HandlesMixedMessageTypes() async throws {
+        // GIVEN
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            ),
+            makeValidAssetMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            ),
+            makeValidLocationMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 3)
+        XCTAssertEqual(result.insertionCount.successCount, 3)
+        XCTAssertEqual(result.rehydrationCount.successCount, 3)
+
+        // Verify that all messages are in database
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 3)
+        }
+    }
+
+    // MARK: - Validation Failure Cases
+
+    func test_AddMessages_ReportsValidationFailure_ForInvalidNonce() async throws {
+        // GIVEN
+        let messages = [
+            makeMessageWithInvalidNonce(),
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.validationCount.failureCount, 1)
+
+        // Only valid message should be in database
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1)
+        }
+    }
+
+    func test_AddMessages_ReportsValidationFailure_ForUnsupportedContentType() async throws {
+        // GIVEN
+        
+        // Create a message with text content but manually create the model
+        // to simulate unsupported content that doesn't pass validation
+        let invalidMessage = MessageBackupModel(
+            id: "invalid-id-format",  // Invalid UUID format
+            conversationID: conversationID,
+            senderUserID: senderID,
+            senderClientID: "client-id",
+            creationDate: Date(),
+            content: .text("test")
+        )
+
+        let validMessage = makeValidTextMessage(
+            conversationID: conversationID,
+            senderID: senderID
+        )
+
+        // WHEN
+        let result = try await sut.addMessages([invalidMessage, validMessage])
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.validationCount.failureCount, 1)
+
+        // Only valid message should be in database
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1)
+        }
+    }
+
+    // MARK: - Rehydration cases with missing sender
+
+    func test_AddMessages_SucceedsWithMissingSender() async throws {
+        // GIVEN
+        // Create message with non-existent sender
+        let nonExistentSenderID = QualifiedID(id: UUID(), domain: "wire.com")
+        let messages = [
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: nonExistentSenderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.insertionCount.successCount, 1)
+        XCTAssertEqual(result.rehydrationCount.successCount, 1)
+
+        // Message should exist with nil sender
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1)
+            
+            guard let message = fetchedMessages.first else {
+                return XCTFail()
+            }
+            XCTAssertNil(message.sender)
+            XCTAssertNotNil(message.visibleInConversation)
+        }
+    }
+
+    // MARK: - Rehydration Failure
+
+    func test_AddMessages_HandlesRehydrationFailure_ForMissingConversation() async throws {
+        // GIVEN
+        // Create message with non-existent conversation
+        let nonExistentConversationID = QualifiedID(id: UUID(), domain: "wire.com")
+        let messages = [
+            makeValidTextMessage(
+                conversationID: nonExistentConversationID,
+                senderID: senderID
+            )
+        ]
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1)
+        XCTAssertEqual(result.insertionCount.successCount, 1)
+        XCTAssertEqual(result.rehydrationCount.successCount, 0)
+        XCTAssertEqual(result.rehydrationCount.failureCount, 1)
+
+        // Zombie message should be cleaned up
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 0)
+        }
+    }
+
+    // MARK: - Performance & Scale
+
+    func testThatAddMessagesHandlesLargeBatch() async throws {
+        // GIVEN - 1000 messages
+        let messages = (0..<1000).map { _ in
+            makeValidTextMessage(
+                conversationID: conversationID,
+                senderID: senderID
+            )
+        }
+
+        // WHEN
+        let result = try await sut.addMessages(messages)
+
+        // THEN
+        XCTAssertEqual(result.validationCount.successCount, 1000)
+        XCTAssertEqual(result.insertionCount.successCount, 1000)
+        XCTAssertEqual(result.rehydrationCount.successCount, 1000)
+
+        try await context.perform { [fetchMessages] in
+            let fetchedMessages = try fetchMessages()
+            XCTAssertEqual(fetchedMessages.count, 1000)
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func makeValidTextMessage(
+        conversationID: QualifiedID,
+        senderID: QualifiedID,
+        senderClientID: String? = "client-id"
+    ) -> MessageBackupModel {
+        MessageBackupModel(
+            id: UUID().uuidString.lowercased(),
+            conversationID: conversationID,
+            senderUserID: senderID,
+            senderClientID: senderClientID,
+            creationDate: Date(),
+            content: .text("Test message \(UUID().uuidString)")
+        )
+    }
+
+    private func makeValidAssetMessage(
+        conversationID: QualifiedID,
+        senderID: QualifiedID
+    ) -> MessageBackupModel {
+        MessageBackupModel(
+            id: UUID().uuidString.lowercased(),
+            conversationID: conversationID,
+            senderUserID: senderID,
+            senderClientID: "client-id",
+            creationDate: Date(),
+            content: .asset(
+                mimeType: "image/jpeg",
+                size: 1024,
+                name: "test.jpg",
+                otrKey: Data(repeating: 1, count: 32),
+                sha256: Data(repeating: 2, count: 32),
+                assetID: UUID().uuidString,
+                assetToken: "token",
+                assetDomain: "wire.com",
+                encryption: .aesGCM,
+                metadata: .image(width: 800, height: 600, tag: nil)
+            )
+        )
+    }
+
+    private func makeValidLocationMessage(
+        conversationID: QualifiedID,
+        senderID: QualifiedID
+    ) -> MessageBackupModel {
+        MessageBackupModel(
+            id: UUID().uuidString.lowercased(),
+            conversationID: conversationID,
+            senderUserID: senderID,
+            senderClientID: "client-id",
+            creationDate: Date(),
+            content: .location(
+                longitude: 8.5417,
+                latitude: 47.3769,
+                name: "Zurich",
+                zoom: 10
+            )
+        )
+    }
+
+    private func makeMessageWithInvalidNonce() -> MessageBackupModel {
+        MessageBackupModel(
+            id: "invalid-nonce-format",
+            conversationID: QualifiedID(id: UUID(), domain: "wire.com"),
+            senderUserID: QualifiedID(id: UUID(), domain: "wire.com"),
+            senderClientID: "client-id",
+            creationDate: Date(),
+            content: .text("This message has invalid nonce")
+        )
+    }
+    
+    func fetchMessages() throws -> [ZMMessage] {
+        let fetchRequest = ZMMessage.fetchRequest()
+        let fetchResult = try context!.fetch(fetchRequest) as? [ZMMessage]
+        return try XCTUnwrap(fetchResult)
+    }
+}

--- a/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
+++ b/wire-ios/Wire-iOS.xcodeproj/project.pbxproj
@@ -541,6 +541,7 @@
 				AvailabilityLabelTests.swift,
 				"AVAsset/AVURLAsset+conversionTests.swift",
 				Backup/BackupExcluderTests.swift,
+				Backup/BackupLocalStoreMessagesTests.swift,
 				"Bundle/URL+WireTests.swift",
 				Bundle/URLsTests.swift,
 				Bundle/WireEmailTests.swift,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageSectionController.swift
@@ -275,9 +275,12 @@ final class ConversationMessageSectionController: NSObject, ZMMessageObserver {
         if shouldCollapseCell() {
             return addCollapsedCell()
         }
+        guard let imageMessageData = message.imageMessageData else {
+            return []
+        }
         let conversationImageMessageCellDescription = ConversationImageMessageCellDescription(
             message: message,
-            image: message.imageMessageData!
+            image: imageMessageData
         )
         return [AnyConversationMessageCellDescription(conversationImageMessageCellDescription)]
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Conversations.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Conversations.swift
@@ -33,8 +33,8 @@ extension BackupLocalStore {
     func fetchAllConversationIDs() async throws -> Set<WireFoundation.QualifiedID> {
         let fetchRequest = ZMConversation.fetchRequest()
         fetchRequest.propertiesToFetch = ["remoteIdentifier_data", "domain"]
-        return try await context.perform { [context] in
-            let conversations = try context.fetch(fetchRequest) as! [ZMConversation]
+        return try await backupContext.perform { [backupContext] in
+            let conversations = try backupContext.fetch(fetchRequest) as! [ZMConversation]
             return Set(conversations.compactMap(\.qualifiedID).map(WireFoundation.QualifiedID.init))
         }
     }
@@ -43,8 +43,8 @@ extension BackupLocalStore {
         AsyncThrowingStream { continuation in
             Task<Void, Never> {
                 do {
-                    try await context.perform {
-                        let conversations = try context.fetch(conversationFetchRequest) as! [ZMConversation]
+                    try await backupContext.perform {
+                        let conversations = try backupContext.fetch(conversationFetchRequest) as! [ZMConversation]
                         for conversation in conversations {
                             autoreleasepool {
                                 if let backupConversation = ConversationBackupModel(conversation) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -28,15 +28,16 @@ import WireNetwork
 extension BackupLocalStore {
 
     func refreshViewContext() async throws {
-        await contextProvider.viewContext.perform { [contextProvider] in
-            contextProvider.viewContext.refreshAllObjects()
+        await contextProvider.viewContext.perform { [context = contextProvider.viewContext] in
+            context.refreshAllObjects()
         }
     }
 
     func fetchAllMessageIDs() async throws -> Set<String> {
-        let fetchRequest = ZMMessage.fetchRequest()
-        fetchRequest.propertiesToFetch = ["nonce_data"]
         return try await backupContext.perform { [backupContext] in
+            let fetchRequest = ZMMessage.fetchRequest()
+            fetchRequest.propertiesToFetch = ["nonce_data"]
+            
             let messages = try backupContext.fetch(fetchRequest) as! [ZMMessage]
             return Set(messages.compactMap(\.nonce).map(\.uuidString))
         }
@@ -262,17 +263,17 @@ extension BackupLocalStore {
         context: NSManagedObjectContext
     ) async throws -> [QualifiedID: T] {
 
-        let fetchRequest = T.fetchRequest()
-
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "%K IN %@", T.remoteIdentifierDataKey(), uuidsData),
-            NSPredicate(format: "%K IN %@", T.domainKey(), domains)
-        ])
-
-        fetchRequest.predicate = predicate
-
         do {
             return try await context.perform {
+                let fetchRequest = T.fetchRequest()
+
+                let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    NSPredicate(format: "%K IN %@", T.remoteIdentifierDataKey(), uuidsData),
+                    NSPredicate(format: "%K IN %@", T.domainKey(), domains)
+                ])
+
+                fetchRequest.predicate = predicate
+
                 let fetchResult = try context.fetch(fetchRequest) as! [T]
 
                 return [QualifiedID: T](uniqueKeysWithValues: fetchResult.compactMap {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -322,7 +322,7 @@ extension BackupLocalStore {
         do {
             insertedMessagesIDs += try await batchInsert(
                 attributes: clientMessagesAttributes,
-                entityDescription: clientMessageEntityDescription,
+                entityName: ZMClientMessage.entityName(),
                 context: backupContext
             )
         } catch {
@@ -332,7 +332,7 @@ extension BackupLocalStore {
         do {
             insertedMessagesIDs += try await batchInsert(
                 attributes: assetMessagesAttributes,
-                entityDescription: assetMessageEntityDescription,
+                entityName: ZMAssetClientMessage.entityName(),
                 context: backupContext
             )
         } catch {
@@ -358,31 +358,36 @@ extension BackupLocalStore {
 
     private func batchInsert(
         attributes: [CoreDataAttributes],
-        entityDescription: NSEntityDescription?,
+        entityName: String,
         context: NSManagedObjectContext
     ) async throws -> [NSManagedObjectID] {
         guard !attributes.isEmpty else { return [] }
 
-        guard let entityDescription else {
-            throw BatchInsertFailure.failedToGetEntityDescription
-        }
-
-        let insertRequest = NSBatchInsertRequest(
-            entity: entityDescription,
-            objects: attributes
-        )
-        insertRequest.resultType = .objectIDs
-
         do {
+
             let insertResult = try await context.perform {
-                try context.execute(insertRequest) as? NSBatchInsertResult
+                
+                guard let entity = NSEntityDescription.entity(
+                    forEntityName: entityName,
+                    in: context
+                ) else {
+                    throw BatchInsertFailure.failedToGetEntityDescription
+                }
+                
+                let insertRequest = NSBatchInsertRequest(
+                    entity: entity,
+                    objects: attributes
+                )
+                insertRequest.resultType = .objectIDs
+                
+                return try context.execute(insertRequest) as? NSBatchInsertResult
             }
 
             return insertResult?.result as? [NSManagedObjectID] ?? []
         } catch {
             throw BatchInsertFailure.failedToInsertBatch(
                 error: error,
-                entity: entityDescription.name ?? "unknown"
+                entity: entityName
             )
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -20,23 +20,24 @@ import GenericMessageProtocol
 import WireBackup
 import WireDataModel
 import WireFoundation
+import WireLogging
 import WireNetwork
+
+// MARK: - Interface
 
 extension BackupLocalStore {
 
-    private var messageFetchRequest: NSFetchRequest<any NSFetchRequestResult> {
-        let fetchRequest = ZMMessage.fetchRequest()
-        fetchRequest.fetchBatchSize = 50
-        fetchRequest.returnsObjectsAsFaults = true
-        fetchRequest.includesPropertyValues = false
-        return fetchRequest
+    func refreshViewContext() async throws {
+        await contextProvider.viewContext.perform { [contextProvider] in
+            contextProvider.viewContext.refreshAllObjects()
+        }
     }
 
     func fetchAllMessageIDs() async throws -> Set<String> {
         let fetchRequest = ZMMessage.fetchRequest()
         fetchRequest.propertiesToFetch = ["nonce_data"]
-        return try await context.perform { [context] in
-            let messages = try context.fetch(fetchRequest) as! [ZMMessage]
+        return try await backupContext.perform { [backupContext] in
+            let messages = try backupContext.fetch(fetchRequest) as! [ZMMessage]
             return Set(messages.compactMap(\.nonce).map(\.uuidString))
         }
     }
@@ -45,8 +46,8 @@ extension BackupLocalStore {
         AsyncThrowingStream { continuation in
             Task<Void, Never> {
                 do {
-                    try await context.perform {
-                        let messages = try context.fetch(messageFetchRequest) as! [ZMMessage]
+                    try await backupContext.perform {
+                        let messages = try backupContext.fetch(messageFetchRequest) as! [ZMMessage]
                         for message in messages {
                             autoreleasepool {
                                 if let backupMessage = MessageBackupModel(message) {
@@ -62,65 +63,505 @@ extension BackupLocalStore {
             }
         }
     }
+}
 
-    func addMessages(_ backupMessages: [MessageBackupModel]) async throws {
+// MARK: - Restoring messages
 
-        // Fetch conversations and last read timestamps related to backup messages
-        let conversationsAndTimestampsByID = await fetchConversationsAndTimestampByID(
-            conversationIDs: Set(backupMessages.map(\.conversationID))
+extension BackupLocalStore {
+
+    // MARK: Private types
+
+    private typealias CoreDataAttributes = [String: Any]
+    private typealias QualifiedID = WireFoundation.QualifiedID
+    private typealias ImportResult = BackupMessagesImportResult
+
+    private struct MessagesImportData {
+        let conversationDomains: Set<String>
+        let conversationIdsData: Set<Data>
+        let senderDomains: Set<String>
+        let senderIdsData: Set<Data>
+        let genericMessagesByNonce: [UUID: GenericMessage]
+        let clientMessagesAttributes: [CoreDataAttributes]
+        let assetMessagesAttributes: [CoreDataAttributes]
+    }
+
+    func addMessages(_ backupMessages: [MessageBackupModel]) async throws -> BackupMessagesImportResult {
+        logPublic("Starting import of \(backupMessages.count) messages")
+
+        // Validate and collect import data
+        let (importData, validationResult) = validateAndCollectMessagesImportData(from: backupMessages)
+        logPublic("Validation: \(validationResult.successCount) valid, \(validationResult.failureCount) invalid")
+
+        // Fetch relationships
+        let (sendersByID, conversationsByID) = try await fetchRelationships(from: importData)
+        logPublic("Fetched \(sendersByID.count) senders, \(conversationsByID.count) conversations")
+
+        // Insert messages
+        let (insertedIDs, insertionResult) = await batchInsertMessages(
+            clientMessagesAttributes: importData.clientMessagesAttributes,
+            assetMessagesAttributes: importData.assetMessagesAttributes
         )
+        logPublic("Insertion: \(insertionResult.successCount) succeeded, \(insertionResult.failureCount) failed")
 
-        // Process all messages
-        for backupMessage in backupMessages {
-            guard
-                let tuple = conversationsAndTimestampsByID[backupMessage.conversationID],
-                let nonce = UUID(transportString: backupMessage.id),
-                let genericMessage = GenericMessage(nonce: nonce, messageContent: backupMessage.content)
-            else { continue }
+        // Rehydrate messages (set relationships and generic message)
+        let rehydrationResult = try await rehydrateAllMessages(
+            insertedIDs: insertedIDs,
+            sendersByID: sendersByID,
+            conversationsByID: conversationsByID,
+            genericMessagesByNonce: importData.genericMessagesByNonce
+        )
+        logPublic("Rehydration: \(rehydrationResult.successCount) succeeded, \(rehydrationResult.failureCount) failed")
 
-            try await processor.processProtobufMessage(
-                genericMessage,
-                conversation: tuple.conversation,
-                conversationID: backupMessage.conversationID,
-                senderID: backupMessage.senderUserID,
-                senderClientID: backupMessage.senderClientID,
-                date: backupMessage.creationDate,
-                eventMessage: ""
-            )
-
+        try await backupContext.perform {
+            // Save context
+            try backupContext.save()
+            // Reset context - frees up memory for the next batch
+            backupContext.reset()
         }
 
-        // Restore `lastReadServerTimeStamp`, messages imported from backups shouldn't be marked as unread
-        await context.perform {
-            conversationsAndTimestampsByID.forEach { entry in
-                entry.value.conversation.lastReadServerTimeStamp = entry.value.date
+        logPublic("Import completed")
+
+        return ImportResult(
+            validationCount: validationResult,
+            insertionCount: insertionResult,
+            rehydrationCount: rehydrationResult
+        )
+    }
+
+    private func logPublic(_ message: String) {
+        WireLogger.backupImport.info(
+            "\(message)",
+            attributes: .safePublic
+        )
+    }
+
+    // MARK: Collecting data for import
+
+    /// Validates backup messages content and collects data needed to fetch relationships in batches
+    /// as well as messages data for batch inserts and rehydration - in a single-pass loop for performance
+    ///
+    /// - Parameter backupMessages: The backup messages from the backup file
+    /// - Returns: A tuple of message data and validation result
+
+    private func validateAndCollectMessagesImportData(
+        from backupMessages: [MessageBackupModel]
+    ) -> (importData: MessagesImportData, validationResult: ImportResult.ResultCount) {
+
+        var conversationDomains = Set<String>()
+        var conversationIdsData = Set<Data>()
+        var senderDomains = Set<String>()
+        var senderIdsData = Set<Data>()
+        var genericMessagesByNonce: [UUID: GenericMessage] = [:]
+        var clientMessagesAttributes: [CoreDataAttributes] = []
+        var assetMessagesAttributes: [CoreDataAttributes] = []
+        var invalidCount = 0
+
+        for message in backupMessages {
+
+            // Validate message
+            guard
+                let nonce = UUID(transportString: message.id),
+                let genericMessage = GenericMessage(nonce: nonce, messageContent: message.content),
+                genericMessage.validateFields()
+            else {
+                invalidCount += 1
+                continue
             }
+
+            // Build Core Data attributes and categorize messages
+            if message.content.isAsset {
+                let attributes = buildCoreDataAttributes(for: message, nonce: nonce)
+                assetMessagesAttributes.append(attributes)
+            } else if message.content.isText || message.content.isLocation {
+                let attributes = buildCoreDataAttributes(for: message, nonce: nonce)
+                clientMessagesAttributes.append(attributes)
+            } else {
+                invalidCount += 1
+                continue
+            }
+
+            // Build generic message mapping to set after insert
+            genericMessagesByNonce[nonce] = genericMessage
+
+            // Collect IDs to fetch relationship objects batches, to set after insert
+            conversationIdsData.insert(message.conversationID.id.uuidData)
+            conversationDomains.insert(message.conversationID.domain)
+            senderIdsData.insert(message.senderUserID.id.uuidData)
+            senderDomains.insert(message.senderUserID.domain)
+        }
+
+        return (
+            importData: MessagesImportData(
+                conversationDomains: conversationDomains,
+                conversationIdsData: conversationIdsData,
+                senderDomains: senderDomains,
+                senderIdsData: senderIdsData,
+                genericMessagesByNonce: genericMessagesByNonce,
+                clientMessagesAttributes: clientMessagesAttributes,
+                assetMessagesAttributes: assetMessagesAttributes
+            ),
+            validationResult: .init(
+                successCount: backupMessages.count - invalidCount,
+                failureCount: invalidCount
+            )
+        )
+    }
+
+    private func buildCoreDataAttributes(
+        for message: MessageBackupModel,
+        nonce: UUID
+    ) -> CoreDataAttributes {
+        var attributes: CoreDataAttributes = [
+            ZMMessageNonceDataKey: nonce.uuidData,
+            #keyPath(ZMOTRMessage.serverTimestamp): message.creationDate,
+            #keyPath(ZMOTRMessage.senderID): message.senderUserID.id,
+            #keyPath(ZMOTRMessage.senderDomain): message.senderUserID.domain,
+            #keyPath(ZMOTRMessage.conversationID): message.conversationID.id,
+            #keyPath(ZMOTRMessage.conversationDomain): message.conversationID.domain
+        ]
+
+        if let senderClientID = message.senderClientID {
+            attributes[#keyPath(ZMOTRMessage.senderClientID)] = senderClientID
+        }
+
+        return attributes
+    }
+
+    // MARK: Fetching relationships
+
+    /// Fetches senders and conversations needed to re-establish relationships with messages.
+    /// Parallelized in batches.
+    /// - Parameter importData: The data containing conversations and senders uuids data and domains
+    /// - Returns: a tuple of dictionaries: senders by qualified ID and conversations by qualified ID
+
+    private func fetchRelationships(
+        from importData: MessagesImportData
+    ) async throws -> (
+        sendersByID: [QualifiedID: ZMUser],
+        conversationsByID: [QualifiedID: ZMConversation]
+    ) {
+
+        async let sendersByID = fetchQualifiedObjects(
+            uuidsData: importData.senderIdsData,
+            domains: importData.senderDomains,
+            context: backupContext
+        ) as [QualifiedID: ZMUser]
+
+        async let conversationsByID = fetchQualifiedObjects(
+            uuidsData: importData.conversationIdsData,
+            domains: importData.conversationDomains,
+            context: backupContext
+        ) as [QualifiedID: ZMConversation]
+
+        return try await (sendersByID, conversationsByID)
+    }
+
+    private func fetchQualifiedObjects<T: ZMManagedObject & HasQualifiedID>(
+        uuidsData: Set<Data>,
+        domains: Set<String>,
+        context: NSManagedObjectContext
+    ) async throws -> [QualifiedID: T] {
+
+        let fetchRequest = T.fetchRequest()
+
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "%K IN %@", T.remoteIdentifierDataKey(), uuidsData),
+            NSPredicate(format: "%K IN %@", T.domainKey(), domains)
+        ])
+
+        fetchRequest.predicate = predicate
+
+        do {
+            return try await context.perform {
+                let fetchResult = try context.fetch(fetchRequest) as! [T]
+
+                return [QualifiedID: T](uniqueKeysWithValues: fetchResult.compactMap {
+                    guard let qualifiedID = $0.qualifiedID?.toFoundationQualifiedID() else { return nil }
+
+                    return (qualifiedID, $0)
+                })
+            }
+        } catch {
+            WireLogger.backupImport.warn("Failed to fetch qualified objects: \(String(describing: error))")
+            throw BackupMessagesImportFailure.failedToFetchRelationships
         }
     }
 
-    private func fetchConversationsAndTimestampByID(
-        conversationIDs: Set<WireFoundation.QualifiedID>
-    ) async -> [WireFoundation.QualifiedID: (conversation: ZMConversation, date: Date)] {
-        await context.perform {
-            var dictionary: [
-                WireFoundation.QualifiedID: (conversation: ZMConversation, date: Date)
-            ] = [:]
+    // MARK: Inserting batches
 
-            conversationIDs.forEach { conversationID in
-                if let conversation = ZMConversation.fetch(
-                    with: conversationID.id,
-                    domain: conversationID.domain,
-                    in: context
-                ) {
-                    dictionary[conversationID] = (
-                        conversation,
-                        conversation.lastReadServerTimeStamp ?? Date()
-                    )
+    /// Inserts asset messages and client messages in batches, directly into the SQLite db.
+    ///
+    /// - Parameters:
+    ///   - clientMessagesAttributes: an array of core data attributes to insert for client messages
+    ///   - assetMessagesAttributes: an array of core data attributes to insert for asset messages
+    /// - Returns: a tuple containing the inserted objects objectIDs and the insertion result count
+
+    private func batchInsertMessages(
+        clientMessagesAttributes: [CoreDataAttributes],
+        assetMessagesAttributes: [CoreDataAttributes]
+    ) async -> (insertedIDs: [NSManagedObjectID], insertionResult: ImportResult.ResultCount) {
+
+        var insertedMessagesIDs: [NSManagedObjectID] = []
+
+        do {
+            insertedMessagesIDs += try await batchInsert(
+                attributes: clientMessagesAttributes,
+                entityDescription: clientMessageEntityDescription,
+                context: backupContext
+            )
+        } catch {
+            WireLogger.backupImport.warn("Failed to insert client messages batch: \(String(describing: error))")
+        }
+
+        do {
+            insertedMessagesIDs += try await batchInsert(
+                attributes: assetMessagesAttributes,
+                entityDescription: assetMessageEntityDescription,
+                context: backupContext
+            )
+        } catch {
+            WireLogger.backupImport.warn("Failed to insert asset messages batch: \(String(describing: error))")
+        }
+
+        let toInsertCount = assetMessagesAttributes.count + clientMessagesAttributes.count
+        let insertedCount = insertedMessagesIDs.count
+
+        return (
+            insertedIDs: insertedMessagesIDs,
+            insertionResult: .init(
+                successCount: insertedCount,
+                failureCount: toInsertCount - insertedCount
+            )
+        )
+    }
+
+    private enum BatchInsertFailure: Error {
+        case failedToInsertBatch(error: Error, entity: String)
+        case failedToGetEntityDescription
+    }
+
+    private func batchInsert(
+        attributes: [CoreDataAttributes],
+        entityDescription: NSEntityDescription?,
+        context: NSManagedObjectContext
+    ) async throws -> [NSManagedObjectID] {
+        guard !attributes.isEmpty else { return [] }
+
+        guard let entityDescription else {
+            throw BatchInsertFailure.failedToGetEntityDescription
+        }
+
+        let insertRequest = NSBatchInsertRequest(
+            entity: entityDescription,
+            objects: attributes
+        )
+        insertRequest.resultType = .objectIDs
+
+        do {
+            let insertResult = try await context.perform {
+                try context.execute(insertRequest) as? NSBatchInsertResult
+            }
+
+            return insertResult?.result as? [NSManagedObjectID] ?? []
+        } catch {
+            throw BatchInsertFailure.failedToInsertBatch(
+                error: error,
+                entity: entityDescription.name ?? "unknown"
+            )
+        }
+    }
+
+    // MARK: Rehydrating messages
+
+    /// Restores messages relationships with senders and conversations,
+    /// sets the underlying generic message data, and marks the message as read.
+    ///
+    /// If any messages failed rehydration, we remove them in a single batch, to avoid zombie objects in DB.
+    ///
+    /// - Parameters:
+    ///   - insertedIDs: The objectIDs of the inserted messages to rehydrate
+    ///   - sendersByID: Dictionary of senders by qualified ID
+    ///   - conversationsByID: Dictionary of conversation by qualified ID
+    ///   - genericMessagesByNonce: Dictionary of generic messages by nonce
+    /// - Returns: The rehydration result count
+
+    private func rehydrateAllMessages(
+        insertedIDs: [NSManagedObjectID],
+        sendersByID: [QualifiedID: ZMUser],
+        conversationsByID: [QualifiedID: ZMConversation],
+        genericMessagesByNonce: [UUID: GenericMessage]
+    ) async throws -> ImportResult.ResultCount {
+        var restoredCount = 0
+        var failedCount = 0
+
+        await backupContext.perform {
+
+            var failedObjectIDs: [NSManagedObjectID] = []
+
+            // Connect relationships and set generic message data
+            for objectID in insertedIDs {
+                autoreleasepool {
+                    do {
+                        try rehydrateSingleMessage(
+                            objectID: objectID,
+                            sendersByID: sendersByID,
+                            conversationsByID: conversationsByID,
+                            genericMessagesByNonce: genericMessagesByNonce
+                        )
+                        restoredCount += 1
+                    } catch {
+                        WireLogger.backupImport.warn("failed to rehydrate message: \(String(describing: error))")
+                        failedObjectIDs.append(objectID)
+                        failedCount += 1
+                    }
                 }
             }
 
-            return dictionary
+            // Remove failed objects
+            if !failedObjectIDs.isEmpty {
+                do {
+                    let deleteRequest = NSBatchDeleteRequest(objectIDs: failedObjectIDs)
+                    try backupContext.execute(deleteRequest)
+                } catch {
+                    WireLogger.backupImport.warn("Failed to delete invalid messages \(String(describing: error))")
+                }
+            }
+        }
+
+        return .init(
+            successCount: restoredCount,
+            failureCount: failedCount
+        )
+    }
+
+    private enum RehydrationFailure: Error {
+        case failedToGetMessageFromCoreData
+        case failedToGetMessageNonce
+        case failedToGetConversation
+        case failedToGetGenericMessage
+        case failedToSetGenericMessage(error: Error)
+    }
+
+    private func rehydrateSingleMessage(
+        objectID: NSManagedObjectID,
+        sendersByID: [QualifiedID: ZMUser],
+        conversationsByID: [QualifiedID: ZMConversation],
+        genericMessagesByNonce: [UUID: GenericMessage]
+    ) throws {
+
+        guard let message = backupContext.object(with: objectID) as? ZMOTRMessage else {
+            throw RehydrationFailure.failedToGetMessageFromCoreData
+        }
+
+        // WORKAROUND: Force Core Data to refresh the object from the persistent store.
+        //
+        // Core Data has an entity-class registration issue where NSManagedObject subclasses
+        // lazily register their entity descriptions through the Objective-C runtime. On first
+        // app launch (before any entity-class mappings have been cached), NSBatchInsertRequest
+        // writes directly to SQLite, and when we retrieve objects via object(with:), Core Data
+        // returns instances with incomplete entity metadata - missing property type information,
+        // causing SIGABRT crashes like "Could not cast '__NSCFNumber' to 'NSString'".
+        //
+        // Calling refresh() forces Core Data to reload the object from the persistent store,
+        // which properly initializes the entity description and all property metadata.
+        //
+        // This same issue causes the Core Data errors seen in logs:
+        // "Failed to find a unique match for an NSEntityDescription to a managed object subclass"
+        //
+        // Works after relaunch because the entity-class mappings get cached during normal use.
+        backupContext.refresh(message, mergeChanges: false)
+
+        guard let nonce = message.nonce else {
+            throw RehydrationFailure.failedToGetMessageNonce
+        }
+
+        guard let conversation = conversation(for: message, from: conversationsByID) else {
+            throw RehydrationFailure.failedToGetConversation
+        }
+
+        guard let genericMessage = genericMessagesByNonce[nonce] else {
+            throw RehydrationFailure.failedToGetGenericMessage
+        }
+
+        do {
+            try setGenericMessage(genericMessage, for: message)
+
+            if let sender = sender(for: message, from: sendersByID) {
+                message.sender = sender
+            }
+
+            message.visibleInConversation = conversation
+            message.markAsSent()
+        } catch {
+            throw RehydrationFailure.failedToSetGenericMessage(error: error)
         }
     }
 
+    private func sender(
+        for message: ZMOTRMessage,
+        from sendersByID: [QualifiedID: ZMUser]
+    ) -> ZMUser? {
+        guard let id = message.senderID, let domain = message.senderDomain else { return nil }
+        return sendersByID[QualifiedID(id: id, domain: domain)]
+    }
+
+    private func conversation(
+        for message: ZMOTRMessage,
+        from conversationsByID: [QualifiedID: ZMConversation]
+    ) -> ZMConversation? {
+        guard let id = message.conversationID, let domain = message.conversationDomain else { return nil }
+        return conversationsByID[QualifiedID(id: id, domain: domain)]
+    }
+
+    private func setGenericMessage(_ genericMessage: GenericMessage, for message: ZMOTRMessage) throws {
+        if let message = message as? ZMClientMessage {
+
+            try message.setNewUnderlyingMessage(genericMessage)
+
+        } else if let message = message as? ZMAssetClientMessage {
+
+            try message.setNewUnderlyingMessage(genericMessage)
+
+            // We assume received assets are V3 since backend no longer supports sending V2 assets.
+            message.version = 3
+
+            assetTransferStateResolver.resolveTransferState(
+                assetMessage: message,
+                genericMessage: genericMessage,
+                context: backupContext
+            )
+        }
+    }
+
+}
+
+// MARK: - Fetching messages
+
+extension BackupLocalStore {
+
+    private var messageFetchRequest: NSFetchRequest<any NSFetchRequestResult> {
+        let fetchRequest = ZMMessage.fetchRequest()
+        fetchRequest.fetchBatchSize = 50
+        fetchRequest.returnsObjectsAsFaults = true
+        fetchRequest.includesPropertyValues = false
+        return fetchRequest
+    }
+
+}
+
+// MARK: - ZMMessage
+
+private extension ZMMessage {
+    @NSManaged var senderID: UUID?
+    @NSManaged var senderDomain: String?
+    @NSManaged var conversationID: UUID?
+    @NSManaged var conversationDomain: String?
+}
+
+// MARK: - Helpers
+
+extension WireDataModel.QualifiedID {
+    func toFoundationQualifiedID() -> WireFoundation.QualifiedID {
+        WireFoundation.QualifiedID(id: uuid, domain: domain)
+    }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -34,10 +34,10 @@ extension BackupLocalStore {
     }
 
     func fetchAllMessageIDs() async throws -> Set<String> {
-        return try await backupContext.perform { [backupContext] in
+        try await backupContext.perform { [backupContext] in
             let fetchRequest = ZMMessage.fetchRequest()
             fetchRequest.propertiesToFetch = ["nonce_data"]
-            
+
             let messages = try backupContext.fetch(fetchRequest) as! [ZMMessage]
             return Set(messages.compactMap(\.nonce).map(\.uuidString))
         }
@@ -76,12 +76,18 @@ extension BackupLocalStore {
     private typealias QualifiedID = WireFoundation.QualifiedID
     private typealias ImportResult = BackupMessagesImportResult
 
+    private struct RehydrationData {
+        let senderID: QualifiedID
+        let conversationID: QualifiedID
+        let genericMessage: GenericMessage
+    }
+
     private struct MessagesImportData {
         let conversationDomains: Set<String>
         let conversationIdsData: Set<Data>
         let senderDomains: Set<String>
         let senderIdsData: Set<Data>
-        let genericMessagesByNonce: [UUID: GenericMessage]
+        let rehydrationDataByNonce: [UUID: RehydrationData]
         let clientMessagesAttributes: [CoreDataAttributes]
         let assetMessagesAttributes: [CoreDataAttributes]
     }
@@ -109,7 +115,7 @@ extension BackupLocalStore {
             insertedIDs: insertedIDs,
             sendersByID: sendersByID,
             conversationsByID: conversationsByID,
-            genericMessagesByNonce: importData.genericMessagesByNonce
+            rehydrationDataByNonce: importData.rehydrationDataByNonce
         )
         logPublic("Rehydration: \(rehydrationResult.successCount) succeeded, \(rehydrationResult.failureCount) failed")
 
@@ -148,13 +154,22 @@ extension BackupLocalStore {
         from backupMessages: [MessageBackupModel]
     ) -> (importData: MessagesImportData, validationResult: ImportResult.ResultCount) {
 
+        // Conversations domains and UUIDs for batch fetch
         var conversationDomains = Set<String>()
         var conversationIdsData = Set<Data>()
+
+        // Senders domains and UUIDs for batch fetch
         var senderDomains = Set<String>()
         var senderIdsData = Set<Data>()
-        var genericMessagesByNonce: [UUID: GenericMessage] = [:]
+
+        // Dictionary to map messages to conversations, senders, and
+        // generic messages to restore after insert
+        var rehydrationDataByNonce: [UUID: RehydrationData] = [:]
+
+        // The attributes from messages for batch insert
         var clientMessagesAttributes: [CoreDataAttributes] = []
         var assetMessagesAttributes: [CoreDataAttributes] = []
+
         var invalidCount = 0
 
         for message in backupMessages {
@@ -181,8 +196,12 @@ extension BackupLocalStore {
                 continue
             }
 
-            // Build generic message mapping to set after insert
-            genericMessagesByNonce[nonce] = genericMessage
+            // Build mapping to set generic messages, senders and conversations after insert
+            rehydrationDataByNonce[nonce] = RehydrationData(
+                senderID: message.senderUserID,
+                conversationID: message.conversationID,
+                genericMessage: genericMessage
+            )
 
             // Collect IDs to fetch relationship objects batches, to set after insert
             conversationIdsData.insert(message.conversationID.id.uuidData)
@@ -197,7 +216,7 @@ extension BackupLocalStore {
                 conversationIdsData: conversationIdsData,
                 senderDomains: senderDomains,
                 senderIdsData: senderIdsData,
-                genericMessagesByNonce: genericMessagesByNonce,
+                rehydrationDataByNonce: rehydrationDataByNonce,
                 clientMessagesAttributes: clientMessagesAttributes,
                 assetMessagesAttributes: assetMessagesAttributes
             ),
@@ -214,11 +233,7 @@ extension BackupLocalStore {
     ) -> CoreDataAttributes {
         var attributes: CoreDataAttributes = [
             ZMMessageNonceDataKey: nonce.uuidData,
-            #keyPath(ZMOTRMessage.serverTimestamp): message.creationDate,
-            #keyPath(ZMOTRMessage.senderID): message.senderUserID.id,
-            #keyPath(ZMOTRMessage.senderDomain): message.senderUserID.domain,
-            #keyPath(ZMOTRMessage.conversationID): message.conversationID.id,
-            #keyPath(ZMOTRMessage.conversationDomain): message.conversationID.domain
+            #keyPath(ZMOTRMessage.serverTimestamp): message.creationDate
         ]
 
         if let senderClientID = message.senderClientID {
@@ -390,7 +405,7 @@ extension BackupLocalStore {
         insertedIDs: [NSManagedObjectID],
         sendersByID: [QualifiedID: ZMUser],
         conversationsByID: [QualifiedID: ZMConversation],
-        genericMessagesByNonce: [UUID: GenericMessage]
+        rehydrationDataByNonce: [UUID: RehydrationData],
     ) async throws -> ImportResult.ResultCount {
         var restoredCount = 0
         var failedCount = 0
@@ -407,7 +422,7 @@ extension BackupLocalStore {
                             objectID: objectID,
                             sendersByID: sendersByID,
                             conversationsByID: conversationsByID,
-                            genericMessagesByNonce: genericMessagesByNonce
+                            rehydrationDataByNonce: rehydrationDataByNonce
                         )
                         restoredCount += 1
                     } catch {
@@ -438,8 +453,8 @@ extension BackupLocalStore {
     private enum RehydrationFailure: Error {
         case failedToGetMessageFromCoreData
         case failedToGetMessageNonce
+        case failedToGetRehydrationData
         case failedToGetConversation
-        case failedToGetGenericMessage
         case failedToSetGenericMessage(error: Error)
     }
 
@@ -447,7 +462,7 @@ extension BackupLocalStore {
         objectID: NSManagedObjectID,
         sendersByID: [QualifiedID: ZMUser],
         conversationsByID: [QualifiedID: ZMConversation],
-        genericMessagesByNonce: [UUID: GenericMessage]
+        rehydrationDataByNonce: [UUID: RehydrationData]
     ) throws {
 
         guard let message = backupContext.object(with: objectID) as? ZMOTRMessage else {
@@ -476,18 +491,18 @@ extension BackupLocalStore {
             throw RehydrationFailure.failedToGetMessageNonce
         }
 
-        guard let conversation = conversation(for: message, from: conversationsByID) else {
+        guard let rehydrationData = rehydrationDataByNonce[nonce] else {
+            throw RehydrationFailure.failedToGetRehydrationData
+        }
+
+        guard let conversation = conversationsByID[rehydrationData.conversationID] else {
             throw RehydrationFailure.failedToGetConversation
         }
 
-        guard let genericMessage = genericMessagesByNonce[nonce] else {
-            throw RehydrationFailure.failedToGetGenericMessage
-        }
-
         do {
-            try setGenericMessage(genericMessage, for: message)
+            try setGenericMessage(rehydrationData.genericMessage, for: message)
 
-            if let sender = sender(for: message, from: sendersByID) {
+            if let sender = sendersByID[rehydrationData.senderID] {
                 message.sender = sender
             }
 
@@ -496,22 +511,6 @@ extension BackupLocalStore {
         } catch {
             throw RehydrationFailure.failedToSetGenericMessage(error: error)
         }
-    }
-
-    private func sender(
-        for message: ZMOTRMessage,
-        from sendersByID: [QualifiedID: ZMUser]
-    ) -> ZMUser? {
-        guard let id = message.senderID, let domain = message.senderDomain else { return nil }
-        return sendersByID[QualifiedID(id: id, domain: domain)]
-    }
-
-    private func conversation(
-        for message: ZMOTRMessage,
-        from conversationsByID: [QualifiedID: ZMConversation]
-    ) -> ZMConversation? {
-        guard let id = message.conversationID, let domain = message.conversationDomain else { return nil }
-        return conversationsByID[QualifiedID(id: id, domain: domain)]
     }
 
     private func setGenericMessage(_ genericMessage: GenericMessage, for message: ZMOTRMessage) throws {
@@ -548,15 +547,6 @@ extension BackupLocalStore {
         return fetchRequest
     }
 
-}
-
-// MARK: - ZMMessage
-
-private extension ZMMessage {
-    @NSManaged var senderID: UUID?
-    @NSManaged var senderDomain: String?
-    @NSManaged var conversationID: UUID?
-    @NSManaged var conversationDomain: String?
 }
 
 // MARK: - Helpers

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -366,20 +366,20 @@ extension BackupLocalStore {
         do {
 
             let insertResult = try await context.perform {
-                
+
                 guard let entity = NSEntityDescription.entity(
                     forEntityName: entityName,
                     in: context
                 ) else {
                     throw BatchInsertFailure.failedToGetEntityDescription
                 }
-                
+
                 let insertRequest = NSBatchInsertRequest(
                     entity: entity,
                     objects: attributes
                 )
                 insertRequest.resultType = .objectIDs
-                
+
                 return try context.execute(insertRequest) as? NSBatchInsertResult
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Users.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Users.swift
@@ -33,8 +33,8 @@ extension BackupLocalStore {
     func fetchAllUserIDs() async throws -> Set<WireFoundation.QualifiedID> {
         let fetchRequest = ZMUser.fetchRequest()
         fetchRequest.propertiesToFetch = ["remoteIdentifier_data", "domain"]
-        return try await context.perform { [context] in
-            let users = try context.fetch(fetchRequest) as! [ZMUser]
+        return try await backupContext.perform { [backupContext] in
+            let users = try backupContext.fetch(fetchRequest) as! [ZMUser]
             return Set(users.compactMap(\.qualifiedID).map(WireFoundation.QualifiedID.init))
         }
     }
@@ -43,8 +43,8 @@ extension BackupLocalStore {
         AsyncThrowingStream { continuation in
             Task<Void, Never> {
                 do {
-                    try await context.perform {
-                        let users = try context.fetch(userFetchRequest) as! [ZMUser]
+                    try await backupContext.perform {
+                        let users = try backupContext.fetch(userFetchRequest) as! [ZMUser]
                         for user in users {
                             autoreleasepool {
                                 if let backupUser = UserBackupModel(user) {
@@ -62,11 +62,14 @@ extension BackupLocalStore {
     }
 
     func addUser(_ backupUser: UserBackupModel) async throws {
-        await context.perform { [context] in
+        // Adding users needs to be done on the sync context. See more in `ZMUser.fetchOrCreate`
+        let syncContext = contextProvider.syncContext
+
+        await syncContext.perform { [syncContext] in
             let user = ZMUser.fetchOrCreate(
                 with: backupUser.qualifiedID.id,
                 domain: backupUser.qualifiedID.domain,
-                in: context
+                in: syncContext
             )
             if user.handle?.isEmpty != false {
                 user.handle = backupUser.handle

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore.swift
@@ -27,8 +27,6 @@ struct BackupLocalStore: BackupLocalStoreProtocol, @unchecked Sendable {
     let backupContext: NSManagedObjectContext
     let contextProvider: ContextProvider
     let assetTransferStateResolver: AssetTransferStateResolverProtocol
-    var clientMessageEntityDescription: NSEntityDescription?
-    var assetMessageEntityDescription: NSEntityDescription?
 
     init(
         contextProvider: ContextProvider,
@@ -39,15 +37,6 @@ struct BackupLocalStore: BackupLocalStoreProtocol, @unchecked Sendable {
         self.backupContext = contextProvider.newBackgroundContext()
 
         setupBackupContext()
-
-        self.clientMessageEntityDescription = NSEntityDescription.entity(
-            forEntityName: ZMClientMessage.entityName(),
-            in: backupContext
-        )
-        self.assetMessageEntityDescription = NSEntityDescription.entity(
-            forEntityName: ZMAssetClientMessage.entityName(),
-            in: backupContext
-        )
     }
 
     private func setupBackupContext() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore.swift
@@ -24,14 +24,49 @@ import WireDomain
 struct BackupLocalStore: BackupLocalStoreProtocol, @unchecked Sendable {
 
     /// The context to call `perform(schedule:_:)` on if needed.
-    let context: NSManagedObjectContext
-    let processor: any ConversationProtobufMessageProcessorProtocol
+    let backupContext: NSManagedObjectContext
+    let contextProvider: ContextProvider
+    let assetTransferStateResolver: AssetTransferStateResolverProtocol
+    var clientMessageEntityDescription: NSEntityDescription?
+    var assetMessageEntityDescription: NSEntityDescription?
+
+    init(
+        contextProvider: ContextProvider,
+        assetTransferStateResolver: AssetTransferStateResolverProtocol = AssetTransferStateResolver()
+    ) {
+        self.contextProvider = contextProvider
+        self.assetTransferStateResolver = assetTransferStateResolver
+        self.backupContext = contextProvider.newBackgroundContext()
+
+        setupBackupContext()
+        
+        clientMessageEntityDescription = NSEntityDescription.entity(
+            forEntityName: ZMClientMessage.entityName(),
+            in: backupContext
+        )
+        assetMessageEntityDescription = NSEntityDescription.entity(
+            forEntityName: ZMAssetClientMessage.entityName(),
+            in: backupContext
+        )
+    }
+
+    private func setupBackupContext() {
+
+        // Ensures imported data overwrites existing values without validation conflicts.
+        backupContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+
+        // Prevents automatic UI context merges that could slow down the import.
+        backupContext.automaticallyMergesChangesFromParent = false
+
+        // Turns off undo manager (Core Data otherwise tracks diffs, which is expensive).
+        backupContext.undoManager = nil
+    }
 
     func countModels() async throws -> (userCount: Int, conversationCount: Int, messageCount: Int) {
-        try await context.perform { [context] in
-            let userCount = try context.count(for: ZMUser.fetchRequest())
-            let conversationCount = try context.count(for: ZMConversation.fetchRequest())
-            let messageCount = try context.count(for: ZMMessage.fetchRequest())
+        try await backupContext.perform { [backupContext] in
+            let userCount = try backupContext.count(for: ZMUser.fetchRequest())
+            let conversationCount = try backupContext.count(for: ZMConversation.fetchRequest())
+            let messageCount = try backupContext.count(for: ZMMessage.fetchRequest())
             return (userCount, conversationCount, messageCount)
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore.swift
@@ -39,12 +39,12 @@ struct BackupLocalStore: BackupLocalStoreProtocol, @unchecked Sendable {
         self.backupContext = contextProvider.newBackgroundContext()
 
         setupBackupContext()
-        
-        clientMessageEntityDescription = NSEntityDescription.entity(
+
+        self.clientMessageEntityDescription = NSEntityDescription.entity(
             forEntityName: ZMClientMessage.entityName(),
             in: backupContext
         )
-        assetMessageEntityDescription = NSEntityDescription.entity(
+        self.assetMessageEntityDescription = NSEntityDescription.entity(
             forEntityName: ZMAssetClientMessage.entityName(),
             in: backupContext
         )

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory+Account.swift
@@ -391,16 +391,8 @@ extension SettingsCellDescriptorFactory {
         // force-unwrapping should be fine, since we should have a session manager and an active user session here
         let sessionManager = SessionManager.shared!
         let selfUser = ZMUser.selfUser()!
-        let context = selfUser.managedObjectContext!.performAndWait {
-            selfUser.managedObjectContext!.zm_sync!
-        }
         let backupLocalStore = BackupLocalStore(
-            context: context,
-            processor: ConversationProtobufMessageProcessor(
-                context: context,
-                localDomain: localDomain,
-                isFederationEnabled: isFederationEnabled
-            )
+            contextProvider: sessionManager.activeUserSession!.contextProvider
         )
         let userSession = sessionManager.activeUserSession!
         let importBackupUseCaseFactory = ImportBackupUseCaseFactory { url in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21300" title="WPB-21300" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21300</a>  [iOS] Refactor backup import to insert messages in batches
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR is an effort to improve the performance of importing messages from a backup. We now process messages in batches instead of processing messages sequentially by reusing single-message processing logic (for messages received in notifications).

Kalium's cross-platform backup API provides us with pagers for each entity saved in the backup file. Each page is a batch of 1000 entities. We use this to process messages in batches.

Page processing is structured in several steps:
1. Parse the backup messages models to collect the relevant data in order to restore messages. (ids and domains to fetch conversations and users, underlying generic messages for each message, message attributes to insert in Core Data..)
2. Fetch batches of users and conversations to establish relationships with messages
3. Insert batches of messages (one batch of client messages - text, location - and one batch of asset messages)
4. "Rehydrate" messages. i.e: establish relationships and set the generic message data + mark message as read
5. Save and reset the context 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.


