### PR TITLE
fix: messages stuck with stale delivery state - WPB-22214

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationContentViewController.swift
@@ -621,8 +621,9 @@ extension ConversationContentViewController: UITableViewDelegate {
         // different to actionControllers[<message.nonce>], so it was out of sync
         // it was fixed but for extra safety backup action controller if not found
         var backupActionController: ConversationMessageActionController?
-        if let nonce = cellDescription?.message?.nonce {
-            backupActionController = dataSource.sectionControllers.get(for: nonce)?.actionController
+
+        if let message = cellDescription?.message, let cacheIdentifier = MessageCacheIdentifier(message: message) {
+            backupActionController = dataSource.sectionControllers.get(for: cacheIdentifier)?.actionController
         }
 
         if cellDescription?.supportsActions ?? false,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -232,7 +232,7 @@ final class ConversationTableViewDataSource: NSObject {
                     }
 
                     // Section model uses nonce for DifferenceKit identity (not cache identifier)
-                    // This ensures the same message is recognized as the same section across delivery state changes
+                    // This ensures the same message is recognized as the same section across delivery state changes.
                     sections.append(ArraySection(
                         model: identifier.nonce,
                         elements: sectionController.tableViewCellDescriptions

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -55,7 +55,13 @@ final class ConversationTableViewDataSource: NSObject {
 
     var registeredCells: [AnyClass] = []
 
-    var sectionControllers = ThreadSafeDictionary<UUID, ConversationMessageSectionController>()
+    /// Cache for section controllers, keyed by message identifier
+    ///
+    /// The identifier includes both nonce and deliveryState to ensure proper cache invalidation
+    /// when a message's delivery state changes (e.g., from `.pending` to `.sent`).
+    ///
+    /// See `MessageCacheIdentifier` for implementation details.
+    var sectionControllers = ThreadSafeDictionary<MessageCacheIdentifier, ConversationMessageSectionController>()
 
     private(set) var hasOlderMessagesToLoad = false
     private(set) var hasNewerMessagesToLoad = false
@@ -152,7 +158,17 @@ final class ConversationTableViewDataSource: NSObject {
             }
 
             // Go through messages and calculate sections
-            let result = messages.enumerated().map { offset, element in
+            let result: [(
+                MessageCacheIdentifier,
+                ConversationMessageSectionController,
+                ConversationMessageContext
+            )] = messages.enumerated().compactMap { offset, element in
+
+                // Create a cache identifier that includes deliveryState to invalidate the cache on state change
+                guard let identifier = MessageCacheIdentifier(message: element) else {
+                    return nil
+                }
+
                 let context = self.context(
                     for: element,
                     at: offset,
@@ -161,10 +177,11 @@ final class ConversationTableViewDataSource: NSObject {
                     messages: messages
                 )
 
-                let sectionController = if let nonce = element.nonce,
-                                           let cachedSectionController = self.sectionControllers.get(for: nonce) {
+                let sectionController = if let cachedSectionController = self.sectionControllers.get(for: identifier) {
+                    // Cache hit - reuse existing section controller
                     cachedSectionController
                 } else {
+                    // Cache miss - create new section controller with fresh cell descriptions
                     self.makeSectionController(
                         message: element,
                         index: offset,
@@ -176,18 +193,18 @@ final class ConversationTableViewDataSource: NSObject {
 
                 // Re-create cell description if the context has changed (message has been moved around
                 // or received new neighbours).
-                return (element.nonce!, sectionController, context)
+                return (identifier, sectionController, context)
             }
 
             // Return back to main thread
             DispatchQueue.main.async {
                 var sections = [Section]()
 
-                for (messageObjectId, sectionController, context) in result {
+                for (identifier, sectionController, context) in result {
 
                     // saving calculations result in local cache
-                    self.sectionControllers.set(value: sectionController, for: messageObjectId)
-                    self.actionControllers.set(value: sectionController.actionController, for: messageObjectId)
+                    self.sectionControllers.set(value: sectionController, for: identifier)
+                    self.actionControllers.set(value: sectionController.actionController, for: identifier.nonce)
 
                     // Re-set messages from Main thread to section controller to not have crash with later interactions
                     // with data
@@ -214,8 +231,10 @@ final class ConversationTableViewDataSource: NSObject {
                         sectionController.recreateCellDescriptions(in: context)
                     }
 
+                    // Section model uses nonce for DifferenceKit identity (not cache identifier)
+                    // This ensures the same message is recognized as the same section across delivery state changes
                     sections.append(ArraySection(
-                        model: messageObjectId,
+                        model: identifier.nonce,
                         elements: sectionController.tableViewCellDescriptions
                     ))
                 }
@@ -387,8 +406,9 @@ final class ConversationTableViewDataSource: NSObject {
         selfUser: any UserType,
         messages: [ZMMessage]
     ) -> ConversationMessageSectionController {
-        if let nonce = message.nonce,
-           let cachedEntry = sectionControllers.get(for: nonce) {
+        let identifier = MessageCacheIdentifier(message: message)
+
+        if let identifier, let cachedEntry = sectionControllers.get(for: identifier) {
             cachedEntry.contentWidth = contentWidth
             return cachedEntry
         }
@@ -401,8 +421,8 @@ final class ConversationTableViewDataSource: NSObject {
             firstUnreadMessageNonce: firstUnreadMessage?.nonce
         )
 
-        if let nonce = message.nonce {
-            sectionControllers.set(value: sectionController, for: nonce)
+        if let identifier {
+            sectionControllers.set(value: sectionController, for: identifier)
         }
 
         return sectionController
@@ -680,7 +700,10 @@ extension ConversationTableViewDataSource: UITableViewDataSource {
     }
 
     func collapse(message: ZMConversationMessage) {
-        guard let nonce = message.nonce, let section = sectionControllers.get(for: nonce) else {
+        guard
+            let identifier = MessageCacheIdentifier(message: message),
+            let section = sectionControllers.get(for: identifier)
+        else {
             return
         }
         section.collapse()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageCacheIdentifier.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageCacheIdentifier.swift
@@ -1,0 +1,49 @@
+//
+// Wire
+// Copyright (C) 2025 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+
+/// Uniquely identifies a message's cached section controller.
+///
+/// The identifier includes both the message's nonce (stable identity) and delivery state
+/// (transient state) to ensure proper cache invalidation when delivery state changes.
+///
+/// When a message's delivery state changes (e.g., from `.pending` to `.sent`), the identifier
+/// changes. This is used to force a cache miss and recreation of the section controller
+/// with updated cell descriptions and prevents the UI from showing stale delivery states.
+/// (see `ConversationTableViewDataSource`)
+///
+struct MessageCacheIdentifier: Hashable {
+    let nonce: UUID
+    let deliveryState: ZMDeliveryState
+
+    init(nonce: UUID, deliveryState: ZMDeliveryState) {
+        self.nonce = nonce
+        self.deliveryState = deliveryState
+    }
+
+    /// Convenience initializer from a message
+    /// Returns nil if the message has no nonce
+
+    init?(message: ZMConversationMessage) {
+        guard let nonce = message.nonce else { return nil }
+        self.nonce = nonce
+        self.deliveryState = message.deliveryState
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22214" title="WPB-22214" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22214</a>  [iOS] - Messages shown as pending delivery and ordering of messages wrong - even though receiver received the message
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Messages sent in 1:1 conversations may sometimes end up showing as `sending` while they're already `sent`

### Cause

If a message is rendered with a `sending` delivery state, the message section will be cached in `ConversationTableViewDataSource`. When the delivery state changes the sections will be recalculated, but since the message section is cached the cache - containing the wrong delivery state - will be used.

### Solution

Use a cache identifier that includes deliveryState to invalidate the cache on state change

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.


