### PR TITLE
chore: update drive copy WPB-22994

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/da.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Version herunterladen";
 "conversation.wireCells.filesVersioning.retry" = "Wiederholen";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Version wird wiederhergestellt...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -260,4 +260,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -238,7 +238,7 @@
 "conversation.wireCells.shareLink.expiration.addExpirationToggle" = "Add expiration";
 "conversation.wireCells.shareLink.expiration.description" = "The link expires automatically after the set date and time. People can't access the content anymore.";
 "conversation.wireCells.shareLink.expiration.datePickerTitle" = "Expires";
-"conversation.wireCells.shareLink.expiration.dateNotSupported" = "Date in the past is not supported";
+"conversation.wireCells.shareLink.expiration.dateNotSupported" = "Date in the past";
 "conversation.wireCells.shareLink.expiration.unableToAddExpiration.title" = "Unable to add expiration date";
 "conversation.wireCells.shareLink.expiration.unableToAddExpiration.message" = "Please check your network connection and try again.";
 "conversation.wireCells.shareLink.expiration.unableToAddExpiration.action" = "Try again";
@@ -255,8 +255,8 @@
 "conversation.wireCells.filesVersioning.restoreAlertTitle" = "Restore version";
 "conversation.wireCells.filesVersioning.restoreAlertMessage" = "This copies the restored version and sets it as the current one. All previous versions remain available.";
 "conversation.wireCells.filesVersioning.restoreAlertAction" = "Restore";
-"conversation.wireCells.filesVersioning.restoreFailureAlertTitle" = "Restoring version failed";
-"conversation.wireCells.filesVersioning.restoreFailureAlertMessage" = "Something went wrong while restoring a version. Please retry.";
+"conversation.wireCells.filesVersioning.restoreFailureAlertTitle" = "Unable to restore version";
+"conversation.wireCells.filesVersioning.restoreFailureAlertMessage" = "Something went wrong while restoring this version. Please try again.";
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/es.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Reintentar";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/et.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/et.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/it.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/lt.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/lt.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Tentar novamente";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Скачать версию";
 "conversation.wireCells.filesVersioning.retry" = "Повторить";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Восстановление версии... ";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Загрузка версии файла";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/sl.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/sl.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "重试";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -254,4 +254,3 @@
 "conversation.wireCells.filesVersioning.downloadVersion" = "Download version";
 "conversation.wireCells.filesVersioning.retry" = "Retry";
 "conversation.wireCells.filesVersioning.restoringVersion" = "Restoring version...";
-"conversation.wireCells.filesVersioning.downloadingVersion" = "Downloading file version";


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR:

1. Deletes `conversation.wireCells.filesVersioning.downloadingVersion` which is unused.
2. Updates copy for the following keys:
  - `conversation.wireCells.filesVersioning.restoreFailureAlertTitle`
  - `conversation.wireCells.filesVersioning.restoreFailureAlertMessage`
  - `conversation.wireCells.shareLink.expiration.dateNotSupported`

### Testing

Only one change can be manually tested:

1. Navigate to a drived enabled conversation.
2. Navigate to a files list and attempt to share a file.
3. Select a time in the past.
4. Note that error message.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.