### PR TITLE
chore: add localization for backup new strings - WPB-21859

### DIFF
--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "متابعة";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/da.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Fortsæt";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/de.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "Diese Backup-Datei wurde von einer anderen Version von Wire erstellt und kann deshalb nicht wiederhergestellt werden.";
 "importBackup.alert.wrongFileError.title" = "Falsche Backup-Datei";
 "importBackup.alert.wrongFileError.message" = "Der Gesprächsverlauf eines anderen Kontos kann nicht wiederhergestellt werden.";
+"importBackup.alert.invalidFileError.title" = "Unzulässiger Dateityp";
+"importBackup.alert.invalidFileError.message" = "Wählen Sie eine Wire Backup-Datei (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Passwort eingeben";
 "importBackup.enterPassword.description" = "Dieses Backup ist passwortgeschützt.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Weiter";
 
 "importBackup.restoringHistory.title" = "Verlauf wird wiederhergestellt…";
+"importBackup.loadingBackup.message" = "Backup wird geladen…";
 "importBackup.restoringHistory.message" = "Unterhaltungen werden geladen…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/es.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "Esta copia de seguridad fue creada por una versión más reciente o obsoleta de Wire y no puede ser restaurada aquí.";
 "importBackup.alert.wrongFileError.title" = "Copia de seguridad incorrecta";
 "importBackup.alert.wrongFileError.message" = "No se puede restaurar el historial de una cuenta diferente.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Introduzca la contraseña";
 "importBackup.enterPassword.description" = "Esta copia de seguridad está protegida por contraseña.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Continuar";
 
 "importBackup.restoringHistory.title" = "Restaurando historial…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Cargando conversaciones…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/et.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/et.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Jätka";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Jatka";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Continuer";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/it.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Continua";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "続行";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/lt.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/lt.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Tęsti";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Ga door";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Kontynuuj";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "Este backup foi criado por uma versão mais recente ou desatualizada do Wire e não pode ser restaurado aqui.";
 "importBackup.alert.wrongFileError.title" = "Arquivo de backup errado";
 "importBackup.alert.wrongFileError.message" = "Você não pode restaurar o histórico de uma conta diferente.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Insira a senha";
 "importBackup.enterPassword.description" = "Este backup está protegido por senha.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Continuar";
 
 "importBackup.restoringHistory.title" = "Restaurando histórico…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Carregando conversas…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "Эта резервная копия была создана в более новой или устаревшей версии Wire и не может быть восстановлена.";
 "importBackup.alert.wrongFileError.title" = "Несовместимый файл резервной копии";
 "importBackup.alert.wrongFileError.message" = "Вы не можете восстановить историю из другой учетной записи.";
+"importBackup.alert.invalidFileError.title" = "Неверный тип файла";
+"importBackup.alert.invalidFileError.message" = "Выберите файл резервной копии Wire (.wbu, .ios_wbu или .ios-wbu).";
 
 "importBackup.enterPassword.title" = "Введите пароль";
 "importBackup.enterPassword.description" = "Эта резервная копия защищена паролем.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Продолжить";
 
 "importBackup.restoringHistory.title" = "Восстановление истории…";
+"importBackup.loadingBackup.message" = "Загрузка резервной копии…";
 "importBackup.restoringHistory.message" = "Загрузка бесед…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/sl.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/sl.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Nadaljuj";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Devam et";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "Продовжити";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "此备份由较新或过时的 Wire 版本创建，无法在此处恢复。";
 "importBackup.alert.wrongFileError.title" = "错误的备份文件";
 "importBackup.alert.wrongFileError.message" = "您无法从其他账户恢复历史记录。";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "键入密码";
 "importBackup.enterPassword.description" = "此备份受密码保护。";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "继续";
 
 "importBackup.restoringHistory.title" = "恢复历史记录中…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "加载对话中…";

--- a/WireUI/Sources/WireSettingsUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/WireUI/Sources/WireSettingsUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -54,6 +54,8 @@
 "importBackup.alert.incompatibleBackupError.message" = "This backup was created by a newer or outdated version of Wire and cannot be restored here.";
 "importBackup.alert.wrongFileError.title" = "Wrong backup file";
 "importBackup.alert.wrongFileError.message" = "You can't restore history from a different account.";
+"importBackup.alert.invalidFileError.title" = "Invalid file type";
+"importBackup.alert.invalidFileError.message" = "Select a Wire backup file (.wbu, .ios_wbu, or .ios-wbu)";
 
 "importBackup.enterPassword.title" = "Enter password";
 "importBackup.enterPassword.description" = "This backup is password protected.";
@@ -63,4 +65,5 @@
 "importBackup.enterPassword.button.title" = "繼續";
 
 "importBackup.restoringHistory.title" = "Restoring history…";
+"importBackup.loadingBackup.message" = "Loading backup…";
 "importBackup.restoringHistory.message" = "Loading conversations…";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21859" title="WPB-21859" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21859</a>  [iOS] Can't select Wire backup file in Google Drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Add missing localization for #3962 


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
