### PR TITLE
fix: conversations marked as read only when failing to establish mls group - WPB-22774

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -86,10 +86,11 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         let selfUser = await userLocalStore.fetchSelfUser()
         let commonProtocol = await getCommonProtocol(between: selfUser, and: user)
 
-        // If there are no common protocols, there can be no communication
-        // yet, so mark it read only FIRST! Otherwise we unblock the conversation
-        // since it can be resolved.
-        // only when conversation messageProtocol's none and iMLSEnabled we'll set conversation to readOnly
+        // If MLS is enabled and there are no common protocols, then
+        // there is no possibility to communicate and the 1-1 will be marked
+        // read only (follow case below). However in all other cases
+        // the conversation should be unmarked so that if they were
+        // previously blocked they are now unblocked.
         if !(mlsProvider.isMLSEnabled && commonProtocol == nil) {
             await setReadOnly(
                 to: false,

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -158,24 +158,26 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         mlsPublicKeys: MLSPublicKeys?,
         user: ZMUser,
         userID: WireDataModel.QualifiedID
-    ) async {
+    ) async throws {
+        // Establish the group if needed.
+        if try await !mlsProvider.service.conversationExists(groupID: mlsGroupID) {
+            let keys = mlsPublicKeys.flatMap {
+                WireDataModel.BackendMLSPublicKeys(removal: $0.toDataModel())
+            }
 
-        let keys = mlsPublicKeys.flatMap { WireDataModel.BackendMLSPublicKeys(removal: $0.toDataModel()) }
-
-        do {
-            try await setupMLSGroup(
-                mlsConversation: mlsConversation,
-                groupID: mlsGroupID,
-                mlsPublicKeys: keys,
-                userID: userID
-            )
-        } catch {
-            try? await context.unpack(user) { $0.oneOnOneConversation?.isForcedReadOnly = true }
-
-            WireLogger.conversation.error(
-                "Failed to setup MLS group with ID", attributes: [.mlsGroupID: mlsGroupID.safeForLoggingDescription]
-            )
-            return
+            do {
+                try await setupMLSGroup(
+                    mlsConversation: mlsConversation,
+                    groupID: mlsGroupID,
+                    mlsPublicKeys: keys,
+                    userID: userID
+                )
+            } catch {
+                WireLogger.conversation.error(
+                    "Failed to setup MLS group with ID", attributes: [.mlsGroupID: mlsGroupID.safeForLoggingDescription]
+                )
+                throw error
+            }
         }
 
         await switchLocalConversationToMLS(

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -85,7 +85,19 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
 
         let selfUser = await userLocalStore.fetchSelfUser()
         let commonProtocol = await getCommonProtocol(between: selfUser, and: user)
-
+        
+        // If there are no common protocols, there can be no communication
+        // yet, so mark it read only FIRST! Otherwise we unblock the conversation
+        // since it can be resolved.
+        // only when conversation messageProtocol's none and iMLSEnabled we'll set conversation to readOnly
+        if !(mlsProvider.isMLSEnabled && commonProtocol == nil) {
+            await setReadOnly(
+                to: false,
+                forOneOnOneWithUser: userID,
+                in: context
+            )
+        }
+        
         if mlsProvider.isMLSEnabled, commonProtocol == .mls {
             let groupId = try await resolveMLSConversation(
                 for: user
@@ -106,6 +118,11 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
                 for: user
             )
         }
+        
+        await context.perform { [context] in
+            _ = context.saveOrRollback()
+        }
+        
         return action
     }
 
@@ -137,7 +154,6 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
             mlsPublicKeys: mlsPublicKeys,
             user: user,
             userID: userID
-
         )
 
         return mlsGroupID
@@ -242,6 +258,24 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         }
     }
 
+    private func setReadOnly(
+        to readOnly: Bool,
+        forOneOnOneWithUser userID: WireDataModel.QualifiedID,
+        in context: NSManagedObjectContext
+    ) async {
+        await context.perform {
+            guard
+                let otherUser = ZMUser.fetch(with: userID, in: context),
+                let conversation = otherUser.oneOnOneConversation,
+                conversation.isForcedReadOnly != readOnly
+            else {
+                return
+            }
+
+            conversation.isForcedReadOnly = readOnly
+        }
+    }
+    
     private func fetchAllTeamOneOnOneProteusConversations(
         otherUserID: WireDataModel.QualifiedID,
         in context: NSManagedObjectContext

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -85,7 +85,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
 
         let selfUser = await userLocalStore.fetchSelfUser()
         let commonProtocol = await getCommonProtocol(between: selfUser, and: user)
-        
+
         // If there are no common protocols, there can be no communication
         // yet, so mark it read only FIRST! Otherwise we unblock the conversation
         // since it can be resolved.
@@ -97,7 +97,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
                 in: context
             )
         }
-        
+
         if mlsProvider.isMLSEnabled, commonProtocol == .mls {
             let groupId = try await resolveMLSConversation(
                 for: user
@@ -118,11 +118,11 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
                 for: user
             )
         }
-        
+
         await context.perform { [context] in
             _ = context.saveOrRollback()
         }
-        
+
         return action
     }
 
@@ -275,7 +275,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
             conversation.isForcedReadOnly = readOnly
         }
     }
-    
+
     private func fetchAllTeamOneOnOneProteusConversations(
         otherUserID: WireDataModel.QualifiedID,
         in context: NSManagedObjectContext

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -137,7 +137,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
             mlsPublicKeys: mlsPublicKeys,
             user: user,
             userID: userID
-            
+
         )
 
         return mlsGroupID
@@ -233,10 +233,12 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
                 // no op
                 return
             }
-            
-            try OneOnOneSource.migrate(toMLSConversation: mlsConversation,
-                                   for: user,
-                                   in: context)
+
+            try OneOnOneSource.migrate(
+                toMLSConversation: mlsConversation,
+                for: user,
+                in: context
+            )
         }
     }
 

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -131,23 +131,14 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
             throw Error.failedToFetchConversation
         }
 
-        let mlsService = mlsProvider.service
-
-        // If conversation already exists, there is no need to perform a migration.
-        let needsMLSMigration = try await mlsService.conversationExists(
-            groupID: mlsGroupID
-        ) == false
-
-        if needsMLSMigration {
-            await migrateToMLS(
-                mlsConversation: mlsConversation,
-                mlsGroupID: mlsGroupID,
-                mlsPublicKeys: mlsPublicKeys,
-                user: user,
-                userID: userID
-
-            )
-        }
+        try await migrateToMLS(
+            mlsConversation: mlsConversation,
+            mlsGroupID: mlsGroupID,
+            mlsPublicKeys: mlsPublicKeys,
+            user: user,
+            userID: userID
+            
+        )
 
         return mlsGroupID
     }
@@ -159,6 +150,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         user: ZMUser,
         userID: WireDataModel.QualifiedID
     ) async throws {
+
         // Establish the group if needed.
         if try await !mlsProvider.service.conversationExists(groupID: mlsGroupID) {
             let keys = mlsPublicKeys.flatMap {
@@ -180,7 +172,7 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
             }
         }
 
-        await switchLocalConversationToMLS(
+        try await switchLocalConversationToMLS(
             mlsConversation: mlsConversation,
             for: user,
             userID: userID
@@ -235,45 +227,16 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
         mlsConversation: ZMConversation,
         for user: ZMUser,
         userID: WireDataModel.QualifiedID
-    ) async {
-        await context.perform {
+    ) async throws {
+        try await context.perform {
             guard !(mlsConversation.migratedToMLS && user.oneOnOneConversation == mlsConversation) else {
+                // no op
                 return
             }
-
-            // Note on proteus, it's possible to have 2 duplicate 1-1 conversations, so we need to fetch both
-            // conversations here.
-            let proteusConversations: [ZMConversation] = fetchAllTeamOneOnOneProteusConversations(
-                otherUserID: userID,
-                in: context
-            )
-
-            var allProteusConversations = Set(proteusConversations)
-            if let existingConversation = user.oneOnOneConversation,
-               existingConversation.messageProtocol == .proteus {
-                allProteusConversations.insert(existingConversation)
-            }
-
-            // move local messages from proteus conversations if they exist
-            for proteusConversation in allProteusConversations {
-                // Since ZMMessages only have a single conversation connected,
-                // forming this union also removes the relationship to the proteus conversation.
-                mlsConversation.migrateMessages(from: proteusConversation)
-            }
-
-            if !allProteusConversations.isEmpty {
-                // insert system message that we moved from proteus to MLS
-                let sender = ZMUser.selfUser(in: context)
-                mlsConversation.appendMLSMigrationFinalizedSystemMessageIfNeeded(sender: sender, at: .now)
-
-                mlsConversation.isForcedReadOnly = false
-                // update just to be sure
-                mlsConversation.needsToBeUpdatedFromBackend = true
-            }
-
-            /// Switch active conversation
-            user.oneOnOneConversation = mlsConversation
-            mlsConversation.migratedToMLS = true
+            
+            try OneOnOneSource.migrate(toMLSConversation: mlsConversation,
+                                   for: user,
+                                   in: context)
         }
     }
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/OneOnOneResolverTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/OneOnOneResolverTests.swift
@@ -307,10 +307,11 @@ final class OneOnOneResolverTests: XCTestCase {
             with: selfUser,
             in: context
         )
-
+        proteusConversation.messageProtocol = .proteus
         proteusConversation.isForcedReadOnly = forcedReadOnly
         user.oneOnOneConversation = proteusConversation
-
+        proteusConversation.addParticipantAndUpdateConversationState(user: user)
+        
         try proteusConversation.appendText(content: "Hello")
         try proteusConversation.appendText(content: "World!")
 

--- a/WireDomain/Tests/WireDomainTests/Synchronization/OneOnOneResolverTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/OneOnOneResolverTests.swift
@@ -311,7 +311,7 @@ final class OneOnOneResolverTests: XCTestCase {
         proteusConversation.isForcedReadOnly = forcedReadOnly
         user.oneOnOneConversation = proteusConversation
         proteusConversation.addParticipantAndUpdateConversationState(user: user)
-        
+
         try proteusConversation.appendText(content: "Hello")
         try proteusConversation.appendText(content: "World!")
 

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -83,6 +83,7 @@ public final class MLSService: MLSServiceInterface {
     var targetUnclaimedKeyPackageCount: Int {
         DeveloperFlag.lowKeyPackageCount.isOn ? 1 : 100
     }
+
     let actionsProvider: MLSActionsProviderProtocol
 
     private let subconversationGroupIDRepository: SubconversationGroupIDRepositoryInterface

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -80,7 +80,9 @@ public final class MLSService: MLSServiceInterface {
         case keyPackageQueriedTime
     }
 
-    let targetUnclaimedKeyPackageCount = 100
+    var targetUnclaimedKeyPackageCount: Int {
+        DeveloperFlag.lowKeyPackageCount.isOn ? 1 : 100
+    }
     let actionsProvider: MLSActionsProviderProtocol
 
     private let subconversationGroupIDRepository: SubconversationGroupIDRepositoryInterface

--- a/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
@@ -98,10 +98,11 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
 
         let messageProtocol = try await protocolSelector.getProtocolForUser(with: userID, in: context)
 
-        // If there are no common protocols, there can be no communication
-        // yet, so mark it read only. Otherwise we unblock the conversation
-        // since it can be resolved.
-        // only when conversation messageProtocol's none and iMLSEnabled we'll set conversation to readOnly
+        // If MLS is enabled and there are no common protocols, then
+        // there is no possibility to communicate and the 1-1 will be marked
+        // read only (follow case below). However in all other cases
+        // the conversation should be unmarked so that if they were
+        // previously blocked they are now unblocked.
         if !(messageProtocol == .none && isMLSEnabled) {
             await setReadOnly(
                 to: false,

--- a/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
@@ -98,15 +98,6 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
 
         let messageProtocol = try await protocolSelector.getProtocolForUser(with: userID, in: context)
 
-        // If there are no common protocols, there can be no communication
-        // yet, so mark it read only. Otherwise we unblock the conversation
-        // since it can be resolved.
-        await setReadOnly(
-            to: messageProtocol == .none,
-            forOneOnOneWithUser: userID,
-            in: context
-        )
-
         let action: OneOnOneConversationResolution
         switch messageProtocol {
         case .none where isMLSEnabled:

--- a/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
@@ -98,9 +98,22 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
 
         let messageProtocol = try await protocolSelector.getProtocolForUser(with: userID, in: context)
 
+        // If there are no common protocols, there can be no communication
+        // yet, so mark it read only. Otherwise we unblock the conversation
+        // since it can be resolved.
+        // only when conversation messageProtocol's none and iMLSEnabled we'll set conversation to readOnly
+        if !(messageProtocol == .none && isMLSEnabled) {
+            await setReadOnly(
+                to: false,
+                forOneOnOneWithUser: userID,
+                in: context
+            )
+        }
+
         let action: OneOnOneConversationResolution
         switch messageProtocol {
         case .none where isMLSEnabled:
+            
             action = try await resolveCommonUserProtocolNone(with: userID, in: context)
         case .mls where isMLSEnabled:
             action = try await resolveCommonUserProtocolMLS(with: userID, in: context)

--- a/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
@@ -98,6 +98,15 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
 
         let messageProtocol = try await protocolSelector.getProtocolForUser(with: userID, in: context)
 
+        // If there are no common protocols, there can be no communication
+        // yet, so mark it read only. Otherwise we unblock the conversation
+        // since it can be resolved.
+        await setReadOnly(
+            to: messageProtocol == .none,
+            forOneOnOneWithUser: userID,
+            in: context
+        )
+
         let action: OneOnOneConversationResolution
         switch messageProtocol {
         case .none where isMLSEnabled:
@@ -197,19 +206,12 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
             throw OneOnOneResolverError.migratorNotFound
         }
 
-        do {
-            let mlsGroupID = try await migrator.migrateToMLS(
-                userID: userID,
-                in: context
-            )
-            await setReadOnly(to: false, forOneOnOneWithUser: userID, in: context)
-            return .migratedToMLSGroup(identifier: mlsGroupID)
-        } catch let MigrateMLSOneOnOneConversationError.failedToEstablishGroup(error) {
-            await setReadOnly(to: true, forOneOnOneWithUser: userID, in: context)
-            throw MigrateMLSOneOnOneConversationError.failedToEstablishGroup(error)
-        } catch {
-            throw error
-        }
+        let mlsGroupID = try await migrator.migrateToMLS(
+            userID: userID,
+            in: context
+        )
+
+        return .migratedToMLSGroup(identifier: mlsGroupID)
     }
 
     private func setReadOnly(

--- a/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/LegacyOneOnOneResolver.swift
@@ -113,7 +113,7 @@ public final class LegacyOneOnOneResolver: OneOnOneResolverInterface {
         let action: OneOnOneConversationResolution
         switch messageProtocol {
         case .none where isMLSEnabled:
-            
+
             action = try await resolveCommonUserProtocolNone(with: userID, in: context)
         case .mls where isMLSEnabled:
             action = try await resolveCommonUserProtocolMLS(with: userID, in: context)

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -161,10 +161,12 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
                 .info(
                     "Migrating messages and link the MLS conversation if needed. Conversation is migrated to MLS: \(mlsConversation.migratedToMLS), is oneOnOneConversation MLS: \(otherUser.oneOnOneConversation == mlsConversation)"
                 )
-            
-            try OneOnOneSource.migrate(toMLSConversation: mlsConversation,
-                                   for: otherUser,
-                                   in: context)
+
+            try OneOnOneSource.migrate(
+                toMLSConversation: mlsConversation,
+                for: otherUser,
+                in: context
+            )
         }
     }
 

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -161,38 +161,10 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
                 .info(
                     "Migrating messages and link the MLS conversation if needed. Conversation is migrated to MLS: \(mlsConversation.migratedToMLS), is oneOnOneConversation MLS: \(otherUser.oneOnOneConversation == mlsConversation)"
                 )
-            // Note on proteus, it's possible to have duplicate 1-1 conversations, so we need to fetch all relevant
-            // 1-1 conversations here.
-            let source = OneOnOneSource(context: context)
-            var proteusConversations: [ZMConversation] = []
-            // NOTE: querying for all types at once triggers a table scan which is very expensive
-            for type in [OneOnOneType.fake, OneOnOneType.proteus, OneOnOneType.proteusPending] {
-                let conversations = try source.fetchOneOnOnes(
-                    user: otherUser,
-                    types: [type]
-                )
-                proteusConversations.append(contentsOf: conversations)
-            }
-
-            // Move local messages from all proteus conversations
-            for proteusConversation in proteusConversations {
-                // Since ZMMessages only have a single conversation connected,
-                // forming this union also removes the relationship to the proteus conversation.
-                mlsConversation.migrateMessages(from: proteusConversation)
-            }
-
-            if !proteusConversations.isEmpty {
-                // insert system message that we moved from proteus to MLS
-                let sender = ZMUser.selfUser(in: context)
-                mlsConversation.appendMLSMigrationFinalizedSystemMessageIfNeeded(sender: sender, at: .now)
-
-                // update just to be sure
-                mlsConversation.needsToBeUpdatedFromBackend = true
-            }
-            // switch active conversation
-            otherUser.oneOnOneConversation = mlsConversation
-
-            mlsConversation.migratedToMLS = true
+            
+            try OneOnOneSource.migrate(toMLSConversation: mlsConversation,
+                                   for: otherUser,
+                                   in: context)
         }
     }
 

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneSource.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneSource.swift
@@ -23,7 +23,7 @@ enum OneOnOneType: Hashable {
     case proteusPending
 }
 
-final class OneOnOneSource {
+public final class OneOnOneSource {
 
     struct Result {
         let candidate: ZMConversation
@@ -107,6 +107,43 @@ final class OneOnOneSource {
 
         return try context.fetch(fetchRequest)
     }
+    
+    
+    public static func migrate(toMLSConversation mlsConversation: ZMConversation, for otherUser: ZMUser, in context: NSManagedObjectContext) throws {
+        
+        // Note on proteus, it's possible to have duplicate 1-1 conversations, so we need to fetch all relevant
+        // 1-1 conversations here.
+        let source = OneOnOneSource(context: context)
+        var proteusConversations: [ZMConversation] = []
+        // NOTE: querying for all types at once triggers a table scan which is very expensive
+        for type in [OneOnOneType.fake, OneOnOneType.proteus, OneOnOneType.proteusPending] {
+            let conversations = try source.fetchOneOnOnes(
+                user: otherUser,
+                types: [type]
+            )
+            proteusConversations.append(contentsOf: conversations)
+        }
+
+        // Move local messages from all proteus conversations
+        for proteusConversation in proteusConversations {
+            // Since ZMMessages only have a single conversation connected,
+            // forming this union also removes the relationship to the proteus conversation.
+            mlsConversation.migrateMessages(from: proteusConversation)
+        }
+
+        if !proteusConversations.isEmpty {
+            // insert system message that we moved from proteus to MLS
+            let sender = ZMUser.selfUser(in: context)
+            mlsConversation.appendMLSMigrationFinalizedSystemMessageIfNeeded(sender: sender, at: .now)
+
+            // update just to be sure
+            mlsConversation.needsToBeUpdatedFromBackend = true
+        }
+        // switch active conversation
+        otherUser.oneOnOneConversation = mlsConversation
+
+        mlsConversation.migratedToMLS = true
+    }
 }
 
 private extension NSPredicate {
@@ -183,3 +220,4 @@ private extension NSPredicate {
     }
 
 }
+

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneSource.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneSource.swift
@@ -107,10 +107,13 @@ public final class OneOnOneSource {
 
         return try context.fetch(fetchRequest)
     }
-    
-    
-    public static func migrate(toMLSConversation mlsConversation: ZMConversation, for otherUser: ZMUser, in context: NSManagedObjectContext) throws {
-        
+
+    public static func migrate(
+        toMLSConversation mlsConversation: ZMConversation,
+        for otherUser: ZMUser,
+        in context: NSManagedObjectContext
+    ) throws {
+
         // Note on proteus, it's possible to have duplicate 1-1 conversations, so we need to fetch all relevant
         // 1-1 conversations here.
         let source = OneOnOneSource(context: context)
@@ -220,4 +223,3 @@ private extension NSPredicate {
     }
 
 }
-

--- a/wire-ios-data-model/Tests/OneOnOne/LegacyOneOnOneResolverTests.swift
+++ b/wire-ios-data-model/Tests/OneOnOne/LegacyOneOnOneResolverTests.swift
@@ -195,7 +195,7 @@ final class LegacyOneOnOneResolverTests: XCTestCase {
         XCTAssertFalse(isReadOnly)
     }
 
-    func test_ResolveOneOnOneConversation_GivenMLS_SetsReadOnlyToTrue_WhenItFailsToEstablishGroup() async throws {
+    func test_ResolveOneOnOneConversation_GivenMLS_DoesNotSetReadOnlyToTrue_WhenItFailsToEstablishGroup() async throws {
         // Given
         let userID: QualifiedID = .random()
         let resolver = makeResolver()
@@ -216,7 +216,7 @@ final class LegacyOneOnOneResolverTests: XCTestCase {
         } catch MigrateMLSOneOnOneConversationError.failedToEstablishGroup {
             // Then
             let isReadOnly = await syncContext.perform { conversation.isReadOnly }
-            XCTAssertTrue(isReadOnly)
+            XCTAssertFalse(isReadOnly)
         } catch {
             XCTFail("unexpected error")
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1375,12 +1375,12 @@ extension ZMUserSession: SyncAgentDelegate {
     }
 
     private func resolveOneOnOneConversationsIfNeeded() async {
-        guard mlsFeature.isEnabled, !didAlreadyResolveAllOneOnOnes else { return }
+        guard let clientSessionComponent, mlsFeature.isEnabled, !didAlreadyResolveAllOneOnOnes else { return }
 
-        let resolveOneOnOneUseCase = makeResolveOneOnOneConversationsUseCase(context: syncContext)
+        let resolveOneOnOneUseCase = clientSessionComponent.oneOnOneResolver
         do {
-            let didResolve = try await resolveOneOnOneUseCase.invoke()
-            didAlreadyResolveAllOneOnOnes = didResolve
+            try await resolveOneOnOneUseCase.resolveAllOneOnOneConversations()
+            didAlreadyResolveAllOneOnOnes = true
         } catch {
             WireLogger.mls.error("Failed to resolve one on one conversations: \(String(reflecting: error))")
         }

--- a/wire-ios-utilities/Source/DeveloperFlag.swift
+++ b/wire-ios-utilities/Source/DeveloperFlag.swift
@@ -42,6 +42,7 @@ public enum DeveloperFlag: String, CaseIterable {
     case useWireAuthentication
     case wireCellsFolders
     case wireMeetings
+    case lowKeyPackageCount
 
     public var description: String {
         switch self {
@@ -106,6 +107,9 @@ public enum DeveloperFlag: String, CaseIterable {
 
         case .wireCellsFolders:
             "Turn on to enable Wire Cells folders"
+
+        case .lowKeyPackageCount:
+            "Turn on to set the minimum number of packages to 1"
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22774" title="WPB-22774" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22774</a>   [iOS] Messages missing in chat & Input field disappeared
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When resolving a 1:1 conversation, for a mls conversation we try to establish the group and then migrate potential messages from previous proteus conversations if any. In case the group fails to establish, we set the conversation as readonly.

As the mls conversation is already migrated, next time we don't resolve this conversation again and can't remove the readonly flag once the conversation successfully establish.

### Testing

1. user A has a 1:1 with a user B
2. user B has no more key packages
3. trigger a mls reset
4. user A can't establish the new group

Result:
~~the conversation is set to readonly~~
the conversation is still accessible

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
