### PR TITLE
fix: update wording for update channel banner - WPB-21527

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/ChannelBannerView/ChannelBannerView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/ChannelBannerView/ChannelBannerView.swift
@@ -103,7 +103,7 @@ public struct ChannelBannerView: View {
     ChannelBannerView(
         configuration: .init(
             title: "Show older messages?",
-            message: "Upgrade to a paid plan to offer channel members the whole history.",
+            message: "To show older messages to channel members, your team needs configuration. Please contact your team admin.",
             mainButtonTitle: "Upgrade now",
             mainButtonAction: {},
             closeButton: .init(

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -86,7 +86,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/et.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/et.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Mettre à niveau maintenant";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/it.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/lt.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/lt.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Ulepsz teraz";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Atualizar agora";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/sl.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/sl.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Upgrade now";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "Оновити зараз";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -83,7 +83,7 @@
 
 // MARK: - Channel history
 "conversation.channelHistory.upgradeBanner.title" = "Show older messages?";
-"conversation.channelHistory.upgradeBanner.message" = "Upgrade to a paid plan to offer channel members the whole history.";
+"conversation.channelHistory.upgradeBanner.message" = "To show older messages to channel members, your team needs configuration. Please contact your team admin.";
 "conversation.channelHistory.upgradeBanner.button" = "立即升級";
 "conversation.channelHistory.upgradeBanner.closeMessage" = "Close banner";
 "conversation.channelHistory.picker.title" = "Conversation history";

--- a/WireMessaging/Tests/WireMessagingTests/ChannelBannerView/ChannelBannerViewTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/ChannelBannerView/ChannelBannerViewTests.swift
@@ -42,7 +42,7 @@ final class ChannelBannerTests: XCTestCase {
         let view = ChannelBannerView(
             configuration: .init(
                 title: "Show older messages?",
-                message: "Upgrade to a paid plan to offer channel members the whole history.",
+                message: "To show older messages to channel members, your team needs configuration. Please contact your team admin.",
                 mainButtonTitle: "Upgrade now",
                 mainButtonAction: {},
                 closeButton: .init(
@@ -67,7 +67,7 @@ final class ChannelBannerTests: XCTestCase {
         let view = ChannelBannerView(
             configuration: .init(
                 title: "Show older messages?",
-                message: "Upgrade to a paid plan to offer channel members the whole history.",
+                message: "To show older messages to channel members, your team needs configuration. Please contact your team admin.",
                 mainButtonTitle: "Upgrade now",
                 mainButtonAction: {},
                 closeButton: .init(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21527" title="WPB-21527" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21527</a>  [iOS] Update “Upgrade Banners” copy for Freemium team users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Changing wording for the update channel banner. See new preview:

<img width="336" height="660" alt="Screenshot 2025-11-11 at 20 18 33" src="https://github.com/user-attachments/assets/6e25b7b8-8787-4902-8634-2e8ae938074e" />

This change targets develop but will cherry-pick with translations to release/cycle-4.10

### Testing

Not sure how to show this banner at the moment

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
