### PR TITLE
fix: UITest failures - WPB-23003

### DIFF
--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -75,10 +75,8 @@ class ConversationsPage: PageModel {
     }
 
     func openUserProfilePage() throws -> UserProfilePage {
-
-        if accountProfileImageView.waitForExistence(timeout: 2), accountProfileImageView.isHittable {
-            accountProfileImageView.tap()
-        }
+        try VerifyUserIsOnConversationsTab()
+        accountProfileImageView.waitAndTap()
         return try UserProfilePage()
     }
 
@@ -130,5 +128,13 @@ class ConversationsPage: PageModel {
 
     func getNameLabel() -> String? {
         conversationCell.label
+    }
+    
+    // Problem: Opening the user profile can occasionally fail while a background sync is in progress.
+    // Workaround: Assert the presence of stable UI elements to give the sync time to complete.
+    func VerifyUserIsOnConversationsTab() throws {
+        XCTAssertTrue(plusButtonToCreateGroup.exists)
+        XCTAssertTrue(archivedButton.exists)
+        XCTAssert(settingsButton.exists)
     }
 }

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -129,7 +129,7 @@ class ConversationsPage: PageModel {
     func getNameLabel() -> String? {
         conversationCell.label
     }
-    
+
     // Problem: Opening the user profile can occasionally fail while a background sync is in progress.
     // Workaround: Assert the presence of stable UI elements to give the sync time to complete.
     func VerifyUserIsOnConversationsTab() throws {

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -130,8 +130,8 @@ class ConversationsPage: PageModel {
         conversationCell.label
     }
 
-    // Problem: Opening the user profile can occasionally fail while a background sync is in progress.
-    // Workaround: Assert the presence of stable UI elements to give the sync time to complete.
+    // Problem: Opening the user profile can occasionally fail while sync is in progress after login
+    // Workaround: Assert the presence of some UI elements to give the sync time to complete.
     func VerifyUserIsOnConversationsTab() throws {
         XCTAssertTrue(plusButtonToCreateGroup.exists)
         XCTAssertTrue(archivedButton.exists)

--- a/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
+++ b/wire-ios/WireUITests/Pages/OptionsOnSettingsPage.swift
@@ -53,15 +53,16 @@ class OptionsOnSettingsPage: PageModel {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passcodeField = springboard.secureTextFields["Passcode field"].firstMatch
 
-        guard passcodeField.waitForExistence(timeout: 3.0) else {
+        guard passcodeField.waitAndTap()
+        else {
             XCTFail("Passcode SecureTextField did not appear")
             throw XCTSkip("Passcode field not available")
         }
         try passcodeField.tapIfKeyboardNotFocused().typeText(pass)
 
         let doneButton = springboard.keyboards.buttons["Done"].firstMatch
-        if doneButton.waitForExistence(timeout: 2.0), doneButton.isHittable {
-            doneButton.tap()
+        if doneButton.waitAndTap() {
+            // Tapped successfully
         } else {
             springboard.typeText(XCUIKeyboardKey.return.rawValue)
         }

--- a/wire-ios/WireUITests/ShareExtensionTests.swift
+++ b/wire-ios/WireUITests/ShareExtensionTests.swift
@@ -61,7 +61,10 @@ final class ShareExtensionTests: WireUITestCase {
         try await userHelper.acceptConnectionRequestFromUser(domain: domain, user1: user1, userId: user2.id)
         let firstTimePage = try app.loginUser(email: user1.email, password: user1.password)
         let conversationsPage = try  firstTimePage.acceptPopup(with: self)
-
+        XCTAssertTrue(
+            conversationsPage.conversationCell.waitForExistence(timeout: 4.0),
+            "Conversation Cell did not show up after login"
+        )
         try await launchPhotosApp()
         try await shareFirstPhotoToWire(name: user2.name)
         try await switchBackToWireApp()

--- a/wire-ios/WireUITests/XCUIElement+Additions.swift
+++ b/wire-ios/WireUITests/XCUIElement+Additions.swift
@@ -60,12 +60,12 @@ extension XCUIElement {
     }
 
     @discardableResult
-       func waitAndTap(timeout: TimeInterval = 5) -> Bool {
-           let predicate = NSPredicate(format: "exists == true && isHittable == true")
-           let exp = XCTNSPredicateExpectation(predicate: predicate, object: self)
-           let result = XCTWaiter().wait(for: [exp], timeout: timeout)
-           guard result == .completed else { return false }
-           tap()
-           return true
-       }
+    func waitAndTap(timeout: TimeInterval = 5) -> Bool {
+        let predicate = NSPredicate(format: "exists == true && isHittable == true")
+        let exp = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        let result = XCTWaiter().wait(for: [exp], timeout: timeout)
+        guard result == .completed else { return false }
+        tap()
+        return true
+    }
 }

--- a/wire-ios/WireUITests/XCUIElement+Additions.swift
+++ b/wire-ios/WireUITests/XCUIElement+Additions.swift
@@ -59,10 +59,13 @@ extension XCUIElement {
         return result == .completed
     }
 
-    func waitAndTap(timeout: TimeInterval = 3) {
-        let predicate = NSPredicate(format: "exists == true && hittable == true")
-        let exp = XCTNSPredicateExpectation(predicate: predicate, object: self)
-        _ = XCTWaiter().wait(for: [exp], timeout: timeout)
-        tap()
-    }
+    @discardableResult
+       func waitAndTap(timeout: TimeInterval = 5) -> Bool {
+           let predicate = NSPredicate(format: "exists == true && isHittable == true")
+           let exp = XCTNSPredicateExpectation(predicate: predicate, object: self)
+           let result = XCTWaiter().wait(for: [exp], timeout: timeout)
+           guard result == .completed else { return false }
+           tap()
+           return true
+       }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23003" title="WPB-23003" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23003</a>  [iOS/QA] fix UITest failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

_Please describe the issue._

**Random failures of critical flow**

### Testing
Ran locally and ran file twice in a row
<img width="1367" height="858" alt="image" src="https://github.com/user-attachments/assets/858fee79-c99d-4777-ad20-608ef76ad7da" />

