### PR TITLE
fix: cancelling uploads - WPB-18574

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/AWSClient.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/AWSClient.swift
@@ -324,17 +324,3 @@ private struct CredentialIdentityResolver: AWSCredentialIdentityResolver {
     }
 
 }
-
-class StrB: Foundation.Stream {
-
-    var cancelled = false
-
-    override var streamError: (any Error)? {
-        if cancelled {
-            return NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError, userInfo: nil)
-        }
-
-        return super.streamError
-    }
-
-}

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/AWSClient.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/AWSClient.swift
@@ -197,10 +197,19 @@ final class AWSClient: Sendable {
         )
 
         try await withTaskCancellationHandler {
-            _ = try await s3.putObject(input: input)
+            do {
+                _ = try await s3.putObject(input: input)
+            } catch {
+                if Task.isCancelled {
+                    WireLogger.wireCells.info("Upload cancelled for node: \(node.path)")
+                    throw CancellationError()
+                }
+
+                throw error
+            }
         } onCancel: {
-            // TODO: [WPB-18574] AWS SDK doesn't support cancelling in flight requests. Find a work around.
             WireLogger.wireCells.info("Cancelling upload for node: \(node.path)")
+            stream.cancel()
         }
     }
 
@@ -312,6 +321,20 @@ private struct CredentialIdentityResolver: AWSCredentialIdentityResolver {
             secret: "gatewaysecret", // This is not used and is safe to commit.
             expiration: accessToken.expirationDate
         )
+    }
+
+}
+
+class StrB: Foundation.Stream {
+
+    var cancelled = false
+
+    override var streamError: (any Error)? {
+        if cancelled {
+            return NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError, userInfo: nil)
+        }
+
+        return super.streamError
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/ObservableStream.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/ObservableStream.swift
@@ -17,15 +17,16 @@
 //
 
 import Foundation
+import os
 import Smithy
 
 /// Wraps a `Smithy.Stream` allowing its progress to be observed. This is a workaround to enable reading upload progress
 /// using the AWS SDK.
-
 final class ObservableStream: Smithy.Stream, Sendable {
 
     private let wrappedStream: any Smithy.Stream
     private let readContinuation: AsyncStream<Int>.Continuation
+    private let cancellationState = OSAllocatedUnfairLock(uncheckedState: false)
 
     let readProgress: AsyncStream<Int>
 
@@ -58,30 +59,40 @@ final class ObservableStream: Smithy.Stream, Sendable {
     }
 
     func read(upToCount count: Int) throws -> Data? {
+        guard isCancelled == false else { return nil }
+
         let result = try wrappedStream.read(upToCount: count)
         readContinuation.yield(position)
         return result
     }
 
     func readAsync(upToCount count: Int) async throws -> Data? {
+        guard isCancelled == false else { return nil }
+
         let result = try await wrappedStream.readAsync(upToCount: count)
         readContinuation.yield(position)
         return result
     }
 
     func readToEnd() throws -> Data? {
+        guard isCancelled == false else { return nil }
+
         let result = try wrappedStream.readToEnd()
         readContinuation.yield(position)
         return result
     }
 
     func readToEndAsync() async throws -> Data? {
+        guard isCancelled == false else { return nil }
+
         let result = try await wrappedStream.readToEndAsync()
         readContinuation.yield(position)
         return result
     }
 
     func seek(toOffset offset: Int) throws {
+        guard isCancelled == false else { throw CancellationError() }
+
         try wrappedStream.seek(toOffset: offset)
         readContinuation.yield(position)
     }
@@ -98,5 +109,22 @@ final class ObservableStream: Smithy.Stream, Sendable {
 
     func closeWithError(_ error: any Error) {
         wrappedStream.closeWithError(error)
+    }
+
+    // MARK: - Cancellation
+
+    private var isCancelled: Bool {
+        cancellationState.withLock { $0 }
+    }
+
+    /// Cancels the stream, causing further read operations to return nil or throw a CancellationError.
+    ///
+    /// This is a hack to work around the lack of cancellation support in the AWS SDK. It relies on implementation
+    /// details of the SDK and its dependencies but it does currently work - when called while a file is being uploaded,
+    /// the upload stops and an error will soon after be thrown.
+    func cancel() {
+        cancellationState.withLock {
+            $0 = true
+        }
     }
 }

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/UploadDraftUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/UploadDraftUseCase.swift
@@ -92,6 +92,8 @@ package struct UploadDraftUseCase: WireCellsUploadDraftUseCaseProtocol, WireCell
                 await draftRepository.updateDraft(draft, for: cellName)
             }
 
+            if draft.status == .cancelled { return }
+
             // Set post upload values
             let latestNode = try await nodesAPI.getNode(nodeID: draft.nodeID)
             if let mimeTime = latestNode.mimeType {

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/NodesAPI/ObservableStreamTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/NodesAPI/ObservableStreamTests.swift
@@ -107,6 +107,21 @@ final class ObservableStreamTests {
         #expect(await progressesTask.value == [2, 5])
     }
 
+    @Test
+    func cancellation() async throws {
+        // Given, When
+        sut.cancel()
+
+        // Then
+        #expect(try sut.read(upToCount: 1) == nil)
+        #expect(try await sut.readAsync(upToCount: 1) == nil)
+        #expect(try sut.readToEnd() == nil)
+        #expect(try await sut.readToEndAsync() == nil)
+        #expect(throws: CancellationError.self) {
+            try sut.seek(toOffset: 0)
+        }
+    }
+
     private func makeObservationProgressTask(readingCount: Int) -> Task<[Int], Never> {
         Task { [sut] in
             var progresses: [Int] = []

--- a/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/UseCases/UploadDraftUseCaseTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireCells/ImplementationTests/UseCases/UploadDraftUseCaseTests.swift
@@ -159,6 +159,48 @@ final class UploadDraftUseCaseTests {
         #expect(updatesParams.map(\.cellName).allSatisfy { $0 == "cell-name" })
     }
 
+    @Test
+    func invokeWithNodeID_whenUploadCancelled() async throws {
+        // Given
+        let nodeID = UUID()
+
+        draftsRepository.fetchDraftNodeIDCellName_MockValue = WireCellsDraft.fixture(
+            nodeID: nodeID,
+            status: .uploading(progress: 0.5)
+        )
+
+        uploadManager
+            .uploadNodeIDVersionIDAssetPathAssetSizeDestNodePath_MockValue
+            = (
+                WireCellsNode(uuid: nodeID, path: "foo.txt"),
+                AsyncStream.make(
+                    [
+                        .uploading(progress: 0.5),
+                        .cancelled
+                    ]
+                )
+            )
+
+        draftsRepository.updateDraftFor_MockMethod = { _, _ in }
+
+        // When
+        try await sut.invoke(nodeID: nodeID)
+
+        // Then if has the correct draft statuses
+        let statuses = draftsRepository.updateDraftFor_Invocations.map(\.draft.status)
+        #expect(
+            statuses == [
+                .uploading(progress: 0.0),
+                .uploading(progress: 0.0),
+                .uploading(progress: 0.5),
+                .cancelled
+            ]
+        )
+
+        // Then it doesn't try to fetch latest node info after uploading
+        #expect(nodesAPI.getNodeNodeID_Invocations.isEmpty)
+    }
+
     // MARK: - invoke(fileURL:)
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18574" title="WPB-18574" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-18574</a>  [iOS] Find a way to cancel uploads via AWS SDK
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently when using wire drive (eg wire cells) the user can cancel uploading files. However this only cancels it from a UX perspective. The file is still actually uploaded to the server. This is because the server is S3 compatible and we use the AWS SDK to upload files. However, this SDK provides no way to cancel uploads 🙀. I opened a ticket for the SDK to improve this but I'm not sure it will be done anytime soon. https://github.com/awslabs/aws-sdk-swift/issues/1977. Amazon has just released a more suitable SDK for our purposes (https://github.com/aws/aws-sdk-swift-s3-transfer-manager) but It is currently in developer preview, so not suitable for production.

Therefore, this PR introduces a hack to force cancellation of uploads. It is very tied to the implementation of the AWS SDK.

This PR adds a cancel method to `ObservableStream` (another hack to allow observing upload progress) that just makes the stream return nil data. This causes the upload to error. Elsewhere we catch this error and return a cancellation error.

### Testing

1. navigate to a wire cells enabled conversation.
2. Begin uploading a large file.
3. Tap the cross icon on the upload preview to cancel the upload.
4. The upload preview disappears.
5. While connected to a debugger, check out the logs display a cancellation message like: `Upload cancelled for node: <path>`

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
