### PR TITLE
fix: UI issues with minimized call - WPB-14540

### DIFF
--- a/WireUI/Sources/WireDesign/Colors/ColorTheme.swift
+++ b/WireUI/Sources/WireDesign/Colors/ColorTheme.swift
@@ -68,6 +68,7 @@ public enum ColorTheme {
         public static let onWarning = UIColor(light: .white, dark: .black)
 
         public static let positive = UIColor(light: .green500Light, dark: .green500Dark)
+        public static let onPositive = UIColor(light: .white, dark: .black)
         public static let onSuccess = UIColor(light: .white, dark: .black)
 
         public static let highlight = UIColor(light: .amber200Dark, dark: .amber300Dark)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Overlay/CallTopOverlayController.swift
@@ -113,7 +113,7 @@ final class CallTopOverlayController: UIViewController {
         tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(openCall(_:)))
 
         view.clipsToBounds = true
-        view.backgroundColor = SemanticColors.View.backgroundCallTopOverlay
+        view.backgroundColor = ColorTheme.Base.positive
         view.accessibilityIdentifier = "OpenOngoingCallButton"
         view.shouldGroupAccessibilityChildren = true
         view.isAccessibilityElement = true
@@ -126,7 +126,7 @@ final class CallTopOverlayController: UIViewController {
         durationLabel.translatesAutoresizingMaskIntoConstraints = false
         interactiveView.addSubview(durationLabel)
         durationLabel.font = FontSpec(.small, .semibold).font
-        durationLabel.textColor = SemanticColors.Label.textDefault
+        durationLabel.textColor = ColorTheme.Base.onPositive
         durationLabel.lineBreakMode = .byTruncatingMiddle
         durationLabel.textAlignment = .center
 
@@ -159,7 +159,7 @@ final class CallTopOverlayController: UIViewController {
             if displayMuteIcon {
                 muteIcon.setIcon(.microphoneOff, size: 12, color: .white)
                 muteIcon.setTemplateIcon(.microphoneOff, size: 12)
-                muteIcon.tintColor = SemanticColors.Icon.foregroundDefaultWhite
+                muteIcon.tintColor = ColorTheme.Base.onPositive
                 muteIconWidth?.constant = 12
             } else {
                 muteIcon.image = nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14540" title="WPB-14540" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-14540</a>  [iOS] UI issues with minimized call UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The text on the green “return to call” banner is black on light mode:
![2bf2ee6f-5495-43c9-a7e3-e0eb25dbe315](https://github.com/user-attachments/assets/8bfc2a56-5192-4fb4-893c-5023d27bdd42)


**Expected**
The text on the green “return to call” banner should follow the correct specs:
- Text: white on light mode, black on dark mode

### Testing



### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
