### PR TITLE
chore: let zenkins approve cherry-picks - WPB-21985

### DIFF
--- a/.github/workflows/auto_approve_cherry_pick.yml
+++ b/.github/workflows/auto_approve_cherry_pick.yml
@@ -2,12 +2,12 @@ name: Auto-approve 🍒 cherry-pick PRs
 
 on:
   pull_request_target:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize, labeled]
 
 jobs:
   auto-approve:
-    # Only run if the title contains the 🍒 emoji
-    if: contains(github.event.pull_request.title, '🍒')
+    # Only run if the PR has the 'cherry-pick' label (added by the cherry-pick action)
+    if: contains(github.event.pull_request.labels.*.name, 'cherry-pick')
     runs-on: ubuntu-latest
 
     # Needed to create a review

--- a/.github/workflows/auto_approve_cherry_pick.yml
+++ b/.github/workflows/auto_approve_cherry_pick.yml
@@ -1,0 +1,34 @@
+name: Auto-approve 🍒 cherry-pick PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  auto-approve:
+    # Only run if the title contains the 🍒 emoji
+    if: contains(github.event.pull_request.title, '🍒')
+    runs-on: ubuntu-latest
+
+    # Needed to create a review
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Approve PR as bot user
+        uses: actions/github-script@v7
+        with:
+          # PAT from zenkins user
+          github-token: ${{ secrets.SUBMODULE_PAT }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            core.info(`Auto-approving PR #${pr.number}: "${pr.title}"`);
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              event: 'APPROVE',
+              body: '✅ Auto-approved cherry-pick PR 🍒.'
+            });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21985" title="WPB-21985" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21985</a>  [iOS] CI auto approve cherry-picks
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Adds a workflow so bot (zenkins) automatically approves all cherry-pick PRs so only one approval is required.

### Testing

merge and see
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
