### PR TITLE
fix: crash when setting the FRC's delegate to nil on background fetch - WPB-22117

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/ConversationUpdatesGenerator.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/ConversationUpdatesGenerator.swift
@@ -28,7 +28,7 @@ public protocol ConversationUpdatesGeneratorProtocol {
 public final class ConversationUpdatesGenerator: NSObject, ConversationUpdatesGeneratorProtocol {
 
     private let context: NSManagedObjectContext
-    private let fetchedResultsController: NSFetchedResultsController<ZMConversation>
+    private var fetchedResultsController: NSFetchedResultsController<ZMConversation>?
     private let repository: ConversationRepositoryProtocol
     private var onConversationUpdated: (UpdateConversationItem) -> Void
 
@@ -37,15 +37,6 @@ public final class ConversationUpdatesGenerator: NSObject, ConversationUpdatesGe
         context: NSManagedObjectContext,
         onConversationUpdated: @escaping (UpdateConversationItem) -> Void
     ) {
-        let request = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
-        request.predicate = ZMConversation.predicateForNeedingToBeUpdatedFromBackend()
-        request.sortDescriptors = [NSSortDescriptor(key: ZMConversationLastServerTimeStampKey, ascending: true)]
-        self.fetchedResultsController = NSFetchedResultsController(
-            fetchRequest: request,
-            managedObjectContext: context,
-            sectionNameKeyPath: nil,
-            cacheName: nil
-        )
         self.context = context
         self.onConversationUpdated = onConversationUpdated
         self.repository = repository
@@ -54,14 +45,18 @@ public final class ConversationUpdatesGenerator: NSObject, ConversationUpdatesGe
 
     /// Starts monitoring and triggers pulls for any needingToBeUpdatedFromBackend conversations.
     public func start() async {
-        fetchedResultsController.delegate = self
+        if fetchedResultsController == nil {
+            fetchedResultsController = createFetchRequestController()
+            fetchedResultsController?.delegate = self
+        }
+
         do {
-            try fetchedResultsController.performFetch()
+            try fetchedResultsController?.performFetch()
         } catch {
             WireLogger.conversation.error("error fetching conversations: \(String(describing: error))")
         }
 
-        let conversations = fetchedResultsController.fetchedObjects ?? []
+        let conversations = fetchedResultsController?.fetchedObjects ?? []
         for conversation in conversations {
             await context.perform {
                 if let id = conversation.qualifiedID {
@@ -75,7 +70,20 @@ public final class ConversationUpdatesGenerator: NSObject, ConversationUpdatesGe
     }
 
     public func stop() {
-        fetchedResultsController.delegate = nil
+        fetchedResultsController = nil
+    }
+
+    private func createFetchRequestController() -> NSFetchedResultsController<ZMConversation> {
+        let request = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+        request.predicate = ZMConversation.predicateForNeedingToBeUpdatedFromBackend()
+        request.sortDescriptors = [NSSortDescriptor(key: ZMConversationLastServerTimeStampKey, ascending: true)]
+        return NSFetchedResultsController(
+            fetchRequest: request,
+            managedObjectContext: context,
+            sectionNameKeyPath: nil,
+            cacheName: nil
+        )
+
     }
 }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/ConversationUpdatesGeneratorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/ConversationUpdatesGeneratorTests.swift
@@ -114,4 +114,35 @@ class ConversationUpdatesGeneratorTests {
         // THEN
         #expect(updateConversationItems.isEmpty)
     }
+
+    @Test("It does not generate an item when stopped")
+    func stopDoesGenerateItems() async throws {
+        // GIVEN
+        await sut.start()
+
+        // WHEN
+        await sut.stop()
+
+        // THEN
+        var updateConversationItems = [UpdateConversationItem]()
+        let newConversationID = QualifiedID.random()
+        try await confirmation("generator delivers an update for a new conversation") { confirm in
+            self.updateConversationItemClosure = {  item in
+                updateConversationItems.append(item)
+                confirm()
+            }
+
+            await coreDataStack.syncContext.perform { [modelHelper, context = coreDataStack.syncContext] in
+                let conversation = modelHelper.createGroupConversation(
+                    id: newConversationID.uuid,
+                    domain: newConversationID.domain,
+                    in: context
+                )
+                conversation.needsToBeUpdatedFromBackend = true
+            }
+            try await Task.sleep(for: .seconds(0.1))
+        }
+
+        #expect(updateConversationItems.isEmpty)
+    }
 }

--- a/WireDomain/Tests/WireDomainTests/Synchronization/ConversationUpdatesGeneratorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/ConversationUpdatesGeneratorTests.swift
@@ -121,7 +121,7 @@ class ConversationUpdatesGeneratorTests {
         await sut.start()
 
         // WHEN
-        await sut.stop()
+        sut.stop()
 
         // THEN
         var updateConversationItems = [UpdateConversationItem]()
@@ -129,7 +129,6 @@ class ConversationUpdatesGeneratorTests {
         try await confirmation("generator delivers an update for a new conversation") { confirm in
             self.updateConversationItemClosure = {  item in
                 updateConversationItems.append(item)
-                confirm()
             }
 
             await coreDataStack.syncContext.perform { [modelHelper, context = coreDataStack.syncContext] in
@@ -141,6 +140,7 @@ class ConversationUpdatesGeneratorTests {
                 conversation.needsToBeUpdatedFromBackend = true
             }
             try await Task.sleep(for: .seconds(0.1))
+            confirm()
         }
 
         #expect(updateConversationItems.isEmpty)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22117" title="WPB-22117" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22117</a>  [iOS] crash when FRC setDelegate is called
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

In case the app is launched for background fetch, we suspend the sync as no operation should be executed on background fetch (syncV2 does not support it).

On suspend, we stop also the ConversationUpdatesGenerator in setting to nil the delegate of the FetchResultsController.

To avoid this, one solution is to tear down the FetchResultsController on stop().

### Testing

This is hard to test, just make sure that normal behaviour is working. Create conversation, the conversation is updated from backend.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
