### PR TITLE
fix: don't reset federated conversations - WPB-22499 🍒

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -811,7 +811,8 @@ public final class ClientSessionComponent {
         mlsService: mlsService,
         conversationLocalStore: conversationLocalStore,
         conversationRepository: conversationRepository,
-        lockRepository: resetMLSConversationLockRepository
+        lockRepository: resetMLSConversationLockRepository,
+        selfDomain: backendMetadata.domain
     )
 
     public lazy var mlsTransport: any WireCoreCryptoUniffi.MlsTransport = MLSTransportImpl(

--- a/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
@@ -37,31 +37,46 @@ public class InitiateResetMLSConversationUseCase: InitiateResetMLSConversationUs
     private let conversationLocalStore: ConversationLocalStoreProtocol
     private let conversationRepository: ConversationRepositoryProtocol
     private let lockRepository: ResetMLSConversationLockRepositoryProtocol
+    private let selfDomain: String?
 
     public init(
         api: MLSAPI,
         mlsService: MLSServiceInterface,
         conversationLocalStore: ConversationLocalStoreProtocol,
         conversationRepository: ConversationRepositoryProtocol,
-        lockRepository: ResetMLSConversationLockRepositoryProtocol
+        lockRepository: ResetMLSConversationLockRepositoryProtocol,
+        selfDomain: String?
     ) {
         self.api = api
         self.mlsService = mlsService
         self.conversationLocalStore = conversationLocalStore
         self.conversationRepository = conversationRepository
         self.lockRepository = lockRepository
+        self.selfDomain = selfDomain
     }
 
-    public func invoke(groupID: WireDataModel.MLSGroupID, epoch: UInt64) async {
-
+    public func invoke(
+        groupID: WireDataModel.MLSGroupID,
+        epoch: UInt64
+    ) async {
         var attributes: LogAttributes = [:]
 
         do {
+            guard let selfDomain else {
+                WireLogger.mls.error("Can't initiate reset broken MLS conversation failed: self domain unknown")
+                return
+            }
 
-            guard let conversation = await conversationLocalStore.fetchMLSConversation(groupID: groupID),
-                  let qualifiedID = await conversationLocalStore.qualifiedID(for: conversation)
+            guard
+                let conversation = await conversationLocalStore.fetchMLSConversation(groupID: groupID),
+                let qualifiedID = await conversationLocalStore.qualifiedID(for: conversation)
             else {
                 WireLogger.mls.error("Initiate reset broken MLS conversation failed: no conversation found")
+                return
+            }
+
+            guard qualifiedID.domain == selfDomain else {
+                WireLogger.mls.warn("Can't initiate reset broken MLS conversation for other domains")
                 return
             }
 

--- a/WireDomain/Tests/WireDomainTests/UseCases/InitiateResetMLSConversationUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/UseCases/InitiateResetMLSConversationUseCaseTests.swift
@@ -75,7 +75,8 @@ final class InitiateResetMLSConversationUseCaseTests: XCTestCase {
             mlsService: mockMLSService,
             conversationLocalStore: mockConversationLocalStore,
             conversationRepository: mockConversationRepository,
-            lockRepository: mockResetLockRepository
+            lockRepository: mockResetLockRepository,
+            selfDomain: conversationID.domain
         )
     }
 
@@ -118,6 +119,27 @@ final class InitiateResetMLSConversationUseCaseTests: XCTestCase {
         XCTAssertEqual(mockMLSService.wipeGroup_Invocations.count, 0)
         XCTAssertEqual(mockMLSService.establishPendingGroupGroupID_Invocations.count, 0)
         XCTAssertEqual(mockResetLockRepository.setInitiatedResetConversationID_Invocations.count, 0)
+    }
+
+    func testInvoke_DoNothing_WhenConversationDomainIsNotSelfDomain() async {
+
+        // Given - conversation with different domain
+        let otherDomain = "other.example.com"
+        let otherDomainConversationID = QualifiedID(uuid: conversationID.uuid, domain: otherDomain)
+        mockConversationLocalStore.qualifiedIDFor_MockValue = otherDomainConversationID
+
+        let groupID = MLSGroupID.random()
+        // When
+        await sut.invoke(groupID: groupID, epoch: 99)
+
+        // Then
+        XCTAssertEqual(mockConversationLocalStore.fetchMLSConversationGroupID_Invocations.count, 1)
+        XCTAssertEqual(mockConversationLocalStore.qualifiedIDFor_Invocations.count, 1)
+        XCTAssertEqual(mockAPI.resetMLSConversationEpochGroupID_Invocations.count, 0)
+        XCTAssertEqual(mockMLSService.wipeGroup_Invocations.count, 0)
+        XCTAssertEqual(mockMLSService.establishPendingGroupGroupID_Invocations.count, 0)
+        XCTAssertEqual(mockResetLockRepository.setInitiatedResetConversationID_Invocations.count, 0)
+        XCTAssertEqual(mockConversationRepository.pullConversationIdDomain_Invocations.count, 0)
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1355,7 +1355,8 @@ extension ZMUserSession: SyncAgentDelegate {
             conversationRepository: clientSessionComponent.conversationRepository,
             lockRepository: ResetMLSConversationLockRepository(
                 userID: userId
-            )
+            ),
+            selfDomain: resolvedBackendMetadata.domain
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22499" title="WPB-22499" target="_blank"><img alt="Epic" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10807?size=medium" />WPB-22499</a>  Triggering MLS resets for a federated conversation will establish a broken group
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Cherry pick of https://github.com/wireapp/wire-ios/pull/4039


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
