### PR TITLE
fix: collabora file edit close button dark mode - WPB-22330

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Edit/EditFileView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Edit/EditFileView.swift
@@ -74,7 +74,8 @@ struct EditFileView<ViewModel>: View where ViewModel: EditFileViewModelProtocol 
             action: { dismiss() },
             label: {
                 Image(.close)
-                    .foregroundStyle(.black)
+                    .renderingMode(.template)
+                    .foregroundStyle(Color.primary)
                     .frame(width: 44, height: 44, alignment: .trailing)
             }
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22330" title="WPB-22330" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22330</a>  [iOS] Collabora close button not visible in dark mode
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The close button (X) image was black in dark mode and therefore not visible.
Fixed by making it white in dark mode.

### Testing

* Ensure Collabora feature flag is enabled.
* Enable dark mode
* Navigate to a cells conversation.
* Send a docx file.
* Navigate to the files tab.
* Select Edit file from the files context menu.
* The Collabora WebView opens.
* The close button on the top right should be visible.