### PR TITLE
fix: map 401 error to an empty state - WPB-20959

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/NodesAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/NodesAPI.swift
@@ -120,8 +120,15 @@ package final actor NodesAPI: NodesAPIProtocol, WireCellsNodesRepositoryProtocol
     package func getNodes(
         _ request: WireCellsGetNodesRequest
     ) async throws -> (nodes: [WireCellsNode], nextOffset: Int?) {
-        let (nodes, nextOffset) = try await restAPI.getNodes(request)
-        return (nodes: nodes.map { $0.toDomainModel() }, nextOffset: nextOffset)
+        do {
+            let (nodes, nextOffset) = try await restAPI.getNodes(request)
+            return (nodes: nodes.map { $0.toDomainModel() }, nextOffset: nextOffset)
+            // no cells conversations exist on the backend
+        } catch let error as CellsSDK.ErrorResponse where error.httpStatusCode == 401 {
+            return (nodes: [], nextOffset: nil)
+        } catch {
+            throw error
+        }
     }
 
     package func createPublicLink(nodeID: UUID, fileName: String) async throws -> WireCellsPublicLink {

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/NodesAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/NodesAPI.swift
@@ -123,7 +123,8 @@ package final actor NodesAPI: NodesAPIProtocol, WireCellsNodesRepositoryProtocol
         do {
             let (nodes, nextOffset) = try await restAPI.getNodes(request)
             return (nodes: nodes.map { $0.toDomainModel() }, nextOffset: nextOffset)
-            // no cells conversations exist on the backend
+            // user not yet created, wire users are "lazily" sync to pydio users the first time they are part of a cells
+            // conversation
         } catch let error as CellsSDK.ErrorResponse where error.httpStatusCode == 401 {
             return (nodes: [], nextOffset: nil)
         } catch {

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -82,13 +82,13 @@ final class RestAPI: Sendable {
             let nextOffset = collection.pagination?.nextOffset
 
             return (nodes: nodes, nextOffset: nextOffset)
-        } catch let error as CellsSDK.ErrorResponse {
-            switch error {
+        } catch let sdkError as CellsSDK.ErrorResponse {
+            switch sdkError {
             case let .error(_, _, _, error):
                 if let urlError = error as? URLError, urlError.code == .cancelled {
                     throw CancellationError()
                 } else {
-                    throw error
+                    throw sdkError
                 }
             }
         } catch {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20959" title="WPB-20959" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20959</a>  [iOS] Empty state screen for all files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When no cells conversations exist on the BE, the API throws a 401 error and show an "error" state screen instead of an "empty" state screen.
This PR fixes that by catching the 401 and mapping it an empty state.

### Testing

- have a new user account with no conversations at all
- navigate to files tabs
- before: show error screen with the reload button
- now: show empty screen as expected

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
