### PR TITLE
fix: make API v14 production ready - WPB-22631

### DIFF
--- a/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
+++ b/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
@@ -51,7 +51,7 @@ public enum APIVersion: UInt, CaseIterable, Comparable, Sendable {
     /// as production ready.
 
     public static let productionVersions: Set<Self> = [
-        .v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8, .v9, .v10, .v11, .v12, .v13
+        .v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8, .v9, .v10, .v11, .v12, .v13, .v14
     ]
 
     /// API versions currently under development and not suitable for production

--- a/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/APIVersionResolver.swift
@@ -186,7 +186,7 @@ public extension APIVersion {
     /// as production ready.
 
     static let productionVersions: Set<Self> = [
-        .v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8, .v9, .v10, .v11, .v12, .v13
+        .v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8, .v9, .v10, .v11, .v12, .v13, .v14
     ]
 
     /// API versions currently under development and not suitable for production


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22631" title="WPB-22631" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22631</a>  [iOS] Re-add removed code to support API v14 (when v14 PROD ready)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR moves API v14 from development to production versions in codebase.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
