### PR TITLE
fix: upload keyPackages if needed every 24 hours - WPB-22902

### DIFF
--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
@@ -108,7 +108,7 @@ public actor WorkAgent {
                     )
                 } catch {
                     WireLogger.workAgent.error(
-                        "item failed, dropping",
+                        "item failed, dropping \(String(describing: error))",
                         attributes: .init(item)
                     )
                     continue

--- a/WireDomain/Tests/WireDomainTests/Synchronization/CommitPendingProposalsGeneratorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/CommitPendingProposalsGeneratorTests.swift
@@ -30,7 +30,7 @@ class CommitPendingProposalsGeneratorTests {
     let coreDataStackHelper = CoreDataStackHelper()
     let coreDataStack: CoreDataStack
     var commitPendingProposalItemClosure: ((CommitPendingProposalItem) -> Void)?
-    var mockMLSService: MockMLSServiceInterface!
+    var mockMLSService: MockMLSServiceInterface
     var isMLSGroupBroken: (MLSGroupID) -> Bool = { _ in false }
 
     init() async throws {
@@ -53,6 +53,11 @@ class CommitPendingProposalsGeneratorTests {
                 self.commitPendingProposalItemClosure?(item)
             }
         )
+    }
+
+    deinit {
+        sut = nil
+        commitPendingProposalItemClosure = nil
     }
 
     @Test(

--- a/wire-ios-data-model/Source/MLS/MLSClientManager.swift
+++ b/wire-ios-data-model/Source/MLS/MLSClientManager.swift
@@ -81,7 +81,6 @@ public final class MLSClientManager: MLSClientManagerProtocol {
         } catch {
             WireLogger.mls.error("Failed to performPendingJoins: \(String(reflecting: error))")
         }
-        await mlsService.uploadKeyPackagesIfNeeded()
         await mlsService.updateKeyMaterialForAllStaleGroupsIfNeeded()
         didPerformMLSClientUpdate = true
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -112,18 +112,6 @@ extension ZMUserSession {
             }
         }
     }
-    
-    var uploadKeyPackagesAction: RecurringAction {
-        .init(id: #function, interval: .oneDay) { [weak self] in
-            do {
-                guard let self else { return }
-
-                await mlsService.uploadKeyPackagesIfNeeded()
-            } catch {
-                WireLogger.e2ei.error("Failed to refresh federation certificates: \(error)")
-            }
-        }
-    }
 
     var checkBuildBlacklistAction: RecurringAction {
         .init(id: #function, interval: .oneHour * 6) { [weak self] in

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+RecurringAction.swift
@@ -112,6 +112,18 @@ extension ZMUserSession {
             }
         }
     }
+    
+    var uploadKeyPackagesAction: RecurringAction {
+        .init(id: #function, interval: .oneDay) { [weak self] in
+            do {
+                guard let self else { return }
+
+                await mlsService.uploadKeyPackagesIfNeeded()
+            } catch {
+                WireLogger.e2ei.error("Failed to refresh federation certificates: \(error)")
+            }
+        }
+    }
 
     var checkBuildBlacklistAction: RecurringAction {
         .init(id: #function, interval: .oneHour * 6) { [weak self] in

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1297,6 +1297,7 @@ extension ZMUserSession: SyncAgentDelegate {
                 WireLogger.mls.warn("`qualifiedClientID` is missing for selfClient")
             }
 
+            // always check if need to upload key packages if needed
             await mlsService.uploadKeyPackagesIfNeeded()
             await calculateSelfSupportedProtocolsIfNeeded()
             await resolveOneOnOneConversationsIfNeeded()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -861,7 +861,7 @@ public final class ZMUserSession: NSObject {
         recurringActionService.registerAction(updateProteusToMLSMigrationStatusAction)
         recurringActionService.registerAction(refreshTeamMetadataAction)
         recurringActionService.registerAction(refreshFederationCertificatesAction)
-
+        recurringActionService.registerAction(uploadKeyPackagesAction)
         if DeveloperFlag.multibackend.isOn {
             recurringActionService.registerAction(checkBuildBlacklistAction)
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1297,9 +1297,10 @@ extension ZMUserSession: SyncAgentDelegate {
                 WireLogger.mls.warn("`qualifiedClientID` is missing for selfClient")
             }
 
+            await mlsService.uploadKeyPackagesIfNeeded()
             await calculateSelfSupportedProtocolsIfNeeded()
             await resolveOneOnOneConversationsIfNeeded()
-
+            
             // TODO: [WPB-18175] Port MLS client creation and related MLS operations from here to the InitialSync
 
             await recurringActionService.performActionsIfNeeded()

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -861,7 +861,7 @@ public final class ZMUserSession: NSObject {
         recurringActionService.registerAction(updateProteusToMLSMigrationStatusAction)
         recurringActionService.registerAction(refreshTeamMetadataAction)
         recurringActionService.registerAction(refreshFederationCertificatesAction)
-        recurringActionService.registerAction(uploadKeyPackagesAction)
+
         if DeveloperFlag.multibackend.isOn {
             recurringActionService.registerAction(checkBuildBlacklistAction)
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1300,7 +1300,7 @@ extension ZMUserSession: SyncAgentDelegate {
             await mlsService.uploadKeyPackagesIfNeeded()
             await calculateSelfSupportedProtocolsIfNeeded()
             await resolveOneOnOneConversationsIfNeeded()
-            
+
             // TODO: [WPB-18175] Port MLS client creation and related MLS operations from here to the InitialSync
 
             await recurringActionService.performActionsIfNeeded()

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -463,6 +463,31 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
         XCTAssertEqual(fetchBackendMLSPublicKeysActionHandler.performedActions.count, 1)
     }
 
+    func test_itUploadKeyPackagesIfNeeded_AfterQuickSync() async throws {
+        // GIVEN
+        mockCoreCryptoProvider.registerMlsTransport_MockMethod = { _ in }
+        await syncMOC.perform { [self, syncMOC] in
+            let domain = "anta.com"
+            ZMUser.selfUser(in: syncMOC).domain = domain
+            let selfUserClient = createSelfClient()
+            // MLS client has been registered
+            selfUserClient.mlsPublicKeys = UserClient.MLSPublicKeys(ed25519: "somekey")
+            selfUserClient.needsToUploadMLSPublicKeys = false
+            ZMUser.selfUser(in: self.syncMOC).domain = domain
+            sut.didRegisterSelfUserClient(selfUserClient)
+            syncMOC.saveOrRollback()
+
+            sut.setUpSyncAgent(clientID: selfUserClient.remoteIdentifier!)
+
+            // WHEN
+            sut.didFinishIncrementalSync(isRecovering: false)
+        }
+
+        // THEN
+        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        XCTAssertEqual(mockMLSService.uploadKeyPackagesIfNeeded_Invocations.count, 1)
+    }
+
     func test_itCreatesMLSClientIfNeeded_AfterQuickSync() {
         // GIVEN
         DeveloperFlag.multibackend.enable(false, storage: .temporary())

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -116,7 +116,7 @@ class ZMUserSessionTestsBase: MessagingTest {
         mockRecurringActionService = MockRecurringActionServiceInterface()
         mockRecurringActionService.registerAction_MockMethod = { _ in }
         mockRecurringActionService.performActionsIfNeeded_MockMethod = {}
-
+        mockMLSService.uploadKeyPackagesIfNeeded_MockMethod = {}
         sut = createSut()
         sut.sessionManager = mockSessionManager
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22902" title="WPB-22902" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22902</a>  [iOS] fix upload key packages if needed
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

During playtest, we dound out that a user without key packages could not be added. Indeed, key packages were only uploaded when someone adds the user to a group (welcome message)

### Testing

- Verify keypackages ~recurring action~ is run every day
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
