### PR TITLE
chore: simplify configuration when requesting nodes - WPB-21418

### DIFF
--- a/WireMessaging/Sources/WireMessagingAssembly/WireMessagingFactory.swift
+++ b/WireMessaging/Sources/WireMessagingAssembly/WireMessagingFactory.swift
@@ -131,20 +131,14 @@ public extension WireMessagingFactory {
     @MainActor
     func makeFilesView(
         cellName: String,
-        isCellsStatePending: Bool,
-        nodeIDs: [UUID]
+        isCellsStatePending: Bool
     ) -> UIViewController {
-        let configuration: WireCellsFetchNodesUseCase.Configuration = nodeIDs
-            .isEmpty ? .conversationFileView(root: .path(cellName)) :
-            .nodesFileView(nodeIDs: nodeIDs)
-
+        let configuration: WireCellsFetchNodesUseCase.Configuration = .conversationFileView(root: .path(cellName))
         let filesView: UIHostingController<FilesView>
-
         filesView = makeFilesHostingController(
             configuration: configuration,
             isCellsStatePending: isCellsStatePending
         )
-
         return filesView
     }
 

--- a/WireMessaging/Sources/WireMessagingAssembly/WireMessagingFactory.swift
+++ b/WireMessaging/Sources/WireMessagingAssembly/WireMessagingFactory.swift
@@ -133,7 +133,7 @@ public extension WireMessagingFactory {
         cellName: String,
         isCellsStatePending: Bool
     ) -> UIViewController {
-        let configuration: WireCellsFetchNodesUseCase.Configuration = .conversationFileView(root: .path(cellName))
+        let configuration: WireCellsGetNodesRequest.Configuration = .conversationFileView(root: .path(cellName))
         let filesView: UIHostingController<FilesView>
         filesView = makeFilesHostingController(
             configuration: configuration,
@@ -144,7 +144,7 @@ public extension WireMessagingFactory {
 
     @MainActor
     func makeFilesBrowserView() -> UIViewController {
-        let configuration: WireCellsFetchNodesUseCase.Configuration = .filesBrowserView()
+        let configuration: WireCellsGetNodesRequest.Configuration = .filesBrowserView
         let filesBrowserView: UIHostingController<FilesBrowserView>
         filesBrowserView = makeFilesHostingController(
             configuration: configuration
@@ -154,7 +154,7 @@ public extension WireMessagingFactory {
 
     @MainActor
     private func makeFilesHostingController<T: FilesViewProtocol>(
-        configuration: WireCellsFetchNodesUseCase.Configuration,
+        configuration: WireCellsGetNodesRequest.Configuration,
         isCellsStatePending: Bool = false
     ) -> UIHostingController<T> {
         let viewModel = FilesViewModel(

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -29,7 +29,6 @@ enum WireCellsNodesAPIError: Error {
 final class RestAPI: Sendable {
 
     private enum Constants {
-        static let sortedBy = "mtime"
         static let deleteBackgroundActionName = "delete"
     }
 
@@ -52,32 +51,11 @@ final class RestAPI: Sendable {
     func getNodes(
         _ request: WireCellsGetNodesRequest
     ) async throws -> (nodes: [WireCellsNodeNetworkModel], nextOffset: Int?) {
-        let request = RestLookupRequest(
-            filters: RestLookupFilter(
-                status: LookupFilterStatusFilter(
-                    deleted: StatusFilterDeletedStatus(request.filter.deletionStatus),
-                    isDraft: false
-                ),
-                text: LookupFilterTextSearch(searchIn: .baseName, term: request.filter.text ?? "*"),
-                type: TreeNodeType(request.filter.type)
-            ),
-            flags: [.withPreSignedURLs],
-            limit: "\(request.limit)",
-            offset: "\(request.offset)",
-            query: request.query.map { query in
-                let nodeIDs = query.nodeIDs?.compactMap { $0.uuidString.lowercased() }
-                return TreeQuery(uUIDs: nodeIDs)
-            },
-            scope: RestLookupScope(
-                recursive: request.scope.isRecursive,
-                root: request.scope.root.map { RestNodeLocator($0) }
-            ),
-            sortDirDesc: true,
-            sortField: Constants.sortedBy
-        )
-
         do {
-            let collection = try await NodeServiceAPI.lookup(body: request, apiConfiguration: makeConfiguration())
+            let collection = try await NodeServiceAPI.lookup(
+                body: request.lookupRequest,
+                apiConfiguration: makeConfiguration()
+            )
             let nodes = collection.nodes?.compactMap { $0.toDTO() } ?? []
             let nextOffset = collection.pagination?.nextOffset
 
@@ -225,20 +203,6 @@ final class RestAPI: Sendable {
 
 // MARK: - Helpers
 
-private extension StatusFilterDeletedStatus {
-
-    init(_ value: WireCellsNodeDeletionStatus) {
-        switch value {
-        case .deleted:
-            self = .only
-        case .notDeleted:
-            self = .not
-        case .any:
-            self = .any
-        }
-    }
-}
-
 private extension RestNodeLocator {
 
     init(_ value: WireCellsNodeLocator) {
@@ -310,4 +274,50 @@ private struct LoggingIntercepter: OpenAPIInterceptor {
             completion: completion
         )
     }
+}
+
+private extension WireCellsGetNodesRequest {
+
+    var lookupRequest: RestLookupRequest {
+        var request = RestLookupRequest(
+            flags: [.withPreSignedURLs],
+            limit: "\(limit)",
+            offset: "\(offset)",
+        )
+
+        switch configuration {
+        case let .conversationFileView(root):
+            request.filters = RestLookupFilter(
+                status: LookupFilterStatusFilter(
+                    deleted: .not,
+                    isDraft: false
+                ),
+                text: LookupFilterTextSearch(searchIn: .baseName, term: searchTerm ?? "*"),
+                type: .leaf
+            )
+            request.scope = RestLookupScope(
+                recursive: true,
+                root: RestNodeLocator(root)
+            )
+            request.sortDirDesc = true
+            request.sortField = "mtime"
+        case .filesBrowserView:
+            request.filters = RestLookupFilter(
+                status: LookupFilterStatusFilter(
+                    deleted: .not,
+                    isDraft: false
+                ),
+                text: LookupFilterTextSearch(searchIn: .baseName, term: searchTerm ?? "*"),
+                type: .leaf
+            )
+            request.scope = RestLookupScope(
+                recursive: true,
+                root: nil
+            )
+            request.sortDirDesc = true
+            request.sortField = "mtime"
+        }
+        return request
+    }
+
 }

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsNodesRepositoryProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Model/WireCellsNodesRepositoryProtocol.swift
@@ -45,45 +45,18 @@ package protocol WireCellsNodesRepositoryProtocol: Sendable {
 
 package struct WireCellsGetNodesRequest: Equatable, Sendable {
 
-    /// Filters the results of the request.
-    package struct Filter: Equatable, Sendable {
+    /// The configuration for the request.
+    package enum Configuration: Equatable, Sendable {
 
-        /// The `DeletionStatus` of the node.
-        package let deletionStatus: WireCellsNodeDeletionStatus
+        /// A `Configuration` suitable for the conversation file view.
+        case conversationFileView(root: WireCellsNodeLocator)
 
-        /// An optional search text of a nodes file name.
-        package let text: String?
-
-        /// The type of the node.
-        package let type: WireCellsNodeType
+        /// A `Configuration` suitable for the files browser view.
+        case filesBrowserView
     }
 
-    /// The query to apply to the scope. `Query` is deprecated but it is necessary until we implement [WPB-16311].
-    package struct Query: Equatable, Sendable {
-
-        /// The IDs of the nodes to fetch. If provided, only nodes with these IDs will be returned.
-        package let nodeIDs: [UUID]?
-    }
-
-    /// The scope of the request.
-    package struct Scope: Equatable, Sendable {
-
-        /// The root locator for the search. If no root is provided, the search will return nodes for all conversations.
-        package let root: WireCellsNodeLocator?
-
-        /// Whether the search should be recursive or not. If true, it will return nodes from sub folders.
-        package let isRecursive: Bool
-    }
-
-    /// The scope of the request.
-    package let scope: Scope
-
-    // FIXME: [WPB-16311] Remove Query once previewing cells files in conversations is implemented.
-    /// The query to apply to the request.
-    package let query: Query?
-
-    /// The filter to apply to the results.
-    package let filter: Filter
+    /// An optional search term to filter nodes by name.
+    package let searchTerm: String?
 
     /// The maximum number of nodes to return.
     package let limit: Int
@@ -91,11 +64,13 @@ package struct WireCellsGetNodesRequest: Equatable, Sendable {
     /// The pagination offset to start the results from.
     package let offset: Int
 
-    package init(scope: Scope, query: Query? = nil, filter: Filter, limit: Int, offset: Int) {
-        self.scope = scope
-        self.query = query
-        self.filter = filter
+    /// The configuration for the request.
+    package let configuration: Configuration
+
+    package init(searchTerm: String?, limit: Int, offset: Int, configuration: Configuration) {
+        self.searchTerm = searchTerm
         self.limit = limit
         self.offset = offset
+        self.configuration = configuration
     }
 }

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
@@ -17,7 +17,7 @@
 //
 
 import CellsSDK
-package import Foundation
+import Foundation
 
 /// Fetches `WireCellNodes`s for the given parameters.
 package struct WireCellsFetchNodesUseCase: Sendable {
@@ -58,17 +58,6 @@ package struct WireCellsFetchNodesUseCase: Sendable {
             Configuration(
                 root: nil,
                 nodeIDs: nil,
-                isRecursive: true,
-                nodeType: .leaf,
-                deletionStatus: .notDeleted
-            )
-        }
-
-        /// A `Configuration` for showing only specific nodes in the file view.
-        package static func nodesFileView(nodeIDs: [UUID]) -> Configuration {
-            Configuration(
-                root: nil,
-                nodeIDs: nodeIDs,
                 isRecursive: true,
                 nodeType: .leaf,
                 deletionStatus: .notDeleted

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsFetchNodesUseCase.swift
@@ -22,51 +22,7 @@ import Foundation
 /// Fetches `WireCellNodes`s for the given parameters.
 package struct WireCellsFetchNodesUseCase: Sendable {
 
-    package struct Configuration: Sendable {
-
-        /// The root container for the nodes. If `nil`, nodes for all conversations will be returned.
-        let root: WireCellsNodeLocator?
-
-        /// Specific nodes to fetch.
-        let nodeIDs: [UUID]?
-
-        /// Whether to fetch nodes recursively from the root container.
-        let isRecursive: Bool
-
-        /// The type of nodes to fetch.
-        let nodeType: WireCellsNodeType
-
-        /// The deletion status of the nodes to fetch.
-        let deletionStatus: WireCellsNodeDeletionStatus
-
-        /// The maximum number of nodes to fetch.
-        let pageSize: Int = 30
-
-        /// A `Configuration` suitable for the conversation file view.
-        package static func conversationFileView(root: WireCellsNodeLocator?) -> Configuration {
-            Configuration(
-                root: root,
-                nodeIDs: nil,
-                isRecursive: true,
-                nodeType: .leaf,
-                deletionStatus: .notDeleted
-            )
-        }
-
-        /// A `Configuration` suitable for the files browser view.
-        package static func filesBrowserView() -> Configuration {
-            Configuration(
-                root: nil,
-                nodeIDs: nil,
-                isRecursive: true,
-                nodeType: .leaf,
-                deletionStatus: .notDeleted
-            )
-        }
-
-    }
-
-    private let configuration: Configuration
+    private let configuration: WireCellsGetNodesRequest.Configuration
     private let repository: any WireCellsNodesRepositoryProtocol
 
     /// Initializes the use case with the required parameters.
@@ -74,7 +30,7 @@ package struct WireCellsFetchNodesUseCase: Sendable {
     ///   - configuration: The configuration for the use case.
     ///   - repository: The repository to use for fetching nodes.
     package init(
-        configuration: Configuration,
+        configuration: WireCellsGetNodesRequest.Configuration,
         repository: any WireCellsNodesRepositoryProtocol
     ) {
         self.configuration = configuration
@@ -93,28 +49,12 @@ package struct WireCellsFetchNodesUseCase: Sendable {
         offset: Int
     ) async throws -> (nodes: [WireCellsNode], isLastPage: Bool) {
         let request = WireCellsGetNodesRequest(
-            scope: WireCellsGetNodesRequest.Scope(
-                root: configuration.root,
-                isRecursive: configuration.isRecursive
-            ),
-            query: configuration.nodeIDs.map { WireCellsGetNodesRequest.Query(nodeIDs: $0) },
-            filter: WireCellsGetNodesRequest.Filter(
-                deletionStatus: configuration.deletionStatus,
-                text: searchTerm,
-                type: configuration.nodeType
-            ),
-            limit: configuration.pageSize,
-            offset: offset
+            searchTerm: searchTerm,
+            limit: 30,
+            offset: offset,
+            configuration: configuration
         )
-        var (nodes, nextOffset) = try await repository.getNodes(request)
-
-        // FIXME: [WPB-16311] Temporary fix to filter out recycled nodes.
-        // This is necessary because the backend doesn't filter out recycled nodes when we have requested specific
-        // nodes. Once we implement showing previews in a conversation this check should move there, if there is no
-        // backend fix.
-        if configuration.deletionStatus == .notDeleted, let nodeIDs = configuration.nodeIDs, !nodeIDs.isEmpty {
-            nodes = nodes.filter { !$0.isRecycled }
-        }
+        let (nodes, nextOffset) = try await repository.getNodes(request)
 
         return (nodes, nextOffset == nil)
     }

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FilesBrowserViewTests/testFilesBrowserView_ReceivedItemsState.dark.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FilesBrowserViewTests/testFilesBrowserView_ReceivedItemsState.dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88b26e55d00974c67a8068ec38fa8315f9019718f102171e35656c92cfaa76f3
+size 85400

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FilesBrowserViewTests/testFilesBrowserView_ReceivedItemsState.light.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FilesBrowserViewTests/testFilesBrowserView_ReceivedItemsState.light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fec0c63c67228e70b9fd5c8de2e6c5287c419ae4b219bbf143b03038f6f96749
+size 79654

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/UseCases/WireCellsFetchNodesUseCaseTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/UseCases/WireCellsFetchNodesUseCaseTests.swift
@@ -54,10 +54,10 @@ struct WireCellsFetchNodesUseCaseTests {
         #expect(
             repository.getNodes_Invocations == [
                 WireCellsGetNodesRequest(
-                    scope: .init(root: .path("some/path"), isRecursive: true),
-                    filter: .init(deletionStatus: .notDeleted, text: nil, type: .leaf),
+                    searchTerm: nil,
                     limit: 30,
-                    offset: 0
+                    offset: 0,
+                    configuration: .conversationFileView(root: .path("some/path"))
                 )
             ]
         )
@@ -90,8 +90,8 @@ struct WireCellsFetchNodesUseCaseTests {
 
         // Then
         try #require(repository.getNodes_Invocations.count == 2)
-        #expect(repository.getNodes_Invocations[0].filter.text == nil)
-        #expect(repository.getNodes_Invocations[1].filter.text == "foo")
+        #expect(repository.getNodes_Invocations[0].searchTerm == nil)
+        #expect(repository.getNodes_Invocations[1].searchTerm == "foo")
     }
 
 }

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -1831,20 +1831,20 @@ class MockWireMessagingFactoryProtocol: WireMessagingFactoryProtocol {
 
     // MARK: - makeFilesView
 
-    var makeFilesViewCellNameIsCellsStatePendingNodeIDs_Invocations: [(cellName: String, isCellsStatePending: Bool, nodeIDs: [UUID])] = []
-    var makeFilesViewCellNameIsCellsStatePendingNodeIDs_MockMethod: ((String, Bool, [UUID]) -> UIViewController)?
-    var makeFilesViewCellNameIsCellsStatePendingNodeIDs_MockValue: UIViewController?
+    var makeFilesViewCellNameIsCellsStatePending_Invocations: [(cellName: String, isCellsStatePending: Bool)] = []
+    var makeFilesViewCellNameIsCellsStatePending_MockMethod: ((String, Bool) -> UIViewController)?
+    var makeFilesViewCellNameIsCellsStatePending_MockValue: UIViewController?
 
     @MainActor
-    func makeFilesView(cellName: String, isCellsStatePending: Bool, nodeIDs: [UUID]) -> UIViewController {
-        makeFilesViewCellNameIsCellsStatePendingNodeIDs_Invocations.append((cellName: cellName, isCellsStatePending: isCellsStatePending, nodeIDs: nodeIDs))
+    func makeFilesView(cellName: String, isCellsStatePending: Bool) -> UIViewController {
+        makeFilesViewCellNameIsCellsStatePending_Invocations.append((cellName: cellName, isCellsStatePending: isCellsStatePending))
 
-        if let mock = makeFilesViewCellNameIsCellsStatePendingNodeIDs_MockMethod {
-            return mock(cellName, isCellsStatePending, nodeIDs)
-        } else if let mock = makeFilesViewCellNameIsCellsStatePendingNodeIDs_MockValue {
+        if let mock = makeFilesViewCellNameIsCellsStatePending_MockMethod {
+            return mock(cellName, isCellsStatePending)
+        } else if let mock = makeFilesViewCellNameIsCellsStatePending_MockValue {
             return mock
         } else {
-            fatalError("no mock for `makeFilesViewCellNameIsCellsStatePendingNodeIDs`")
+            fatalError("no mock for `makeFilesViewCellNameIsCellsStatePending`")
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController.swift
@@ -873,8 +873,7 @@ extension ConversationViewController: ConversationInputBarViewControllerDelegate
         let filesView = wireMessagingFactory
             .makeFilesView(
                 cellName: conversation.wireCellName,
-                isCellsStatePending: wireCellsState == .pending,
-                nodeIDs: []
+                isCellsStatePending: wireCellsState == .pending
             )
 
         filesView.presentOverAll(animated: true)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/WireMessagingFactoryProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/WireMessagingFactoryProtocol.swift
@@ -34,7 +34,7 @@ protocol WireMessagingFactoryProtocol {
     func makeRetryUploadDraftUseCase(cellName: String) -> WireCellsRetryUploadDraftUseCaseProtocol
     func makeDeleteNodesUseCase() -> WireCellsDeleteNodesUseCaseProtocol
     @MainActor
-    func makeFilesView(cellName: String, isCellsStatePending: Bool, nodeIDs: [UUID]) -> UIViewController
+    func makeFilesView(cellName: String, isCellsStatePending: Bool) -> UIViewController
     @MainActor
     func makeFilesBrowserView() -> UIViewController
     @MainActor


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21418" title="WPB-21418" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21418</a>  [iOS] As a user I want to see folders in the files view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When fetching nodes via the /nodes endpoint there is a lot of configuration that can be done to the requests to handle filtering, scope of nodes fetched etc. This is defined in the CellsSDK a library we use generated from our swagger files.

When implementing the files view I needed a way to configure `WireCellsFetchNodesUseCase` with this information. My solution was to essentially duplicate the configuration from `CellsSDK` to `WireMessagingDomain` and map this in the data layer.

I thought it was nice that we could configure the API from `WireMessagingDomain`. However in practice I've found `/nodes` behavior to be surprising and we've had to set CellsSDK parameters slightly magically to have behavior we want.

As I'm making more changes here I don't want this leaking through to the domain layer so in this PR I have changed how things are done:

- Deleted duplicate configuration objects
- Rather than the domain passing a complex configuration object it passes a simple one which names what it wants - eg. `conversationFileView(root: WireCellsNodeLocator)`. It is then the data layer that maps that simple configuaration to the complex configuration required by the CellsSDK.

### Testing

1. Navigate to the files view of a conversation and check that files are loaded as expected.
2. Navigate to the all files view and check that files are loaded as expected.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
