### PR TITLE
feat: small video preview - WPB-16313

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewItemView.swift
@@ -62,15 +62,12 @@ struct WireCellsAttachmentsPreviewItemView: View {
                     )
                 )
             case (.video, .small):
-                WireCellsDocumentAttachmentPreview(
-                    headerIcon: Image(viewModel.icon),
-                    headerText: viewModel.headerText,
-                    labelText: viewModel.fileName,
+                WireCellsSmallVideoPreviewView(
+                    url: viewModel.imagePreviewURL,
                     progress: viewModel.progress,
-                    isError: viewModel.isAssetDownloadError,
+                    downloadError: viewModel.isAssetDownloadError,
+                    duration: viewModel.attachmentDuration,
                 )
-                .frame(height: 74)
-                .frame(idealWidth: 288)
             case (.video, .large):
                 WireCellsLargeVideoPreviewView(
                     headerIcon: Image(viewModel.icon),

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewSizes.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsAttachmentsPreviewSizes.swift
@@ -1,0 +1,24 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+
+enum WireCellsAttachmentsPreviewSizes {
+    static let smallWidth: CGFloat = 120
+    static let smallHeight: CGFloat = 120
+}

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsSmallVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsSmallVideoPreviewView.swift
@@ -1,0 +1,104 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+import WireDesign
+import WireFoundation
+
+struct WireCellsSmallVideoPreviewView: View {
+
+    let url: URL?
+    let progress: Double?
+    let downloadError: Bool
+    let duration: String?
+
+    var body: some View {
+        WireCellsAttachmentPreview(
+            progress: progress,
+            progressColor: downloadError ? ColorTheme.Base.error.color : ColorTheme.Base.primary.color,
+        ) {
+            ZStack(alignment: .center) {
+                if let url {
+                    asyncImage(url: url)
+                }
+
+                if url == nil, !downloadError {
+                    ProgressView()
+                }
+
+                if downloadError {
+                    WireCellsAttachmentPreviewErrorCircle()
+                }
+            }
+            .frame(
+                width: WireCellsAttachmentsPreviewSizes.smallWidth,
+                height: WireCellsAttachmentsPreviewSizes.smallHeight
+            )
+            .overlay(alignment: .bottom) {
+                if let duration {
+                    durationView(duration: duration)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func asyncImage(url: URL) -> some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .empty:
+                ProgressView()
+            case let .success(image):
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .overlay {
+                        if !downloadError {
+                            PlayIcon()
+                                .disabled(false)
+                        }
+                    }
+            case .failure:
+                WireCellsAttachmentPreviewErrorCircle()
+            @unknown default:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func durationView(duration: String) -> some View {
+        Text(duration)
+            .font(for: .body1)
+            .foregroundColor(ColorTheme.Backgrounds.onTransparentDark.color)
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, 6)
+    }
+}
+
+#Preview {
+    WireCellsSmallVideoPreviewView(
+        url: URL(
+            string:
+            "https://i.kym-cdn.com/entries/icons/facebook/000/018/012/this_is_fine.jpg"
+        ),
+        progress: 0.7,
+        downloadError: false,
+        duration: "2:22",
+    )
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-16313" title="WPB-16313" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-16313</a>  [iOS] Small video previews in a conversation message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

What was done in this PR:

- Adding new View for small Video preview files.
- Update WireCellsAttachmentsPreviewItemView to use the new small video preview.

### Testing

On a group with File collaboration enabled, share multiple files on a chat being at least one video in it.
Shared video file will show on the conversation using the new small video preview.
<img width="641" height="632" alt="Captura de pantalla 2025-11-11 a las 9 58 55" src="https://github.com/user-attachments/assets/73c0f313-5b68-48ad-bec2-5cdd4ba51994" />

UI test can't be done, no way of mocking AsyncImage.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
