### PR TITLE
fix: add missing localizations - WPB-21441

### DIFF
--- a/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "إتاحة هذه المحادثة لأشخاص خارج فريقك.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "إشعار بالقراءة";
 "conversation.create.receipts.subtitle" = "When this is on, people can see when their messages in this conversation are read.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Åbn denne samtale for personer uden for dit team.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Read receipts";
 "conversation.create.receipts.subtitle" = "When this is on, people can see when their messages in this conversation are read.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Öffnen Sie diese Unterhaltung für Personen außerhalb Ihres Teams.";
 "conversation.create.apps.title" = "Apps zulassen";
 "conversation.create.apps.subtitle" = "Öffnen Sie diese Unterhaltung für Apps.";
+"conversation.create.apps_disabled.title" = "Ihr Team verwendet noch keine Apps";
+"conversation.create.apps_disabled.message" = "Um Ihren Workflow mit Apps zu verbessern, muss Ihr Team angepasst werden. Bitte wenden Sie sich an Ihren Team-Admin.";
 "conversation.create.receipts.title" = "Lesebestätigungen";
 "conversation.create.receipts.subtitle" = "Wenn diese Option aktiviert ist, können Sender sehen, wenn ihre Nachrichten gelesen werden.";
 "conversation.create.mls.title" = "Protokoll";

--- a/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Abrir esta conversación a personas fuera de su equipo.";
 "conversation.create.apps.title" = "Permitir aplicaciones";
 "conversation.create.apps.subtitle" = "Abrir esta conversación a aplicaciones.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Confirmaciones de lectura";
 "conversation.create.receipts.subtitle" = "Cuando esto está activado, la gente puede ver cuándo se leen sus mensajes en esta conversación.";
 "conversation.create.mls.title" = "Protocolo";

--- a/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Ava see vestlus meeskonnast väljas olevatele inimestele.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Lugemiskinnitused";
 "conversation.create.receipts.subtitle" = "Kui see on sees, saavad inimesed näha, kas nende vestluse sõnumid on loetud.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Open this conversation to people outside your team.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Lukukuittaukset";
 "conversation.create.receipts.subtitle" = "When this is on, people can see when their messages in this conversation are read.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Rendre cette conversation accessible à des personnes externes à votre équipe.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Accusés de lecture";
 "conversation.create.receipts.subtitle" = "Quand cette option est activée, les participants peuvent voir quand leurs messages ont été lus dans cette conversation.";
 "conversation.create.mls.title" = "Protocole";

--- a/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Apri questa conversazione a persone esterne al tuo team.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Conferme di lettura";
 "conversation.create.receipts.subtitle" = "Quando è attivo, le persone potranno vedere quando i loro messaggi vengono letti in questa conversazione.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "チーム外の人々にこの会話を公開します。";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "開封通知";
 "conversation.create.receipts.subtitle" = "この設定がオンのとき、この会話内のメッセージが読まれたかどうか確認できます。";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Leiskite matyti šį susirašinėjimą žmonėms nesantiems komandoje.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Perskaitymo patvirtinimai";
 "conversation.create.receipts.subtitle" = "Įjungus, žmonės gali matyti ar jų žinutės buvo perskaitytos.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Open dit gesprek voor mensen buiten jouw team.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Leesbevestigingen";
 "conversation.create.receipts.subtitle" = "Wanneer dit aanstaat, kunnen mensen zien wanneer je hun berichten gelezen hebt.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Wyraź zgodę na dołączenie do rozmowy osób spoza twojej drużyny.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Potwierdzenie odczytu";
 "conversation.create.receipts.subtitle" = "Gdy włączone, rozmówcy mogą zobaczyć, kiedy ich wiadomości zostały odczytane w tej rozmowie.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Abra esta conversa para pessoas de fora da sua equipe.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Recibos de Leitura";
 "conversation.create.receipts.subtitle" = "Quando isso está ativado, as pessoas podem ver quando suas mensagens nessa conversa são lidas.";
 "conversation.create.mls.title" = "Protocolo";

--- a/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Открыть эту беседу для пользователей не из вашей команды.";
 "conversation.create.apps.title" = "Разрешить приложения";
 "conversation.create.apps.subtitle" = "Открыть эту беседу для приложений.";
+"conversation.create.apps_disabled.title" = "Ваша команда еще не использует приложения";
+"conversation.create.apps_disabled.message" = "Для улучшения рабочего процесса с приложениями, вашей команде требуется настройка. Пожалуйста, свяжитесь с администратором вашей команды.";
 "conversation.create.receipts.title" = "Отчеты о прочтении";
 "conversation.create.receipts.subtitle" = "При включении ваши собеседники смогут видеть когда было прочитано их сообщение.";
 "conversation.create.mls.title" = "Протокол";

--- a/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Open this conversation to people outside your team.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Read receipts";
 "conversation.create.receipts.subtitle" = "When this is on, people can see when their messages in this conversation are read.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Open this conversation to people outside your team.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Okundu bilgisi";
 "conversation.create.receipts.subtitle" = "Bu açıkken, insanlar bu görüşmedeki mesajlarının ne zaman okunduğunu görebilir.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "Зробити цю розмову доступною для людей поза межами вашої команди.";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "Звіти про перегляд";
 "conversation.create.receipts.subtitle" = "Якщо ця опція увімкнена, учасники розмови можуть бачити, коли їхні повідомлення в цій розмові були переглянуті.";
 "conversation.create.mls.title" = "Protocol";

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "开放这个对话与团队以外的访客。";
 "conversation.create.apps.title" = "允许应用";
 "conversation.create.apps.subtitle" = "开启与应用的对话。";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "已读回执";
 "conversation.create.receipts.subtitle" = "当这启用时，参与者可以看到他们在此对话中的消息何时已阅读。";
 "conversation.create.mls.title" = "协议";

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -354,6 +354,8 @@
 "conversation.create.guests.subtitle" = "開放這個對話與團隊以外的訪客。";
 "conversation.create.apps.title" = "Allow apps";
 "conversation.create.apps.subtitle" = "Open this conversation to apps.";
+"conversation.create.apps_disabled.title" = "Your team doesn't use apps yet";
+"conversation.create.apps_disabled.message" = "To improve your workflow with apps, your team needs configuration. Please contact your team admin.";
 "conversation.create.receipts.title" = "讀取回條";
 "conversation.create.receipts.subtitle" = "當這啓用時，參與者可以看到他們在此對話中的消息何時已閱讀。";
 "conversation.create.mls.title" = "Protocol";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21441" title="WPB-21441" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21441</a>  [iOS] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds missing translations from `develop`.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
