### PR TITLE
chore: Bump AVS version - WPB-22114

### DIFF
--- a/WireAVS/Package.swift
+++ b/WireAVS/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WireAVS",
-            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.32/avs.xcframework.zip",
-            checksum: "afc584620d72e5dec54720050833b840245765fd96551126f91926d4733a0676"
+            url: "https://github.com/wireapp/wire-avs/releases/download/10.1.33/avs.xcframework.zip",
+            checksum: "acfdabb39cba9b98a481b43b2531c4e7ded8393178ffd2a6b3b1091b63bd1338"
         )
     ]
 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22114" title="WPB-22114" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22114</a>  [iOS] Bump AVS 10.1.33
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Bump AVS **10.1.33** version.
https://github.com/wireapp/wire-avs/releases/tag/10.1.33

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
