### PR TITLE
fix(ci): wrong previous version found for changelog generation - WPB-22186

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -47,14 +47,14 @@ jobs:
         run: echo "CURRENT_TAG=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
       - name: 'Set previous Git tag to latest tag if comparing to head'
         if: "${{ env.HEAD_TAG_DIFF != '0' }}"
-        run: echo "PREVIOUS_TAG=$(git tag | grep -E '${{ env.regex }}' | tail -n 1)" >> "$GITHUB_ENV"
+        run: echo "PREVIOUS_TAG=$(git tag | grep -E '${{ env.regex }}' | sort -V | tail -n 1)" >> "$GITHUB_ENV"
 
       - name: 'Set current Git tag to latest tagged commit'
         if: "${{ env.HEAD_TAG_DIFF == '0' }}"
-        run: echo "CURRENT_TAG=$(git tag | grep -E '${{ env.regex }}' | tail -n 1)" >> "$GITHUB_ENV"
+        run: echo "CURRENT_TAG=$(git tag | grep -E '${{ env.regex }}' | sort -V | tail -n 1)" >> "$GITHUB_ENV"
       - name: 'Set previous Git tag previous tag because head is latest tag'
         if: "${{ env.HEAD_TAG_DIFF == '0' }}"
-        run: echo "PREVIOUS_TAG=$(git tag | grep -E '${{ env.regex }}' | tail -n 2 | head -n 1)" >> "$GITHUB_ENV"
+        run: echo "PREVIOUS_TAG=$(git tag | grep -E '${{ env.regex }}' | sort -V | tail -n 2 | head -n 1)" >> "$GITHUB_ENV"
 
       - name: 'Print environment variables'
         run: |


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22186" title="WPB-22186" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22186</a>  [iOS] Manage release iOS 4.12.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The changelog is wrong because the wrong version is retrieved.

git tag (and your pipeline) are sorting lexicographically (as strings), not as semantic versions.

Compare these two as strings:
	•	appstore/4.9.0
	•	appstore/4.11.0

Character-by-character:
	•	appstore/4. = same
	•	then it compares '9' vs '1' → '9' is greater than '1'

So 4.9.0 is retrieved instead of 4.11.0

### Testing

tried on command line : 
```
git tag | grep -E ''appstore/[0-9]+\.[0-9]+\.[0-9]*'' | sort -V | tail -n 1
```

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
