### PR TITLE
fix: crash on context merge resolution during backup import - WPB-21725

### DIFF
--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+UnreadCount.m
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+UnreadCount.m
@@ -44,7 +44,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 
 - (void)setLastUnreadKnockDate:(NSDate *)lastUnreadKnockDate
 {
-    RequireString(self.managedObjectContext.zm_isSyncContext, "lastUnreadKnockDate should only be set from the sync context");
+    RequireString(!self.managedObjectContext.zm_isUserInterfaceContext, "lastUnreadKnockDate should NOT be set from the UI context");
     
     [self willChangeValueForKey:ZMConversationLastUnreadKnockDateKey];
     [self setPrimitiveValue:lastUnreadKnockDate forKey:ZMConversationLastUnreadKnockDateKey];
@@ -53,7 +53,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 
 - (void)setLastUnreadMissedCallDate:(NSDate *)lastUnreadMissedCallDate
 {
-    RequireString(self.managedObjectContext.zm_isSyncContext, "lastUnreadMissedCallDate should only be set from the sync context");
+    RequireString(!self.managedObjectContext.zm_isUserInterfaceContext, "lastUnreadMissedCallDate should NOT be set from the UI context");
     
     [self willChangeValueForKey:ZMConversationLastUnreadMissedCallDateKey];
     [self setPrimitiveValue:lastUnreadMissedCallDate forKey:ZMConversationLastUnreadMissedCallDateKey];
@@ -147,7 +147,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 
 - (void)setInternalEstimatedUnreadCount:(int64_t)internalEstimatedUnreadCount
 {
-    RequireString(self.managedObjectContext.zm_isSyncContext, "internalEstimatedUnreadCount should only be set from the sync context");
+    RequireString(!self.managedObjectContext.zm_isUserInterfaceContext, "internalEstimatedUnreadCount should NOT be set from the UI context");
     
     [self willChangeValueForKey:ZMConversationInternalEstimatedUnreadCountKey];
     [self setPrimitiveValue:@(internalEstimatedUnreadCount) forKey:ZMConversationInternalEstimatedUnreadCountKey];
@@ -156,7 +156,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 
 - (void)setInternalEstimatedUnreadSelfMentionCount:(int64_t)internalEstimatedUnreadSelfMentionCount
 {
-    RequireString(self.managedObjectContext.zm_isSyncContext, "internalEstimatedUnreadSelfMentionCount should only be set from the sync context");
+    RequireString(!self.managedObjectContext.zm_isUserInterfaceContext, "internalEstimatedUnreadSelfMentionCount should NOT be set from the UI context");
     
     [self willChangeValueForKey:ZMConversationInternalEstimatedUnreadSelfMentionCountKey];
     [self setPrimitiveValue:@(internalEstimatedUnreadSelfMentionCount) forKey:ZMConversationInternalEstimatedUnreadSelfMentionCountKey];
@@ -165,7 +165,7 @@ NSString *const ZMConversationLastReadLocalTimestampKey = @"lastReadLocalTimesta
 
 - (void)setInternalEstimatedUnreadSelfReplyCount:(int64_t)internalEstimatedUnreadSelfReplyCount
 {
-    RequireString(self.managedObjectContext.zm_isSyncContext, "internalEstimatedUnreadSelfReplyCount should only be set from the sync context");
+    RequireString(!self.managedObjectContext.zm_isUserInterfaceContext, "internalEstimatedUnreadSelfReplyCount should NOT be set from the UI context");
     
     [self willChangeValueForKey:ZMConversationInternalEstimatedUnreadSelfReplyCountKey];
     [self setPrimitiveValue:@(internalEstimatedUnreadSelfReplyCount) forKey:ZMConversationInternalEstimatedUnreadSelfReplyCountKey];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21725" title="WPB-21725" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21725</a>  [iOS] - Crash during context merge resolution on backup import 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

During backup import, the backup context periodically saves. Sometimes it needs to handle merge conflicts. During the conflict resolution, it tries to set `internalEstimatedUnreadCount`. However, setting this property is restricted to the sync context. Modifying it from the backup context triggers a crash.

### Solution

Lift the restriction to allow background contexts to modify these properties. To avoid completely removing the requirement, I updated it to disallow updates from the UI context.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
