### PR TITLE
fix: crash when uploading link preview upload - WPB-20714

### DIFF
--- a/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactory.swift
+++ b/wire-ios-request-strategy/Sources/Helpers/AssetRequestFactory.swift
@@ -47,13 +47,18 @@ public final class AssetRequestFactory: NSObject {
         public init(
             conversationID: QualifiedID,
             fileName: String,
-            mimeType: String
+            mimeType: String?
         ) {
             self.conversationID = conversationID
             self.fileName = fileName
-            self.mimeType = mimeType
-        }
 
+            if let mimeType, !mimeType.isEmpty {
+                self.mimeType = mimeType
+            } else {
+                // Fallback to "raw bytes".
+                self.mimeType = "application/octet-stream"
+            }
+        }
     }
 
     private enum Constant {

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
@@ -184,10 +184,7 @@ extension LinkPreviewAssetUploadRequestStrategy: ZMUpstreamTranscoder {
 
         var extraMetaData: AssetRequestFactory.AssetAuditLogMetaData?
         if shouldUploadExtraMetaData {
-            guard
-                let original = managedObjectContext.zm_fileAssetCache.originalImageData(for: message),
-                let domain = conversation.domain ?? localDomain
-            else {
+            guard let domain = conversation.domain ?? localDomain else {
                 WireLogger.assets.warn(
                     "should include extra metadata for link preview but not able to",
                     attributes: logAttributes

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/Link Preview/LinkPreviewAssetUploadRequestStrategy.swift
@@ -206,7 +206,7 @@ extension LinkPreviewAssetUploadRequestStrategy: ZMUpstreamTranscoder {
             extraMetaData = .init(
                 conversationID: conversationID,
                 fileName: image.name,
-                mimeType: image.utType?.preferredMIMEType ?? ""
+                mimeType: image.utType?.preferredMIMEType
             )
         }
 

--- a/wire-ios-sync-engine/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/Strategies/UserImageAssetUpdateStrategy.swift
@@ -281,7 +281,7 @@ public final class UserImageAssetUpdateStrategy: AbstractRequestStrategy, ZMCont
                 extraMetaData = .init(
                     conversationID: QualifiedID(uuid: nullID, domain: localDomain),
                     fileName: image.name,
-                    mimeType: image.utType?.preferredMIMEType ?? ""
+                    mimeType: image.utType?.preferredMIMEType
                 )
             }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20714" title="WPB-20714" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-20714</a>  [iOS] Upload asset with additional metadata
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
If asset audit log is enabled, when I send a link in a conversation that generates a preview, then the app crashes and will keep crashing each time the app is relaunched.

The reason is that when trying to upload the link preview we always generate a nil request because we can't find the original image data and then later hit an assertion failure.

It appears that there is no need to get the original asset data, so the fix is to simply remove the guard. This fixes the crash, but the upload still fails because the mime type is empty And the backend rejects it. To resolve this, we provide a default `"application/octet-stream"` mime type ("consider this raw bytes") which the backend accepts and we can upload the link preview. 

### Testing
1. Log in to anta
2. send a link that generates a link preview
3. assert that the link preview is successfully sent and received on the other side (with image)

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
