### PR TITLE
fix: camera button: leaving blank space in place of keyboard - WPB-20252

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
@@ -111,6 +111,8 @@ final class ConfirmAssetViewController: UIViewController {
         createConstraints()
 
         setupStyle()
+        
+        self.presentationController?.delegate = self
     }
 
     override var prefersStatusBarHidden: Bool {
@@ -414,5 +416,12 @@ final class ConfirmAssetViewController: UIViewController {
 extension ConfirmAssetViewController: CanvasViewControllerDelegate {
     func canvasViewController(_ canvasViewController: CanvasViewController, didExportImage image: UIImage) {
         context.onConfirm?(image)
+    }
+}
+
+extension ConfirmAssetViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // this is called (only) when the user swipes down the sheet.
+        context.onCancel?()
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Controllers/ConfirmAssetViewController/ConfirmAssetViewController.swift
@@ -111,8 +111,8 @@ final class ConfirmAssetViewController: UIViewController {
         createConstraints()
 
         setupStyle()
-        
-        self.presentationController?.delegate = self
+
+        presentationController?.delegate = self
     }
 
     override var prefersStatusBarHidden: Bool {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20252" title="WPB-20252" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20252</a>  [iOS][iOS26] White space shows in place of keyboard on opening gif/camera/markers 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Swiping down the asset-confirm sheet has been causing a blank area in place of the keyboard.

### Solution

The onCancel callback was called on Cancel button pressed but not on user swipe down for ConfirmAssetViewController.
Adding the callback call to the swipe down dismissal fixed the issue.

### Testing

- Open camera
- Click a picture or choose a file
- On preview page where it shows OK to send swipe down to dismiss the page
