### PR TITLE
fix: conversation sorted after backup import - WPB-21925

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullAllConversationsSync.swift
@@ -97,7 +97,7 @@ public final class PullAllConversationsSync: PullAllConversationsSyncProtocol {
         for conversation in conversations.found {
             await store.storeConversation(
                 conversation.toDomainModel(),
-                timestamp: .now,
+                timestamp: conversation.lastEventTime ?? Date.distantPast,
                 isFederationEnabled: isFederationEnabled,
                 isMLSEnabled: isMLSEnabled
             )

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -65,7 +65,7 @@ final class PullAllConversationsSyncTests: XCTestCase {
         })
 
         api.getConversationsFor_MockValue = .init(
-            found: [Scaffolding.remoteConversation1],
+            found: [Scaffolding.remoteConversation1, Scaffolding.remoteConversation4],
             notFound: [Scaffolding.conversationID2],
             failed: [Scaffolding.conversationID3]
         )
@@ -84,11 +84,15 @@ final class PullAllConversationsSyncTests: XCTestCase {
         XCTAssertEqual(api.getConversationsFor_Invocations[0], Scaffolding.conversationIDs)
 
         let storeFoundInvocations = store.storeConversationTimestampIsFederationEnabledIsMLSEnabled_Invocations
-        try XCTAssertCount(storeFoundInvocations, count: 1)
+        try XCTAssertCount(storeFoundInvocations, count: 2)
         XCTAssertEqual(storeFoundInvocations[0].conversation, Scaffolding.localConversation1)
         XCTAssertEqual(storeFoundInvocations[0].isFederationEnabled, Scaffolding.isFederationEnabled)
         XCTAssertEqual(storeFoundInvocations[0].isMLSEnabled, Scaffolding.isMLSEnabled)
         XCTAssertEqual(storeFoundInvocations[0].timestamp, Date.distantPast)
+        XCTAssertEqual(storeFoundInvocations[1].conversation, Scaffolding.localConversation4)
+        XCTAssertEqual(storeFoundInvocations[1].isFederationEnabled, Scaffolding.isFederationEnabled)
+        XCTAssertEqual(storeFoundInvocations[1].isMLSEnabled, Scaffolding.isMLSEnabled)
+        XCTAssertEqual(storeFoundInvocations[1].timestamp, Scaffolding.aGivenDate)
 
         let storeNotFoundInvocations = store
             .storeConversationNeedsBackendUpdateConversationIDConversationDomain_Invocations
@@ -210,12 +214,14 @@ private enum Scaffolding {
     static let conversationID1 = WireNetwork.QualifiedID(id: UUID(), domain: localDomain)
     static let conversationID2 = WireNetwork.QualifiedID(id: UUID(), domain: localDomain)
     static let conversationID3 = WireNetwork.QualifiedID(id: UUID(), domain: localDomain)
+    static let conversationID4 = WireNetwork.QualifiedID(id: UUID(), domain: localDomain)
 
     static var conversationIDs: [WireNetwork.QualifiedID] {
         [
             conversationID1,
             conversationID2,
-            conversationID3
+            conversationID3,
+            conversationID4
         ]
     }
 
@@ -244,9 +250,38 @@ private enum Scaffolding {
         lastEvent: nil,
         lastEventTime: nil
     )
+    
+    static let remoteConversation4 = WireNetwork.Conversation(
+        id: conversationID4.id,
+        qualifiedID: conversationID4,
+        teamID: UUID(),
+        type: .group,
+        messageProtocol: .proteus,
+        mlsGroupID: nil,
+        cipherSuite: nil,
+        epoch: nil,
+        epochTimestamp: nil,
+        creator: UUID(),
+        members: nil,
+        name: "conversation 1",
+        messageTimer: nil,
+        readReceiptMode: nil,
+        access: nil,
+        accessRoles: nil,
+        legacyAccessRole: nil,
+        lastEvent: nil,
+        lastEventTime: aGivenDate
+    )
 
     static var localConversation1: WireDomain.Conversation {
         remoteConversation1.toDomainModel()
     }
-
+    
+    static var localConversation4: WireDomain.Conversation {
+        remoteConversation4.toDomainModel()
+    }
+    
+    static var aGivenDate: Date {
+        ISO8601DateFormatter().date(from: "2025-10-31T10:00:00Z") ?? Date.now
+    }
 }

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -88,6 +88,7 @@ final class PullAllConversationsSyncTests: XCTestCase {
         XCTAssertEqual(storeFoundInvocations[0].conversation, Scaffolding.localConversation1)
         XCTAssertEqual(storeFoundInvocations[0].isFederationEnabled, Scaffolding.isFederationEnabled)
         XCTAssertEqual(storeFoundInvocations[0].isMLSEnabled, Scaffolding.isMLSEnabled)
+        XCTAssertEqual(storeFoundInvocations[0].timestamp, Date.distantPast)
 
         let storeNotFoundInvocations = store
             .storeConversationNeedsBackendUpdateConversationIDConversationDomain_Invocations

--- a/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/PullAllConversationsSyncTests.swift
@@ -250,7 +250,7 @@ private enum Scaffolding {
         lastEvent: nil,
         lastEventTime: nil
     )
-    
+
     static let remoteConversation4 = WireNetwork.Conversation(
         id: conversationID4.id,
         qualifiedID: conversationID4,
@@ -276,11 +276,11 @@ private enum Scaffolding {
     static var localConversation1: WireDomain.Conversation {
         remoteConversation1.toDomainModel()
     }
-    
+
     static var localConversation4: WireDomain.Conversation {
         remoteConversation4.toDomainModel()
     }
-    
+
     static var aGivenDate: Date {
         ISO8601DateFormatter().date(from: "2025-10-31T10:00:00Z") ?? Date.now
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/Backup/BackupLocalStore/BackupLocalStore+Messages.swift
@@ -512,6 +512,10 @@ extension BackupLocalStore {
             }
 
             message.visibleInConversation = conversation
+            if let messageServerTimestamp = message.serverTimestamp {
+                conversation.updateLastModified(messageServerTimestamp)
+            }
+
             message.markAsSent()
         } catch {
             throw RehydrationFailure.failedToSetGenericMessage(error: error)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21925" title="WPB-21925" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21925</a>  [iOS] Conversation list isn't ordered based on latest messages after backup import
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

During restoring backup process, conversation timestamp is set with its latest message timestamp. (Video attached)

<!--do not remove the jira markers to link tickets automatically -->


### Issue

When user is logged in empty conversations are pulled from server and its .lastModifiedDate is set to login time, so all conversations are at the same timestamp. On recovering backup messages, no order can be set on adding messages to conversations because all message timestamps are earlier to login timestamp, so is not possible set an order in the conversations.

SOLUTION: On pulling conversations, timestamp is set to minimum (instead of current), and when messages are added to conversations conversation timestamp is set when message time is greater than conversation time, in that way most recent conversations are presented at the beginning of the list.


### Testing


Pre: Select Staging environment and Login in with provided credentials
1. Write any message in any conversation, BUT NOT the first.
2. Get back to conversations lists, now the conversation where we wrote the message is at top.
3.  Do a backup (Adjustments/Account/Copy or restore/do not encrypt/Save in files)
4. Logout
5. Select staging environment.
6. Login with provided credentials, OBSERVE that conversation order is not kept because conversation timestamp was set to login timestamp.
7. Restore step 3 backup ((Adjustments/Account/Copy or restore/do not encrypt/Save in files)
8. Get back at conversation list and check that top conversation is same as step 2.

Video:
https://github.com/user-attachments/assets/1ead3aef-cc2d-4cf2-9793-46c5bcdc5f25

## Unit test

* On PullAllConversationsSyncTests.testPull(), is assert(ed) that conversation timestamp is set to minimum, for enabling update conversation timestamp when messages timestamp are closer to now.
<img width="962" height="330" alt="image" src="https://github.com/user-attachments/assets/0984cbe4-63ac-492a-b16c-ebf7d94f0676" />


### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
