### PR TITLE
feat: file upload dialog for autorename - WPB-22584

### DIFF
--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/Protocols/WireCellsUploadDraftUseCaseProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/Protocols/WireCellsUploadDraftUseCaseProtocol.swift
@@ -30,6 +30,8 @@ public protocol WireCellsUploadDraftUseCaseProtocol: Sendable {
     /// Creates a file using `imageData` and uploads it to the cells server.
 
     func invoke(data: Data, type: UTType) async throws
+
+    var charactersToReplace: [Character] { get }
 }
 
 public enum WireCellsUploadDraftUseCaseError: Error, Sendable {

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/UploadDraftUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/UploadDraftUseCase.swift
@@ -38,6 +38,8 @@ package struct UploadDraftUseCase: WireCellsUploadDraftUseCaseProtocol, WireCell
     private let intermediaryFilesDirectory: URL
     private let filenameGenerator: FilenameGenerator
 
+    package let charactersToReplace: [Character] = ["\\", "\""]
+
     package init(
         cellName: String,
         draftRepository: any DraftsRepositoryProtocol,
@@ -127,13 +129,19 @@ package struct UploadDraftUseCase: WireCellsUploadDraftUseCaseProtocol, WireCell
             throw WireCellsUploadDraftUseCaseError.missingFileSize
         }
 
+        var filename = fileURL.lastPathComponent
+
+        for characterToReplace in charactersToReplace {
+            filename = filename.replacingOccurrences(of: String(characterToReplace), with: "_")
+        }
+
         let draft = WireCellsDraft(
             nodeID: UUID(),
             versionID: UUID(),
             assetURL: fileURL,
             fileType: resourceValues.contentType,
             status: .uploading(progress: 0),
-            name: fileURL.lastPathComponent,
+            name: filename,
             bytes: fileSize,
             mimeType: nil,
             requiresCleanup: requiresCleanup,

--- a/wire-ios/Wire-iOS Tests/Mocks/WireCells/WireCellsUploadDraftUseCaseProtocolMock.swift
+++ b/wire-ios/Wire-iOS Tests/Mocks/WireCells/WireCellsUploadDraftUseCaseProtocolMock.swift
@@ -30,4 +30,5 @@ final class WireCellsUploadDraftUseCaseProtocolMock: WireCellsUploadDraftUseCase
         fatalError("Implement")
     }
 
+    let charactersToReplace: [Character] = ["\\", "\""]
 }

--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -2514,6 +2514,20 @@ internal enum L10n {
           internal static let body = L10n.tr("Localizable", "content.system.unknown_message_received.body", fallback: "You have received a message that can't be displayed. You may be using an older version of Wire.")
         }
       }
+      internal enum UploadedFileNeedsRename {
+        /// Cancel
+        internal static let cancelButton = L10n.tr("Localizable", "content.uploaded_file_needs_rename.cancelButton", fallback: "Cancel")
+        /// Replace
+        internal static let confirmButton = L10n.tr("Localizable", "content.uploaded_file_needs_rename.confirmButton", fallback: "Replace")
+        /// %@ characters are not allowed.
+        /// 
+        /// Tap Replace to exchange them with accepted characters or Cancel to rename the file yourself.
+        internal static func message(_ p1: Any) -> String {
+          return L10n.tr("Localizable", "content.uploaded_file_needs_rename.message", String(describing: p1), fallback: "%@ characters are not allowed.\n\nTap Replace to exchange them with accepted characters or Cancel to rename the file yourself.")
+        }
+        /// File name incompatible
+        internal static let title = L10n.tr("Localizable", "content.uploaded_file_needs_rename.title", fallback: "File name incompatible")
+      }
     }
     internal enum Conversation {
       internal enum Action {

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.strings
@@ -742,6 +742,12 @@
 "content.message.reply.files.count" = "%@ files";
 "content.message.reply.files.notAvailable" = "File not available";
 
+// Uploaded file needs rename
+"content.uploaded_file_needs_rename.title" = "File name incompatible";
+"content.uploaded_file_needs_rename.message" = "%@ characters are not allowed.\n\nTap Replace to exchange them with accepted characters or Cancel to rename the file yourself.";
+"content.uploaded_file_needs_rename.confirmButton" = "Replace";
+"content.uploaded_file_needs_rename.cancelButton" = "Cancel";
+
 // Reactions
 "content.reactions.title" = "Select reaction";
 "content.reactions.search" = "Search for emoji";

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Files.swift
@@ -51,6 +51,16 @@ extension ConversationInputBarViewController {
     func uploadFiles(at urls: [URL]) {
         guard !urls.isEmpty else { return }
 
+        let charactersToReplace = uploadDraftUseCase.charactersToReplace
+
+        if urls.contains(where: { $0.lastPathComponent.contains(where: { charactersToReplace.contains($0) }) }) {
+            showAlertForFileNeedsRename(urls: urls)
+        } else {
+            continueUploadFiles(at: urls)
+        }
+    }
+
+    private func continueUploadFiles(at urls: [URL]) {
         if userSession.isWireCellsEnabled, conversation.isCellsEnabled {
             for url in urls {
                 Task.detached { [uploadDraftUseCase] in
@@ -152,6 +162,33 @@ extension ConversationInputBarViewController {
             title: L10n.Localizable.General.ok,
             style: .cancel
         ))
+
+        present(alert, animated: true)
+    }
+
+    private func showAlertForFileNeedsRename(urls: [URL]) {
+        let formattedCharacters = uploadDraftUseCase.charactersToReplace.map { String($0) }.joined(separator: " ")
+
+        let alert = UIAlertController(
+            title: L10n.Localizable.Content.UploadedFileNeedsRename.title,
+            message: L10n.Localizable.Content.UploadedFileNeedsRename.message(formattedCharacters),
+            preferredStyle: .alert
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: L10n.Localizable.Content.UploadedFileNeedsRename.cancelButton,
+                style: .cancel
+            )
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: L10n.Localizable.Content.UploadedFileNeedsRename.confirmButton,
+                style: .default,
+                handler: { [weak self] _ in
+                    self?.continueUploadFiles(at: urls)
+                }
+            )
+        )
 
         present(alert, animated: true)
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22584" title="WPB-22584" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22584</a>  [iOS] Disallow \ and " in file names when uploading a file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The characters `\` and `"` are not allowed in filenames of uploaded files.
Before a file is uploaded and added as an attachment to a message, the code will check if the filename contains those characters and if it does, it will show an alert with two buttons:
* Cancel will keep the message in the state before adding the files to upload.
* Replace will add the files as attachments and upload them.

Files which are uploaded, are automatically renamed by replacing invalid characters with the underscore character `_`.

### Testing

* open a Wire Drive enabled conversation
* upload one or multiple files as attachments to a message
* if a filename has invalid characters, it should trigger the alert
  * cancelling the alert should do nothing and the message should have no attachments
  * confirming the alert should add the attachments and and upload the files
* send the message
* if the message contained attached files, those files should appear in the file list
  * check if the filenames of the new files don't contain the invalid characters `\` or `"` and are replaced by `_`.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
