### PR TITLE
fix: restore conversations not available on local backend - WPB-22231

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -30,6 +30,7 @@ import WireDataModel
 ///
 /// Check out the Confluence page for full details
 /// [here](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/20514628/Conversations)
+// soucery: AutoMockable
 public protocol ConversationLocalStoreProtocol {
 
     func qualifiedID(for conversation: ZMConversation) async -> QualifiedID?

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationLocalStoreProtocol.swift
@@ -30,7 +30,6 @@ import WireDataModel
 ///
 /// Check out the Confluence page for full details
 /// [here](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/20514628/Conversations)
-// soucery: AutoMockable
 public protocol ConversationLocalStoreProtocol {
 
     func qualifiedID(for conversation: ZMConversation) async -> QualifiedID?

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -82,8 +82,6 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
             for: [qualifiedID]
         )
 
-        
-        
         if let conversation = conversationList.found.first {
             await conversationsLocalStore.storeConversation(
                 conversation.toDomainModel(),

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -82,16 +82,21 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
             for: [qualifiedID]
         )
 
-        guard let conversation = conversationList.found.first else {
+        
+        
+        if let conversation = conversationList.found.first {
+            await conversationsLocalStore.storeConversation(
+                conversation.toDomainModel(),
+                timestamp: .now,
+                isFederationEnabled: isFederationEnabled,
+                isMLSEnabled: isMLSEnabled
+            )
+        } else if conversationList.notFound.contains(qualifiedID) {
             throw ConversationRepositoryError.conversationNotFound
+        } else {
+            throw ConversationRepositoryError.conversationFailed
         }
 
-        await conversationsLocalStore.storeConversation(
-            conversation.toDomainModel(),
-            timestamp: .now,
-            isFederationEnabled: isFederationEnabled,
-            isMLSEnabled: isMLSEnabled
-        )
     }
 
     public func fetchConversation(

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -92,7 +92,7 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
         } else if conversationList.notFound.contains(qualifiedID) {
             throw ConversationRepositoryError.conversationNotFound
         } else {
-            throw ConversationRepositoryError.conversationFailed
+            throw ConversationRepositoryError.retrievalFailed
         }
 
     }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepositoryError.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepositoryError.swift
@@ -24,7 +24,7 @@ enum ConversationRepositoryError: Error {
 
     /// Conversation failed to be retrieved
 
-    case conversationFailed
+    case retrievalFailed
 
     /// Conversation not found
 

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepositoryError.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepositoryError.swift
@@ -23,9 +23,9 @@ import Foundation
 enum ConversationRepositoryError: Error {
 
     /// Conversation failed to be retrieved
-    
+
     case conversationFailed
-    
+
     /// Conversation not found
 
     case conversationNotFound

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepositoryError.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepositoryError.swift
@@ -22,6 +22,10 @@ import Foundation
 
 enum ConversationRepositoryError: Error {
 
+    /// Conversation failed to be retrieved
+    
+    case conversationFailed
+    
     /// Conversation not found
 
     case conversationNotFound

--- a/WireLogging/Sources/WireLogging/WireLogger+Instances.swift
+++ b/WireLogging/Sources/WireLogging/WireLogger+Instances.swift
@@ -19,7 +19,7 @@
 public extension WireLogger {
 
     static let apiMigration = WireLogger(tag: "api-migration")
-    static let appVersionMigration = WireLogger(tag: "api-version-migration")
+    static let appVersionMigration = WireLogger(tag: "app-version-migration")
     static let appState = WireLogger(tag: "AppState")
     static let appDelegate = WireLogger(tag: "AppDelegate")
     static let appLock = WireLogger(tag: "AppLock")

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Messaging.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Messaging.swift
@@ -333,7 +333,7 @@ public extension ZMConversation {
 
         return try context.fetch(request)
     }
-    
+
     static func fetchDeleted(in context: NSManagedObjectContext) -> [ZMConversation] {
         let request = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
         request.predicate = NSPredicate(format: "%K == YES", #keyPath(ZMConversation.isDeletedRemotely))

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Messaging.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Messaging.swift
@@ -333,6 +333,12 @@ public extension ZMConversation {
 
         return try context.fetch(request)
     }
+    
+    static func fetchDeleted(in context: NSManagedObjectContext) -> [ZMConversation] {
+        let request = NSFetchRequest<ZMConversation>(entityName: ZMConversation.entityName())
+        request.predicate = NSPredicate(format: "%K == YES", #keyPath(ZMConversation.isDeletedRemotely))
+        return (try? context.fetch(request)) ?? []
+    }
 }
 
 // MARK: - NSPredicate Extensions

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
@@ -47,6 +47,10 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
             "\(deletedConversationIds.count) Deleted conversations found",
             attributes: .safePublic
         )
+        guard !deletedConversationIds.isEmpty else {
+            // no deleted conversation, just skip
+            return
+        }
 
         let conversationList = try await api.getConversations(for: deletedConversationIds)
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
@@ -66,15 +66,13 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
 
         try await context.perform {
             for existingConversation in conversationList.found {
+
                 let conversations = conversationIds.compactMap { ZMConversation.existingObject(for: $0, in: context) }
                 if let conversation = conversations.first(where: {
-                    $0.qualifiedID?.domain ==
-                        existingConversation.qualifiedID?.domain &&
-                        $0.qualifiedID?.uuid ==
-                        existingConversation.qualifiedID?.id
+                    $0.qualifiedID?.toNetworkModel() == existingConversation.qualifiedID
                 }) {
                     conversation.isDeletedRemotely = false
-                    WireLogger.appVersionMigration.debug(
+                    WireLogger.appVersionMigration.info(
                         "Restore deleted conversation",
                         attributes: [.conversationId: conversation.qualifiedID?.safeForLoggingDescription],
                         .safePublic
@@ -82,8 +80,31 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
                 }
             }
 
+            for failedConversationID in conversationList.failed {
+
+                let conversation = ZMConversation.fetch(
+                    with: failedConversationID.id,
+                    domain: failedConversationID.domain,
+                    in: context
+                )
+                if let conversation {
+                    conversation.isDeletedRemotely = false
+                    WireLogger.appVersionMigration.info(
+                        "Restoring failed conversation",
+                        attributes: [.conversationId: conversation.qualifiedID?.safeForLoggingDescription],
+                        .safePublic
+                    )
+
+                }
+            }
+
             try context.save()
         }
     }
+}
 
+private extension WireDataModel.QualifiedID {
+    func toNetworkModel() -> WireNetwork.QualifiedID {
+        .init(id: uuid, domain: domain)
+    }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
@@ -33,7 +33,7 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
         let context = coreDataStack.syncContext
 
         var conversationIds: [NSManagedObjectID] = []
-        let deletedConversationIds = await context.perform {
+        let deletedConversationIDs = await context.perform {
             // fetch all deleted conversations
             let conversations = ZMConversation.fetchDeleted(in: context)
             conversationIds = conversations.map(\.objectID)
@@ -44,15 +44,15 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
         }
 
         WireLogger.appVersionMigration.info(
-            "\(deletedConversationIds.count) Deleted conversations found",
+            "\(deletedConversationIDs.count) Deleted conversations found",
             attributes: .safePublic
         )
-        guard !deletedConversationIds.isEmpty else {
+        guard !deletedConversationIDs.isEmpty else {
             // no deleted conversation, just skip
             return
         }
 
-        let conversationList = try await api.getConversations(for: deletedConversationIds)
+        let conversationList = try await api.getConversations(for: deletedConversationIDs)
 
         WireLogger.appVersionMigration.info(
             "\(conversationList.found.count) conversations found",

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
@@ -1,0 +1,70 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDomain
+import WireNetwork
+import WireLogging
+
+/// **Issue:**: Missing conversations - [WPB-22231]
+struct AppVersionMigration_4_12_1: AppVersionMigration {
+
+    let version: SemanticVersion = "4.12.1"
+    let coreDataStack: CoreDataStackProtocol
+    let api: ConversationsAPI
+    let store: ConversationLocalStoreProtocol
+    
+    func perform() async throws {
+        let context = coreDataStack.syncContext
+    
+        var conversationIds: [NSManagedObjectID] = []
+        let deletedConversationIds = await context.perform {
+            // fetch all deleted conversations
+            let conversations = ZMConversation.fetchDeleted(in: context)
+            conversationIds = conversations.map { $0.objectID }
+            return conversations.compactMap { $0.qualifiedID.map { WireNetwork.QualifiedID(id: $0.uuid, domain: $0.domain)} }
+        }
+        
+        WireLogger.appVersionMigration.info("\(deletedConversationIds.count) Deleted conversations found", attributes: .safePublic)
+        
+        let conversationList = try await api.getConversations(for: deletedConversationIds)
+        
+        WireLogger.appVersionMigration.info("\(conversationList.found.count) conversations found", attributes: .safePublic)
+        WireLogger.appVersionMigration.info("\(conversationList.notFound.count) conversations really deleted", attributes:
+                .safePublic)
+        WireLogger.appVersionMigration.info("\(conversationList.failed.count) conversations failed", attributes: .safePublic)
+        
+        try await context.perform {
+            for existingConversation in conversationList.found {
+                let conversations = conversationIds.compactMap { ZMConversation.existingObject(for: $0, in: context)}
+                if let conversation = conversations.first(where: {
+                    $0.qualifiedID?.domain ==
+                    existingConversation.qualifiedID?.domain &&
+                    $0.qualifiedID?.uuid ==
+                    existingConversation.qualifiedID?.id
+                }) {
+                    conversation.isDeletedRemotely = false
+                    WireLogger.appVersionMigration.debug("Restore deleted conversation", attributes: [.conversationId: conversation.qualifiedID?.safeForLoggingDescription], .safePublic)
+                }
+            }
+            
+            try context.save()
+        }
+    }
+
+}

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
@@ -18,8 +18,8 @@
 
 import Foundation
 import WireDomain
-import WireNetwork
 import WireLogging
+import WireNetwork
 
 /// **Issue:**: Missing conversations - [WPB-22231]
 struct AppVersionMigration_4_12_1: AppVersionMigration {
@@ -28,41 +28,60 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
     let coreDataStack: CoreDataStackProtocol
     let api: ConversationsAPI
     let store: ConversationLocalStoreProtocol
-    
+
     func perform() async throws {
         let context = coreDataStack.syncContext
-    
+
         var conversationIds: [NSManagedObjectID] = []
         let deletedConversationIds = await context.perform {
             // fetch all deleted conversations
             let conversations = ZMConversation.fetchDeleted(in: context)
-            conversationIds = conversations.map { $0.objectID }
-            return conversations.compactMap { $0.qualifiedID.map { WireNetwork.QualifiedID(id: $0.uuid, domain: $0.domain)} }
+            conversationIds = conversations.map(\.objectID)
+            return conversations.compactMap { $0.qualifiedID.map { WireNetwork.QualifiedID(
+                id: $0.uuid,
+                domain: $0.domain
+            ) } }
         }
-        
-        WireLogger.appVersionMigration.info("\(deletedConversationIds.count) Deleted conversations found", attributes: .safePublic)
-        
+
+        WireLogger.appVersionMigration.info(
+            "\(deletedConversationIds.count) Deleted conversations found",
+            attributes: .safePublic
+        )
+
         let conversationList = try await api.getConversations(for: deletedConversationIds)
-        
-        WireLogger.appVersionMigration.info("\(conversationList.found.count) conversations found", attributes: .safePublic)
-        WireLogger.appVersionMigration.info("\(conversationList.notFound.count) conversations really deleted", attributes:
-                .safePublic)
-        WireLogger.appVersionMigration.info("\(conversationList.failed.count) conversations failed", attributes: .safePublic)
-        
+
+        WireLogger.appVersionMigration.info(
+            "\(conversationList.found.count) conversations found",
+            attributes: .safePublic
+        )
+        WireLogger.appVersionMigration.info(
+            "\(conversationList.notFound.count) conversations really deleted",
+            attributes:
+            .safePublic
+        )
+        WireLogger.appVersionMigration.info(
+            "\(conversationList.failed.count) conversations failed",
+            attributes: .safePublic
+        )
+
         try await context.perform {
             for existingConversation in conversationList.found {
-                let conversations = conversationIds.compactMap { ZMConversation.existingObject(for: $0, in: context)}
+                let conversations = conversationIds.compactMap { ZMConversation.existingObject(for: $0, in: context) }
                 if let conversation = conversations.first(where: {
                     $0.qualifiedID?.domain ==
-                    existingConversation.qualifiedID?.domain &&
-                    $0.qualifiedID?.uuid ==
-                    existingConversation.qualifiedID?.id
+                        existingConversation.qualifiedID?.domain &&
+                        $0.qualifiedID?.uuid ==
+                        existingConversation.qualifiedID?.id
                 }) {
                     conversation.isDeletedRemotely = false
-                    WireLogger.appVersionMigration.debug("Restore deleted conversation", attributes: [.conversationId: conversation.qualifiedID?.safeForLoggingDescription], .safePublic)
+                    WireLogger.appVersionMigration.debug(
+                        "Restore deleted conversation",
+                        attributes: [.conversationId: conversation.qualifiedID?.safeForLoggingDescription],
+                        .safePublic
+                    )
                 }
             }
-            
+
             try context.save()
         }
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1.swift
@@ -69,9 +69,11 @@ struct AppVersionMigration_4_12_1: AppVersionMigration {
         )
 
         try await context.perform {
+
+            let conversations = conversationIds.compactMap { ZMConversation.existingObject(for: $0, in: context) }
+
             for existingConversation in conversationList.found {
 
-                let conversations = conversationIds.compactMap { ZMConversation.existingObject(for: $0, in: context) }
                 if let conversation = conversations.first(where: {
                     $0.qualifiedID?.toNetworkModel() == existingConversation.qualifiedID
                 }) {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1712,7 +1712,7 @@ extension ZMUserSession {
 extension ZMUserSession {
 
     private func makeAppVersionMigrations() -> [any AppVersionMigration] {
-        [
+        var migrations: [any AppVersionMigration] = [
             AppVersionMigration_4_1_1(journal: journal, logFilesProvider: logFilesProvider),
             AppVersionMigration_4_2_0(
                 appGroupIdentifier: Bundle.main.appGroupIdentifier,
@@ -1727,6 +1727,18 @@ extension ZMUserSession {
                 repairGenerator: clientSessionComponent?.repairFaultyMLSRemovalKeysGenerator
             )
         ]
+        
+        if let clientSessionComponent {
+            migrations.append(
+                AppVersionMigration_4_12_1(coreDataStack: coreDataStack,
+                                           api: clientSessionComponent.conversationsAPI,
+                                           store: clientSessionComponent.conversationLocalStore)
+            )
+        } else {
+            // skip migration when first login, ok since there is no bug to fix then
+        }
+        
+        return migrations
     }
 
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1727,17 +1727,19 @@ extension ZMUserSession {
                 repairGenerator: clientSessionComponent?.repairFaultyMLSRemovalKeysGenerator
             )
         ]
-        
+
         if let clientSessionComponent {
             migrations.append(
-                AppVersionMigration_4_12_1(coreDataStack: coreDataStack,
-                                           api: clientSessionComponent.conversationsAPI,
-                                           store: clientSessionComponent.conversationLocalStore)
+                AppVersionMigration_4_12_1(
+                    coreDataStack: coreDataStack,
+                    api: clientSessionComponent.conversationsAPI,
+                    store: clientSessionComponent.conversationLocalStore
+                )
             )
         } else {
             // skip migration when first login, ok since there is no bug to fix then
         }
-        
+
         return migrations
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
@@ -125,7 +125,8 @@ struct AppVersionMigration_4_12_1Tests {
         let conversationID = QualifiedID.random()
         let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
 
-        mockConversationsAPI.getConversationsFor_MockError = ConversationsAPIError.illegalArgument(message: "identifiers between 0 and 1000")
+        mockConversationsAPI.getConversationsFor_MockError = ConversationsAPIError
+            .illegalArgument(message: "identifiers between 0 and 1000")
 
         let context = stack.syncContext
 
@@ -137,8 +138,7 @@ struct AppVersionMigration_4_12_1Tests {
         // WHEN / THEN
         try await sut.perform() // should not throw
     }
-    
-    
+
     @Test("Restores deleted conversations that were missing from backend")
     func testFailedMigration() async throws {
         let conversationID = QualifiedID.random()

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
@@ -17,46 +17,54 @@
 //
 import Foundation
 import Testing
-import WireNetwork
 import WireDataModelSupport
 import WireDomainSupport
+import WireNetwork
 import WireNetworkSupport
 @testable import WireSyncEngine
 
 struct AppVersionMigration_4_12_1Tests {
-    
+
     let coreDataHelper = CoreDataStackHelper()
     let modelHelper = ModelHelper()
-    
+
     let mockConversationsAPI = MockConversationsAPI()
     let mockConversationLocalStore = MockConversationLocalStoreProtocol()
 
     let stack: CoreDataStack
     let sut: AppVersionMigration_4_12_1
-    
+
     init() async throws {
-        stack = try await coreDataHelper.createStack()
-        sut = AppVersionMigration_4_12_1(coreDataStack: stack,
-                                             api: mockConversationsAPI,
-                                             store: mockConversationLocalStore)
+        self.stack = try await coreDataHelper.createStack()
+        self.sut = AppVersionMigration_4_12_1(
+            coreDataStack: stack,
+            api: mockConversationsAPI,
+            store: mockConversationLocalStore
+        )
 
     }
-    
+
     @Test("Restores deleted conversations that are still in backend ")
-    func testMigration() async throws{
+    func testMigration() async throws {
         let conversationID = QualifiedID.random()
         let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
-        
-        mockConversationsAPI.getConversationsFor_MockValue = .init(found: [.init(qualifiedID: qualifiedId)],
-                                                                   notFound: [],
-                                                                   failed: [])
-        
+
+        mockConversationsAPI.getConversationsFor_MockValue = .init(
+            found: [.init(qualifiedID: qualifiedId)],
+            notFound: [],
+            failed: []
+        )
+
         let context = stack.syncContext
-        
+
         var conversationA: ZMConversation?
         var conversationB: ZMConversation?
         try await context.perform {
-            conversationA = modelHelper.createGroupConversation(id: qualifiedId.id, domain: qualifiedId.domain, in: context)
+            conversationA = modelHelper.createGroupConversation(
+                id: qualifiedId.id,
+                domain: qualifiedId.domain,
+                in: context
+            )
             conversationA?.isDeletedRemotely = true
 
             conversationB = modelHelper.createGroupConversation(in: context)
@@ -65,7 +73,7 @@ struct AppVersionMigration_4_12_1Tests {
 
         // WHEN
         try await sut.perform()
-        
+
         // THEN
         try await context.perform {
             let updatedConversation = try XCTUnwrap(conversationA)
@@ -73,23 +81,28 @@ struct AppVersionMigration_4_12_1Tests {
             XCTAssertTrue(conversationB?.isDeletedRemotely == false)
         }
     }
-    
-    
+
     @Test("Don't restore deleted conversations not found in backend")
-    func testDoesNotRestore() async throws{
+    func testDoesNotRestore() async throws {
         let conversationID = QualifiedID.random()
         let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
-        
-        mockConversationsAPI.getConversationsFor_MockValue = .init(found: [],
-                                                                   notFound: [qualifiedId],
-                                                                   failed: [])
-        
+
+        mockConversationsAPI.getConversationsFor_MockValue = .init(
+            found: [],
+            notFound: [qualifiedId],
+            failed: []
+        )
+
         let context = stack.syncContext
-        
+
         var conversationA: ZMConversation?
         var conversationB: ZMConversation?
         try await context.perform {
-            conversationA = modelHelper.createGroupConversation(id: qualifiedId.id, domain: qualifiedId.domain, in: context)
+            conversationA = modelHelper.createGroupConversation(
+                id: qualifiedId.id,
+                domain: qualifiedId.domain,
+                in: context
+            )
             conversationA?.isDeletedRemotely = true
 
             conversationB = modelHelper.createGroupConversation(in: context)
@@ -98,7 +111,7 @@ struct AppVersionMigration_4_12_1Tests {
 
         // WHEN
         try await sut.perform()
-        
+
         // THEN
         try await context.perform {
             let updatedConversation = try XCTUnwrap(conversationA)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
@@ -1,0 +1,109 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+import Foundation
+import Testing
+import WireNetwork
+import WireDataModelSupport
+import WireDomainSupport
+import WireNetworkSupport
+@testable import WireSyncEngine
+
+struct AppVersionMigration_4_12_1Tests {
+    
+    let coreDataHelper = CoreDataStackHelper()
+    let modelHelper = ModelHelper()
+    
+    let mockConversationsAPI = MockConversationsAPI()
+    let mockConversationLocalStore = MockConversationLocalStoreProtocol()
+
+    let stack: CoreDataStack
+    let sut: AppVersionMigration_4_12_1
+    
+    init() async throws {
+        stack = try await coreDataHelper.createStack()
+        sut = AppVersionMigration_4_12_1(coreDataStack: stack,
+                                             api: mockConversationsAPI,
+                                             store: mockConversationLocalStore)
+
+    }
+    
+    @Test("Restores deleted conversations that are still in backend ")
+    func testMigration() async throws{
+        let conversationID = QualifiedID.random()
+        let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
+        
+        mockConversationsAPI.getConversationsFor_MockValue = .init(found: [.init(qualifiedID: qualifiedId)],
+                                                                   notFound: [],
+                                                                   failed: [])
+        
+        let context = stack.syncContext
+        
+        var conversationA: ZMConversation?
+        var conversationB: ZMConversation?
+        try await context.perform {
+            conversationA = modelHelper.createGroupConversation(id: qualifiedId.id, domain: qualifiedId.domain, in: context)
+            conversationA?.isDeletedRemotely = true
+
+            conversationB = modelHelper.createGroupConversation(in: context)
+            try context.save()
+        }
+
+        // WHEN
+        try await sut.perform()
+        
+        // THEN
+        try await context.perform {
+            let updatedConversation = try XCTUnwrap(conversationA)
+            XCTAssertFalse(updatedConversation.isDeletedRemotely)
+            XCTAssertTrue(conversationB?.isDeletedRemotely == false)
+        }
+    }
+    
+    
+    @Test("Don't restore deleted conversations not found in backend")
+    func testDoesNotRestore() async throws{
+        let conversationID = QualifiedID.random()
+        let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
+        
+        mockConversationsAPI.getConversationsFor_MockValue = .init(found: [],
+                                                                   notFound: [qualifiedId],
+                                                                   failed: [])
+        
+        let context = stack.syncContext
+        
+        var conversationA: ZMConversation?
+        var conversationB: ZMConversation?
+        try await context.perform {
+            conversationA = modelHelper.createGroupConversation(id: qualifiedId.id, domain: qualifiedId.domain, in: context)
+            conversationA?.isDeletedRemotely = true
+
+            conversationB = modelHelper.createGroupConversation(in: context)
+            try context.save()
+        }
+
+        // WHEN
+        try await sut.perform()
+        
+        // THEN
+        try await context.perform {
+            let updatedConversation = try XCTUnwrap(conversationA)
+            XCTAssertTrue(updatedConversation.isDeletedRemotely)
+            XCTAssertFalse(conversationB?.isDeletedRemotely == false)
+        }
+    }
+}

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_1Tests.swift
@@ -119,4 +119,61 @@ struct AppVersionMigration_4_12_1Tests {
             XCTAssertFalse(conversationB?.isDeletedRemotely == false)
         }
     }
+
+    @Test("Don't fail if no deleted conversations")
+    func testNoDeletedConversations() async throws {
+        let conversationID = QualifiedID.random()
+        let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
+
+        mockConversationsAPI.getConversationsFor_MockError = ConversationsAPIError.illegalArgument(message: "identifiers between 0 and 1000")
+
+        let context = stack.syncContext
+
+        try await context.perform {
+            modelHelper.createGroupConversation(in: context)
+            try context.save()
+        }
+
+        // WHEN / THEN
+        try await sut.perform() // should not throw
+    }
+    
+    
+    @Test("Restores deleted conversations that were missing from backend")
+    func testFailedMigration() async throws {
+        let conversationID = QualifiedID.random()
+        let qualifiedId = WireNetwork.QualifiedID(id: conversationID.uuid, domain: conversationID.domain)
+
+        mockConversationsAPI.getConversationsFor_MockValue = .init(
+            found: [],
+            notFound: [],
+            failed: [qualifiedId]
+        )
+
+        let context = stack.syncContext
+
+        var conversationA: ZMConversation?
+        var conversationB: ZMConversation?
+        try await context.perform {
+            conversationA = modelHelper.createGroupConversation(
+                id: qualifiedId.id,
+                domain: qualifiedId.domain,
+                in: context
+            )
+            conversationA?.isDeletedRemotely = true
+
+            conversationB = modelHelper.createGroupConversation(in: context)
+            try context.save()
+        }
+
+        // WHEN
+        try await sut.perform()
+
+        // THEN
+        try await context.perform {
+            let updatedConversation = try XCTUnwrap(conversationA)
+            XCTAssertFalse(updatedConversation.isDeletedRemotely)
+            XCTAssertTrue(conversationB?.isDeletedRemotely == false)
+        }
+    }
 }

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		015519462C20D20800037358 /* WireDomain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 015519452C20D20800037358 /* WireDomain.framework */; };
 		015DE3A72DB29CE000DC34E8 /* SessionManagerEncryptionAtRestMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015DE3A62DB29CE000DC34E8 /* SessionManagerEncryptionAtRestMigrationTests.swift */; };
 		015DE3A92DB29D4000DC34E8 /* MockUserSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015DE3A82DB29D4000DC34E8 /* MockUserSessionDelegate.swift */; };
+		0177AAC42F15225600303844 /* WireNetworkSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 0177AAC32F15225600303844 /* WireNetworkSupport */; };
 		018F17B92B83B70A00E0594D /* AVSConversationType+Conference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018F17B82B83B70A00E0594D /* AVSConversationType+Conference.swift */; };
 		01C774292D9EF01400A2FF07 /* WireAVS in Frameworks */ = {isa = PBXBuildFile; productRef = 01C774282D9EF01400A2FF07 /* WireAVS */; };
 		0601900B2678750D0043F8F8 /* DeepLinkURLActionProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161ACB3E23F6E4C200ABFF33 /* DeepLinkURLActionProcessorTests.swift */; };
@@ -1226,6 +1227,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		0177AABF2F151E5A00303844 /* ZMUserSession */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ZMUserSession; sourceTree = "<group>"; };
 		591E5E252D28084200284F11 /* WireCallCenterNotifications */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WireCallCenterNotifications; sourceTree = "<group>"; };
 		598410982D3EC1980062D022 /* Use cases */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Use cases"; sourceTree = "<group>"; };
 		5993EA532DAD078300F08A0E /* Support */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (5993EA5B2DAD078300F08A0E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Support; sourceTree = "<group>"; };
@@ -1252,6 +1254,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0177AAC42F15225600303844 /* WireNetworkSupport in Frameworks */,
 				544BA1571A43424F00D3B852 /* WireSyncEngine.framework in Frameworks */,
 				591B6E102C8B0926009F8A7B /* WireMockTransport.framework in Frameworks */,
 			);
@@ -1302,13 +1305,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0149B6172EE1C8510081EA8A /* Generators */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Generators;
-			sourceTree = "<group>";
-		};
 		060C06662B7619C600B484C6 /* E2EI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1660,7 +1656,6 @@
 				F19F1D361EFBF60A00275E27 /* SessionManager */,
 				F19F1D121EFBC17A00275E27 /* UnauthenticatedSession */,
 				3E89FFA3191B6E15002D3A3E /* Data Model */,
-				0149B6172EE1C8510081EA8A /* Generators */,
 				85D85DBFC1F3A95767DEEA45 /* Synchronization */,
 				3EAD6A08199BB6C800D519DB /* Calling */,
 				EE88B0522BF62B430013F0BD /* Services */,
@@ -1788,6 +1783,7 @@
 				1662B0F823D9CE8F00B8C7C5 /* UnauthenticatedSessionTests+DomainLookup.swift */,
 				167F383C23E04A93006B6AA9 /* UnauthenticatedSessionTests+SSO.swift */,
 				168CF42E2007BCD9009FCB89 /* TeamInvitationStatusTests.swift */,
+				0177AABF2F151E5A00303844 /* ZMUserSession */,
 				D55272E92062732100F542BE /* AssetDeletionStatusTests.swift */,
 				874A16932052C64B001C6760 /* UserExpirationObserverTests.swift */,
 				87D2555821D6275800D03789 /* BuildTypeTests.swift */,
@@ -2556,6 +2552,7 @@
 				0145AE932B1155760097E3B8 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
+				0177AABF2F151E5A00303844 /* ZMUserSession */,
 				598410982D3EC1980062D022 /* Use cases */,
 				59C60D1A2D00672300CAC544 /* Transcoders */,
 			);
@@ -3720,6 +3717,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0177AAC32F15225600303844 /* WireNetworkSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireNetworkSupport;
+		};
 		01C774282D9EF01400A2FF07 /* WireAVS */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WireAVS;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22231" title="WPB-22231" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22231</a>  [iOS] Missing Chats After Prod Migration - Federated Chats Affected
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When syncing a federated conversation with the backend, it can happen the local backend does not have the conversation and returns it as a failure. In this case the UpdateConversationItem is marking the conversation as deletedRemotely.

This PR fixes this in checking correctly the failed and notFound keys of the ConversationsAPI.

It also adds a app version migration to restore all wrongly deleted conversations

### Testing

Scenario
user A logins on Anta and user B logins on Foma
user B on Foma creates a conversation with user A on backend Anta (so conversation is owned by Foma)
turn off Foma
user B resumes the app on foreground (which syncs with Foma backend) not reachable
user B don’t see the conversation

---


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
