### PR TITLE
fix: do not close webSocket if there is an ongoing call - WPB-21358 🍒

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
+++ b/wire-ios-sync-engine/Source/Calling/CallKitManager.swift
@@ -41,6 +41,10 @@ protocol CallKitManagerDelegate: AnyObject {
 
     func endAllCalls()
 
+    /// Called when all calls have ended
+
+    func didEndAllCalls()
+
 }
 
 @objc
@@ -675,6 +679,10 @@ extension CallKitManager: CXProviderDelegate {
                 action.fulfill()
                 callRegister.unregisterCall(call)
                 logger.info("success: perform end call action", attributes: .safePublic)
+
+                if callRegister.allCalls.isEmpty {
+                    delegate.didEndAllCalls()
+                }
 
             case let .failure(error):
                 logger.error(

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+CallKitManagerDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+CallKitManagerDelegate.swift
@@ -89,4 +89,13 @@ extension SessionManager: CallKitManagerDelegate {
         }
     }
 
+    func didEndAllCalls() {
+        WireLogger.calling.info("all calls ended, suspending background tasks", attributes: .safePublic)
+        Task {
+            for userSession in backgroundUserSessions.values {
+                await userSession.syncAgent?.suspend()
+            }
+        }
+    }
+
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+LifeCycle.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+LifeCycle.swift
@@ -64,9 +64,15 @@ public extension ZMUserSession {
 
     @objc
     func applicationDidEnterBackground(_ note: Notification?) {
-        Task {
-            await syncAgent?.suspend()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let hasActiveCalls = callCenter?.activeCalls.isEmpty == false
+
+            if !hasActiveCalls {
+                await syncAgent?.suspend()
+            }
         }
+
         stopEphemeralTimers()
         lockDatabase()
         recalculateUnreadMessages()

--- a/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/CallKitManagerTests.swift
@@ -200,6 +200,11 @@ class MockCallKitManagerDelegate: WireSyncEngine.CallKitManagerDelegate {
         hasEndedAllCalls = true
     }
 
+    var invokeDidEndAllCalls: Bool = false
+    func didEndAllCalls() {
+        invokeDidEndAllCalls = true
+    }
+
 }
 
 class CallKitManagerTest: DatabaseTest {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21358" title="WPB-21358" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21358</a>  [iOS] Audio drops after a while when the app is in background (screen locked)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

<!--do not remove the jira markers to link tickets automatically -->


This PR was automatically cherry-picked based on the following PR:
https://github.com/wireapp/wire-ios/pull/4000

### Issue

We close the webSocket connection when the app goes into the background. As a result, the app doesn't receive epoch changes during the call and can no longer decode audio. So client loses audio in the middle of the call.

### Solution

Don't close the webSocket if there is an ongoing call. And close it when the user ends the call via CallKit.


### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
