### PR TITLE
fix: ZMUserSession memory leak - WPB-18909

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -956,6 +956,8 @@ public final class SessionManager: NSObject, SessionManagerType {
 
             await configureAnalytics(for: session)
             await requestCertificateEnrollmentIfNeeded()
+        } else {
+            WireLogger.sessionManager.debug("User is not logged in, complete login elsewhere")
         }
 
         return session

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -723,6 +723,14 @@ public final class ZMUserSession: NSObject {
         tokens.removeAll()
         application.unregisterObserverForStateChange(self)
         callStateObserver = nil
+
+        // Clear delegates to break retain cycles
+        earService.delegate = nil
+        appLockController.delegate = nil
+        applicationStatusDirectory.clientRegistrationStatus.registrationStatusDelegate = nil
+
+        syncAgent?.delegate = nil
+        syncAgent = nil
         syncStrategy?.tearDown()
         syncStrategy = nil
         operationLoop?.tearDown()
@@ -732,6 +740,10 @@ public final class ZMUserSession: NSObject {
         callCenter?.tearDown()
         coreDataStack.close()
         contextStorage.clear()
+
+        // Note: strategyDirectory, legacyUpdateEventProcessor, and urlActionProcessors
+        // are left to be cleaned up when ZMUserSession is deallocated to avoid
+        // triggering strategy teardowns while async operations may still be running.
 
         NotificationCenter.default.removeObserver(self)
         WireLogger.authentication.clearClientID()

--- a/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
+++ b/wire-ios-transport/Source/Authentication/ZMAccessTokenHandler.m
@@ -90,6 +90,8 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 
 - (void)dealloc {
     [self.backoff tearDown];
+    self->_accessTokenRenewalFailureHandler = nil;
+    self->_accessTokenRenewalSuccessHandler = nil;
 }
 
 - (void)setAccessTokenRenewalFailureHandler:(ZMCompletionHandlerBlock)handler

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -247,9 +247,13 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (void)tearDown
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
+
     self.tornDown = YES;
-    
+
+    // Clear access token handlers to break retain cycles
+    [self.accessTokenHandler setAccessTokenRenewalFailureHandler:nil];
+    [self.accessTokenHandler setAccessTokenRenewalSuccessHandler:nil];
+
     self.reachabilityObserverToken = nil;
     [self.workGroup enter];
     [self.workQueue addOperationWithBlock:^{
@@ -257,7 +261,7 @@ static NSInteger const DefaultMaximumRequests = 6;
         [self.sessionsDirectory tearDown];
         [self.workGroup leave];
     }];
-    
+
     // Wait until all the requests have been cancelled
     [self.workQueue waitUntilAllOperationsAreFinished];
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-18909" title="WPB-18909" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-18909</a>  [iOS] ZMUserSession is still retained in memory after logout
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When logout ZMUSerSession is still around, this PR fixes it.

### Testing

1. login
2. logout
3. check memory debugger
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
