### PR TITLE
fix: delete permanently when folders feature disabled - WPB-22238

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesItemViewModel.swift
@@ -60,6 +60,7 @@ final class FilesItemViewModel: ObservableObject {
     let subtitle: String?
     let icon: FileIcon
     let isInRecycleBin: Bool
+    let isFoldersEnabled: Bool
 
     struct TagsInfo {
         let firstTag: String?
@@ -80,6 +81,8 @@ final class FilesItemViewModel: ObservableObject {
         calendar: Calendar = .autoupdatingCurrent,
         timeZone: TimeZone = .autoupdatingCurrent,
         isInRecycleBin: Bool,
+        isFoldersEnabled: Bool
+
     ) {
         self.nodeID = item.id
         self.item = item
@@ -95,6 +98,7 @@ final class FilesItemViewModel: ObservableObject {
         self.icon = item.icon
         self.localAssetRepository = localAssetRepository
         self.isInRecycleBin = isInRecycleBin
+        self.isFoldersEnabled = isFoldersEnabled
 
         localAssetRepository.observeAsset(nodeID: nodeID).sink { [weak self] asset in
             self?.asset = asset

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesPreviewHelpers.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesPreviewHelpers.swift
@@ -121,6 +121,7 @@ extension FilesItemViewModel {
             localAssetRepository: PreviewLocalAssetRepository(),
             onItemAction: { _, _ in },
             isInRecycleBin: false,
+            isFoldersEnabled: false,
         )
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -126,7 +126,7 @@ private extension FilesView {
             }
         }
 
-        if !viewModel.isRecycleBin {
+        if !viewModel.isRecycleBin, viewModel.isFoldersEnabled {
             ToolbarItem(placement: .navigationBarTrailing) {
                 moreActionsButton
             }
@@ -162,16 +162,14 @@ private extension FilesView {
 
     var moreActionsButton: some View {
         Menu {
-            if viewModel.isFoldersEnabled {
-                Button {
-                    viewModel.onCreateFolder()
-                } label: {
-                    Label {
-                        Text(Strings.Files.List.newFolder)
-                    } icon: {
-                        Image(systemName: "folder")
-                            .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
-                    }
+            Button {
+                viewModel.onCreateFolder()
+            } label: {
+                Label {
+                    Text(Strings.Files.List.newFolder)
+                } icon: {
+                    Image(systemName: "folder")
+                        .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
                 }
             }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -126,7 +126,7 @@ private extension FilesView {
             }
         }
 
-        if !viewModel.isRecycleBin, viewModel.isFoldersEnabled {
+        if !viewModel.isRecycleBin {
             ToolbarItem(placement: .navigationBarTrailing) {
                 moreActionsButton
             }
@@ -162,14 +162,16 @@ private extension FilesView {
 
     var moreActionsButton: some View {
         Menu {
-            Button {
-                viewModel.onCreateFolder()
-            } label: {
-                Label {
-                    Text(Strings.Files.List.newFolder)
-                } icon: {
-                    Image(systemName: "folder")
-                        .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
+            if viewModel.isFoldersEnabled {
+                Button {
+                    viewModel.onCreateFolder()
+                } label: {
+                    Label {
+                        Text(Strings.Files.List.newFolder)
+                    } icon: {
+                        Image(systemName: "folder")
+                            .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
+                    }
                 }
             }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewItemView.swift
@@ -137,7 +137,7 @@ struct FilesViewItemView: View {
                     }
 
                     if canDeleteFiles {
-                        if viewModel.isInRecycleBin {
+                        if viewModel.isInRecycleBin || !viewModel.isFoldersEnabled {
                             Button(
                                 role: .destructive,
                                 action: { delete(permanently: true) },

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewItemView.swift
@@ -102,11 +102,13 @@ struct FilesViewItemView: View {
                 Spacer()
 
                 Menu {
-                    Button(action: open) {
-                        Label(Strings.Files.Item.Menu.open, systemImage: "arrow.up.forward.square")
-                    }.disabled(viewModel.isDownloading)
+                    if !viewModel.isInRecycleBin {
+                        Button(action: open) {
+                            Label(Strings.Files.Item.Menu.open, systemImage: "arrow.up.forward.square")
+                        }.disabled(viewModel.isDownloading)
+                    }
 
-                    if viewModel.isDownloadOptionAvailable {
+                    if viewModel.isDownloadOptionAvailable, !viewModel.isInRecycleBin  {
                         Button(action: download) {
                             Label(Strings.Files.Item.Menu.download, systemImage: "square.and.arrow.down")
                         }.disabled(viewModel.isDownloading)
@@ -118,7 +120,7 @@ struct FilesViewItemView: View {
                         }
                     }
 
-                    if canMoveToFolder {
+                    if canMoveToFolder, !viewModel.isInRecycleBin {
                         Button(action: moveToFolder) {
                             Label(Strings.Files.Item.Menu.moveToFolder, systemImage: "folder")
                         }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewItemView.swift
@@ -102,13 +102,11 @@ struct FilesViewItemView: View {
                 Spacer()
 
                 Menu {
-                    if !viewModel.isInRecycleBin {
-                        Button(action: open) {
-                            Label(Strings.Files.Item.Menu.open, systemImage: "arrow.up.forward.square")
-                        }.disabled(viewModel.isDownloading)
-                    }
+                    Button(action: open) {
+                        Label(Strings.Files.Item.Menu.open, systemImage: "arrow.up.forward.square")
+                    }.disabled(viewModel.isDownloading)
 
-                    if viewModel.isDownloadOptionAvailable, !viewModel.isInRecycleBin  {
+                    if viewModel.isDownloadOptionAvailable {
                         Button(action: download) {
                             Label(Strings.Files.Item.Menu.download, systemImage: "square.and.arrow.down")
                         }.disabled(viewModel.isDownloading)
@@ -120,7 +118,7 @@ struct FilesViewItemView: View {
                         }
                     }
 
-                    if canMoveToFolder, !viewModel.isInRecycleBin {
+                    if canMoveToFolder {
                         Button(action: moveToFolder) {
                             Label(Strings.Files.Item.Menu.moveToFolder, systemImage: "folder")
                         }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewModel.swift
@@ -310,6 +310,7 @@ package final class FilesViewModel: ObservableObject {
                 }
             },
             isInRecycleBin: isRecycleBin,
+            isFoldersEnabled: isFoldersEnabled,
         )
     }
 

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/Files/FilesViewTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/UITests/Components/Files/FilesViewTests.swift
@@ -374,7 +374,8 @@ private extension FilesItemViewModel {
             locale: Locale(identifier: "en_US_POSIX"),
             calendar: Calendar(identifier: .gregorian),
             timeZone: .gmt,
-            isInRecycleBin: false
+            isInRecycleBin: false,
+            isFoldersEnabled: false
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22238" title="WPB-22238" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22238</a>  [iOS] Add folders feature flag check to 4.12
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue where if the folder's feature is disabled and therefore the recycling bin is disabled, the delete option would still move the file to the recycle bin. Now the delete option will permanently delete the file.

### Testing

0. Ensure that the wire cells folders feature is disabled.
1. Navigate to a cells enabled conversation.
2. navigate to the file list.
3. Tap on the files menu and select "Delete permanently".
4. A sheet is displayed giving you information that the file will be permanently deleted.
5. Tap "Delete permanently".
6. The file is deleted.
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
