### PR TITLE
fix: can't send screenshot via share extension - WPB-20501

### DIFF
--- a/wire-ios/Wire-iOS Share Extension/Sources/Content/UnsentSendable.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/Content/UnsentSendable.swift
@@ -196,14 +196,13 @@ final class UnsentImageSendable: UnsentSendableBase, UnsentSendable {
 
                     error?.log(message: "Unable to load image from attachment")
 
-                    let image: UIImage?
-                    switch item {
+                    let image: UIImage? = switch item {
                     case let data as Data:
-                        image = UIImage(data: data)
+                        UIImage(data: data)
                     case let uiImage as UIImage:
-                        image = uiImage
+                        uiImage
                     default:
-                        image = nil
+                        nil
                     }
 
                     if let image {

--- a/wire-ios/Wire-iOS Share Extension/Sources/Content/UnsentSendable.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/Content/UnsentSendable.swift
@@ -189,20 +189,29 @@ final class UnsentImageSendable: UnsentSendableBase, UnsentSendable {
 
                 // if it fails, it will attach the content directly
 
-                self?.attachment
-                    .loadItem(
-                        forTypeIdentifier: UTType.image.identifier,
-                        options: options
-                    ) { [weak self] image, error in
+                self?.attachment.loadItem(
+                    forTypeIdentifier: UTType.image.identifier,
+                    options: options
+                ) { [weak self] item, error in
 
-                        error?.log(message: "Unable to load image from attachment")
+                    error?.log(message: "Unable to load image from attachment")
 
-                        if let image = image as? UIImage {
-                            self?.imageData = image.jpegData(compressionQuality: 0.9)
-                        }
-
-                        completion()
+                    let image: UIImage?
+                    switch item {
+                    case let data as Data:
+                        image = UIImage(data: data)
+                    case let uiImage as UIImage:
+                        image = uiImage
+                    default:
+                        image = nil
                     }
+
+                    if let image {
+                        self?.imageData = image.jpegData(compressionQuality: 0.9)
+                    }
+
+                    completion()
+                }
             }
 
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20501" title="WPB-20501" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20501</a>  [iOS] Can't send screenshot via ShareExt in iOS 26
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Given I'm on iOS 26, when I take a screenshot and try to share via Wire, then it always fails.

The reason is that we try to load the attachment as an `UIImage` but it's actually `Data`. It's likely that detail changed from iOS 18 to 26.

The solution is to handle both cases.

### Testing

1. Take a screenshot anywhere in iOS
2. Tap the share button, select Wire
3. Choose a conversation and share it.
4. Assert it succeeds.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
