### PR TITLE
fix: disable multipart upload - WPB-21823

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/AWSClient.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/AWSClient.swift
@@ -159,7 +159,8 @@ final class AWSClient: Sendable {
         let fileSize = try FileManager.default.attributesOfItem(atPath: path.path)[.size] as! Int64
 
         if fileSize > Constants.maxRegularUploadSize {
-            try await uploadMultipart(path: path, node: node, versionID: versionID, onProgressUpdate: onProgressUpdate)
+            // FIXME: [WPB-18598] Use multipart upload when working
+            try await uploadRegular(path: path, node: node, versionID: versionID, onProgressUpdate: onProgressUpdate)
         } else {
             try await uploadRegular(path: path, node: node, versionID: versionID, onProgressUpdate: onProgressUpdate)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21823" title="WPB-21823" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21823</a>  [iOS] Disable multi-part upload
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

We use S3 API to upload files to wire cells. The S3 API offers away to upload files in multiple parts. This allows faster uploads. We should use this method for files above 100 MB. Currently however this is broken. That means we can't upload files over 100 MB without an error.

This PR disables multipart upload and uses regular upload for large files. It is a temporary fix.

### Testing

1. Navigate to wire cells enabled conversation
2. Upload a file less than 100 MB
3. Upload a file greater than 100 MB.
4. Sent the files
5. Check that both files can be viewed.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
