### PR TITLE
fix: Disable interactive dismiss on modal - WPB-21620

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -66,6 +66,7 @@ package struct FilesView: FilesViewProtocol {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbarBackground(.visible, for: .navigationBar) // shows navigation bar divider
                 .toolbarBackground(ColorTheme.Backgrounds.background.color, for: .navigationBar)
+                .interactiveDismissDisabled()
                 .toolbar { toolbarContent }
                 .onAppear { reloadTask() }
                 .alert(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21620" title="WPB-21620" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21620</a>  [iOS] Files view - cannot pull to refresh as it interferes with the modal pull down action
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In the files view, we can’t pull to refresh as it interferes with the pull down action to dismiss the modal.
We need to disable the pull down action to allow users to pull to refresh.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
