### PR TITLE
fix: opening an archived conversation unarchives it - WPB-3772

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/ArchivedList/ArchivedListViewController.swift
@@ -155,7 +155,6 @@ extension ArchivedListViewController: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let conversation = viewModel[indexPath.row]
-        viewModel.unarchiveConversation(at: indexPath.row)
         delegate?.archivedListViewController(self, didSelectConversation: conversation)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-3772" title="WPB-3772" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-3772</a>  [iOS] Opening an archived conversation unarchives it
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Navigating to the archive list and opening an archived conversation will show the conversation (expected) and also unarchive it (not expected).

For some reason there is an explicit call to unarchive the conversation, the fix is to remove this call.

### Testing
1. Archive a conversation
2. Go to archive, see the conversation, open it
3. See the conversation content, go back
4. Assert the conversation is still in the archive.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
