### PR TITLE
fix: UI self deleting message icon input bar - WPB-21571

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -120,6 +120,10 @@ final class ConversationInputBarViewController: UIViewController,
 
         button.setIcon(.hourglass, size: .tiny, for: UIControl.State.normal)
         button.accessibilityIdentifier = "ephemeralTimeSelectionButton"
+        
+        if conversation.isSelfDeletingMessageSendingDisabled {
+            button.isEnabled = false
+        }
 
         configureEphemeralKeyboardButton(button)
 
@@ -269,9 +273,8 @@ final class ConversationInputBarViewController: UIViewController,
                 locationButton
             ]
         }
-        if !conversation.isSelfDeletingMessageSendingDisabled {
-            buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
-        }
+
+        buttonsArray.insert(hourglassButton, at: buttonsArray.startIndex)
 
         if shouldExcludeLocationButton {
             if let index = buttonsArray.firstIndex(of: locationButton) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -120,7 +120,7 @@ final class ConversationInputBarViewController: UIViewController,
 
         button.setIcon(.hourglass, size: .tiny, for: UIControl.State.normal)
         button.accessibilityIdentifier = "ephemeralTimeSelectionButton"
-        
+
         if conversation.isSelfDeletingMessageSendingDisabled {
             button.isEnabled = false
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21571" title="WPB-21571" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21571</a>  [iOS] When self deleting message is disabled, conversation input bar shows weird empty space
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When self deleting message is disabled, we were removing the related button from the conversation input bar resulting in a weird empty space. this PR fixes it by keeping the button icon but **disabling** it

### Testing

on a conv with wire cells enabled, check the "hourglass" button in the input bar. it should be grayed out and not tappable

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
