### PR TITLE
fix: crash setting supported protocols - WPB-21668

### DIFF
--- a/wire-ios-data-model/Source/Model/User/ZMUser+SupportedProtocols.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMUser+SupportedProtocols.swift
@@ -25,8 +25,8 @@ public extension ZMUser {
     @NSManaged private var primitiveSupportedProtocols: [Int16]?
 
     /// Objc-C helper method because enum 'MessageProtocol' is not available.
-    @objc(setSupportedProtocols:)
-    internal func _setSupportedProtocols(_ protocols: Set<String>) {
+    @objc(updateSupportedProtocols:)
+    internal func _updateSupportedProtocols(_ protocols: Set<String>) {
         supportedProtocols = Set(protocols.compactMap {
             guard let messageProtocol = MessageProtocol(rawValue: $0) else {
                 assertionFailure("can not map value \($0) as MessageProtocol!")

--- a/wire-ios-data-model/Source/Model/User/ZMUser.m
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.m
@@ -505,11 +505,11 @@ static NSString *const PrimaryKey = @"primaryKey";
     NSArray<NSString *> *arrayProtocols = [transportData optionalArrayForKey:@"supported_protocols"];
     if (arrayProtocols != nil) {
         NSSet<NSString *> *supportedProtocols = [[NSSet alloc] initWithArray:arrayProtocols];
-        [self setSupportedProtocols:supportedProtocols];
+        [self updateSupportedProtocols:supportedProtocols];
     } else {
         // fallback to proteus as default supported protocol,
         // we don't have swift constants here unfortunately.
-        [self setSupportedProtocols:[[NSSet alloc] initWithObjects:@"proteus", nil]];
+        [self updateSupportedProtocols:[[NSSet alloc] initWithObjects:@"proteus", nil]];
     }
 
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21668" title="WPB-21668" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21668</a>  [iOS] - Crash when setting supported protocols
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

There’s a crash when core data merges conflicts after a context save. 

<img width="810" height="754" alt="Screenshot 2025-11-07 at 17 12 54" src="https://github.com/user-attachments/assets/29728240-4cb6-4bf0-bbdc-b24ca69e1a07" />

### Cause

Core data is likely attempting to update `ZMUser.supportedProtocols` by calling its own synthesized setter but instead ends up calling the objc selector `ZMUser.setSupportedProtocols` defined in `ZMUser+SupportedProtocols.swift`

### Solution

Rename the method to avoid clashing with Core Data

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

