### PR TITLE
revert: disable critical flows temporarily - WPB-21303

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -135,10 +135,10 @@ jobs:
         run: |
           bundle exec fastlane generate_env
 
-      # - name: "Test new critical flows"
-      #   if: ${{ inputs.run_critical_flows }}
-      #   run: |
-      #     bundle exec fastlane run_uitests
+      - name: "Test new critical flows"
+        if: ${{ inputs.run_critical_flows }}
+        run: |
+          bundle exec fastlane run_uitests
 
       - name: "Test all selected frameworks"
         if: ${{ inputs.test_dependencies || inputs.all }}

--- a/wire-ios-request-strategy/Sources/Payloads/Payload.swift
+++ b/wire-ios-request-strategy/Sources/Payloads/Payload.swift
@@ -157,7 +157,7 @@ public enum Payload {
         let scimExternalID: String?
     }
 
-    enum UserType: Codable {
+    enum UserType: String, Codable {
         case regular
         case app
         case bot

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -33,7 +33,7 @@ class WireUITestCase: XCTestCase {
         let launchArguments = [
             "-resetData",
             "--useEnvStaging",
-            "--preferred-api-version=8"
+            "--preferred-api-version=12"
         ]
 
         app = XCUIApplication()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21303" title="WPB-21303" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21303</a>  [iOS] maintenance of critical flows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
This reverts commit f26eb8fcc9e9f3e5f2ea5aa5e5a414fa18922d2e.

<!--do not remove the jira markers to link tickets automatically -->


### Issue

As stars are up now, this reverts disabling the critical flows from running. See #3793 

### Testing
N/A

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
