### PR TITLE
fix: error icon when loading preview - WPB-21781

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsLargeVideoPreviewView.swift
@@ -94,7 +94,7 @@ struct WireCellsLargeVideoPreviewView: View {
                             .disabled(false)
                     }
             case .failure:
-                errorView(text: Self.errorMessage)
+                loadingView(text: Self.loadingMessage)
             @unknown default:
                 EmptyView()
             }

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsSmallVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/AttachmentsPreviewView/WireCellsSmallVideoPreviewView.swift
@@ -76,7 +76,7 @@ struct WireCellsSmallVideoPreviewView: View {
                         }
                     }
             case .failure:
-                WireCellsAttachmentPreviewErrorCircle()
+                ProgressView()
             @unknown default:
                 EmptyView()
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21781" title="WPB-21781" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21781</a>  [iOS] Error icon while showing preview
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fix the erro icon being show while loading for a brief moment on small and large video previews.

The issue was happening when the user was scrolling thru a conversation and the previews were reloading.

Now it will keep showing the loading until the thumbnail is shown.

### Testing

- Open a conversation with large and small video previews.
- Scroll until you don't see the previews on screen.
- Scroll again until you see the previews.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
