### PR TITLE
chore(qa): change critical flow trigger - WPB-22260

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -194,6 +194,7 @@ jobs:
             build/reports/*.junit
             artifacts/**/*.junit
             app-group.zip
+            fastlane/app-group.zip
 
       - name: Prepare visual representation of test results
         uses: EnricoMi/publish-unit-test-result-action/macos@v2

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -193,6 +193,7 @@ jobs:
           path: |
             build/reports/*.junit
             artifacts/**/*.junit
+            app-group.zip
 
       - name: Prepare visual representation of test results
         uses: EnricoMi/publish-unit-test-result-action/macos@v2

--- a/.github/workflows/critical_flows.yaml
+++ b/.github/workflows/critical_flows.yaml
@@ -1,0 +1,23 @@
+name: Critical Flows
+
+on:
+  workflow_dispatch:
+  push:
+    - 'develop'
+    - 'release/cycle-*'
+  
+# This is what will cancel the workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  critical_flows:
+    uses: ./.github/workflows/_reusable_run_tests.yml
+    with:
+      all: false
+      notify_secret: WIRE_IOS_CI_WEBHOOK
+      test_dependencies: false
+      run_critical_flows: true
+    secrets: inherit

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -106,5 +106,5 @@ jobs:
       folders: ${{ join(fromJson(needs.detect-changes.outputs.folders), ',') }}
       notify_secret: WIRE_IOS_CI_WEBHOOK
       test_dependencies: ${{ github.event_name != 'pull_request' || startsWith(github.base_ref, 'release/cycle') }} # run on merge_queue or release branch PRs
-      run_critical_flows: ${{ github.event_name != 'pull_request' || startsWith(github.base_ref, 'release/cycle') }} # run on merge_queue or release branch PRs
+      run_critical_flows: false # separare workflow
     secrets: inherit

--- a/WireNetwork/Sources/WireNetwork/APIs/Rest/AuthenticationAPI/AuthenticationAPIV0.swift
+++ b/WireNetwork/Sources/WireNetwork/APIs/Rest/AuthenticationAPI/AuthenticationAPIV0.swift
@@ -276,6 +276,7 @@ class AuthenticationAPIV0: AuthenticationAPI, VersionedAPI {
         try ResponseParser()
             .success(code: .ok)
             .failure(code: .badRequest, label: "bad-request", error: AuthenticationAPIError.invalidEmail)
+            .parse(code: response.statusCode, data: data)
     }
 
     func requestEmailVerificationCode(for email: String) async throws {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :ios do
     after_all do |lane|
         delete_keychain_if_needed unless [:prepare_for_tests, :select_framework, :select_frameworks, :generate_framework_list, :test_frameworks, :test_only_frameworks, :run_uitests].include?(lane)
     end
-
+    
     desc "Test frameworks given folders"
     lane :test_frameworks do |options|
         if options[:all]
@@ -111,9 +111,12 @@ platform :ios do
     lane :run_uitests do |options|
         schemes = ["WireUITests"]
         options[:testplan] = "UITests"
+        options[:number_of_retries] = 0 # no retries
         begin
             run_tests_frameworks(schemes, options)
         rescue => e
+            device_id = ENV['IOS_SIM_ID']
+            sh "../scripts/zip_logs.sh 'com.wearezeta.zclient.alpha' 'group.com.wearezeta.zclient.alpha' 'app-group.zip' '#{device_id}'"
             UI.test_failure!("Failing running tests #{e.to_s}")
         end
     end
@@ -568,7 +571,7 @@ platform :ios do
             cloned_source_packages_path: ENV['PACKAGES_DIR'],
             disable_package_automatic_updates: true,
             skip_package_dependencies_resolution: true,
-            number_of_retries: 2,
+            number_of_retries: build.number_of_retries,
             xcargs: ci_args
         )
     end
@@ -725,7 +728,8 @@ class Build
     attr_reader :send_to_externals
     attr_reader :countly_api_key
     attr_reader :enable_countly
-
+    attr_reader :number_of_retries
+    
     def initialize(options:)
         build_number = options[:build_number]
         if build_number.nil?
@@ -750,7 +754,8 @@ class Build
         @enable_datadog = ENV['ENABLE_DATADOG'] == "true" || ENV['ENABLE_DATADOG'] == "1"
         @skip_security_tests = ENV['SKIP_SECURITY_TESTS'] == "true" || ENV['SKIP_SECURITY_TESTS'] == "1"
         @build_number = build_number
-
+        @number_of_retries = options[:number_of_retries] || 2
+        
         for_simulator = options[:for_simulator]
         if for_simulator.nil? 
             @for_simulator = false
@@ -764,6 +769,7 @@ class Build
         else
             @configuration = configuration
         end
+        
     end
 
     # Helpers

--- a/scripts/zip_logs.sh
+++ b/scripts/zip_logs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUNDLE_ID="${1:-com.wearezeta.zclient.alpha}"
+GROUP_ID="${2:-group.com.wearezeta.zclient.alpha}"
+OUT_ZIP="${3:-app-group.zip}"
+DEVICE_ID="${4:-booted}"
+
+echo "BUNDLE_ID=$BUNDLE_ID"
+echo "GROUP_ID=$GROUP_ID"
+echo "OUT_ZIP=$OUT_ZIP"
+echo "DEVICE_ID=$DEVICE_ID"
+
+echo "Checking app is installed..."
+if ! xcrun simctl get_app_container "$DEVICE_ID" "$BUNDLE_ID" data >/dev/null 2>&1; then
+  echo "ERROR: App not installed (or wrong device). Try:" >&2
+  echo "  xcrun simctl list devices booted" >&2
+  echo "  xcrun simctl install <UDID|booted> <path-to-app>" >&2
+  exit 10
+fi
+
+echo "Reading appinfo..."
+if ! APPINFO="$(xcrun simctl appinfo "$DEVICE_ID" "$BUNDLE_ID" 2>&1)"; then
+  echo "ERROR: simctl appinfo failed:" >&2
+  echo "$APPINFO" >&2
+  exit 11
+fi
+
+# Extract URL for the group id
+GROUP_URL="$(
+python3 - "$APPINFO" "$GROUP_ID" <<'PY'
+import re, sys
+text = sys.argv[1]
+group_id = sys.argv[2]
+pattern = r'"%s"\s*=\s*"([^"]+)"' % re.escape(group_id)
+m = re.search(pattern, text)
+print(m.group(1) if m else "", end="")
+PY
+)"
+
+if [[ -z "$GROUP_URL" ]]; then
+  echo "ERROR: Could not find GroupContainers value for: $GROUP_ID" >&2
+  echo "appinfo output was:" >&2
+  echo "$APPINFO" >&2
+  exit 12
+fi
+
+# file:///... -> /...
+GROUP_PATH="${GROUP_URL#file://}"
+GROUP_PATH="${GROUP_PATH%/}"
+
+echo "Resolved group path: $GROUP_PATH"
+
+if [[ ! -d "$GROUP_PATH" ]]; then
+  echo "ERROR: Resolved group path is not a directory: $GROUP_PATH" >&2
+  exit 13
+fi
+
+echo "Zipping..."
+rm -f "$OUT_ZIP"
+ditto -c -k --sequesterRsrc --keepParent "$GROUP_PATH" "$OUT_ZIP"
+
+echo "Created zip: $(pwd)/$OUT_ZIP"

--- a/wire-ios-mono.xcworkspace/contents.xcworkspacedata
+++ b/wire-ios-mono.xcworkspace/contents.xcworkspacedata
@@ -88,6 +88,9 @@
       <FileRef
          location = "group:test_pr_changes.yml">
       </FileRef>
+      <FileRef
+         location = "group:critical_flows.yaml">
+      </FileRef>
    </Group>
    <FileRef
       location = "group:Gemfile">

--- a/wire-ios/Tests/TestPlans/UITests.xctestplan
+++ b/wire-ios/Tests/TestPlans/UITests.xctestplan
@@ -61,8 +61,8 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "MultiBackendSupportTests",
-        "MultiBackendSupportTests\/test_Add_MultiBackend_Accounts()",
+        "BackupRestoreHistoryTests\/test_CreateBackupAndRestoreHistory()",
+        "TeamManageTests\/test_GroupAdmin_RemoveAndAddParticipantFromGroup()",
         "WireUITestCase"
       ],
       "target" : {

--- a/wire-ios/Tests/TestPlans/UITests.xctestplan
+++ b/wire-ios/Tests/TestPlans/UITests.xctestplan
@@ -60,6 +60,11 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "MultiBackendSupportTests",
+        "MultiBackendSupportTests\/test_Add_MultiBackend_Accounts()",
+        "WireUITestCase"
+      ],
       "target" : {
         "containerPath" : "container:Wire-iOS.xcodeproj",
         "identifier" : "01DFC4302D7B4C6F00D1962A",

--- a/wire-ios/Tests/TestPlans/UITests.xctestplan
+++ b/wire-ios/Tests/TestPlans/UITests.xctestplan
@@ -61,8 +61,6 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "BackupRestoreHistoryTests\/test_CreateBackupAndRestoreHistory()",
-        "TeamManageTests\/test_GroupAdmin_RemoveAndAddParticipantFromGroup()",
         "WireUITestCase"
       ],
       "target" : {

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -20,13 +20,13 @@ import WireFoundation
 import XCTest
 
 final class AccountManagementTests: WireUITestCase {
-    
+
     var teamMember: UserInfo!
-    
+
     @MainActor
     func test_Account_Management_Lock_With_Passcode() async throws {
         let passcode = UserGenerator.generateAppPasscode()
-        
+
         do {
             let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
             let ownerAccessToken = try await userHelper.fetchAccessToken(
@@ -34,7 +34,7 @@ final class AccountManagementTests: WireUITestCase {
                 password: teamOwner.password
             )
             let teamID = try XCTUnwrap(teamOwner.teamID)
-            
+
             let (_, userInfo) = try await userHelper.registerUsersAsTeamMember(
                 ownerAccessToken: ownerAccessToken,
                 teamID: teamID
@@ -43,7 +43,7 @@ final class AccountManagementTests: WireUITestCase {
         } catch {
             throw XCTSkip("error in setup of test: \(error)")
         }
-        
+
         let page = try await app.loginUser(email: teamMember.email, password: teamMember.password)
             .acceptPopupOnTeamMemberSetup(with: self)
             .setUsername(teamMember.username)
@@ -72,7 +72,7 @@ final class AccountManagementTests: WireUITestCase {
                 password: teamOwner.password
             )
             let teamID = try XCTUnwrap(teamOwner.teamID)
-            
+
             let (_, userInfo) = try await userHelper.registerUsersAsTeamMember(
                 ownerAccessToken: ownerAccessToken,
                 teamID: teamID
@@ -81,7 +81,7 @@ final class AccountManagementTests: WireUITestCase {
         } catch {
             throw XCTSkip("error in setup of test: \(error)")
         }
-        
+
         let verifyEmailPage = try app.loginUser(email: teamMember.email, password: teamMember.password)
             .acceptPopupOnTeamMemberSetup(with: self)
             .setUsername(teamMember.username)

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -20,23 +20,30 @@ import WireFoundation
 import XCTest
 
 final class AccountManagementTests: WireUITestCase {
-
+    
+    var teamMember: UserInfo!
+    
     @MainActor
     func test_Account_Management_Lock_With_Passcode() async throws {
         let passcode = UserGenerator.generateAppPasscode()
-
-        let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
-        let ownerAccessToken = try await userHelper.fetchAccessToken(
-            email: teamOwner.email,
-            password: teamOwner.password
-        )
-        let teamID = try XCTUnwrap(teamOwner.teamID)
-
-        let (_, teamMember) = try await userHelper.registerUsersAsTeamMember(
-            ownerAccessToken: ownerAccessToken,
-            teamID: teamID
-        )
-
+        
+        do {
+            let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
+            let ownerAccessToken = try await userHelper.fetchAccessToken(
+                email: teamOwner.email,
+                password: teamOwner.password
+            )
+            let teamID = try XCTUnwrap(teamOwner.teamID)
+            
+            let (_, userInfo) = try await userHelper.registerUsersAsTeamMember(
+                ownerAccessToken: ownerAccessToken,
+                teamID: teamID
+            )
+            teamMember = userInfo
+        } catch {
+            throw XCTSkip("error in setup of test: \(error)")
+        }
+        
         let page = try await app.loginUser(email: teamMember.email, password: teamMember.password)
             .acceptPopupOnTeamMemberSetup(with: self)
             .setUsername(teamMember.username)
@@ -58,18 +65,23 @@ final class AccountManagementTests: WireUITestCase {
     func test_Account_Management_Update_Email_Reset_password() async throws {
         let updatedUserDetails = UserGenerator.generateUniqueUserInfo()
 
-        let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
-        let ownerAccessToken = try await userHelper.fetchAccessToken(
-            email: teamOwner.email,
-            password: teamOwner.password
-        )
-        let teamID = try XCTUnwrap(teamOwner.teamID)
-
-        let (_, teamMember) = try await userHelper.registerUsersAsTeamMember(
-            ownerAccessToken: ownerAccessToken,
-            teamID: teamID
-        )
-
+        do {
+            let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
+            let ownerAccessToken = try await userHelper.fetchAccessToken(
+                email: teamOwner.email,
+                password: teamOwner.password
+            )
+            let teamID = try XCTUnwrap(teamOwner.teamID)
+            
+            let (_, userInfo) = try await userHelper.registerUsersAsTeamMember(
+                ownerAccessToken: ownerAccessToken,
+                teamID: teamID
+            )
+            teamMember = userInfo
+        } catch {
+            throw XCTSkip("error in setup of test: \(error)")
+        }
+        
         let verifyEmailPage = try app.loginUser(email: teamMember.email, password: teamMember.password)
             .acceptPopupOnTeamMemberSetup(with: self)
             .setUsername(teamMember.username)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22260" title="WPB-22260" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22260</a>  [iOS] Failing critical flows
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Looking at last nightly, two tests are failing:

- test_CreateBackupAndRestoreHistory() 
- test_GroupAdmin_RemoveAndAddParticipantFromGroup() 

This PR changes how we run critical flows, it will run them after PR merged.

### Testing

-  check if CI pass
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
