### PR TITLE
fix: crash on fetchResultsController perform - WPB-22117

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/ConversationUpdatesGenerator.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/ConversationUpdatesGenerator.swift
@@ -49,16 +49,16 @@ public final class ConversationUpdatesGenerator: NSObject, ConversationUpdatesGe
             fetchedResultsController = createFetchRequestController()
             fetchedResultsController?.delegate = self
         }
+        await context.perform {
+            do {
+                try self.fetchedResultsController?.performFetch()
+            } catch {
+                WireLogger.conversation.error("error fetching conversations: \(String(describing: error))")
+            }
 
-        do {
-            try fetchedResultsController?.performFetch()
-        } catch {
-            WireLogger.conversation.error("error fetching conversations: \(String(describing: error))")
-        }
+            let conversations = self.fetchedResultsController?.fetchedObjects ?? []
+            for conversation in conversations {
 
-        let conversations = fetchedResultsController?.fetchedObjects ?? []
-        for conversation in conversations {
-            await context.perform {
                 if let id = conversation.qualifiedID {
                     self.onConversationUpdated(UpdateConversationItem(
                         repository: self.repository,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22117" title="WPB-22117" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22117</a>  [iOS] crash when FRC setDelegate is called
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following #3976, crash still occurs:

<img width="809" height="409" alt="Screenshot 2025-12-11 at 21 12 43" src="https://github.com/user-attachments/assets/79a829bb-8ff6-4b8b-9203-204ff41aadd4" />

This PR tries to solve this.
### Testing

N/A

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
