### PR TITLE
fix: multipart asset UUID - WPB-21622

### DIFF
--- a/wire-ios-data-model/Source/Model/Message/MultipartAttachment.swift
+++ b/wire-ios-data-model/Source/Model/Message/MultipartAttachment.swift
@@ -17,6 +17,7 @@
 //
 
 import GenericMessageProtocol
+import WireTransport
 
 public struct MultipartAttachment {
 
@@ -85,7 +86,7 @@ extension MultipartAttachment {
     func toProto() -> Attachment {
         Attachment.with { attachment in
             attachment.cellAsset = CellAsset.with { asset in
-                asset.uuid = uuid.uuidString
+                asset.uuid = uuid.transportString()
                 asset.contentType = contentType
 
                 // Only set if values are not nil to avoid protobufs setting nonsense defaults.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21622" title="WPB-21622" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21622</a>  [iOS] Fix uppercase UUID being sent with assets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently the `uuid` being sent with mutlipart asset protobufs is uppercase. It should be lowercase as other clients and the backend generally expect it to be lowercase.

### Testing

- General testing of wire cells

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.