### PR TITLE
fix: sketch and file-attachment leaving blank area iOS 26 - WPB-20252

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+FilesPopover.swift
@@ -154,7 +154,6 @@ extension ConversationInputBarViewController {
 
     private func showFileUploadActionSheet(_ sender: IconButton) {
         mode = ConversationInputBarViewControllerMode.textInput
-        inputBar.textView.resignFirstResponder()
 
         let controller = createFileUploadActionSheet(sender: sender)
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -1026,7 +1026,6 @@ extension ConversationInputBarViewController: UIImagePickerControllerDelegate {
     }
 
     private func sketch() {
-        inputBar.textView.resignFirstResponder()
         let viewController = CanvasViewController()
         viewController.delegate = self
         viewController.setupNavigationBarTitle(conversation.displayNameWithFallback)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20252" title="WPB-20252" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20252</a>  [iOS][iOS26] White space shows in place of keyboard on opening gif/camera/markers 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This is an addition to https://github.com/wireapp/wire-ios/pull/3768.

In addition to the gif button, there are also other buttons which have the same problem.

I fixed the buttons for sketch and file-attachment in the same way, by removing the unfocussing (keyboard dismissal).

### Testing

On iOS 26, open a conversation and tap into the text message input field so that the virtual keyboard appears.
Then tap on the sketch button (in a second test, the file-attachment button).
The keyboard should disappear automatically.
Dismiss/cancel the sketch/attachment picker.
There should be no blank space where the keyboard was.
Instead, the keyboard should be visible again.