### PR TITLE
fix: long press no longer working on multipart attachments  - WPB-20974

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationCell/CellTypes/MultipartAttachments/MultipartAttachmentsConversationCell.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationCell/CellTypes/MultipartAttachments/MultipartAttachmentsConversationCell.swift
@@ -20,13 +20,17 @@ import SwiftUI
 
 final class MultipartAttachmentsConversationCell: UITableViewCell {
 
-    func configure(content: WireCellsAttachmentsPreviewView, insets: EdgeInsets) {
+    func configure(content: WireCellsAttachmentsPreviewView, insets: EdgeInsets, onLongPress: @escaping (UITableViewCell) -> Void) {
         contentConfiguration = UIHostingConfiguration {
             content
+                .onLongPressGesture {
+                    onLongPress(self)
+                }
         }
         .margins(.all, insets)
         .minSize(width: 0, height: 0)
         .background(.clear)
+        
     }
 
     override func prepareForReuse() {

--- a/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationCell/CellTypes/MultipartAttachments/MultipartAttachmentsConversationCell.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationCell/CellTypes/MultipartAttachments/MultipartAttachmentsConversationCell.swift
@@ -20,7 +20,11 @@ import SwiftUI
 
 final class MultipartAttachmentsConversationCell: UITableViewCell {
 
-    func configure(content: WireCellsAttachmentsPreviewView, insets: EdgeInsets, onLongPress: @escaping (UITableViewCell) -> Void) {
+    func configure(
+        content: WireCellsAttachmentsPreviewView,
+        insets: EdgeInsets,
+        onLongPress: @escaping (UITableViewCell) -> Void
+    ) {
         contentConfiguration = UIHostingConfiguration {
             content
                 .onLongPressGesture {
@@ -30,7 +34,7 @@ final class MultipartAttachmentsConversationCell: UITableViewCell {
         .margins(.all, insets)
         .minSize(width: 0, height: 0)
         .background(.clear)
-        
+
     }
 
     override func prepareForReuse() {

--- a/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationCellProvider.swift
+++ b/WireMessaging/Sources/WireMessagingUI/Conversation/ConversationCellProvider.swift
@@ -49,17 +49,22 @@ public final class ConversationCellProvider {
     public func provideCell(
         for model: ConversationCellModel,
         tableView: UITableView,
-        indexPath: IndexPath
+        indexPath: IndexPath,
+        onLongPress: @escaping (UITableViewCell) -> Void
     ) -> UITableViewCell {
         model.registerIfNeeded(in: tableView)
         let cell = tableView.dequeueReusableCell(withIdentifier: model.cellReuseIdentifier, for: indexPath)
-        configureCell(cell, with: model)
+        configureCell(cell, with: model, onLongPress: onLongPress)
 
         return cell
     }
 
     @MainActor
-    private func configureCell(_ cell: UITableViewCell, with model: ConversationCellModel) {
+    private func configureCell(
+        _ cell: UITableViewCell,
+        with model: ConversationCellModel,
+        onLongPress: @escaping (UITableViewCell) -> Void
+    ) {
         switch model {
 
         case let .timeDivider(model):
@@ -84,7 +89,8 @@ public final class ConversationCellProvider {
             )
             cell.configure(
                 content: WireCellsAttachmentsPreviewView(viewModel: viewModel),
-                insets: EdgeInsets(top: 0, leading: insets.leading, bottom: 0, trailing: insets.trailing)
+                insets: EdgeInsets(top: 0, leading: insets.leading, bottom: 0, trailing: insets.trailing),
+                onLongPress: onLongPress
             )
         }
     }

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -302,20 +302,20 @@ class MockConversationCellProviderProtocol: ConversationCellProviderProtocol {
 
     // MARK: - provideCell
 
-    var provideCellForTableViewIndexPath_Invocations: [(model: ConversationCellModel, tableView: UITableView, indexPath: IndexPath)] = []
-    var provideCellForTableViewIndexPath_MockMethod: ((ConversationCellModel, UITableView, IndexPath) -> UITableViewCell)?
-    var provideCellForTableViewIndexPath_MockValue: UITableViewCell?
+    var provideCellForTableViewIndexPathOnLongPress_Invocations: [(model: ConversationCellModel, tableView: UITableView, indexPath: IndexPath, onLongPress: (UITableViewCell) -> Void)] = []
+    var provideCellForTableViewIndexPathOnLongPress_MockMethod: ((ConversationCellModel, UITableView, IndexPath, @escaping (UITableViewCell) -> Void) -> UITableViewCell)?
+    var provideCellForTableViewIndexPathOnLongPress_MockValue: UITableViewCell?
 
     @MainActor
-    func provideCell(for model: ConversationCellModel, tableView: UITableView, indexPath: IndexPath) -> UITableViewCell {
-        provideCellForTableViewIndexPath_Invocations.append((model: model, tableView: tableView, indexPath: indexPath))
+    func provideCell(for model: ConversationCellModel, tableView: UITableView, indexPath: IndexPath, onLongPress: @escaping (UITableViewCell) -> Void) -> UITableViewCell {
+        provideCellForTableViewIndexPathOnLongPress_Invocations.append((model: model, tableView: tableView, indexPath: indexPath, onLongPress: onLongPress))
 
-        if let mock = provideCellForTableViewIndexPath_MockMethod {
-            return mock(model, tableView, indexPath)
-        } else if let mock = provideCellForTableViewIndexPath_MockValue {
+        if let mock = provideCellForTableViewIndexPathOnLongPress_MockMethod {
+            return mock(model, tableView, indexPath, onLongPress)
+        } else if let mock = provideCellForTableViewIndexPathOnLongPress_MockValue {
             return mock
         } else {
-            fatalError("no mock for `provideCellForTableViewIndexPath`")
+            fatalError("no mock for `provideCellForTableViewIndexPathOnLongPress`")
         }
     }
 

--- a/wire-ios/Wire-iOS Tests/ArticleViewTests.swift
+++ b/wire-ios/Wire-iOS Tests/ArticleViewTests.swift
@@ -27,7 +27,7 @@ import XCTest
 final class MockConversationMessageCellDelegate: ConversationMessageCellDelegate {
 
     func conversationMessageCell(
-        _ contentView: any ConversationMessageCell,
+        _ contentView: UIView,
         present viewController: UIViewController
     ) {
         // no-op

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -24,7 +24,7 @@ import WireUtilities
 protocol ConversationMessageCellDelegate: AnyObject, MessageActionResponder {
 
     func conversationMessageCell(
-        _ contentView: any ConversationMessageCell,
+        _ contentView: UIView,
         present viewController: UIViewController
     )
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController+ConversationMessageCellDelegate.swift
@@ -48,7 +48,7 @@ extension UIView {
 extension ConversationContentViewController: ConversationMessageCellDelegate {
 
     func conversationMessageCell(
-        _ contentView: any ConversationMessageCell,
+        _ contentView: UIView,
         present viewController: UIViewController
     ) {
         if let popoverPresentationController = viewController.popoverPresentationController {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -722,8 +722,23 @@ extension ConversationTableViewDataSource: UITableViewDataSource {
 
         let cellDescription = section.elements[indexPath.row]
         if let model = cellDescription.conversationCellModel {
-
-            return cellProvider.provideCell(for: model, tableView: tableView, indexPath: indexPath)
+            return cellProvider.provideCell(
+                for: model,
+                tableView: tableView,
+                indexPath: indexPath,
+                onLongPress: { [weak self] cell in
+                    guard let actionController = cellDescription.actionController else { return }
+                    
+                    let messageActionController = MessageActionsViewController.controller(
+                        withActions: MessageAction.allCases,
+                        actionController: actionController
+                    )
+                    
+                    self?.conversationCellDelegate?.conversationMessageCell(
+                        cell,
+                        present: messageActionController
+                    )
+                })
 
         } else {
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -728,17 +728,18 @@ extension ConversationTableViewDataSource: UITableViewDataSource {
                 indexPath: indexPath,
                 onLongPress: { [weak self] cell in
                     guard let actionController = cellDescription.actionController else { return }
-                    
+
                     let messageActionController = MessageActionsViewController.controller(
                         withActions: MessageAction.allCases,
                         actionController: actionController
                     )
-                    
+
                     self?.conversationCellDelegate?.conversationMessageCell(
                         cell,
                         present: messageActionController
                     )
-                })
+                }
+            )
 
         } else {
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/WireMessagingFactoryProtocol.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/WireMessagingFactoryProtocol.swift
@@ -61,7 +61,8 @@ protocol ConversationCellProviderProtocol {
     func provideCell(
         for model: ConversationCellModel,
         tableView: UITableView,
-        indexPath: IndexPath
+        indexPath: IndexPath,
+        onLongPress: @escaping (UITableViewCell) -> Void
     ) -> UITableViewCell
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20974" title="WPB-20974" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20974</a>  [iOS] Deleting a message with assets also deletes shared assets
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes a bug that was recently introduced where we could no longer access the actions menu through a long press to delete assets.

### Testing

with wire cells enabled, on multipart attachments, long press on the attachments, actions menu should open and when deleting an asset, it will reflect on the files lists as before.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
