### PR TITLE
fix: Some UITests failures observed on CI - WPB-22623

### DIFF
--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -64,6 +64,7 @@ public enum Locators {
         case conversationCell
         case blockOptionOnContextMenu = "Block…"
         case blockButtonOnBottomSheet
+        case accountProfileImageView
     }
 
     public enum SettingsPage: String {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController+NavigationBar/ConversationListViewController+NavigationBar.swift
@@ -46,7 +46,7 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
     ) {
 
         accountImageView?.source = accountImage
-        accountImageView?.accessibilityIdentifier = "account_profile_image_view"
+        accountImageView?.accessibilityIdentifier = Locators.ConversationsPage.accountProfileImageView.rawValue
 
         if let userName = viewModel.userSession.selfUser.name {
             accountImageView?.accessibilityValue = L10n.Localizable.ConversationList.Header.SelfTeam
@@ -79,6 +79,7 @@ extension ConversationListViewController: ConversationListContainerViewModelDele
         accountImageView.availability = viewModel.selfUserStatus.availability.mapToAccountImageAvailability()
         accountImageView.hideProfileNotificationsBadge = viewModel.hideProfileNotificationsBadge
         accountImageView.isAccessibilityElement = true
+        accountImageView.accessibilityIdentifier = Locators.ConversationsPage.accountProfileImageView.rawValue
         accountImageView.accessibilityValue = L10n.Localizable.ConversationList.Header.SelfTeam
             .accessibilityValue(viewModel.userSession.selfUser.name ?? "")
         accountImageView.accessibilityTraits = .button

--- a/wire-ios/WireUITests/MultiBackendSupportTests.swift
+++ b/wire-ios/WireUITests/MultiBackendSupportTests.swift
@@ -54,7 +54,7 @@ final class MultiBackendSupportTests: WireUITestCase {
         _ = try accountPageBackend1
             .backToSettings()
             .switchToConversationsTab()
-            .openUserAccountPageForUser(with: userBackend1.name)
+            .openUserProfilePage()
             .tapAddAccountOrTeamButton()
 
         try switchBackend(target: .anta)
@@ -64,7 +64,7 @@ final class MultiBackendSupportTests: WireUITestCase {
         accountPageBackend1 = try accountPageBackend2
             .backToSettings()
             .switchToConversationsTab()
-            .openUserAccountPageForUser(with: userBackend2.name)
+            .openUserProfilePage()
             .switchUserAccountForUser(withName: userBackend1.name)
             .openSettings()
             .openAccountSettings()

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -56,16 +56,19 @@ class ConversationsPage: PageModel {
         app.buttons[Locators.ConnectionRequestsPage.connectRequestButton.rawValue]
     }
 
+    var accountProfileImageView: XCUIElement {
+        app.buttons[Locators.ConversationsPage.accountProfileImageView.rawValue]
+    }
+
     func openSettings() throws -> SettingsPage {
         settingsButton.tap()
         return try SettingsPage()
     }
 
-    func openUserAccountPageForUser(with input: String) throws -> UserProfilePage {
-        let predicate = NSPredicate(format: "value BEGINSWITH %@", input)
-        let button = app.buttons.containing(predicate).firstMatch
-        if button.waitForExistence(timeout: 2), button.isHittable {
-            button.tap()
+    func openUserProfilePage() throws -> UserProfilePage {
+
+        if accountProfileImageView.waitForExistence(timeout: 2), accountProfileImageView.isHittable {
+            accountProfileImageView.tap()
         }
         return try UserProfilePage()
     }

--- a/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
+++ b/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
@@ -51,7 +51,13 @@ class OptionsOnSettingsPage: PageModel {
 
     func enterPasscode(_ pass: String) throws -> ConversationsPage {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        try springboard.secureTextFields["Passcode field"].tapIfKeyboardNotFocused().typeText(pass)
+        let passcodeField = springboard.secureTextFields["Passcode field"].firstMatch
+
+        guard passcodeField.waitForExistence(timeout: 3.0) else {
+            XCTFail("Passcode SecureTextField did not appear")
+            throw XCTSkip("Passcode field not available")
+        }
+        try passcodeField.tapIfKeyboardNotFocused().typeText(pass)
 
         let doneButton = springboard.keyboards.buttons["Done"].firstMatch
         if doneButton.waitForExistence(timeout: 2.0), doneButton.isHittable {

--- a/wire-ios/WireUITests/PersonalUserTests.swift
+++ b/wire-ios/WireUITests/PersonalUserTests.swift
@@ -88,7 +88,7 @@ final class PersonalUsersTests: WireUITestCase {
         _ = try userDetailsPage.sendConnectionRequest()
             .closeProfilePage()
             .closeNewConversationPage()
-            .openUserAccountPageForUser(with: userA.name)
+            .openUserProfilePage()
             .tapAddAccountOrTeamButton()
         let connectionRequestsPage = try app.loginUser(email: userB.email, password: userB.password)
             .acceptPopup(with: self)
@@ -104,7 +104,7 @@ final class PersonalUsersTests: WireUITestCase {
         let nameA = try XCTUnwrap(conversationsPage.getNameLabel())
         XCTAssertEqual(nameA, userA.name, "name didn't match \(userA.name)")
 
-        conversationsPage = try conversationsPage.openUserAccountPageForUser(with: userB.name)
+        conversationsPage = try conversationsPage.openUserProfilePage()
             .switchUserAccountForUser(withName: userA.name)
 
         let nameUserB = try XCTUnwrap(conversationsPage.getNameLabel())

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -27,14 +27,14 @@ final class TeamManageTests: WireUITestCase {
 
         let conversationPage = try app.loginUser(email: user.email, password: user.password)
             .acceptPopup(with: self)
-            .openUserAccountPageForUser(with: user.name)
+            .openUserProfilePage()
             .tapCreateTeamButton()
             .tapContinue()
             .typeTeamNameAndContinue(user.teamName)
             .acceptTheConfirmationAndContinue()
             .tapBackToWireButton()
 
-        let userProfilePage = try conversationPage.openUserAccountPageForUser(with: user.name)
+        let userProfilePage = try conversationPage.openUserProfilePage()
 
         let teamName = try XCTUnwrap(userProfilePage.getTeamName())
         XCTAssertEqual(teamName, user.teamName, "Team name didn't match expected value \(user.teamName)")
@@ -64,7 +64,7 @@ final class TeamManageTests: WireUITestCase {
         let firstTimePage = try app.loginUser(email: memberUser.email, password: memberUser.password)
         let userProfilePage = try firstTimePage.acceptPopupOnTeamMemberSetup(with: self)
             .setUsername(memberUser.username)
-            .openUserAccountPageForUser(with: memberUser.username)
+            .openUserProfilePage()
 
         let teamName = try XCTUnwrap(userProfilePage.getTeamName())
         XCTAssertEqual(teamName, owner.teamName, "Team name didn't match expected value \(owner.teamName)")

--- a/wire-ios/WireUITests/WireAuthenticationTests.swift
+++ b/wire-ios/WireUITests/WireAuthenticationTests.swift
@@ -40,6 +40,7 @@ final class WireAuthenticationTests: WireUITestCase {
             .enterEmailOrSSO(LoginCredentials.email)
 
         XCTAssertEqual(app.textFields["Enter email"].value as? String, LoginCredentials.email)
+        XCTAssertTrue(loginPage.nextButton.waitForExistence(timeout: 2.0))
         XCTAssertFalse(loginPage.nextButton.isEnabled, "nextButton should be disabled if no password")
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22623" title="WPB-22623" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22623</a>  [iOS/QA] Fix failure uitests on CI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


<hr />

<h2>Summary</h2>
<p><em>Briefly describe about this PR changes.</em></p>

On datadog some failures observed:

<img width="1131" height="223" alt="image" src="https://github.com/user-attachments/assets/9638365c-a528-4883-8f43-e3cefc4f5086" />

Fixes:
1. AccessbilityID being updated and used rather than custom predicate to open UserProfilePage
2. Next button doesn't shown disabled when no password, added another assert before this to check if next button exist, this give some time till this nextButton.isEnabled return correct.
3. On Background and foreground, password field doesn't able to locate, so added waitFor


<hr />

<h2>Testing</h2>
<p><em>Describe how to verify the changes locally. Attach screenshots of local execution if relevant.</em></p>
It ran successfully on local

<img width="2851" height="1317" alt="image" src="https://github.com/user-attachments/assets/c1754d23-0075-4dea-a309-586918cadfa5" />




<h2>Additional Information</h2>
<p><em>any more info, add here.</em></p>