### PR TITLE
fix: showing/hiding bots when adding participants to a Proteus conversation - WPB-21441

### DIFF
--- a/wire-ios/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
+++ b/wire-ios/Wire-iOS Tests/AddParticipantsViewControllerSnapshotTests.swift
@@ -88,13 +88,23 @@ final class AddParticipantsViewControllerSnapshotTests: XCTestCase {
             selfUser: mockSelfUser
         )
 
-        sut = AddParticipantsViewController(context: .create(newValues), userSession: userSession)
+        sut = AddParticipantsViewController(
+            context: .create(newValues),
+            userSession: userSession,
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true
+        )
         snapshotHelper.verify(matching: sut)
     }
 
     func testForAddParticipantsButtonIsShown() {
         let conversation = MockGroupDetailsConversation()
-        sut = AddParticipantsViewController(context: .add(conversation), userSession: userSession)
+        sut = AddParticipantsViewController(
+            context: .add(conversation),
+            userSession: userSession,
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true
+        )
         let user = MockUserType.createUser(name: "Bill")
         sut.userSelection.add(user)
         sut.userSelection(UserSelection(), didAddUser: user)
@@ -112,7 +122,12 @@ final class AddParticipantsViewControllerSnapshotTests: XCTestCase {
         mockConversation.allowApps = true
         mockConversation.messageProtocol = .proteus
 
-        sut = AddParticipantsViewController(context: .add(mockConversation), userSession: userSession)
+        sut = AddParticipantsViewController(
+            context: .add(mockConversation),
+            userSession: userSession,
+            isAppsFeatureEnabled: true,
+            areLegacyBotsAvailable: true
+        )
 
         // THEN
         XCTAssertTrue(mockConversation.botCanBeAdded)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -188,7 +188,9 @@ final class AddParticipantsViewController: UIViewController {
     ) {
         self.userSession = userSession
 
-        self.viewModel = AddParticipantsViewModel(with: context)
+        self.viewModel = AddParticipantsViewModel(
+            context: context
+        )
 
         self.collectionViewLayout = UICollectionViewFlowLayout()
         collectionViewLayout.scrollDirection = .vertical
@@ -376,7 +378,9 @@ final class AddParticipantsViewController: UIViewController {
                 encryptionProtocol: userSession.defaultProtocol,
                 selfUser: userSession.selfUser
             )
-            viewModel = AddParticipantsViewModel(with: .create(updated))
+            viewModel = AddParticipantsViewModel(
+                context: .create(updated)
+            )
         }
 
         // Enable button & collection view content inset

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewController.swift
@@ -153,11 +153,15 @@ final class AddParticipantsViewController: UIViewController {
 
     convenience init(
         conversation: GroupDetailsConversationType,
-        userSession: UserSession
+        userSession: UserSession,
+        isAppsFeatureEnabled: Bool,
+        areLegacyBotsAvailable: Bool
     ) {
         self.init(
             context: .add(conversation),
-            userSession: userSession
+            userSession: userSession,
+            isAppsFeatureEnabled: isAppsFeatureEnabled,
+            areLegacyBotsAvailable: areLegacyBotsAvailable
         )
     }
 
@@ -184,12 +188,15 @@ final class AddParticipantsViewController: UIViewController {
 
     init(
         context: Context,
-        userSession: UserSession
+        userSession: UserSession,
+        isAppsFeatureEnabled: Bool,
+        areLegacyBotsAvailable: Bool
     ) {
         self.userSession = userSession
-
         self.viewModel = AddParticipantsViewModel(
-            context: context
+            context: context,
+            isAppsFeatureEnabled: isAppsFeatureEnabled,
+            areLegacyBotsAvailable: areLegacyBotsAvailable
         )
 
         self.collectionViewLayout = UICollectionViewFlowLayout()
@@ -379,7 +386,9 @@ final class AddParticipantsViewController: UIViewController {
                 selfUser: userSession.selfUser
             )
             viewModel = AddParticipantsViewModel(
-                context: .create(updated)
+                context: .create(updated),
+                isAppsFeatureEnabled: values.isAppsFeatureEnabled,
+                areLegacyBotsAvailable: values.areLegacyBotsAvailable
             )
         }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -23,15 +23,33 @@ import WireLocators
 
 struct AddParticipantsViewModel {
     let context: AddParticipantsViewController.Context
+    let isAppsFeatureEnabled: Bool
+    let areLegacyBotsAvailable: Bool
 
-    init(with context: AddParticipantsViewController.Context) {
+    init(
+        context: AddParticipantsViewController.Context
+    ) {
         self.context = context
+        // TODO: fix
+        isAppsFeatureEnabled = false
+        areLegacyBotsAvailable = false
     }
 
-    var botCanBeAdded: Bool {
+    var botCanBeAdded: Bool { // TODO: apps vs bots?
         switch context {
-        case .create: false
-        case let .add(conversation): conversation.botCanBeAdded
+        case .create:
+            return false
+        case let .add(conversation):
+            guard conversation.botCanBeAdded else { return false }
+
+            switch conversation.messageProtocol {
+            case .mls where isAppsFeatureEnabled:
+                return true
+            case .proteus where areLegacyBotsAvailable:
+                return true
+            default:
+                return false
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -36,7 +36,7 @@ struct AddParticipantsViewModel {
         self.areLegacyBotsAvailable = areLegacyBotsAvailable
     }
 
-    var botCanBeAdded: Bool { // TODO: apps vs bots?
+    var botCanBeAdded: Bool { // TODO: [WPB-20362] apps vs bots?
         switch context {
         case .create:
             return false

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -45,9 +45,9 @@ struct AddParticipantsViewModel {
 
             switch conversation.messageProtocol {
             case .mls where isAppsFeatureEnabled:
-                return true
+                return conversation.allowApps
             case .proteus where areLegacyBotsAvailable:
-                return true
+                return conversation.allowApps
             default:
                 return false
             }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/AddContacts/AddParticipantsViewModel.swift
@@ -27,12 +27,13 @@ struct AddParticipantsViewModel {
     let areLegacyBotsAvailable: Bool
 
     init(
-        context: AddParticipantsViewController.Context
+        context: AddParticipantsViewController.Context,
+        isAppsFeatureEnabled: Bool,
+        areLegacyBotsAvailable: Bool
     ) {
         self.context = context
-        // TODO: fix
-        isAppsFeatureEnabled = false
-        areLegacyBotsAvailable = false
+        self.isAppsFeatureEnabled = isAppsFeatureEnabled
+        self.areLegacyBotsAvailable = areLegacyBotsAvailable
     }
 
     var botCanBeAdded: Bool { // TODO: apps vs bots?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/ConversationCreationController.swift
@@ -49,6 +49,7 @@ final class ConversationCreationController: UIViewController {
     typealias CreateGroupName = L10n.Localizable.Conversation.Create.GroupName
 
     private let userSession: UserSession
+    private let isAppsFeatureEnabled: Bool
     private let areLegacyBotsAvailable: Bool
 
     private let collectionViewController = SectionCollectionViewController()
@@ -180,6 +181,7 @@ final class ConversationCreationController: UIViewController {
     ) {
         self.preSelectedParticipants = preSelectedParticipants
         self.userSession = userSession
+        self.isAppsFeatureEnabled = isAppsFeatureEnabled
         self.areLegacyBotsAvailable = areLegacyBotsAvailable
         self.values = ConversationCreationValues(
             isChannel: false,
@@ -289,7 +291,9 @@ final class ConversationCreationController: UIViewController {
 
             let participantsController = AddParticipantsViewController(
                 context: .create(values),
-                userSession: userSession
+                userSession: userSession,
+                isAppsFeatureEnabled: isAppsFeatureEnabled,
+                areLegacyBotsAvailable: areLegacyBotsAvailable
             )
 
             participantsController.conversationCreationDelegate = self

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/WireConversationChannelCreationFormViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Create/WireConversationChannelCreationFormViewController.swift
@@ -150,7 +150,9 @@ final class WireConversationChannelCreationFormViewController: UIViewController 
 
         let participantsController = AddParticipantsViewController(
             context: .create(values),
-            userSession: userSession
+            userSession: userSession,
+            isAppsFeatureEnabled: values.isAppsFeatureEnabled,
+            areLegacyBotsAvailable: values.areLegacyBotsAvailable
         )
 
         participantsController.conversationCreationDelegate = self

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -377,7 +377,9 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
         case .invite:
             let addParticipantsViewController = AddParticipantsViewController(
                 conversation: conversation,
-                userSession: userSession
+                userSession: userSession,
+                isAppsFeatureEnabled: isAppsFeatureEnabled,
+                areLegacyBotsAvailable: areLegacyBotsAvailable
             )
             let navigationController = addParticipantsViewController.wrapInNavigationController()
             navigationController.modalPresentationStyle = .currentContext


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21441" title="WPB-21441" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />WPB-21441</a>  [iOS] [Integration] Toggle Apps in Conversation Flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In a Proteus conversation the adding participants screen must not allow listing/searching bots if no bots are whitelisted or the conversation has bots disabled.

### Testing

Navigate to a Proteus conversation's details and add participants. Check that the switch control (people/apps) is only shown when it should.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
