### PR TITLE
fix: cherry pick workflow - WPB-21648

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -22,7 +22,6 @@
 # 7. If any conflicts arise during the cherry-pick, they are committed.
 # 8. The branch with the cherry-picked changes is pushed.
 # 9. A new pull request is created against the target branch with the cherry-picked changes.
-#
 
 name: "Cherry-pick from release to next release or develop"
 
@@ -47,7 +46,7 @@ jobs:
         with:
           lfs: 'true'
           token: ${{ secrets.SUBMODULE_PAT }}
-          fetch-depth: 1
+          fetch-depth: 0
           submodules: recursive
 
       - name: Setup Python

--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lfs: 'true'
           token: ${{ secrets.SUBMODULE_PAT }}
-          fetch-depth: 0
+          fetch-depth: 1
           submodules: recursive
 
       - name: Setup Python
@@ -58,6 +58,10 @@ jobs:
         id: target-branch
         run: |
           scripts/determine-cherry-pick-target.py "${{ github.event.pull_request.base.ref }}"
+
+      - name: Fetch target branch
+        run: |
+          git fetch origin ${{ steps.target-branch.outputs.target }}:${{ steps.target-branch.outputs.target }}
 
       - name: Cherry pick to target branch
         uses: wireapp/action-auto-cherry-pick@v1.0.2


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21648" title="WPB-21648" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21648</a>  [iOS] Support cherry-picking to next release branch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

PR #3863 broke cherry-picking because it optimized the cloning by setting `fetch-depth` to 1.
However, now the reference for the target branch is missing when performing the cherry-pick.

This PR fixes it by adding another step.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
