### PR TITLE
chore(ci): automatically deliver to wire employees - WPB-21902

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -18,4 +18,5 @@ jobs:
       fastlane_action: development
       is_cloud_build: true
       produce_changelog: false
+      distribute_externals: true # automatically deliver to Wire Employees
     secrets: inherit


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21902" title="WPB-21902" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21902</a>  [iOS] Make edge builds automatically available to Wire Employees
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

People joining the edge testflight internally don't get any build at the moment. Any build should automatically go to the Wire Employees testflight group


### Testing

Merging this to test
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
