### PR TITLE
chore: update AVS version - WPB-20924

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.0.40/avs.xcframework.zip",
-            checksum: "531fd0afa5da7827afefce4149b332077d45a2985405d045bcb464d366f9927c"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.22/avs.xcframework.zip",
+            checksum: "fb1b1f6c020ccb56e3cbbd0ec46065572caf287fcf307f4fcd5653eb4acd63b0"
         )
     ]
 )

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -516,7 +516,10 @@ extension WireCallCenterV3 {
                     let snapshot = callSnapshots[conversationId],
                     let groupIDs = snapshot.groupIDs
                 else {
-                    Self.logger.error("Cannot get group IDs for MLS conference", attributes: [.conversationId: conversationId.safeForLogging)
+                    Self.logger.error(
+                        "Cannot get group IDs for MLS conference",
+                        attributes: [.conversationId: conversationId.safeForLoggingDescription]
+                    )
                     return
                 }
 
@@ -579,13 +582,19 @@ extension WireCallCenterV3 {
                     }
 
                     guard let json = AVSClientList(clients: clients).jsonString(encoder) else {
-                        Self.logger.error("Could not encode MLS client list to JSON")
+                        Self.logger.error(
+                            "Could not encode MLS client list to JSON",
+                            attributes: [.mlsGroupID: parentGroupID.safeForLoggingDescription]
+                        )
                         return
                     }
 
                     completion(json)
                 } catch {
-                    Self.logger.error("Failed to generate conference info: \(String(reflecting: error))")
+                    Self.logger.error(
+                        "Failed to generate conference info: \(String(reflecting: error))",
+                        attributes: [.conversationId: conversationId.safeForLoggingDescription]
+                    )
                 }
             }
         }
@@ -604,7 +613,10 @@ extension WireCallCenterV3 {
 
         transport?.requestClientsList(conversationId: conversationId) { clients in
             guard let json = AVSClientList(clients: clients).jsonString(encoder) else {
-                Self.logger.error("Could not encode client list to JSON")
+                Self.logger.error(
+                    "Could not encode client list to JSON",
+                    attributes: [.conversationId: conversationId.safeForLoggingDescription]
+                )
                 return
             }
 
@@ -729,4 +741,12 @@ extension WireCallCenterV3 {
             }
         }
     }
+}
+
+extension AVSIdentifier: @retroactive SafeForLoggingStringConvertible {
+
+    public var safeForLoggingDescription: String {
+        "\(identifier.safeForLoggingDescription) - \(String(describing: domain?.readableHash))"
+    }
+
 }

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -507,28 +507,108 @@ extension WireCallCenterV3 {
         conversationId: AVSIdentifier,
         completion: @escaping (_ clients: String) -> Void
     ) {
-        handleEventInContext("request-clients") { [weak self, encoder] _ in
+        handleEventInContext("request-clients") { [weak self, encoder] context in
+            guard let self else { return }
+
+            // Check if this is an MLS conference call
+            if conversationType(from: conversationId) == .mlsConference {
+                guard
+                    let snapshot = callSnapshots[conversationId],
+                    let groupIDs = snapshot.groupIDs
+                else {
+                    Self.logger.error("Cannot get group IDs for MLS conference")
+                    return
+                }
+
+                handleMLSConferenceClientsRequest(
+                    conversationId: conversationId,
+                    parentGroupID: groupIDs.parent,
+                    subconversationGroupID: groupIDs.subconversation,
+                    context: context,
+                    encoder: encoder,
+                    completion: completion
+                )
+            } else {
+                handleNonMLSConferenceClientsRequest(
+                    conversationId: conversationId,
+                    encoder: encoder,
+                    completion: completion
+                )
+            }
+        }
+    }
+
+    private func handleMLSConferenceClientsRequest(
+        conversationId: AVSIdentifier,
+        parentGroupID: MLSGroupID,
+        subconversationGroupID: MLSGroupID,
+        context: NSManagedObjectContext,
+        encoder: JSONEncoder,
+        completion: @escaping (_ clients: String) -> Void
+    ) {
+        guard let syncContext = context.zm_sync else {
+            Self.logger.error("Cannot get sync context for MLS conference")
+            return
+        }
+
+        syncContext.perform { [weak self] in
             guard
                 let self,
-                conversationType(from: conversationId) != .mlsConference
+                let mlsService = syncContext.mlsService
             else {
                 return
             }
 
-            // This handler is called once per call, but the participants may be
-            // added or removed from the conversation during this time. Therefore
-            // we store the completion so that it can be re-invoked with an updated
-            // client list.
-            clientsRequestCompletionsByConversationId[conversationId] = completion
+            Task {
+                do {
+                    let conferenceInfo = try await mlsService.generateConferenceInfo(
+                        parentGroupID: parentGroupID,
+                        subconversationGroupID: subconversationGroupID
+                    )
 
-            transport?.requestClientsList(conversationId: conversationId) { clients in
-                guard let json = AVSClientList(clients: clients).jsonString(encoder) else {
-                    Self.logger.error("Could not encode client list to JSON")
-                    return
+                    self.avsWrapper.setMLSConferenceInfo(
+                        conversationId: conversationId,
+                        info: conferenceInfo
+                    )
+
+                    let clients = conferenceInfo.members.compactMap {
+                        AVSClient(
+                            member: $0,
+                            isFederationEnabled: self.isFederationEnabled
+                        )
+                    }
+
+                    guard let json = AVSClientList(clients: clients).jsonString(encoder) else {
+                        Self.logger.error("Could not encode MLS client list to JSON")
+                        return
+                    }
+
+                    completion(json)
+                } catch {
+                    Self.logger.error("Failed to generate conference info: \(String(reflecting: error))")
                 }
-
-                completion(json)
             }
+        }
+    }
+
+    private func handleNonMLSConferenceClientsRequest(
+        conversationId: AVSIdentifier,
+        encoder: JSONEncoder,
+        completion: @escaping (_ clients: String) -> Void
+    ) {
+        // This handler is called once per call, but the participants may be
+        // added or removed from the conversation during this time. Therefore
+        // we store the completion so that it can be re-invoked with an updated
+        // client list.
+        clientsRequestCompletionsByConversationId[conversationId] = completion
+
+        transport?.requestClientsList(conversationId: conversationId) { clients in
+            guard let json = AVSClientList(clients: clients).jsonString(encoder) else {
+                Self.logger.error("Could not encode client list to JSON")
+                return
+            }
+
+            completion(json)
         }
     }
 

--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3+Events.swift
@@ -516,7 +516,7 @@ extension WireCallCenterV3 {
                     let snapshot = callSnapshots[conversationId],
                     let groupIDs = snapshot.groupIDs
                 else {
-                    Self.logger.error("Cannot get group IDs for MLS conference")
+                    Self.logger.error("Cannot get group IDs for MLS conference", attributes: [.conversationId: conversationId.safeForLogging)
                     return
                 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20924" title="WPB-20924" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20924</a>  [iOS]  Dropping and joining a video enabled group call, doesn't show other participant video 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Dropping and joining a video enabled group call, doesn't show other participant video.

### Solution

This issue was resolved in two steps:
- in the new AVS version
- and as part of this PR, which I will explain below.

The issue being addressed on the client side occurs when a user wants to join a call using the "Start Call" button (without waiting for the "Join" button to appear). 
When restarting a call by clicking "Start call" (instead of "Join"), we set `epoch_info` for the initial call hash. However, AVS detects an ongoing call and switches to it (which has a different hash). During this switch, AVS clears all keys and calls `request_clients_handler `expecting new `epoch_info`, but it never arrives for the new hash. This causes leaving the joined call without the keys needed to decrypt media.

To fix this issue for `MLSConference`, we call `wcall_set_epoch_info`, which is part of `setMLSConferenceInfo` on the `wcall_set_req_clients_handler`.
 
### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
