### PR TITLE
fix: add debug command to trigger key repair - WPB-22447 🍒

### DIFF
--- a/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Helpers/InitiateResetMLSConversationUseCase.swift
@@ -65,7 +65,11 @@ public class InitiateResetMLSConversationUseCase: InitiateResetMLSConversationUs
                 return
             }
 
-            attributes = [.conversationId: qualifiedID.safeForLoggingDescription]
+            attributes = [
+                .public: true,
+                .conversationId: qualifiedID.safeForLoggingDescription,
+                .mlsGroupID: groupID.safeForLoggingDescription
+            ]
 
             lockRepository.setInitiatedReset(conversationID: qualifiedID)
 

--- a/WireDomain/Sources/WireDomain/UseCases/RepairRemovalKeysUseCase.swift
+++ b/WireDomain/Sources/WireDomain/UseCases/RepairRemovalKeysUseCase.swift
@@ -23,7 +23,15 @@ import WireNetwork
 // sourcery: AutoMockable
 /// Repairs conversations with faulty removal keys
 public protocol RepairRemovalKeysUseCaseProtocol {
-    func invoke() async throws
+    @discardableResult
+    func invoke() async throws -> RepairRemovalKeysResult
+}
+
+public struct RepairRemovalKeysResult {
+
+    public var faultyConversationsFound = 0
+    public var conversationsRepaired = 0
+
 }
 
 public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
@@ -52,7 +60,8 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
         self.initiateResetUseCase = initiateResetUseCase
     }
 
-    public func invoke() async throws {
+    @discardableResult
+    public func invoke() async throws -> RepairRemovalKeysResult {
         WireLogger.mls.info(
             "initiating repair of faulty removal keys",
             attributes: .safePublic
@@ -63,16 +72,31 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
                 "no faulty removal keys to repair, aborting",
                 attributes: .safePublic
             )
-            return
+            return RepairRemovalKeysResult()
         }
+
+        var resultsByDomain: [String: RepairRemovalKeysResult] = [:]
 
         // Process each domain
         for (domain, faultyKeyHexStrings) in faultyMLSRemovalKeysByDomain {
-            try await processDomain(
+            let domainResult = try await processDomain(
                 domain: domain,
                 faultyKeyHexStrings: faultyKeyHexStrings
             )
+            resultsByDomain[domain] = domainResult
         }
+
+        let totalFaultyConversationsFound = resultsByDomain.values.reduce(0) {
+            $0 + $1.faultyConversationsFound
+        }
+        let totalConversationsRepaired = resultsByDomain.values.reduce(0) {
+            $0 + $1.conversationsRepaired
+        }
+
+        return RepairRemovalKeysResult(
+            faultyConversationsFound: totalFaultyConversationsFound,
+            conversationsRepaired: totalConversationsRepaired
+        )
     }
 
     // MARK: - Private
@@ -80,7 +104,7 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
     private func processDomain(
         domain: String,
         faultyKeyHexStrings: [String]
-    ) async throws {
+    ) async throws -> RepairRemovalKeysResult {
         WireLogger.mls.info(
             "checking domain for \(faultyKeyHexStrings.count) faulty key(s)",
             attributes: .safePublic
@@ -93,7 +117,7 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
                 "failed to decode some faulty removal key hex strings",
                 attributes: .safePublic
             )
-            return
+            return RepairRemovalKeysResult()
         }
 
         let allMLSConversations = try await conversationLocalStore.fetchAllMLSConversations(
@@ -106,22 +130,29 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
             faultyKeys: faultyKeyDataList
         )
 
+        let faultyConversationsFound = faultyConversations.count
+
         WireLogger.mls.info(
-            "detected \(faultyConversations.count)/\(allMLSConversations.count) affected conversations",
+            "detected \(faultyConversationsFound)/\(allMLSConversations.count) affected conversations",
             attributes: .safePublic
         )
 
-        // Repair each faulty conversation in parallel
-        await withTaskGroup(of: Void.self) { group in
-            for (groupID, qualifiedID) in faultyConversations {
-                group.addTask {
-                    await repairConversation(
-                        groupID: groupID,
-                        qualifiedID: qualifiedID
-                    )
-                }
+        // Repair each faulty conversation serially
+        var conversationsRepaired = 0
+        for (groupID, qualifiedID) in faultyConversations {
+            let success = await repairConversation(
+                groupID: groupID,
+                qualifiedID: qualifiedID
+            )
+            if success {
+                conversationsRepaired += 1
             }
         }
+
+        return RepairRemovalKeysResult(
+            faultyConversationsFound: faultyConversationsFound,
+            conversationsRepaired: conversationsRepaired
+        )
     }
 
     private func findFaultyConversations(
@@ -165,7 +196,13 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
     private func repairConversation(
         groupID: MLSGroupID,
         qualifiedID: WireDataModel.QualifiedID
-    ) async {
+    ) async -> Bool {
+        let logAttributes: LogAttributes = [
+            .public: true,
+            .conversationId: qualifiedID.safeForLoggingDescription,
+            .mlsGroupID: groupID.safeForLoggingDescription
+        ]
+
         let remoteConversation: WireNetwork.Conversation?
         do {
             remoteConversation = try await conversationsAPI.getConversations(
@@ -174,26 +211,27 @@ public struct RepairRemovalKeysUseCase: RepairRemovalKeysUseCaseProtocol {
         } catch {
             WireLogger.mls.error(
                 "failed to get epoch for a group, skipping: \(String(describing: error))",
-                attributes: .safePublic, [.conversationId: qualifiedID.safeForLoggingDescription]
+                attributes: logAttributes
             )
-            return
+            return false
         }
 
         guard let remoteConversation else {
             WireLogger.mls.error(
                 "remote conversation for a group not found, skipping",
-                attributes: .safePublic, [.conversationId: qualifiedID.safeForLoggingDescription]
+                attributes: logAttributes
             )
-            return
+            return false
         }
 
         WireLogger.mls.info(
             "initiating reset for faulty conversation: \(qualifiedID)",
-            attributes: .safePublic, [.conversationId: qualifiedID.safeForLoggingDescription]
+            attributes: logAttributes
         )
 
         let epoch = UInt64(remoteConversation.epoch ?? 0)
         await initiateResetUseCase.invoke(groupID: groupID, epoch: epoch)
+        return true
     }
 
 }

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -3893,20 +3893,24 @@ public class MockRepairRemovalKeysUseCaseProtocol: RepairRemovalKeysUseCaseProto
 
     public var invoke_Invocations: [Void] = []
     public var invoke_MockError: Error?
-    public var invoke_MockMethod: (() async throws -> Void)?
+    public var invoke_MockMethod: (() async throws -> RepairRemovalKeysResult)?
+    public var invoke_MockValue: RepairRemovalKeysResult?
 
-    public func invoke() async throws {
+    @discardableResult
+    public func invoke() async throws -> RepairRemovalKeysResult {
         invoke_Invocations.append(())
 
         if let error = invoke_MockError {
             throw error
         }
 
-        guard let mock = invoke_MockMethod else {
+        if let mock = invoke_MockMethod {
+            return try await mock()
+        } else if let mock = invoke_MockValue {
+            return mock
+        } else {
             fatalError("no mock for `invoke`")
         }
-
-        try await mock()
     }
 
 }

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DebugActions/DeveloperDebugActionsViewModel.swift
@@ -87,7 +87,7 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
             .init(title: "Invalidate all conversations", action: invalidateAllConversations),
             .init(title: "Set last app version migration", action: requestAppVersionInput),
             .init(title: "Initiate reset of first from top MLS", action: initiateResetBrokenMLSConversation),
-            .init(title: "Repair faulty removal key", action: initiateRepairRemovalKeys),
+            .init(title: "Initiate reset of affected MLS groups", action: initiateRepairRemovalKeys),
             .init(title: "Logout", action: logout)
 
         ]
@@ -211,7 +211,11 @@ final class DeveloperDebugActionsViewModel: ObservableObject {
                 attributes: .safePublic
             )
             do {
-                try await useCase.invoke()
+                let result = try await useCase.invoke()
+                WireLogger.mls.info(
+                    "manual trigger to initiate repair removal keys compete. Repaired initiated for \(result.conversationsRepaired)/\(result.faultyConversationsFound) affected conversations.",
+                    attributes: .safePublic
+                )
             } catch {
                 WireLogger.mls.error(
                     "manual trigger to repair removal keys failed: \(String(describing: error))",

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -246,6 +246,9 @@ enum DebugActions {
 
             case .resyncResources:
                 DebugActions.triggerResyncResources()
+
+            case .repairFaultyMLSRemovalKeys:
+                DebugActions.repairFaultyMLSRemovalKeys()
             }
         }
     }
@@ -270,6 +273,35 @@ enum DebugActions {
                         .fromLegacyAccessRole(.nonActivated)
                 )
                 action.send(in: userSession.notificationContext)
+            }
+        }
+    }
+
+    static func repairFaultyMLSRemovalKeys() {
+        guard let userSession = ZMUserSession.shared() else {
+            alert("Error: No user session available")
+            return
+        }
+
+        guard let useCase = userSession.clientSessionComponent?.repairFaultyRemovalKeysUsecase else {
+            alert("Error: Repair use case not available")
+            return
+        }
+
+        Task {
+            do {
+                let result = try await useCase.invoke()
+                await MainActor.run {
+                    let message = """
+                    Found: \(result.faultyConversationsFound) faulty conversation(s)
+                    Repaired: \(result.conversationsRepaired) conversation(s)
+                    """
+                    alert(message, title: "Faulty MLS Removal Keys Repair")
+                }
+            } catch {
+                await MainActor.run {
+                    alert("Error: \(error.localizedDescription)", title: "Repair Failed")
+                }
             }
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugCommand.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugCommand.swift
@@ -30,6 +30,11 @@ enum DebugCommand {
 
     case resyncResources
 
+    /// Repair conversations with faulty MLS removal keys based
+    /// on the configuration in SessionManagerConfiguration.
+
+    case repairFaultyMLSRemovalKeys
+
     init?(string: String) {
         // We may want to have commands that accept arguments, which means
         // we'd have to do the parsing of the command here.
@@ -39,6 +44,9 @@ enum DebugCommand {
 
         case "resync resources":
             self = .resyncResources
+
+        case "initiateResetMLSGroups":
+            self = .repairFaultyMLSRemovalKeys
 
         default:
             return nil


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22447" title="WPB-22447" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22447</a>  [iOS] "Message could not be decrypted" from federated connection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This a manual cherry pick of https://github.com/wireapp/wire-ios/pull/4046 targeting `develop`. Another cherry pick exists (https://github.com/wireapp/wire-ios/pull/4047) but that PR has various issues - (merge conflicts, additional code, missing methods). I'm not sure how it was created. I think something must have gone wrong.

This cherry pick was easy and has the same changes as the original.
