### PR TITLE
fix: broken input bar - WPB-20837

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -1127,7 +1127,7 @@ extension ConversationInputBarViewController: UIGestureRecognizerDelegate {
     }
 
     private func addAttachmentsCarousel() {
-        guard useWireCells() else { return }
+        guard conversation.isCellsEnabled else { return }
 
         let carouselViewController = UIHostingController(
             rootView: AttachmentsCarousel(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20837" title="WPB-20837" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20837</a>  [iOS] Input bar layout broken with wire cells enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes a broken input bar (see ticket for screenshot) that occurs when:

- The wire cells developer flag is **disabled**
- The conversation is a wire cells enabled **conversation**

The issue happens because currently we add a view for attachments if the conversation is wire cells enabled but we only configure the layout constraints on the view if it is both wire cells enabled conversation and the developer flag is enabled.

The fix is to remove the check for the developer flag when configuring the attachments view. 

This is a minimum fix to not slow release of 4.8. I will do a better fix for 4.9.

### Testing

- Disable wire cells developer flag
- Navigate to wire cells enabled conversation
- Check everything looks fine
- Navigate to a non wire cells enabled conversation
- Check everything looks fine.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
