### PR TITLE
fix: Call UI not maximizing after account switch - WPB-20468 🍒

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/PresentationDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/PresentationDelegate.swift
@@ -70,4 +70,8 @@ public protocol PresentationDelegate: AnyObject {
 
     // Called when showing the password prompt before joining a group conversation
     func showPasswordPrompt(for conversationName: String, completion: @escaping (String?) -> Void)
+
+    /// Updates the calling UI state if there's an active call
+    func updateActiveCallPresentationStateIfNeeded()
+
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+Push.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+Push.swift
@@ -125,6 +125,23 @@ extension SessionManager: UNUserNotificationCenterDelegate {
             fatalError("User session \(session) is not present in backgroundSessions")
         }
     }
+
+    /// Registers an observer to update active call presentation state when the conversation becomes visible.
+    fileprivate func observeConversationDidBecomeVisible() {
+        conversationVisibleObserver = NotificationCenter.default.addObserver(
+            forName: .conversationDidBecomeVisible,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+
+            if let observer = conversationVisibleObserver {
+                NotificationCenter.default.removeObserver(observer)
+                conversationVisibleObserver = nil
+            }
+            presentationDelegate?.updateActiveCallPresentationStateIfNeeded()
+        }
+    }
 }
 
 public extension SessionManager {
@@ -136,6 +153,11 @@ public extension SessionManager {
     ) {
         guard !conversation.isDeletedRemotely else {
             return
+        }
+
+        // If switching accounts, observe when conversation becomes visible to update call UI
+        if session != activeUserSession {
+            observeConversationDidBecomeVisible()
         }
 
         activateAccount(for: session) {
@@ -152,4 +174,8 @@ public extension SessionManager {
     func showUserProfile(user: UserType) {
         presentationDelegate?.showUserProfile(user: user)
     }
+}
+
+public extension Notification.Name {
+    static let conversationDidBecomeVisible = Notification.Name("ConversationDidBecomeVisible")
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -342,6 +342,7 @@ public final class SessionManager: NSObject, SessionManagerType {
     let jailbreakDetector: JailbreakDetectorProtocol?
     fileprivate var accountTokens: [UUID: [Any]] = [:]
     fileprivate var memoryWarningObserver: NSObjectProtocol?
+    var conversationVisibleObserver: NSObjectProtocol?
     fileprivate var isSelectingAccount: Bool = false
 
     var proxyCredentials: WireTransport.ProxyCredentials?

--- a/wire-ios-sync-engine/Tests/Source/MockPresentationDelegate.swift
+++ b/wire-ios-sync-engine/Tests/Source/MockPresentationDelegate.swift
@@ -74,4 +74,6 @@ class MockPresentationDelegate: PresentationDelegate {
         completion(mockPassword)
     }
 
+    func updateActiveCallPresentationStateIfNeeded() {}
+
 }

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -509,8 +509,6 @@ extension AppRootRouter {
             presentAlertForDeletedAccountIfNeeded(error)
             sessionManager.processPendingURLActionDoesNotRequireAuthentication()
         case .authenticated:
-            // This is needed to display an ongoing call when coming from the background.
-            authenticatedRouter?.updateActiveCallPresentationState()
             urlActionRouter.authenticatedRouter = authenticatedRouter
             ZClientViewController.shared?.legalHoldDisclosureController?.discloseCurrentState(cause: .appOpen)
             sessionManager.processPendingURLActionRequiresAuthentication()

--- a/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
@@ -143,6 +143,10 @@ class URLActionRouter: URLActionRouterProtocol {
 
 extension URLActionRouter: PresentationDelegate {
 
+    func updateActiveCallPresentationStateIfNeeded() {
+        authenticatedRouter?.updateActiveCallPresentationState()
+    }
+
     func showPasswordPrompt(for conversationName: String, completion: @escaping (String?) -> Void) {
         typealias ConversationAlert = L10n.Localizable.Join.Group.Conversation.Alert
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ViewLifeCycle.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/ConversationViewController+ViewLifeCycle.swift
@@ -41,5 +41,15 @@ extension ConversationViewController {
         isAppearing = false
 
         syncCellsState()
+        notifyConversationDidBecomeVisible()
+
     }
+
+    private func notifyConversationDidBecomeVisible() {
+        NotificationCenter.default.post(
+            name: .conversationDidBecomeVisible,
+            object: nil
+        )
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20468" title="WPB-20468" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20468</a>  [iOS] Accepting call on 2nd account doesn't open calling UI but only show green banner on top with connected timer in the conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR was automatically cherry-picked based on the following PR:
https://github.com/wireapp/wire-ios/pull/3897

### Testing


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
