### PR TITLE
fix: infinite sync bar during app version migration 4.10 migration - WPB-20123

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -965,11 +965,13 @@ public final class ZMUserSession: NSObject {
         } else if resourcesSync {
             await triggerResourcesSync()
         } else if journal[.isConversationSyncRequired] {
-            // as wanted this should not be blocking, see AppVersionMigration_4_1_1
+            // as wanted this should not be blocking, see AppVersionMigration_4_1_1, AppVersionMigration_4_10_0
             Task {
                 let sync = clientSessionComponent?.pullAllConversationsSync
                 try? await sync?.pull()
             }
+            // trigger the sync in this case too, to get the right sync bar state
+            syncAgent?.resume()
         } else {
             syncAgent?.resume()
         }


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Upgrading from 4.9 to 4.10 causes an infinite sync bar. The 4.10 app migration triggers a non blocking conversations sync. In this case, no incremental sync is triggered which let the app's sync bar in onlineSynchronising.

**Note:** the ZMUserSession.networkState is what represents the syncbar state. It originally is `online` but when the reachability updates (isNetworkOnline = true, isPerformingSync= true) it resolves to onlineSynchronising.

The fix is to resume the syncAgent in this case so the sync bar gets the correct state, and the incrementalSync + liveSync are run

### Testing

Upgrade from 4.9 to 4.10

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
