### PR TITLE
fix: crash UI freeze when opening a image - WPB-22990

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -44,7 +44,7 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
             rhs: ConversationTextMessageCell.Configuration
         ) -> Bool {
             lhs.isObfuscated == rhs.isObfuscated &&
-                lhs.attributedText.description == rhs.attributedText.description
+                lhs.attributedText.isEqual(to: rhs.attributedText)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22990" title="WPB-22990" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22990</a>  [iOS] Wire: specialized closure #8 in AnyConversationMessageCellDescription.init<A>(_:)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
When opening a image sometimes the app completely freezes which would end up (after a while) in a crash

```
Thread 0 name:   Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   CoreFoundation                	       0x1a078c530 _CFStringCheckAndGetCharacterAtIndex + 12
1   CoreFoundation                	       0x1a078c670 -[__NSCFString characterAtIndex:] + 64
2   libswiftCore.dylib            	       0x19f02d46c _StringGuts.foreignErrorCorrectedUTF16CodeUnit(at:) + 60
3   libswiftCore.dylib            	       0x19f02ab40 String.UnicodeScalarView._foreignIndex(after:) + 24
4   libswiftCore.dylib            	       0x19ef9f204 specialized closure #1 in Unicode._InternalNFC.Iterator.next() + 616
5   libswiftCore.dylib            	       0x19ef9f8d4 Unicode._NFDNormalizer._resume(consuming:) + 320
6   libswiftCore.dylib            	       0x19f13d038 specialized Unicode._NFCNormalizer._resume(consumingNFD:) + 132
7   libswiftCore.dylib            	       0x19f0162ec _StringGutsSlice._slowCompare(with:expecting:) + 804
8   libswiftCore.dylib            	       0x19f015160 _stringCompareSlow(_:_:expecting:) + 88
9   Wire                          	       0x102fb9a54 specialized ConversationMessageCellDescription<>.isConfigurationEqual(with:) (in Wire) (ConversationMessageCell.swift:303) + 2431572
10  Wire                          	       0x102fc53ec specialized closure #8 in AnyConversationMessageCellDescription.init<A>(_:) (in Wire) + 76 + 2479084
11  Wire                          	       0x102fd67a0 partial apply for specialized closure #8 in AnyConversationMessageCellDescription.init<A>(_:) (in Wire) (/<compiler-generated>:0) + 2549664
12  Wire                          	       0x103026ab4 specialized StagedChangeset<>.init(source:target:) (in Wire) (/<compiler-generated>:0) + 2878132
13  Wire                          	       0x103029be4 closure #1 in ConversationTableViewDataSource.messageSectionController(_:didRequestRefreshForMessage:) (in Wire) (ConversationTableViewDataSource.swift:782) + 2890724
14  ...5845629AC2BC_PackageProduct	       0x1045391e4 closure #1 in LeadingTrailingDebouncer.call(id:block:) (in WireFoundation_30ED5845629AC2BC_PackageProduct) (/<compiler-generated>:0) + 20964
15  ...5845629AC2BC_PackageProduct	       0x1045392a4 thunk for @escaping @callee_guaranteed @Sendable () -> () (in WireFoundation_30ED5845629AC2BC_PackageProduct) (/<compiler-generated>:0) + 21156
16  libdispatch.dylib             	       0x1a8718584 _dispatch_client_callout + 16
17  libdispatch.dylib             	       0x1a8703560 _dispatch_continuation_pop + 596
18  libdispatch.dylib             	       0x1a8716348 _dispatch_source_latch_and_call + 396
19  libdispatch.dylib             	       0x1a8715020 _dispatch_source_invoke + 844
20  libdispatch.dylib             	       0x1a87354ec _dispatch_main_queue_drain.cold.5 + 592
21  libdispatch.dylib             	       0x1a870dd30 _dispatch_main_queue_drain + 180
22  libdispatch.dylib             	       0x1a870dc6c _dispatch_main_queue_callback_4CF + 44
23  CoreFoundation                	       0x1a07cec30 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16
24  CoreFoundation                	       0x1a0772394 __CFRunLoopRun + 1980
25  CoreFoundation                	       0x1a0773adc CFRunLoopRunSpecific + 572
26  GraphicsServices              	       0x1ed599454 GSEventRunModal + 168
27  UIKitCore                     	       0x1a3195274 -[UIApplication _run] + 816
28  UIKitCore                     	       0x1a3160a28 UIApplicationMain + 336
29  Wire                          	       0x102d6c0f0 main (in Wire) (/<compiler-generated>:0) + 16624
30  dyld                          	       0x1c7205f08 start + 6040
```

**Root Cause**

  The app was killed by the iOS watchdog (0x8BADF00D) after taking more than 10 seconds to update the UI. The issue was in the conversation message diff calculation:

  Stack Trace Analysis:
  Thread 0 Crashed:
  ConversationTextMessageCell.Configuration.== (line 46-47)
    → String comparison with Unicode NFC normalization
    → StagedChangeset diff calculation
    → ConversationTableViewDataSource.reloadSections()

**The Problem**

  In ConversationTextMessageCell.swift:46-47, the equality check was comparing attributed strings like this:

  lhs.attributedText.description == rhs.attributedText.description

  This triggered expensive Unicode normalization (NFC) on the main thread. With many messages containing long text, this could take >10 seconds, causing the watchdog to kill the app.

**Solution**

Replaced the inefficient string comparison with the optimized NSAttributedString comparison method:

  Before:
  lhs.attributedText.description == rhs.attributedText.description

  After:
  lhs.attributedText.isEqual(to: rhs.attributedText)

  Why This Works

  NSAttributedString.isEqual(to:) is specifically designed for this use case and:
  - Performs pointer equality check first (O(1) fast path)
  - Compares lengths before comparing content
  - Avoids expensive Unicode normalization
  - Efficiently compares both text and attributes

  This should dramatically reduce the time spent in diff calculation and prevent the watchdog timeout.
  ```

### Testing

- [ ] run playground build and see if this still happens
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
