### PR TITLE
fix: text change drive - WPB-22881

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -1654,13 +1654,13 @@ internal enum L10n {
           internal static let title = L10n.tr("Localizable", "collections.section.links.title", fallback: "Links")
         }
         internal enum SearchFiles {
-          /// Search files
-          internal static let description = L10n.tr("Localizable", "collections.section.searchFiles.description", fallback: "Search files")
+          /// Search Files
+          internal static let description = L10n.tr("Localizable", "collections.section.searchFiles.description", fallback: "Search Files")
           internal enum Alert {
-            /// Find files in conversations with Shared Drive.
-            internal static let message = L10n.tr("Localizable", "collections.section.searchFiles.alert.message", fallback: "Find files in conversations with Shared Drive.")
-            /// Wire Drive
-            internal static let title = L10n.tr("Localizable", "collections.section.searchFiles.alert.title", fallback: "Wire Drive")
+            /// Find any file or folder in this conversation.
+            internal static let message = L10n.tr("Localizable", "collections.section.searchFiles.alert.message", fallback: "Find any file or folder in this conversation.")
+            /// Shared Drive
+            internal static let title = L10n.tr("Localizable", "collections.section.searchFiles.alert.title", fallback: "Shared Drive")
           }
         }
         internal enum Videos {

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -1874,9 +1874,9 @@ Enter your identity provider’s credentials in the next step to update the cert
 "collections.search.field.placeholder" = "Search text messages";
 "collections.search.no_items" = "No results";
 
-"collections.section.searchFiles.description" = "Search files";
-"collections.section.searchFiles.alert.title" = "Wire Drive";
-"collections.section.searchFiles.alert.message" = "Find files in conversations with Shared Drive.";
+"collections.section.searchFiles.description" = "Search Files";
+"collections.section.searchFiles.alert.title" = "Shared Drive";
+"collections.section.searchFiles.alert.message" = "Find any file or folder in this conversation.";
 
 
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22881" title="WPB-22881" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22881</a>  [iOS] Copy update for search files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Changed Base language (EN) text of the Search Files Dialog/Alert.

### Testing

* go to files search
* open the alert
* check if the text matches the figma design