### PR TITLE
revert: disable critical flows temporarily - WPB-21303 🍒

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -135,10 +135,10 @@ jobs:
         run: |
           bundle exec fastlane generate_env
 
-      # - name: "Test new critical flows"
-      #   if: ${{ inputs.run_critical_flows }}
-      #   run: |
-      #     bundle exec fastlane run_uitests
+      - name: "Test new critical flows"
+        if: ${{ inputs.run_critical_flows }}
+        run: |
+          bundle exec fastlane run_uitests
 
       - name: "Test all selected frameworks"
         if: ${{ inputs.test_dependencies || inputs.all }}

--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Registration/PersonalAccountCreation/PersonalAccountCreationView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Registration/PersonalAccountCreation/PersonalAccountCreationView.swift
@@ -108,6 +108,7 @@ package struct PersonalAccountCreationView: View {
         .autocapitalization(.words)
         .autocorrectionDisabled()
         .textContentType(.name)
+        .accessibilityIdentifier("enterNameField")
     }
 
     @ViewBuilder private var emailField: some View {
@@ -130,6 +131,7 @@ package struct PersonalAccountCreationView: View {
             passwordRules: viewModel.localizedPasswordRules,
             isValidPassword: { _ in viewModel.isPasswordValid }
         )
+        .accessibilityIdentifier("enterPasswordField")
     }
 
     @ViewBuilder private var confirmPasswordField: some View {
@@ -140,6 +142,7 @@ package struct PersonalAccountCreationView: View {
             passwordRules: Strings.InputConfirmPassword.error,
             isValidPassword: { _ in viewModel.isPasswordMatchConfirmedPassword }
         )
+        .accessibilityIdentifier("enterConfirmPasswordField")
     }
 
     @ViewBuilder private var dataUsageAgreementView: some View {

--- a/wire-ios/WireUITests/Helper/WireUITestCase.swift
+++ b/wire-ios/WireUITests/Helper/WireUITestCase.swift
@@ -33,7 +33,7 @@ class WireUITestCase: XCTestCase {
         let launchArguments = [
             "-resetData",
             "--useEnvStaging",
-            "--preferred-api-version=8"
+            "--preferred-api-version=12"
         ]
 
         app = XCUIApplication()

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -64,7 +64,9 @@ class ConversationsPage: PageModel {
     func openUserAccountPageForUser(with input: String) throws -> UserAccountPage {
         let predicate = NSPredicate(format: "value BEGINSWITH %@", input)
         let button = app.buttons.containing(predicate).firstMatch
-        button.tap()
+        if button.waitForExistence(timeout: 2), button.isHittable {
+            button.tap()
+        }
         return try UserAccountPage()
     }
 

--- a/wire-ios/WireUITests/Pages/CreatePersonalAccountFormPage.swift
+++ b/wire-ios/WireUITests/Pages/CreatePersonalAccountFormPage.swift
@@ -25,24 +25,23 @@ class CreatePersonalAccountFormPage: PageModel {
     }
 
     var nameTextField: XCUIElement {
-        app.descendants(matching: .any)["Enter your name"].firstMatch
-    }
-
-    var showPasswordButton: XCUIElement {
-        app.descendants(matching: .any)["eye.slash"].firstMatch
+        app.descendants(matching: .textField)["enterNameField"].firstMatch
     }
 
     var passwordField: XCUIElement {
-        app.descendants(matching: .any)["Enter a password"].firstMatch
+        app.descendants(matching: .textField)["enterPasswordField"].firstMatch
     }
 
     var confirmPasswordField: XCUIElement {
-        app.descendants(matching: .any)["Confirm password"].firstMatch
+        app.descendants(matching: .textField)["enterConfirmPasswordField"].firstMatch
+    }
+
+    var showPasswordIcon: XCUIElement {
+        app.descendants(matching: .button)["Show password"].firstMatch
     }
 
     var continueButton: XCUIElement {
-        let elementsQuery = app.scrollViews.otherElements
-        return elementsQuery.buttons["Continue"]
+        app.descendants(matching: .button)["Continue"].firstMatch
     }
 
     var acceptButton: XCUIElement {
@@ -56,14 +55,16 @@ class CreatePersonalAccountFormPage: PageModel {
     }
 
     func enterPassword(_ password: String) throws -> CreatePersonalAccountFormPage {
-        showPasswordButton.tap()
-        try passwordField.tapIfKeyboardNotFocused().typeText(password)
+        showPasswordIcon.tap()
+        try passwordField.tapIfKeyboardNotFocused()
+        passwordField.typeText(password)
         return self
     }
 
     func enterConfirmPassword(_ confirmPassword: String) throws -> CreatePersonalAccountFormPage {
-        showPasswordButton.tap()
-        try confirmPasswordField.tapIfKeyboardNotFocused().typeText(confirmPassword)
+        showPasswordIcon.tap()
+        try confirmPasswordField.tapIfKeyboardNotFocused()
+        confirmPasswordField.typeText(confirmPassword)
         return self
     }
 
@@ -77,5 +78,4 @@ class CreatePersonalAccountFormPage: PageModel {
         acceptButton.tap()
         return try VerificationCodePage()
     }
-
 }

--- a/wire-ios/WireUITests/Pages/FirstTimePage.swift
+++ b/wire-ios/WireUITests/Pages/FirstTimePage.swift
@@ -43,12 +43,17 @@ class FirstTimePage: PageModel {
         app.buttons["Not Now"]
     }
 
+    var validationRuleForUsername: XCUIElement {
+        app.descendants(matching: .staticText)["validation-rules"].firstMatch
+    }
+
     var handler: (XCTestCase, any NSObjectProtocol)?
 
     // Tap OK button on first time using Wire popup
     func acceptFirstTimeAlert() -> FirstTimePage {
         dismissSavePasswordAlertIfPresent()
         okButton.tap()
+        okButton.waitToDisappear()
         return self
     }
 

--- a/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
+++ b/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
@@ -56,12 +56,12 @@ class OptionsOnSettingsPage: PageModel {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         try springboard.secureTextFields["Passcode field"].tapIfKeyboardNotFocused().typeText(pass)
 
-        if springboard.keyboards.buttons["Done"].exists {
-            springboard.keyboards.buttons["Done"].tap()
+        let doneButton = springboard.keyboards.buttons["Done"].firstMatch
+        if doneButton.waitForExistence(timeout: 2.0), doneButton.isHittable {
+            doneButton.tap()
         } else {
             springboard.typeText(XCUIKeyboardKey.return.rawValue)
         }
         return try ConversationsPage()
     }
-
 }

--- a/wire-ios/WireUITests/Pages/SetUsernamePage.swift
+++ b/wire-ios/WireUITests/Pages/SetUsernamePage.swift
@@ -25,18 +25,28 @@ class SetUsernamePage: PageModel {
     }
 
     var usernameField: XCUIElement {
-        let elementsQuery = app.descendants(matching: .any)["UsernameField"]
-        return elementsQuery.firstMatch
+        app.descendants(matching: .textField)["UsernameField"].firstMatch
     }
 
-    var usernameConfirmButton: XCUIElement {
-        let elementsQuery = usernameField.buttons
-        return elementsQuery.firstMatch
+    var confirmUsernameButton: XCUIElement {
+        app.descendants(matching: .button)["ConfirmButton"].firstMatch
     }
 
     func setUsername(_ username: String) throws -> ConversationsPage {
-        try usernameField.tapIfKeyboardNotFocused().typeText(username)
-        usernameConfirmButton.tap()
+        XCTAssertTrue(usernameField.waitForExistence(timeout: 3), "Username field not found")
+
+        let predicate = NSPredicate(format: "exists == true AND hittable == true")
+        let element = XCTNSPredicateExpectation(predicate: predicate, object: usernameField)
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [element], timeout: 3),
+            .completed,
+            "Username field not ready due to animation to type"
+        )
+
+        try usernameField.tapIfKeyboardNotFocused()
+        _ = app.keyboards.firstMatch.waitForExistence(timeout: 2)
+        usernameField.typeText(username)
+        confirmUsernameButton.tap()
         return try ConversationsPage()
     }
 }

--- a/wire-ios/WireUITests/XCUIElement+Additions.swift
+++ b/wire-ios/WireUITests/XCUIElement+Additions.swift
@@ -26,22 +26,36 @@ extension XCUIElement {
 
     @discardableResult
     func tapIfKeyboardNotFocused(timeout: TimeInterval = 3.0) throws -> XCUIElement {
-        while !(value(forKey: "hasKeyboardFocus") as? Bool ?? false) {
+        tap()
+        let keyboard = XCUIApplication().keyboards.element
+
+        _ = keyboard.waitForExistence(timeout: 0.5)
+        let hasFocus = (value(forKey: "hasKeyboardFocus") as? Bool) ?? false
+
+        if !(keyboard.exists || hasFocus) {
             tap()
-            if Date() > Date().addingTimeInterval(timeout) {
-                throw KeyboardFocusError
-                    .failedToFocusWithinTimeout(message: "Failed to focus keyboard within \(timeout) seconds")
-            }
+            _ = keyboard.waitForExistence(timeout: 0.5)
         }
         return self
     }
 
     @discardableResult
-    func waitToDisappear(timeout: TimeInterval = 2) -> Bool {
-        let exp = XCTNSPredicateExpectation(
+    func waitToDisappear(andThenWaitFor nextElement: XCUIElement? = nil, timeout: TimeInterval = 5) -> Bool {
+
+        let disappearExpectation = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "exists == false"),
             object: self
         )
-        return XCTWaiter().wait(for: [exp], timeout: timeout) == .completed
+        let disappearResult = XCTWaiter().wait(for: [disappearExpectation], timeout: timeout)
+        guard disappearResult == .completed else { return false }
+
+        guard let next = nextElement else { return true }
+
+        let appearExpectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == true AND hittable == true"),
+            object: next
+        )
+        let result = XCTWaiter().wait(for: [appearExpectation], timeout: timeout)
+        return result == .completed
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21303" title="WPB-21303" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21303</a>  [iOS] maintenance of critical flows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->

### Issue

As stars are up now, this reverts disabling the critical flows from running. See #3793 

This PR is recreated because https://github.com/wireapp/wire-ios/pull/3810 was accidentally merged.

### Testing
N/A

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
