### PR TITLE
fix: cherry pick workflow - WPB-21648

### DIFF
--- a/.github/workflows/cherry-pick-from-release-to-develop.yml
+++ b/.github/workflows/cherry-pick-from-release-to-develop.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lfs: 'true'
           token: ${{ secrets.SUBMODULE_PAT }}
-          fetch-depth: 1
+          fetch-depth: 0
           submodules: recursive
 
       - name: Setup Python
@@ -58,10 +58,6 @@ jobs:
         id: target-branch
         run: |
           scripts/determine-cherry-pick-target.py "${{ github.event.pull_request.base.ref }}"
-
-      - name: Fetch target branch
-        run: |
-          git fetch origin ${{ steps.target-branch.outputs.target }}:${{ steps.target-branch.outputs.target }}
 
       - name: Cherry pick to target branch
         uses: wireapp/action-auto-cherry-pick@v1.0.2

--- a/scripts/determine-cherry-pick-target.py
+++ b/scripts/determine-cherry-pick-target.py
@@ -15,6 +15,7 @@ Output:
     Writes the target branch to GITHUB_OUTPUT environment file.
 """
 
+
 import os
 import re
 import subprocess


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21648" title="WPB-21648" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21648</a>  [iOS] Support cherry-picking to next release branch
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Follow-up PR of https://github.com/wireapp/wire-ios/pull/3879 with an attempt to fix the cherry-pick workflow.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
