### PR TITLE
fix: sending messages - WPB-20880

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -81,6 +81,19 @@ extension AssetClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
             return
         }
 
+        if object.shouldExpire, object.expirationDate?.isInThePast == true {
+            // this message is a retry from when we got interrupted (i.e. crashed)
+            WireLogger.messaging.info(
+                "asset message expired before sending: \(object)",
+                attributes: [.nonce: object.nonce?.safeForLoggingDescription ?? "<nil>"],
+                .safePublic
+            )
+            object.expire(withReason: .timeout)
+            managedObjectContext.saveOrRollback()
+            completion()
+            return
+        }
+
         let logAttributesBuilder = MessageLogAttributesBuilder(context: managedObjectContext)
         let logAttributes = logAttributesBuilder.syncLogAttributes(object)
         WireLogger.messaging.debug("inserting message", attributes: logAttributes)

--- a/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Assets/AssetClientMessageRequestStrategy.swift
@@ -82,7 +82,9 @@ extension AssetClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
         }
 
         if object.shouldExpire, object.expirationDate?.isInThePast == true {
-            // this message is a retry from when we got interrupted (i.e. crashed)
+            // When unsent messages past their expiration date they should be expired.
+            // It's likely this message failed to send before but the app crashed or was
+            // terminated before it succeeded.
             WireLogger.messaging.info(
                 "asset message expired before sending: \(object)",
                 attributes: [.nonce: object.nonce?.safeForLoggingDescription ?? "<nil>"],

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -111,7 +111,9 @@ extension ClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
         }
 
         if object.shouldExpire, object.expirationDate?.isInThePast == true {
-            // this message is a retry from when we got interrupted (i.e. crashed)
+            // When unsent messages past their expiration date they should be expired.
+            // It's likely this message failed to send before but the app crashed or was
+            // terminated before it succeeded.
             WireLogger.messaging.info(
                 "client message expired before sending: \(object)",
                 attributes: [.nonce: object.nonce?.safeForLoggingDescription ?? "<nil>"],

--- a/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/Client Message/ClientMessageRequestStrategy.swift
@@ -110,6 +110,18 @@ extension ClientMessageRequestStrategy: InsertedObjectSyncTranscoder {
             return
         }
 
+        if object.shouldExpire, object.expirationDate?.isInThePast == true {
+            // this message is a retry from when we got interrupted (i.e. crashed)
+            WireLogger.messaging.info(
+                "client message expired before sending: \(object)",
+                attributes: [.nonce: object.nonce?.safeForLoggingDescription ?? "<nil>"],
+                .safePublic
+            )
+            object.expire(withReason: .timeout)
+            context.saveOrRollback()
+            completion()
+            return
+        }
         let logAttributesBuilder = MessageLogAttributesBuilder(context: context)
         let logAttributes = logAttributesBuilder.syncLogAttributes(object)
         WireLogger.messaging.debug("inserting message", attributes: logAttributes)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20880" title="WPB-20880" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20880</a>  [iOS] Failed image message prevent any further message to be sent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Follow up on #3815, when user will update, we don't want to retry all unsent messages as some might not be relevant. This PR adds a check on the expiration date (inserted when first try to send) to check if message should be expired instead of sending.

### Testing

1. send message offline
2. put network up after some time 1min
3. it should expire the message and see errror in chat instead of sending
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
