### PR TITLE
fix: iPad app crashes on blocking user - WPB-21169

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Block.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Block.swift
@@ -72,6 +72,12 @@ extension ConversationActionController {
             preferredStyle: .actionSheet
         )
         BlockResult.all(isBlocked: user.isBlocked).map { $0.action(handler) }.forEach(controller.addAction)
+
+        if let sourceView, let superView = sourceView.superview,
+           let popover = controller.popoverPresentationController {
+            currentContext = .sourceView(superView, sourceView.frame)
+            popover.permittedArrowDirections = .left
+        }
         present(controller)
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+ClearContent.swift
@@ -58,9 +58,12 @@ extension ConversationActionController {
     func requestClearContentResult(for conversation: ZMConversation, handler: @escaping (ClearContentResult) -> Void) {
         let controller = UIAlertController(title: ClearContentResult.title, message: nil, preferredStyle: .actionSheet)
         ClearContentResult.options(for: conversation).map { $0.action(handler) }.forEach(controller.addAction)
-        if let sourceView, controller.popoverPresentationController != nil {
-            currentContext = .sourceView(sourceView.superview!, sourceView.frame)
+        if let sourceView, let superView = sourceView.superview,
+           let popover = controller.popoverPresentationController {
+            currentContext = .sourceView(superView, sourceView.frame)
+            popover.permittedArrowDirections = .left
         }
+
         present(controller)
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Notifications.swift
@@ -77,6 +77,13 @@ extension ConversationActionController {
         let title = "\(conversation.displayNameWithFallback) • \(NotificationResult.title)"
         let controller = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         NotificationResult.allCases.map { $0.action(for: conversation, handler: handler) }.forEach(controller.addAction)
+
+        if let sourceView, let superView = sourceView.superview,
+           let popover = controller.popoverPresentationController {
+            currentContext = .sourceView(superView, sourceView.frame)
+            popover.permittedArrowDirections = .left
+        }
+
         present(controller)
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController.swift
@@ -59,9 +59,9 @@ final class ConversationActionController {
         actions.map(alertAction).forEach(controller.addAction)
         controller.addAction(.cancel())
 
-        if controller.popoverPresentationController != nil {
+        if let superView = sourceView.superview, controller.popoverPresentationController != nil {
             currentContext = .sourceView(
-                sourceView: sourceView.superview!,
+                sourceView: superView,
                 sourceRect: sourceView.frame
             )
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21169" title="WPB-21169" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21169</a>  [iOS/iPad] App crashes on blocking user
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Note: this reapply a cherry-pick from https://github.com/wireapp/wire-ios/pull/3934

~~No idea how it disappeared 🙈~~ actually found the commit / PR that reverted it -> https://github.com/wireapp/wire-ios/pull/3834/changes#diff-97a4bbe65192ab4a1cc7d74bc16a53d64f88d8af48bd1dc632f8dc7e9a2f9e4eR41-R48

### Testing

There should be a critical flow test for this @findms 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
