### PR TITLE
feat: large video previews - WPB-21076

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -72,14 +72,16 @@ struct WireCellsAttachmentsPreviewItemView: View {
                 .frame(height: 74)
                 .frame(idealWidth: 288)
             case (.video, .large):
-                WireCellsDocumentAttachmentPreview(
+                WireCellsLargeVideoPreviewView(
                     headerIcon: Image(viewModel.icon),
                     headerText: viewModel.headerText,
                     labelText: viewModel.fileName,
                     progress: viewModel.progress,
-                    isError: viewModel.isAssetDownloadError,
+                    downloadError: viewModel.isAssetDownloadError,
+                    url: viewModel.imagePreviewURL,
+                    imageAspectRatio: viewModel.previewAspectRatio,
+                    duration: viewModel.attachmentDuration,
                 )
-                .frame(height: 74)
                 .frame(idealWidth: 288)
             case (.document, .small):
                 WireCellsDocumentAttachmentPreview(

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemViewModel.swift
@@ -176,6 +176,21 @@ final class WireCellsAttachmentsPreviewItemViewModel: ObservableObject {
         previewSize?.width as? Double // Explicit conversion necessary due to compiler bug
     }
 
+    var attachmentDuration: String? {
+        let fileType = attachment.contentType.flatMap { UTType(mimeType: $0) }
+
+        guard fileType == .video || fileType == .audio else {
+            return nil
+        }
+
+        guard let durationInMS = attachment.initialMetadata?.duration else {
+            return nil
+        }
+
+        let duration = Duration.milliseconds(durationInMS)
+        return duration.formatted(.time(pattern: .minuteSecond))
+    }
+
     // MARK: - Private
 
     private var nodeID: UUID {

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsLargeVideoPreviewView.swift
@@ -88,7 +88,8 @@ struct WireCellsLargeVideoPreviewView: View {
                     .resizable()
                     .scaledToFill()
                     .overlay {
-                        PlayIcon(isEnabled: true)
+                        PlayIcon()
+                            .disabled(false)
                     }
             case .failure:
                 errorView(text: Self.errorMessage)

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsLargeVideoPreviewView.swift
@@ -1,0 +1,168 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WireDesign
+import WireFoundation
+
+struct WireCellsLargeVideoPreviewView: View {
+    private static let errorMessage = L10n.Localizable.Conversation.Message
+        .Attachment.previewNotAvailable
+    private static let downloadErrorMessage = L10n.Localizable.Conversation
+        .Message.Attachment.unableToDownload
+    private static let loadingMessage = L10n.Localizable.Conversation.Message
+        .Attachment.loadingContent
+    private static let defaultAspectRatio = CGFloat(16.0 / 9.0)
+    private static let previewCornerRadius = 10.0
+
+    let headerIcon: Image
+    let headerText: String
+    let labelText: String
+    let progress: Double?
+    let downloadError: Bool
+    let url: URL?
+    var imageAspectRatio: CGFloat? = defaultAspectRatio
+    let duration: String?
+
+    var body: some View {
+        WireCellsAttachmentPreview(
+            progress: progress,
+            progressColor: downloadError
+                ? ColorTheme.Base.error.color : ColorTheme.Base.primary.color
+        ) {
+            VStack {
+                WireCellsDocumentHeaderView(
+                    headerIcon: headerIcon,
+                    headerText: headerText,
+                    labelText: labelText,
+                    progress: progress,
+                    isError: downloadError
+                )
+                .background(ColorTheme.Backgrounds.surfaceVariant.color)
+                .frame(height: 74)  // This might break the UI if text font is too big
+                .frame(maxWidth: .infinity)
+
+                previewContainer {
+                    if downloadError {
+                        errorView(text: Self.downloadErrorMessage)
+                    } else {
+                        if let url {
+                            asyncImage(url: url)
+                        } else {
+                            errorView(text: Self.errorMessage)
+                        }
+                    }
+                }
+                .overlay(alignment: .bottom) {
+                    if let duration {
+                        durationView(duration: duration)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func asyncImage(url: URL) -> some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .empty:
+                loadingView(text: Self.loadingMessage)
+            case let .success(image):
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .overlay {
+                        PlayIcon(isEnabled: true)
+                    }
+            case .failure:
+                errorView(text: Self.errorMessage)
+            @unknown default:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func previewContainer(@ViewBuilder content: () -> some View)
+        -> some View {
+        Color.clear
+            .aspectRatio(imageAspectRatio ?? Self.defaultAspectRatio, contentMode: .fit)
+            .background(alignment: .top) {
+                content()
+            }
+            .clipShape(RoundedRectangle(cornerRadius: Self.previewCornerRadius))
+    }
+
+    @ViewBuilder
+    private func loadingView(text: String) -> some View {
+        ZStack {
+            Color(ColorTheme.Backdrop.background)
+            VStack {
+                ProgressView()
+                    .tint(ColorTheme.Backgrounds.onTransparentDark.color)
+                Text(text)
+                    .font(for: .body2)
+                    .foregroundColor(ColorTheme.Backgrounds.onTransparentDark.color)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func errorView(text: String) -> some View {
+        ZStack {
+            Color(ColorTheme.Backdrop.background)
+            Text(text)
+                .font(for: .body2)
+                .foregroundColor(ColorTheme.Backgrounds.onTransparentDark.color)
+                .multilineTextAlignment(.center)
+                .padding()
+        }
+    }
+
+    @ViewBuilder
+    private func durationView(duration: String) -> some View {
+        Text(duration)
+            .font(for: .body2)
+            .foregroundColor(ColorTheme.Backgrounds.onTransparentDark.color)
+            .frame(maxWidth: .infinity)
+            .background(ColorTheme.Backdrop.background.color)
+            .clipShape(
+                UnevenRoundedRectangle(
+                    bottomLeadingRadius: Self.previewCornerRadius,
+                    bottomTrailingRadius: Self.previewCornerRadius
+                )
+            )
+    }
+}
+
+#Preview {
+    WireCellsLargeVideoPreviewView(
+        headerIcon: Image(FileIcon.pdf.resource),
+        headerText: "PDF (336 KB)",
+        labelText: "CDR_20220120 Accessibility Review Reviewed Final Plus",
+        progress: 0.7,
+        downloadError: false,
+        url: URL(
+            string:
+            "https://i.kym-cdn.com/entries/icons/facebook/000/018/012/this_is_fine.jpg"
+        ),
+        imageAspectRatio: CGFloat(16.0 / 9.0),
+        duration: "02:34",
+    )
+}

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Previews/WireCellsVideoAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Previews/WireCellsVideoAttachmentPreview.swift
@@ -58,7 +58,7 @@ struct WireCellsVideoAttachmentPreview: View {
     }
 }
 
-private struct PlayIcon: View {
+struct PlayIcon: View {
 
     private typealias Theme = ColorTheme.Buttons.Secondary
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Previews/WireCellsVideoAttachmentPreview.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Previews/WireCellsVideoAttachmentPreview.swift
@@ -46,7 +46,8 @@ struct WireCellsVideoAttachmentPreview: View {
                 }
 
                 if thumbnail != nil, !isError {
-                    PlayIcon(isEnabled: canPlay)
+                    PlayIcon()
+                        .disabled(!canPlay)
                 }
 
                 if isError {
@@ -62,7 +63,7 @@ struct PlayIcon: View {
 
     private typealias Theme = ColorTheme.Buttons.Secondary
 
-    let isEnabled: Bool
+    @Environment(\.isEnabled) private var isEnabled: Bool
 
     var body: some View {
         Image(systemName: "play.circle.fill")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21076" title="WPB-21076" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21076</a>  [iOS] Large video previews in a conversation message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

What was done in this PR:

1. Adding new View for large Video preview files.
2. Update WireCellsAttachmentsPreviewItemView to use the new large video preview.

### Testing

Using a version that has Wire Cells enabled, send a single video file on a chat.
When single video is shared, large video preview should be shown.

UI test can't be done, no way of mocking AsyncImage.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
