### PR TITLE
Fix: Work around for backups stored on google drive, using file provider extension

### DIFF
--- a/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupView.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupView.swift
@@ -44,7 +44,7 @@ struct ImportBackupView: View {
             .foregroundStyle(Color.primaryText)
             .fileImporter(
                 isPresented: $isFileImporterPresented,
-                allowedContentTypes: WireBackupUTIs,
+                allowedContentTypes: [.data], // Allow all data files; validation happens in ViewModel
                 onCompletion: viewModel.pickedBackupFile
             )
 

--- a/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
@@ -163,8 +163,8 @@ final class ImportBackupViewModel: ObservableObject {
             } catch ImportBackupError.invalidFileExtension {
                 logger.warn("restore failed due to invalid file extension")
                 alertContent = .init(
-                    title: Strings.Alert.IncompatibleBackupError.title,
-                    message: Strings.Alert.IncompatibleBackupError.message,
+                    title: Strings.Alert.InvalidFileExtensionError.title,
+                    message: Strings.Alert.InvalidFileExtensionError.message,
                     action: Strings.Alert.ok
                 )
                 state = .restoreFailed

--- a/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
+++ b/WireUI/Sources/WireSettingsUI/Account/BackupImportExport/Import/ImportBackupViewModel.swift
@@ -160,6 +160,14 @@ final class ImportBackupViewModel: ObservableObject {
                 logger.warn("failed to decrypt backup file, presenting the password input again")
                 state = .requestingPassword(url: url, isPasswordIncorrect: true)
                 return // don't clean up temporary file
+            } catch ImportBackupError.invalidFileExtension {
+                logger.warn("restore failed due to invalid file extension")
+                alertContent = .init(
+                    title: Strings.Alert.IncompatibleBackupError.title,
+                    message: Strings.Alert.IncompatibleBackupError.message,
+                    action: Strings.Alert.ok
+                )
+                state = .restoreFailed
             } catch ImportBackupError.incompatibleFileFormat {
                 logger.warn("restore failed due to incompatible file format")
                 alertContent = .init(

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/en.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "importBackup.alert.success.message" = "Your history is restored.";
 "importBackup.alert.genericError.title" = "Something went wrong";
 "importBackup.alert.genericError.message" = "Your history could not be restored. Please try again or contact the Wire customer support.";
+"importBackup.alert.invalidFileExtensionError.title" = "Invalid file";
+"importBackup.alert.invalidFileExtensionError.message" = "The selected file is not a valid backup file. Please select a file with extension .wbu, .ios_wbu, or .ios-wbu.";
 "importBackup.alert.incompatibleBackupError.title" = "Incompatible backup";
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";


### PR DESCRIPTION
[WPB-21859] Fix backup file import from cloud storage by allowing all data files

<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Backup files stored in google drive cloud storage appear greyed out and were unselectable when attempting to import them through the file picker. This occurred because SwiftUI's `.fileImporter` with custom UTType identifiers doesn't reliably recognize files stored in cloud storage locations.

(no WPB for this PR)

**Technical Approach:**
Instead of filtering files by specific UTType identifiers at the file picker level, we now allow all data files (`.data` type) to be selectable. File validation is then performed after selection in the `ImportBackupViewModel`, where the file extension is checked against the allowed backup file extensions (`.wbu`, `.ios_wbu`, `.ios-wbu`). This approach:
- Ensures files in cloud storage are visible and selectable
- Maintains proper validation through existing `ImportBackupUseCaseFactory`
- Provides clear error messages when invalid files are selected

**Changes:**
1. Modified `ImportBackupView.swift` to use `[.data]` instead of `WireBackupUTIs` for `allowedContentTypes`
2. Added specific error handling in `ImportBackupViewModel.swift` for `ImportBackupError.invalidFileExtension` to show appropriate error messages

### Testing

**Test Case 1: Import from Google Drive**
1. Save a backup file (`.wbu`) to Google Drive
2. Open Wire app → Settings → Account → Back up or Restore
3. Tap "Restore from Backup"
4. Navigate to Google Drive through the file picker
5. **Expected:** Backup files should be visible and selectable (not greyed out)
6. Select a valid backup file
7. **Expected:** Import process should start normally

**Test Case 2: Import from iCloud Drive**
1. Save a backup file to iCloud Drive
2. Follow steps 2-7 from Test Case 1
3. **Expected:** Same behavior as Google Drive

**Test Case 3: Invalid file selection**
1. In the file picker, select a file with an invalid extension (e.g., `.txt`, `.pdf`)
2. **Expected:** An error alert should appear with an appropriate message indicating the file is not a valid backup file

**Test Case 4: Valid backup file import (regression)**
1. Save a backup file locally on the device
2. Follow steps 2-7 from Test Case 1
3. **Expected:** Import should work as before (no regression)

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [x] Make sure you use the API for UI elements that support large fonts.
- [x] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [x] New UI elements have Accessibility strings for VoiceOver.

**Note:** This PR only modifies the file picker configuration and error handling logic. No new UI elements were added, and existing UI elements remain unchanged. The error messages use existing localization strings.

[WPB-21859]: https://wearezeta.atlassian.net/browse/WPB-21859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ