### PR TITLE
feat: make syncV2 available for apiVersion 7 - WPB-21456

### DIFF
--- a/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
+++ b/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
@@ -77,6 +77,6 @@ public enum APIVersion: UInt, CaseIterable, Comparable, Sendable {
 
 // swiftlint:enable identifier_name
 
-extension APIVersion {
-    public static let minimumSyncV2CompatibleVersion: APIVersion = .v7
+public extension APIVersion {
+    static let minimumSyncV2CompatibleVersion: APIVersion = .v7
 }

--- a/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
+++ b/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
@@ -78,5 +78,5 @@ public enum APIVersion: UInt, CaseIterable, Comparable, Sendable {
 // swiftlint:enable identifier_name
 
 extension APIVersion {
-    public static let minimumLegacySyncVersion: APIVersion = .v7
+    public static let minimumSyncV2CompatibleVersion: APIVersion = .v7
 }

--- a/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
+++ b/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
@@ -76,3 +76,7 @@ public enum APIVersion: UInt, CaseIterable, Comparable, Sendable {
 }
 
 // swiftlint:enable identifier_name
+
+extension APIVersion {
+    public static let minimumLegacySyncVersion: APIVersion = .v7
+}

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -249,7 +249,7 @@ public struct SharingSessionLoader {
 
     // TODO: [WPB-17732] de-duplicate when implementing NSE
     private func shouldEnableSyncV2(metadata: ResolvedBackendMetadata) -> Bool {
-        let isAvailable = metadata.apiVersion >= .minimumLegacySyncVersion
+        let isAvailable = metadata.apiVersion >= .minimumSyncV2CompatibleVersion
         let isAlreadyEnabled = journal[.isSyncV2Enabled]
         return isAvailable && !isAlreadyEnabled
     }

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -249,7 +249,7 @@ public struct SharingSessionLoader {
 
     // TODO: [WPB-17732] de-duplicate when implementing NSE
     private func shouldEnableSyncV2(metadata: ResolvedBackendMetadata) -> Bool {
-        let isAvailable = metadata.apiVersion >= .v8
+        let isAvailable = metadata.apiVersion >= .minimumLegacySyncVersion
         let isAlreadyEnabled = journal[.isSyncV2Enabled]
         return isAvailable && !isAlreadyEnabled
     }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1037,7 +1037,7 @@ public final class SessionManager: NSObject, SessionManagerType {
         if let session = backgroundUserSessions[account.userIdentifier] {
             WireLogger.sessionManager.debug("Session for \(account) is already loaded")
             return session
-        } else if DeveloperFlag.multibackend.isOn {
+        } else {
             do {
                 let loader = try UserSessionLoader(
                     account: account,
@@ -1125,8 +1125,6 @@ public final class SessionManager: NSObject, SessionManagerType {
                 )
                 return nil
             }
-        } else {
-            return await setupUserSession(account: account)
         }
     }
 
@@ -1156,132 +1154,6 @@ public final class SessionManager: NSObject, SessionManagerType {
                 activeUserSession = nil
                 completion()
             }
-        }
-    }
-
-    @MainActor
-    private func setupUserSession(account: Account) async -> ZMUserSession? {
-        let coreDataStack = CoreDataStack(
-            account: account,
-            applicationContainer: sharedContainerURL,
-            dispatchGroup: dispatchGroup,
-            localDomain: BackendInfo.domain,
-            isFederationEnabled: BackendInfo.isFederationEnabled
-        )
-
-        if coreDataStack.needsMigration {
-            await withCheckedContinuation { continuation in
-                guard let delegate else {
-                    continuation.resume()
-                    return
-                }
-                delegate.sessionManagerWillMigrateAccount {
-                    continuation.resume()
-                }
-            }
-        }
-
-        do {
-            try await coreDataStack.load()
-        } catch {
-            delegate?.sessionManagerDidFailToLoadDatabase(error: error)
-            return nil
-        }
-
-        let journal = Journal(
-            userID: account.userIdentifier,
-            storage: sharedUserDefaults
-        )
-
-        if shouldEnableSyncV2(journal: journal) {
-            await enableSyncV2(
-                journal: journal,
-                coreDataStack: coreDataStack
-            )
-        }
-
-        let userSession = startBackgroundSession(
-            for: account,
-            with: coreDataStack,
-            journal: journal,
-            logFilesProvider: logFilesProvider
-        )
-
-        let migrationService = userSession.makeAppVersionMigrationService()
-        if migrationService.isMigrationNeeded {
-            await delegate?.sessionManagerWillMigrateAccount()
-
-            do {
-                try await migrationService.performAppMigrations()
-            } catch {
-                WireLogger.session.error(
-                    "Failed to perform app version migrations: \(String(describing: error))"
-                )
-            }
-        }
-
-        var shouldTriggerSync = true
-        do {
-            try await userSession.migrateToConsumableNotificationsIfNeeded()
-        } catch ZMUserSessionError.selfClientNotReady {
-            // We skip trigger sync, because in this case (fresh login),
-            // we don't have a registered client yet, so no consumable capability
-            WireLogger.sync.warn("No consumable-notifications migrator available")
-            shouldTriggerSync = false
-        } catch {
-            return nil
-        }
-
-        if shouldTriggerSync {
-            await userSession.triggerSync()
-        }
-
-        return userSession
-    }
-
-    private func shouldEnableSyncV2(journal: Journal) -> Bool {
-        guard let apiVersion = BackendInfo.apiVersion else {
-            fatalError("api version unknown")
-        }
-
-        let isAvailable = apiVersion >= .v8
-        let isAlreadyEnabled = journal[.isSyncV2Enabled]
-        return isAvailable && !isAlreadyEnabled
-    }
-
-    private func enableSyncV2(
-        journal: Journal,
-        coreDataStack: CoreDataStack
-    ) async {
-        guard let localDomain = BackendInfo.domain else {
-            fatalError("local domain unknown")
-        }
-
-        let dao: UpdateEventMigratorDAOProtocol = if #available(iOS 17, *) {
-            ActorBasedUpdateEventMigratorDAO(context: coreDataStack.eventContext)
-        } else {
-            UpdateEventMigratorDAO(context: coreDataStack.eventContext)
-        }
-
-        let migrator = UpdateEventMigrator(
-            dao: dao,
-            localDomain: localDomain
-        )
-
-        do {
-            if try await migrator.isMigrationNeeded() {
-                try await migrator.migrateLegacyUpdateEvents()
-                // Since we only migrate some events, we require an
-                // initial sync to ensure we didn't miss updates.
-                journal[.isInitialSyncRequired] = true
-            } else {
-                WireLogger.sync.debug("no migration needed")
-            }
-
-            journal[.isSyncV2Enabled] = true
-
-        } catch {
-            WireLogger.sync.critical("failed to migrate update events: \(error)")
         }
     }
 

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -353,7 +353,7 @@ final class UserSessionLoader {
         metadata: ResolvedBackendMetadata,
         eventContext: NSManagedObjectContext
     ) async throws {
-        let isAvailable = metadata.apiVersion >= .v8
+        let isAvailable = metadata.apiVersion >= .minimumLegacySyncVersion
         let isAlreadyEnabled = journal[.isSyncV2Enabled]
         let shouldEnable = isAvailable && !isAlreadyEnabled
 

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -353,7 +353,7 @@ final class UserSessionLoader {
         metadata: ResolvedBackendMetadata,
         eventContext: NSManagedObjectContext
     ) async throws {
-        let isAvailable = metadata.apiVersion >= .minimumLegacySyncVersion
+        let isAvailable = metadata.apiVersion >= .minimumSyncV2CompatibleVersion
         let isAlreadyEnabled = journal[.isSyncV2Enabled]
         let shouldEnable = isAvailable && !isAlreadyEnabled
 

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -111,7 +111,7 @@ final class NotificationService: UNNotificationServiceExtension {
             return nil
         }
 
-        if apiVersion >= .v8 {
+        if apiVersion >= APIVersion.minimumLegacySyncVersion {
             WireLogger.notifications.info(
                 "loading new notification service",
                 attributes: .safePublic

--- a/wire-ios/Wire Notification Service Extension/NotificationService.swift
+++ b/wire-ios/Wire Notification Service Extension/NotificationService.swift
@@ -111,7 +111,7 @@ final class NotificationService: UNNotificationServiceExtension {
             return nil
         }
 
-        if apiVersion >= APIVersion.minimumLegacySyncVersion {
+        if apiVersion >= APIVersion.minimumSyncV2CompatibleVersion {
             WireLogger.notifications.info(
                 "loading new notification service",
                 attributes: .safePublic

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -33,7 +33,7 @@ class WireUITestCase: XCTestCase {
         let launchArguments = [
             "-resetData",
             "--useEnvStaging",
-            "--preferred-api-version=7" // temporary test critical flows with v7
+            "--preferred-api-version=12"
         ]
 
         app = XCUIApplication()

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -33,7 +33,7 @@ class WireUITestCase: XCTestCase {
         let launchArguments = [
             "-resetData",
             "--useEnvStaging",
-            "--preferred-api-version=12"
+            "--preferred-api-version=7" // temporary test critical flows with v7
         ]
 
         app = XCUIApplication()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21456" title="WPB-21456" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21456</a>  [iOS] Make syncV2 available for apiVersion 7
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In order to deprecate legacy sync, we need to make syncV2 available to supported versions below 8: 5, 6, 7.

This PR makes it available for apiVersion 7

* Add constant for syncV2 check
* Remove dead code
* [TMP] run critical flows with apiVersion 7

### Testing

1. Set preferredAPIVersion to v7
2. login
check for (parsing) errors 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
