### PR TITLE
fix: log query parameter - WPB-22183

### DIFF
--- a/WireLogging/Sources/WireLogging/Network/RequestLog.swift
+++ b/WireLogging/Sources/WireLogging/Network/RequestLog.swift
@@ -79,8 +79,38 @@ struct RequestLog: Codable {
 }
 
 public extension URL {
+
     var endpointRemoteLogDescription: String {
-        absoluteString
+        var components = URLComponents(string: absoluteString)
+        let searchContactPath = "/search/contacts"
+
+        let path = components?.path ?? ""
+        guard path.contains(searchContactPath) else {
+            return absoluteString
+        }
+
+        // redact query param
+        var queryComponents = components?.queryItems ?? []
+        queryComponents.enumerated().forEach { item in
+            var redactedItem = item.element
+            if redactedItem.name == "q" {
+                redactedItem.value = "***"
+            }
+            queryComponents[item.offset] = redactedItem
+        }
+
+        components?.queryItems = queryComponents
+
+        var endpoint = [
+            "\(components?.scheme ?? ""):/",
+            components?.host,
+            path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        ]
+        .compactMap(\.self)
+        .filter { !$0.isEmpty }
+        .joined(separator: "/")
+        endpoint.append(components?.query?.isEmpty == false ? "?\(components!.query!)" : "")
+        return endpoint
     }
 }
 

--- a/WireLogging/Tests/WireLogging/Network/RequestLogTests.swift
+++ b/WireLogging/Tests/WireLogging/Network/RequestLogTests.swift
@@ -50,6 +50,24 @@ class RequestLogTests: XCTestCase {
         )
     }
 
+    func testParsingEndpointWithSearchContactsRedactedQueryParams() throws {
+        let request =
+            NSURLRequest(
+                url: URL(
+                    string: "https://prod-nginz-https.wire.com/v13/search/contacts?q=test&size=10"
+                )!
+            )
+        guard let sut: RequestLog = .init(request) else {
+            XCTFail("could not create RequestLog")
+            return
+        }
+
+        XCTAssertEqual(
+            sut.endpoint,
+            "https://prod-nginz-https.wire.com/v13/search/contacts?q=***&size=10"
+        )
+    }
+
     func testAuthorizationHeaderValueIsRedacted() throws {
         let request = NSMutableURLRequest(url: URL(string: "https://prod-nginz-https.wire.com/push/tokens")!)
         request.addValue("Bearer wertrtetetr42343242432456789p", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22183" title="WPB-22183" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-22183</a>  [iOS] Cleanup logged values
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The `/search/contacts?q=<cleared content>` request can contain user's information that should not be logged. This PR redact the query parameter for this endpoint

### Testing

Added test

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
