### PR TITLE
fix: core crypto key migration flags - WPB-21849

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
@@ -147,7 +147,7 @@ final class NSEUserScope: Component<NSEUserScopeDependency> {
             throw Failure.mainAppRequired(message: "cryptobox migration required")
         }
 
-        guard coreCryptoKeyMigrationManager.isAnyMigrationRequired else {
+        guard !coreCryptoKeyMigrationManager.isAnyMigrationRequired else {
             throw Failure.mainAppRequired(message: "core crypto key migration required")
         }
 

--- a/wire-ios-data-model/Source/Core Crypto/CoreCryptoKeyProvider.swift
+++ b/wire-ios-data-model/Source/Core Crypto/CoreCryptoKeyProvider.swift
@@ -103,7 +103,7 @@ public class CoreCryptoKeyProvider {
     private func migrateToScopedDatabaseKey(path: String) throws {
 
         guard coreCryptoKeyMigrationManager.isMigrationToScopedKeyNeeded else { return }
-            
+
         guard let unscopedKey = try fetchCoreCryptoKey(scoped: false) else {
             // No unscoped key was found, we can mark this as done
             coreCryptoKeyMigrationManager.markMigrationToScopedKeyDone()

--- a/wire-ios-data-model/Source/Core Crypto/CoreCryptoKeyProvider.swift
+++ b/wire-ios-data-model/Source/Core Crypto/CoreCryptoKeyProvider.swift
@@ -102,10 +102,13 @@ public class CoreCryptoKeyProvider {
 
     private func migrateToScopedDatabaseKey(path: String) throws {
 
-        guard
-            coreCryptoKeyMigrationManager.isMigrationToScopedKeyNeeded,
-            let unscopedKey = try fetchCoreCryptoKey(scoped: false)
-        else { return }
+        guard coreCryptoKeyMigrationManager.isMigrationToScopedKeyNeeded else { return }
+            
+        guard let unscopedKey = try fetchCoreCryptoKey(scoped: false) else {
+            // No unscoped key was found, we can mark this as done
+            coreCryptoKeyMigrationManager.markMigrationToScopedKeyDone()
+            return
+        }
 
         if (try fetchCoreCryptoKey(scoped: true)) != nil {
             coreCryptoKeyMigrationManager.markMigrationToScopedKeyDone()

--- a/wire-ios-data-model/Tests/Core Crypto/CoreCryptoKeyProviderTests.swift
+++ b/wire-ios-data-model/Tests/Core Crypto/CoreCryptoKeyProviderTests.swift
@@ -250,6 +250,17 @@ class CoreCryptoKeyProviderTests: XCTestCase {
         // THEN
         XCTAssertEqual(mockMigrationManager.markMigrationToScopedKeyDone_Invocations.count, 1)
     }
+    
+    func test_itMarksScopedKeyMigrationAsDone_WhenAllowed_AndThereIsNoUnscopedKey() async throws {
+        // GIVEN
+        mockMigrationManager.isMigrationToScopedKeyNeeded = true
+        
+        // WHEN
+        _ = try? await sut.coreCryptoKey(allowCreation: true, path: "")
+        
+        // THEN
+        XCTAssertEqual(mockMigrationManager.markMigrationToScopedKeyDone_Invocations.count, 1)
+    }
 
     // MARK: Rotating key
 

--- a/wire-ios-data-model/Tests/Core Crypto/CoreCryptoKeyProviderTests.swift
+++ b/wire-ios-data-model/Tests/Core Crypto/CoreCryptoKeyProviderTests.swift
@@ -250,14 +250,14 @@ class CoreCryptoKeyProviderTests: XCTestCase {
         // THEN
         XCTAssertEqual(mockMigrationManager.markMigrationToScopedKeyDone_Invocations.count, 1)
     }
-    
+
     func test_itMarksScopedKeyMigrationAsDone_WhenAllowed_AndThereIsNoUnscopedKey() async throws {
         // GIVEN
         mockMigrationManager.isMigrationToScopedKeyNeeded = true
-        
+
         // WHEN
         _ = try? await sut.coreCryptoKey(allowCreation: true, path: "")
-        
+
         // THEN
         XCTAssertEqual(mockMigrationManager.markMigrationToScopedKeyDone_Invocations.count, 1)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21849" title="WPB-21849" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21849</a>  [iOS] New user unable to send messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In a recent PR (https://github.com/wireapp/wire-ios/pull/3909) a fix was made to how core crypto key migrations are handled. Since then, we don't receive notifications and can't share files via the share extension. 

Context:
- We return early in the extensions if there are migrations pending.
- Migrations as marked as pending by default. 

Causes:
- On fresh install, when migrations aren't needed, they should be marked as done. This was missing for one of the migrations.
- In the NSE, the `guard` statement was wrong. 🤦 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.


