### PR TITLE
fix(backup): duplicate messages after import - WPB-21759

### DIFF
--- a/WireBackup/Sources/WireBackup/Protocols/BackupLocalStoreProtocol.swift
+++ b/WireBackup/Sources/WireBackup/Protocols/BackupLocalStoreProtocol.swift
@@ -17,6 +17,7 @@
 //
 
 public import WireFoundation
+public import Foundation
 
 // sourcery: AutoMockable
 public protocol BackupLocalStoreProtocol: Sendable {
@@ -47,7 +48,7 @@ public protocol BackupLocalStoreProtocol: Sendable {
     // MARK: -
 
     /// Returns the IDs of all messages stored in the local database, including deleted ones.
-    func fetchAllMessageIDs() async throws -> Set<String>
+    func fetchAllMessageIDs() async throws -> Set<UUID>
 
     /// Returns all messages stored in the local database, including deleted ones.
     func fetchAllMessages() -> AsyncThrowingStream<MessageBackupModel, any Error>

--- a/WireBackup/Sources/WireBackup/UseCases/ImportBackupUseCase.swift
+++ b/WireBackup/Sources/WireBackup/UseCases/ImportBackupUseCase.swift
@@ -196,14 +196,17 @@ public struct ImportBackupUseCase: ImportBackupUseCaseProtocol {
 
     private func mapBackupMessages(
         fromPage page: KotlinArray<BackupMessage>,
-        storedMessageIDs: Set<String>
+        storedMessageIDs: Set<UUID>
     ) -> [MessageBackupModel] {
         var backupMessages: [MessageBackupModel] = []
 
         for current in 0 ..< page.size {
-            guard let backupMessage = page.get(index: current) else { continue }
+            guard
+                let backupMessage = page.get(index: current),
+                let backupMessageID = UUID(uuidString: backupMessage.id)
+            else { continue }
 
-            if !storedMessageIDs.contains(backupMessage.id),
+            if !storedMessageIDs.contains(backupMessageID),
                let message = MessageBackupModel(backupMessage) {
                 backupMessages.append(message)
             }

--- a/WireBackup/Sources/WireBackupSupport/Sourcery/sourcery.yml
+++ b/WireBackup/Sources/WireBackupSupport/Sourcery/sourcery.yml
@@ -5,5 +5,4 @@ templates:
 output:
   ${DERIVED_SOURCES_DIR}
 args:
-  autoMockableImports: ["Foundation"]
-  autoMockablePublicImports: ["WireBackup", "WireFoundation"]
+  autoMockablePublicImports: ["Foundation", "WireBackup", "WireFoundation"]

--- a/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
+++ b/WireBackup/Tests/WireBackupTests/UseCases/CreateAndImportBackupUseCaseTests.swift
@@ -102,7 +102,7 @@ final class CreateAndImportBackupUseCaseTests: XCTestCase {
         // import
 
         backupLocalStoreMock.fetchAllUserIDsSetQualifiedIDReturnValue = []
-        backupLocalStoreMock.fetchAllMessageIDsSetStringReturnValue = []
+        backupLocalStoreMock.fetchAllMessageIDsSetUUIDReturnValue = []
 
         let importBackupUseCase = importBackupUseCaseFactory(backupURL)
         let importEvents = try await importBackupUseCase.invoke(password: password)

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -348,37 +348,6 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         }
     }
 
-    // MARK: - Formatting assessment
-
-    func test_FetchAllMessageIDs_ReturnsLowercaseUUIDs() async throws {
-        // GIVEN - Insert a message into the database
-        let messageNonce = UUID()
-        let context = try XCTUnwrap(context)
-
-        try await context.perform { [context, conversationID] in
-            let message = ZMClientMessage(context: context)
-            message.nonce = messageNonce
-
-            let id = try XCTUnwrap(conversationID)
-            let conversation = try XCTUnwrap(ZMConversation.fetch(
-                with: id.id,
-                domain: id.domain,
-                in: context
-            ))
-            message.visibleInConversation = conversation
-
-            try context.save()
-        }
-
-        // WHEN
-        let fetchedIDs = try await sut.fetchAllMessageIDs()
-
-        // THEN - Should return lowercase UUID (transport format)
-        let expectedID = messageNonce.transportString() // lowercase
-        XCTAssertTrue(fetchedIDs.contains(expectedID), "Should contain lowercase UUID")
-        XCTAssertFalse(fetchedIDs.contains(messageNonce.uuidString), "Should not contain uppercase UUID")
-    }
-
     // MARK: - Performance & Scale
 
     func testThatAddMessagesHandlesLargeBatch() async throws {

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -348,6 +348,38 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         }
     }
 
+    // MARK: - Formatting assessment 
+
+    func test_FetchAllMessageIDs_ReturnsLowercaseUUIDs() async throws {
+        // GIVEN - Insert a message into the database
+        let messageNonce = UUID()
+        let context = try XCTUnwrap(self.context)
+        
+        try await context.perform { [context, conversationID] in
+            let message = ZMClientMessage(context: context)
+            message.nonce = messageNonce
+            
+            let id = try XCTUnwrap(conversationID)
+            let conversation = try XCTUnwrap(ZMConversation.fetch(
+                with: id.id,
+                domain: id.domain,
+                in: context
+            ))
+            message.visibleInConversation = conversation
+
+            try context.save()
+        }
+
+        // WHEN
+        let fetchedIDs = try await sut.fetchAllMessageIDs()
+
+        // THEN - Should return lowercase UUID (transport format)
+        let expectedID = messageNonce.transportString() // lowercase
+        XCTAssertTrue(fetchedIDs.contains(expectedID), "Should contain lowercase UUID")
+        XCTAssertFalse(fetchedIDs.contains(messageNonce.uuidString), "Should not contain uppercase UUID")
+    }
+
+
     // MARK: - Performance & Scale
 
     func testThatAddMessagesHandlesLargeBatch() async throws {

--- a/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
+++ b/wire-ios/Wire-iOS Tests/Backup/BackupLocalStoreMessagesTests.swift
@@ -348,17 +348,17 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         }
     }
 
-    // MARK: - Formatting assessment 
+    // MARK: - Formatting assessment
 
     func test_FetchAllMessageIDs_ReturnsLowercaseUUIDs() async throws {
         // GIVEN - Insert a message into the database
         let messageNonce = UUID()
-        let context = try XCTUnwrap(self.context)
-        
+        let context = try XCTUnwrap(context)
+
         try await context.perform { [context, conversationID] in
             let message = ZMClientMessage(context: context)
             message.nonce = messageNonce
-            
+
             let id = try XCTUnwrap(conversationID)
             let conversation = try XCTUnwrap(ZMConversation.fetch(
                 with: id.id,
@@ -378,7 +378,6 @@ final class BackupLocalStoreMessagesTests: XCTestCase {
         XCTAssertTrue(fetchedIDs.contains(expectedID), "Should contain lowercase UUID")
         XCTAssertFalse(fetchedIDs.contains(messageNonce.uuidString), "Should not contain uppercase UUID")
     }
-
 
     // MARK: - Performance & Scale
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -33,13 +33,13 @@ extension BackupLocalStore {
         }
     }
 
-    func fetchAllMessageIDs() async throws -> Set<String> {
+    func fetchAllMessageIDs() async throws -> Set<UUID> {
         try await backupContext.perform { [backupContext] in
             let fetchRequest = ZMMessage.fetchRequest()
             fetchRequest.propertiesToFetch = ["nonce_data"]
 
             let messages = try backupContext.fetch(fetchRequest) as! [ZMMessage]
-            return Set(messages.compactMap(\.nonce).map { $0.transportString() })
+            return Set(messages.compactMap(\.nonce))
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -39,7 +39,7 @@ extension BackupLocalStore {
             fetchRequest.propertiesToFetch = ["nonce_data"]
 
             let messages = try backupContext.fetch(fetchRequest) as! [ZMMessage]
-            return Set(messages.compactMap(\.nonce).map(\.uuidString))
+            return Set(messages.compactMap(\.nonce).map { $0.transportString() })
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21759" title="WPB-21759" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21759</a>  [iOS] Duplicate messages when importing universal backup
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In **ImportBackupUseCase** we filter out messages that already exist in the database:
 ```if !storedMessageIDs.contains(backupMessage.id) ... // then filter out```

The stored messages are returned by  **BackupLocalStore+Messages**:
  ```return Set(messages.compactMap(\.nonce).map(\.uuidString))```

  This returns UUIDs in uppercase format (e.g., "A1B2C3D4-...")

  But backup message IDs use `.transportString()` which is lowercase (e.g., "a1b2c3d4-...")

  The comparison is case-sensitive, so "a1b2c3d4-..." doesn't match "A1B2C3D4-...", causing the filter to fail and allowing duplicates through.

### Solution

  ~Change from~
 ~``` return Set(messages.compactMap(\.nonce).map(\.uuidString))```~

 ~to:~
  ~```return Set(messages.compactMap(\.nonce).map { $0.transportString() })```~

  ~This ensures both stored and backup message IDs use the same lowercase format for comparison.~

**Use UUIDs for comparison instead of Strings**

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

