### PR TITLE
fix: add missing developer flag check - WPB-22238

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -126,7 +126,7 @@ private extension FilesView {
             }
         }
 
-        if !viewModel.isRecycleBin {
+        if !viewModel.isRecycleBin && viewModel.isFoldersEnabled {
             ToolbarItem(placement: .navigationBarTrailing) {
                 moreActionsButton
             }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -126,7 +126,7 @@ private extension FilesView {
             }
         }
 
-        if !viewModel.isRecycleBin && viewModel.isFoldersEnabled {
+        if !viewModel.isRecycleBin, viewModel.isFoldersEnabled {
             ToolbarItem(placement: .navigationBarTrailing) {
                 moreActionsButton
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22238" title="WPB-22238" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22238</a>  [iOS] Add folders feature flag check to 4.12
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a missing developer flag check. This check ensures that neither the create folder button or the recycle bin feature is visible unless the folders feature is available.

### Testing

1. Ensure the wireCellsFolders developer flag is disabled.
2. navigate to a cells enabled conversation
3. Navigate to the file list.
4. The only button in the navigation bar should be a closed button.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
