### PR TITLE
fix: send message - WPB-20880

### DIFF
--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMChangeTrackerBootstrap.h
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMChangeTrackerBootstrap.h
@@ -25,5 +25,5 @@
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context changeTrackers:(NSArray *)changeTrackers;
 
 - (void)fetchObjectsForChangeTrackers;
-
+- (void)addChangeTrackers:(NSArray *)changeTrackers;
 @end

--- a/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMChangeTrackerBootstrap.m
+++ b/wire-ios-request-strategy/Sources/Object Syncs/Helpers/ZMChangeTrackerBootstrap.m
@@ -55,16 +55,15 @@
     return entity;
 }
 
-- (void)fetchObjectsForChangeTrackers
-{
-    NSArray *fetchRequests = [self.changeTrackers mapWithBlock:^id(id tracker) {
+- (void)fetchObjectsForChangeTrackers:(NSArray*)trackers {
+    NSArray *fetchRequests = [trackers mapWithBlock:^id(id tracker) {
         return [tracker fetchRequestForTrackedObjects];
     }];
     
     NSMapTable *entityToRequestMap = [self sortFetchRequestsByEntity:fetchRequests];
     NSMapTable *entityToResultsMap = [self executeMappedFetchRequests:entityToRequestMap];
     
-    for (id <ZMContextChangeTracker> tracker in self.changeTrackers) {
+    for (id <ZMContextChangeTracker> tracker in trackers) {
         NSFetchRequest *request = [tracker fetchRequestForTrackedObjects];
         if (request == nil) {
             continue;
@@ -82,6 +81,20 @@
             [tracker addTrackedObjects:objectsToUpdate];
         }
     }
+}
+
+- (void)fetchObjectsForChangeTrackers
+{
+    [self fetchObjectsForChangeTrackers:self.changeTrackers];
+}
+
+- (void)addChangeTrackers:(NSArray *)changeTrackers
+{
+    [self fetchObjectsForChangeTrackers:changeTrackers];
+    
+    NSMutableArray* allTrackers = changeTrackers.mutableCopy;
+    [allTrackers addObjectsFromArray:changeTrackers];
+    self.changeTrackers = allTrackers;
 }
 
 - (NSMapTable *)sortFetchRequestsByEntity:(NSArray *)fetchRequests;

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -29,6 +29,7 @@ public protocol StrategyDirectoryProtocol {
     var eventAsyncConsumers: [ZMEventAsyncConsumer] { get }
     var requestStrategies: [RequestStrategy] { get }
     var contextChangeTrackers: [ZMContextChangeTracker] { get }
+    var clientContextChangeTrackers: [ZMContextChangeTracker] { get }
 
 }
 
@@ -40,6 +41,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
     public private(set) var eventConsumers: [ZMEventConsumer]
     public private(set) var eventAsyncConsumers: [ZMEventAsyncConsumer]
     public private(set) var contextChangeTrackers: [ZMContextChangeTracker]
+    public private(set) var clientContextChangeTrackers: [ZMContextChangeTracker] = []
     public private(set) var initiateResetMLSConversationUseCaseFactory: (NSManagedObjectContext) -> WireRequestStrategy
         .InitiateResetMLSConversationUseCaseProtocol
 
@@ -472,16 +474,16 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             self.requestStrategies.append(contentsOf: strategies.compactMap { $0 as? RequestStrategy })
             self.eventConsumers.append(contentsOf: strategies.compactMap { $0 as? ZMEventConsumer })
             self.eventAsyncConsumers.append(contentsOf: strategies.compactMap { $0 as? ZMEventAsyncConsumer })
-            self.contextChangeTrackers
-                .append(contentsOf: strategies.flatMap { (object: Any) -> [ZMContextChangeTracker] in
-                    if let source = object as? ZMContextChangeTrackerSource {
-                        return source.contextChangeTrackers
-                    } else if let tracker = object as? ZMContextChangeTracker {
-                        return [tracker]
-                    } else {
-                        return []
-                    }
-                })
+            self.clientContextChangeTrackers = strategies.flatMap { (object: Any) -> [ZMContextChangeTracker] in
+                if let source = object as? ZMContextChangeTrackerSource {
+                    return source.contextChangeTrackers
+                } else if let tracker = object as? ZMContextChangeTracker {
+                    return [tracker]
+                } else {
+                    return []
+                }
+            }
+            self.contextChangeTrackers.append(contentsOf: clientContextChangeTrackers)
         }
     }
 

--- a/wire-ios-sync-engine/Source/Synchronization/ZMSyncStrategy.h
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMSyncStrategy.h
@@ -43,6 +43,7 @@
                            eventProcessingTracker:(id<EventProcessingTrackerProtocol> _Nonnull)eventProcessingTracker;
 
 - (void)tearDown;
+- (void)updateStrategyClientContextChangeTrackers;
 
 @property (nonatomic, readonly, nonnull) NSManagedObjectContext *syncMOC;
 @property (nonatomic, nullable) id<EventProcessingTrackerProtocol> eventProcessingTracker;

--- a/wire-ios-sync-engine/Source/Synchronization/ZMSyncStrategy.m
+++ b/wire-ios-sync-engine/Source/Synchronization/ZMSyncStrategy.m
@@ -123,6 +123,13 @@ ZM_EMPTY_ASSERTING_INIT()
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (void)updateStrategyClientContextChangeTrackers
+{
+    [self.syncMOC performBlock:^{
+        [self.changeTrackerBootStrap addChangeTrackers:self.strategyDirectory.clientContextChangeTrackers];
+    }];
+}
+
 - (NSManagedObjectContext *)moc
 {
     return self.syncMOC;

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -676,7 +676,7 @@ public final class ZMUserSession: NSObject {
                 incrementalSyncObserver: incrementalSyncObserver,
                 metadata: resolvedBackendMetadata
             )
-            self.syncStrategy?.updateClientContextChangeTrackers()
+            syncStrategy?.updateClientContextChangeTrackers()
         }
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -676,6 +676,7 @@ public final class ZMUserSession: NSObject {
                 incrementalSyncObserver: incrementalSyncObserver,
                 metadata: resolvedBackendMetadata
             )
+            self.syncStrategy?.updateClientContextChangeTrackers()
         }
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/MockStrategyDirectory.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/MockStrategyDirectory.swift
@@ -20,7 +20,7 @@ import Foundation
 
 @objcMembers
 public class MockStrategyDirectory: NSObject, StrategyDirectoryProtocol {
-    public var clientContextChangeTrackers: [any ZMContextChangeTracker] = []   
+    public var clientContextChangeTrackers: [any ZMContextChangeTracker] = []
 
     public var eventConsumers: [ZMEventConsumer] = []
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/MockStrategyDirectory.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/MockStrategyDirectory.swift
@@ -20,6 +20,7 @@ import Foundation
 
 @objcMembers
 public class MockStrategyDirectory: NSObject, StrategyDirectoryProtocol {
+    public var clientContextChangeTrackers: [any ZMContextChangeTracker] = []   
 
     public var eventConsumers: [ZMEventConsumer] = []
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20880" title="WPB-20880" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20880</a>  [iOS] Failed image message prevent any further message to be sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When sending a message, if something goes wrong, the message is stuck in pending state. This is because the changeTrackers that are added after init of StrategyDirectory are not added. This PR fixes this

### Testing

1. turn networklink with 100% bad network
2. send a message
3. kill app
4. relaunch app with normal network
5. the message gets sent

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
