### PR TITLE
fix: establish groups pending join if epoch is 0 - WPB-22496

### DIFF
--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -876,13 +876,13 @@ public final class MLSService: MLSServiceInterface {
                     }
 
                     do {
-                        let (epoch, isSelfConversation) = await context.perform {
-                            (pendingGroup.epoch, pendingGroup.isSelfConversation)
+                        let epoch = await context.perform {
+                            pendingGroup.epoch
                         }
                         let conversationExists = try await self.conversationExists(
                             groupID: mlsGroupID
                         )
-                        let shouldEstablishGroup = epoch == 0 && isSelfConversation && !conversationExists
+                        let shouldEstablishGroup = epoch == 0 && !conversationExists
 
                         if shouldEstablishGroup {
                             try await self.internalEstablishPendingGroup(

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1428,7 +1428,35 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     // MARK: - Joining conversations
 
-    func test_PerformPendingJoins_It_Establishes_Group() async throws {
+    func test_PerformPendingJoins_It_Establishes_Group_SelfConversation() async throws {
+        try await assert_PerformPendingJoins_It_Establishes_Group(
+            conversationType: .`self`,
+            file: #file,
+            line: #line
+        )
+    }
+
+    func test_PerformPendingJoins_It_Establishes_Group_OneOnOne() async throws {
+        try await assert_PerformPendingJoins_It_Establishes_Group(
+            conversationType: .oneOnOne,
+            file: #file,
+            line: #line
+        )
+    }
+
+    func test_PerformPendingJoins_It_Establishes_Group_Group() async throws {
+        try await assert_PerformPendingJoins_It_Establishes_Group(
+            conversationType: .group,
+            file: #file,
+            line: #line
+        )
+    }
+
+    func assert_PerformPendingJoins_It_Establishes_Group(
+        conversationType: ZMConversationType,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async throws {
         // Given
         let groupID = MLSGroupID.random()
         let conversationID = UUID.create()
@@ -1438,9 +1466,13 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             conversation.remoteIdentifier = conversationID
             conversation.domain = domain
             conversation.mlsGroupID = groupID
-            conversation.mlsStatus = .pendingJoin
-            conversation.conversationType = .`self`
             conversation.messageProtocol = .mls
+            conversation.mlsStatus = .pendingJoin
+            conversation.conversationType = conversationType
+
+            // Only epoch 0 leads to establishing group
+            conversation.epoch = 0
+
             return conversation
         }
 
@@ -1460,17 +1492,17 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         // it creates CC conversation
         let createCoreCryptoConversationInvocations = mockCoreCryptoContext
             .createConversationConversationIdCreatorCredentialTypeConfig_Invocations
-        XCTAssertEqual(createCoreCryptoConversationInvocations.count, 1)
+        XCTAssertEqual(createCoreCryptoConversationInvocations.count, 1, file: file, line: line)
 
         // it commits pending proposals
-        XCTAssertEqual(mockMLSActionExecutor.commitPendingProposalsCount, 1)
+        XCTAssertEqual(mockMLSActionExecutor.commitPendingProposalsCount, 1, file: file, line: line)
 
         // it updates key material
-        XCTAssertEqual(mockMLSActionExecutor.updateKeyMaterialCount, 1)
+        XCTAssertEqual(mockMLSActionExecutor.updateKeyMaterialCount, 1, file: file, line: line)
 
         // it sets conversation state to ready
         let conversationMLSStatus = await uiMOC.perform { conversation.mlsStatus }
-        XCTAssertEqual(conversationMLSStatus, .ready)
+        XCTAssertEqual(conversationMLSStatus, .ready, file: file, line: line)
     }
 
     func test_PerformPendingJoins_IsSuccessful() async throws {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22496" title="WPB-22496" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22496</a>  [iOS] Don't join pending group via external commit if epoch is 0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
It was discovered that there is a case where the iOS client tries to join an mls group via external commit (because the user is a participant of the conversation but not yet a member of the underlying mls group) even when the epoch is 0. If the epoch is 0 it's likely because the group has been reset by another user but they failed to establish it. In this case, the iOS client should establish the group, otherwise if they try to join by external commit it would likely not succeed.

Note: we do have a `reEstablishPendingGroup` method that handles this correctly, but it only is invoked when trying to send a message and only in the case that the mls reset event has been received. This is not the case when the group has been reset but not established and then a user logs into to a new iOS client, since all the mls groups would be get a `pendingJoin` status rather than `pendingJoinAfterReset` status.

### Testing
1. Be in an mls group but logged out.
2. Have another reset the group but not establish it (e.g via curl call to backend mls reset endpoint)
3. Log in
4. Assert that the groups can be joined.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
