### PR TITLE
fix: Files not correctly sorted and share link feature no longer available - WPB-22784

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -459,12 +459,23 @@ private extension WireCellsGetNodesRequest {
 
         switch configuration {
         case let .conversationFileView(root):
+            let lookupFilterTextSearch: LookupFilterTextSearch? = if let searchTerm {
+                LookupFilterTextSearch(searchIn: .baseName, term: searchTerm)
+            } else {
+                nil
+            }
+
+            if searchTerm != nil {
+                request.sortField = "mtime"
+                request.sortDirDesc = true
+            }
+
             request.filters = RestLookupFilter(
                 status: LookupFilterStatusFilter(
                     deleted: .not,
                     isDraft: false
                 ),
-                text: LookupFilterTextSearch(searchIn: .baseName, term: searchTerm ?? "*"),
+                text: lookupFilterTextSearch,
                 type: .unknown // .unknown includes files (leafs) & folders (collections)
             )
             request.scope = RestLookupScope(

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Item/FilesItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Item/FilesItemView.swift
@@ -171,6 +171,17 @@ struct FilesItemView: View {
             }
         }
 
+        menuItem(.shareLink) { item in
+            Button {
+                viewModel.performMenuAction(item)
+            } label: {
+                Label(
+                    Strings.Files.Item.Menu.shareLink,
+                    systemImage: "square.and.arrow.up"
+                )
+            }
+        }
+
         menuItem(.showVersionHistory) { item in
             Button {
                 viewModel.performMenuAction(item)

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Item/FilesItemViewModel.swift
@@ -263,6 +263,9 @@ final class FilesItemViewModel: ObservableObject {
 
         if !isInRecycleBin {
             actions.insert(.open)
+            if item.kind == .file {
+                actions.insert(.shareLink)
+            }
         }
 
         if !isBrowsing {
@@ -270,7 +273,9 @@ final class FilesItemViewModel: ObservableObject {
                 actions.insert(.restore)
                 actions.insert(.deletePermanently)
             } else {
-                actions.insert(.showVersionHistory)
+                if item.kind == .file {
+                    actions.insert(.showVersionHistory)
+                }
                 actions.insert(.moveToFolder)
                 actions.insert(.rename)
                 actions.insert(.editTags)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22784" title="WPB-22784" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22784</a>  [iOS] Share link feature no longer available, files not correctly sorted
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes some issues found during PT, specifically the share link feature was no longer available due to merge issue, this PR reintroduces the missing code. 

It also fixes an issue with files sorting and finally hide some specific actions when item is a folder as these actions should not be available for folders.

### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
