### PR TITLE
fix: leaking continuation in search task - WPB-21441

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -126,7 +126,7 @@ private extension FilesView {
             }
         }
 
-        if !viewModel.isRecycleBin {
+        if !viewModel.isRecycleBin, viewModel.isFoldersEnabled {
             ToolbarItem(placement: .navigationBarTrailing) {
                 moreActionsButton
             }

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -681,7 +681,7 @@ extension SearchTask {
 extension SearchTask {
 
     func performRemoteSearchForServices() {
-        let teamIdentifier = searchContext.performAndWait({ ZMUser.selfUser(in: searchContext).team?.remoteIdentifier })
+        let teamIdentifier = searchContext.performAndWait { ZMUser.selfUser(in: searchContext).team?.remoteIdentifier }
         guard
             let apiVersion,
             let teamIdentifier,

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -681,8 +681,10 @@ extension SearchTask {
 extension SearchTask {
 
     func performRemoteSearchForServices() {
+        let teamIdentifier = searchContext.performAndWait({ ZMUser.selfUser(in: searchContext).team?.remoteIdentifier })
         guard
             let apiVersion,
+            let teamIdentifier,
             case let .search(searchRequest) = task,
             !searchRequest.searchOptions.contains(.localResultsOnly),
             searchRequest.searchOptions.contains(.services)
@@ -691,8 +693,6 @@ extension SearchTask {
         tasksRemaining += 1
 
         searchContext.performGroupedBlock { [self] in
-            let selfUser = ZMUser.selfUser(in: searchContext)
-            guard let teamIdentifier = selfUser.team?.remoteIdentifier else { return }
 
             let request = type(of: self).servicesSearchRequest(
                 teamIdentifier: teamIdentifier,

--- a/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
+++ b/wire-ios-sync-engine/Source/UserSession/Search/SearchTask.swift
@@ -681,8 +681,10 @@ extension SearchTask {
 extension SearchTask {
 
     func performRemoteSearchForServices() {
+        let teamIdentifier = searchContext.performAndWait { ZMUser.selfUser(in: searchContext).team?.remoteIdentifier }
         guard
             let apiVersion,
+            let teamIdentifier,
             case let .search(searchRequest) = task,
             !searchRequest.searchOptions.contains(.localResultsOnly),
             searchRequest.searchOptions.contains(.services)
@@ -691,8 +693,6 @@ extension SearchTask {
         tasksRemaining += 1
 
         searchContext.performGroupedBlock { [self] in
-            let selfUser = ZMUser.selfUser(in: searchContext)
-            guard let teamIdentifier = selfUser.team?.remoteIdentifier else { return }
 
             let request = type(of: self).servicesSearchRequest(
                 teamIdentifier: teamIdentifier,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21441" title="WPB-21441" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21441</a>  [iOS] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When searching for people or bots with an account without a team, the `tasksRemaining` counter is not decreased to 0, leading to a `continuation` of `withCheckedThrowingContinuation` is never called in `SearchUsersUseCase`.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
