### PR TITLE
fix: resolve cells URL manually (temporary fix) - WPB-22571

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -178,10 +178,9 @@ public final class ZMUserSession: NSObject {
     }
 
     public var isWireCellsEnabled: Bool {
-        let isFeatureEnabled = wireCellsFeature.status == .enabled
-        let hasBackendURL = wireCellsBackendURL != nil
+        wireCellsFeature.status == .enabled
+//        let hasBackendURL = wireCellsBackendURL != nil
 
-        return isFeatureEnabled && hasBackendURL
     }
 
     public var conferenceCallingFeature: Feature.ConferenceCalling {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -181,6 +181,7 @@ public final class ZMUserSession: NSObject {
         wireCellsFeature.status == .enabled
 //        let hasBackendURL = wireCellsBackendURL != nil
 
+//        return isFeatureEnabled && hasBackendURL
     }
 
     public var conferenceCallingFeature: Feature.ConferenceCalling {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -179,9 +179,6 @@ public final class ZMUserSession: NSObject {
 
     public var isWireCellsEnabled: Bool {
         wireCellsFeature.status == .enabled
-//        let hasBackendURL = wireCellsBackendURL != nil
-
-//        return isFeatureEnabled && hasBackendURL
     }
 
     public var conferenceCallingFeature: Feature.ConferenceCalling {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
@@ -34,14 +34,27 @@ final class ZClientControllerBuilder {
     private(set) var trackingManager: TrackingManager?
     let legacyEnvironment: WireTransport.BackendEnvironment
     let newEnvironment: WireNetwork.BackendEnvironment2?
-    private lazy var wireCellsBackendURL: URL? = {
-        let contextProvider = userSession.contextProvider
-        let syncContext = contextProvider.syncContext
-        let featureRepository = LegacyFeatureRepository(context: syncContext)
-
-        return syncContext.performAndWait {
-            featureRepository.fetchCellsInternal()?.config.backend.url
+    private lazy var wireCellsBackendURL: URL = {
+        let serverURL = newEnvironment?.config.endpoints.restAPIURL ?? legacyEnvironment.backendURL
+        return switch serverURL.host {
+        case "prod-nginz-https.wire.com": // Production
+            URL(string: "https://cells-beta.wire.com")!
+        case "staging-nginz-https.zinfra.io": // Staging
+            URL(string: "https://cells.staging.zinfra.io")!
+        case "nginz-https.fulu.wire.link": // Fulu
+            URL(string: "https://cells.fulu.wire.link")!
+        case "nginz-https.imai.wire.link": // Imai
+            URL(string: "https://cells.imai.wire.link")!
+        default:
+            serverURL
         }
+//        let contextProvider = userSession.contextProvider
+//        let syncContext = contextProvider.syncContext
+//        let featureRepository = LegacyFeatureRepository(context: syncContext)
+//
+//        return syncContext.performAndWait {
+//            featureRepository.fetchCellsInternal()?.config.backend.url
+//        }
     }()
 
     init(
@@ -85,7 +98,7 @@ final class ZClientControllerBuilder {
                 case missingCellsBackendURL
             }
 
-            guard let self, let wireCellsBackendURL else {
+            guard let self /* , let wireCellsBackendURL */ else {
                 throw Failure.missingCellsBackendURL
             }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
@@ -48,13 +48,6 @@ final class ZClientControllerBuilder {
         default:
             serverURL
         }
-//        let contextProvider = userSession.contextProvider
-//        let syncContext = contextProvider.syncContext
-//        let featureRepository = LegacyFeatureRepository(context: syncContext)
-//
-//        return syncContext.performAndWait {
-//            featureRepository.fetchCellsInternal()?.config.backend.url
-//        }
     }()
 
     init(
@@ -98,7 +91,7 @@ final class ZClientControllerBuilder {
                 case missingCellsBackendURL
             }
 
-            guard let self /* , let wireCellsBackendURL */ else {
+            guard let self else {
                 throw Failure.missingCellsBackendURL
             }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22571" title="WPB-22571" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22571</a>  [iOS] Manage release iOS 4.13.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds a temporary workaround to enable cells feature on 4.13 release since API v14 is not ready yet. So here we resolve the cells URL manually. Removed code will be re-added when Api v14 is PROD ready (which should be soon).

### Testing

Tested on PROD in new canary team, cells feature should be enabled  as before even if we're not under API v14.
cells enabled conv have cells features available.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
