### PR TITLE
fix: wire backup tests - WPB-21707

### DIFF
--- a/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
+++ b/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
@@ -87,6 +87,12 @@ final class CreateAndImportBackupUseCaseTests: XCTestCase {
             .makeStream(of: [conversation])
         backupLocalStoreMock.fetchAllMessagesAsyncThrowingStreamMessageBackupModelAnyErrorReturnValue =
             .makeStream(of: [message])
+        backupLocalStoreMock.addMessagesBackupMessagesMessageBackupModelBackupMessagesImportResultReturnValue =
+            BackupMessagesImportResult(
+                validationCount: .init(successCount: 1, failureCount: 0),
+                insertionCount: .init(successCount: 1, failureCount: 0),
+                rehydrationCount: .init(successCount: 1, failureCount: 0)
+            )
 
         let password = UUID().uuidString
         let createEvents = try await createBackupUseCase.invoke(password: password)
@@ -106,7 +112,8 @@ final class CreateAndImportBackupUseCaseTests: XCTestCase {
         XCTAssertEqual(importEvents.last, .done)
         XCTAssertEqual(backupLocalStoreMock.addUserUserUserBackupModelVoidReceivedInvocations, [user])
         XCTAssertEqual(
-            backupLocalStoreMock.addMessagesBackupMessagesMessageBackupModelVoidReceivedInvocations,
+            backupLocalStoreMock
+                .addMessagesBackupMessagesMessageBackupModelBackupMessagesImportResultReceivedInvocations,
             [[message]]
         )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21707" title="WPB-21707" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21707</a>  [iOS] Fix `WireBackupAll` tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes wire backup tests (compile error prevents crash)

### Testing

Run automated tests

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
