### PR TITLE
fix: slow request strategies tests - WPB-22487

### DIFF
--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -69,7 +69,6 @@ class EventDecoderTest: MessagingTestBase {
         super.tearDown()
     }
 
-
     private func decryptAndStoreEvents(
         _ events: [ZMUpdateEvent],
         publicKeys: EARPublicKeys? = nil

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -47,9 +47,9 @@ class EventDecoderTest: MessagingTestBase {
             lastEventIDRepository: lastEventIDRepository,
             isFederationEnabled: false
         )
-        
+
         lastEventIDRepository.storeLastEventID_MockMethod = { _ in }
-        
+
         syncMOC.performGroupedAndWait {
             self.syncMOC.mlsService = self.mockMLSService
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
@@ -68,8 +68,8 @@ class EventDecoderTest: MessagingTestBase {
         sut = nil
         super.tearDown()
     }
-    
-    
+
+
     private func decryptAndStoreEvents(
         _ events: [ZMUpdateEvent],
         publicKeys: EARPublicKeys? = nil
@@ -87,7 +87,7 @@ extension EventDecoderTest {
         // given
         var didCallBlock = false
         let event = await syncMOC.perform {
-            return self.eventStreamEvent()
+            self.eventStreamEvent()
         }
 
         _ = try await decryptAndStoreEvents([event])

--- a/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
+++ b/wire-ios-request-strategy/Sources/Synchronization/Decoding/EventDecoderTest.swift
@@ -47,9 +47,9 @@ class EventDecoderTest: MessagingTestBase {
             lastEventIDRepository: lastEventIDRepository,
             isFederationEnabled: false
         )
-
+        
         lastEventIDRepository.storeLastEventID_MockMethod = { _ in }
-
+        
         syncMOC.performGroupedAndWait {
             self.syncMOC.mlsService = self.mockMLSService
             let selfUser = ZMUser.selfUser(in: self.syncMOC)
@@ -59,7 +59,6 @@ class EventDecoderTest: MessagingTestBase {
             selfConversation.conversationType = .self
         }
         disableZMLogError(true)
-
     }
 
     override func tearDown() {
@@ -68,6 +67,15 @@ class EventDecoderTest: MessagingTestBase {
         EventDecoder.testingBatchSize = nil
         sut = nil
         super.tearDown()
+    }
+    
+    
+    private func decryptAndStoreEvents(
+        _ events: [ZMUpdateEvent],
+        publicKeys: EARPublicKeys? = nil
+    ) async throws -> [ZMUpdateEvent] {
+        try await setupProteusService()
+        return try await sut.decryptAndStoreEvents(events, publicKeys: publicKeys)
     }
 }
 
@@ -79,10 +87,10 @@ extension EventDecoderTest {
         // given
         var didCallBlock = false
         let event = await syncMOC.perform {
-            self.eventStreamEvent()
+            return self.eventStreamEvent()
         }
 
-        _ = try await sut.decryptAndStoreEvents([event])
+        _ = try await decryptAndStoreEvents([event])
 
         // when
         await sut.processStoredEvents { events in
@@ -120,7 +128,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = try await sut.decryptAndStoreEvents(
+        _ = try await decryptAndStoreEvents(
             [event],
             publicKeys: publicKeys
         )
@@ -149,7 +157,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = try await sut.decryptAndStoreEvents([event1])
+        _ = try await decryptAndStoreEvents([event1])
 
         // when
         _ = try await sut.decryptAndStoreEvents([event2])
@@ -189,7 +197,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = try await sut.decryptAndStoreEvents([event1, event2, event3, event4])
+        _ = try await decryptAndStoreEvents([event1, event2, event3, event4])
 
         // when
         await sut.processStoredEvents { events in
@@ -228,7 +236,7 @@ extension EventDecoderTest {
             self.eventStreamEvent()
         }
 
-        _ = try await sut.decryptAndStoreEvents([event1, event2])
+        _ = try await decryptAndStoreEvents([event1, event2])
 
         await sut.processStoredEvents(with: nil) { events in
             XCTAssert(events.contains(event1))
@@ -354,7 +362,7 @@ extension EventDecoderTest {
         }
 
         // when
-        _ = try await sut.decryptAndStoreEvents([pushEvent])
+        _ = try await decryptAndStoreEvents([pushEvent])
         await sut.processStoredEvents { events in
             XCTAssertTrue(events.contains(pushEvent))
             pushProcessed.fulfill()
@@ -365,7 +373,7 @@ extension EventDecoderTest {
 
         // and when
         let streamProcessed = customExpectation(description: "Stream event processed")
-        _ = try await sut.decryptAndStoreEvents([streamEvent])
+        _ = try await decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { events in
             XCTAssertTrue(events.contains(streamEvent))
             streamProcessed.fulfill()
@@ -389,7 +397,7 @@ extension EventDecoderTest {
         }
 
         // when
-        _ = try await sut.decryptAndStoreEvents([pushEvent])
+        _ = try await decryptAndStoreEvents([pushEvent])
         await sut.processStoredEvents { events in
             XCTAssertTrue(events.contains(pushEvent))
             pushProcessed.fulfill()
@@ -401,7 +409,7 @@ extension EventDecoderTest {
         // and when
         let streamProcessed = customExpectation(description: "Stream event not processed")
 
-        _ = try await sut.decryptAndStoreEvents([streamEvent])
+        _ = try await decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { events in
             // as filtering is removed, event with same id can go through process twice
             XCTAssertTrue(events.contains(streamEvent))
@@ -426,7 +434,7 @@ extension EventDecoderTest {
         }
 
         // when
-        _ = try await sut.decryptAndStoreEvents([pushEvent])
+        _ = try await decryptAndStoreEvents([pushEvent])
         await sut.processStoredEvents { events in
             XCTAssertTrue(events.contains(pushEvent))
             pushProcessed.fulfill()
@@ -438,7 +446,7 @@ extension EventDecoderTest {
         // and when
         let streamProcessed = customExpectation(description: "Stream event processed")
 
-        _ = try await sut.decryptAndStoreEvents([streamEvent])
+        _ = try await decryptAndStoreEvents([streamEvent])
         await sut.processStoredEvents { events in
             XCTAssertTrue(events.contains(streamEvent))
             streamProcessed.fulfill()
@@ -846,7 +854,7 @@ extension EventDecoderTest {
         mockMLSService.processWelcomeMessageWelcomeMessageContext_MockValue = groupID
 
         // When
-        let result = try await sut.decryptAndStoreEvents([event])
+        let result = try await decryptAndStoreEvents([event])
 
         // Then
         XCTAssertEqual(result, [event])
@@ -861,7 +869,7 @@ extension EventDecoderTest {
         mockMLSService.processWelcomeMessageWelcomeMessageContext_MockValue = groupID
 
         // When
-        _ = try await sut.decryptAndStoreEvents([event])
+        _ = try await decryptAndStoreEvents([event])
 
         // Then
         XCTAssertEqual(mockMLSService.processWelcomeMessageWelcomeMessageContext_Invocations.count, 1)

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -36,9 +36,33 @@ class MessagingTestBase: ZMTBaseTest {
     fileprivate(set) var otherClient: UserClient!
     fileprivate(set) var coreDataStack: CoreDataStack!
     fileprivate(set) var accountIdentifier: UUID!
-    fileprivate(set) var coreCrypto: SafeCoreCrypto!
-    fileprivate(set) var proteusService: ProteusServiceInterface!
-    fileprivate(set) var proteusClientSimulator: ProteusClientSimulator!
+
+    // Lazy Proteus/CoreCrypto properties - only initialized when accessed
+    private var _coreCrypto: SafeCoreCrypto?
+    private var _proteusService: ProteusServiceInterface?
+    private var _proteusClientSimulator: ProteusClientSimulator?
+    private var _isProteusInitialized = false
+
+    var coreCrypto: SafeCoreCrypto {
+        get async throws {
+            try await ensureProteusInitialized()
+            return _coreCrypto!
+        }
+    }
+
+    var proteusService: ProteusServiceInterface {
+        get async throws {
+            try await ensureProteusInitialized()
+            return _proteusService!
+        }
+    }
+
+    var proteusClientSimulator: ProteusClientSimulator {
+        get async throws {
+            try await ensureProteusInitialized()
+            return _proteusClientSimulator!
+        }
+    }
 
     let owningDomain = "example.com"
 
@@ -72,23 +96,10 @@ class MessagingTestBase: ZMTBaseTest {
             inMemoryStore: useInMemoryStore
         )
 
-        // Set up proteus client simulator
-
-        let cacheFolder = try XCTUnwrap(FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
-        let storageURL = cacheFolder.appendingPathComponent("OtherClients")
-        try? FileManager.default.removeItem(at: storageURL)
-
-        proteusClientSimulator = ProteusClientSimulator(
-            syncMOC: syncMOC,
-            owningDomain: owningDomain,
-            storageURL: storageURL
-        )
-
-        // Caches, timers and proteus service
+        // Caches and timers (lightweight setup)
 
         await setupCaches(in: coreDataStack)
         await setupTimers()
-        try await setupProteusService()
 
         // Set up managed objects
 
@@ -100,8 +111,9 @@ class MessagingTestBase: ZMTBaseTest {
             syncMOC.saveOrRollback()
         }
 
-        // Establish session after users/clients are created
-        try await proteusClientSimulator.establishSessionFromSelf(to: otherClient)
+        // Note: Proteus/CoreCrypto initialization is now lazy - it will be set up
+        // automatically when tests first access proteusService, coreCrypto, or
+        // proteusClientSimulator properties
     }
 
     override func tearDown() async throws {
@@ -115,14 +127,19 @@ class MessagingTestBase: ZMTBaseTest {
             self.groupConversation = nil
         }
         await stopEphemeralMessageTimers()
-        proteusClientSimulator.cleanup()
-        try coreCrypto.tearDown()
 
-        proteusService = nil
-        coreCrypto = nil
+        // Only clean up Proteus if it was initialized
+        if _isProteusInitialized {
+            _proteusClientSimulator?.cleanup()
+            try _coreCrypto?.tearDown()
+        }
+
+        _proteusService = nil
+        _coreCrypto = nil
+        _proteusClientSimulator = nil
+        _isProteusInitialized = false
         accountIdentifier = nil
         coreDataStack = nil
-        proteusClientSimulator = nil
 
         try await super.tearDown()
     }
@@ -608,6 +625,32 @@ extension MessagingTestBase {
 
 extension MessagingTestBase {
 
+    /// Ensures Proteus/CoreCrypto is initialized - call this before accessing proteus properties
+    private func ensureProteusInitialized() async throws {
+        guard !_isProteusInitialized else { return }
+
+        // Set up proteus client simulator
+        let cacheFolder = try XCTUnwrap(FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
+        let storageURL = cacheFolder.appendingPathComponent("OtherClients")
+        try? FileManager.default.removeItem(at: storageURL)
+
+        _proteusClientSimulator = ProteusClientSimulator(
+            syncMOC: syncMOC,
+            owningDomain: owningDomain,
+            storageURL: storageURL
+        )
+
+        // Set up Proteus service and CoreCrypto
+        try await setupProteusService()
+
+        // Establish session after users/clients are created
+        if let otherClient = self.otherClient {
+            try await _proteusClientSimulator!.establishSessionFromSelf(to: otherClient)
+        }
+
+        _isProteusInitialized = true
+    }
+
     func setupProteusService() async throws {
         let accountDir = coreDataStack.accountContainer
 
@@ -630,12 +673,12 @@ extension MessagingTestBase {
         )
 
         // Initialize CoreCrypto (this calls proteusInit internally)
-        coreCrypto = try await coreCryptoProvider.coreCrypto() as? SafeCoreCrypto
+        _coreCrypto = try await coreCryptoProvider.coreCrypto() as? SafeCoreCrypto
 
         // Create ProteusService with the provider
-        proteusService = ProteusService(coreCryptoProvider: coreCryptoProvider)
+        _proteusService = ProteusService(coreCryptoProvider: coreCryptoProvider)
 
-        await syncMOC.perform { [syncMOC, service = self.proteusService] in
+        await syncMOC.perform { [syncMOC, service = self._proteusService] in
             syncMOC.proteusService = service
         }
     }

--- a/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
+++ b/wire-ios-request-strategy/Tests/Helpers/MessagingTestBase.swift
@@ -644,7 +644,7 @@ extension MessagingTestBase {
         try await setupProteusService()
 
         // Establish session after users/clients are created
-        if let otherClient = self.otherClient {
+        if let otherClient {
             try await _proteusClientSimulator!.establishSessionFromSelf(to: otherClient)
         }
 

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests.swift
@@ -86,6 +86,7 @@ class ZMLocalNotificationTests: MessagingTestBase {
 
     override func tearDown() {
         sender = nil
+        selfUser = nil
         otherUser1 = nil
         otherUser2 = nil
         userWithNoName = nil

--- a/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
+++ b/wire-ios-request-strategy/Tests/Sources/Notifications/PushNotifications/ZMLocalNotificationTests_Message.swift
@@ -35,7 +35,6 @@ final class ZMLocalNotificationTests_Message: ZMLocalNotificationTests {
     func teamTest(_ block: () -> Void) {
         selfUser.teamIdentifier = UUID()
         block()
-        selfUser.teamIdentifier = nil
     }
 
     func textNotification(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22487" title="WPB-22487" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22487</a>  [iOS] fix request strategies slow tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

While introducing ProteusClientSimulator the ReqeustStrategies tests became really slow (4-6 seconds) per test.
This is due to calling CoreCrypto instance on each setup of tests even if there is no cryptographic tests.

Solution:

Make initialization lazy so only the required tests setup CC. This will result in tests being finished between 45-90 seconds (pretty similar as before see 4.11)


Note: ultimately we would use a mock, but this would be another optimization.

### Testing

run tests

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
