### PR TITLE
fix: recycle bin copy update - WPB-22639

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesViewProtocol.swift
@@ -65,7 +65,9 @@ extension FilesViewProtocol {
     @ViewBuilder private var listBackgroundView: some View {
         switch viewModel.state {
         case let .received(items) where items.isEmpty:
-            FilesInfoView(info: .noFilesFound(scope: isBrowsing ? .allConversations : .oneConversation))
+            FilesInfoView(info: .noFilesFound(
+                scope: viewModel.isRecycleBin ? .recycleBin : isBrowsing ? .allConversations : .oneConversation)
+            )
         case .pending:
             FilesInfoView(info: .preparingFiles)
         default:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22639" title="WPB-22639" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22639</a>  [iOS] Bin empty state update - add support article and update copy
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Recycle bin copy updates introduced in this [PR](https://github.com/wireapp/wire-ios/pull/4135) was not showing up in the app due to caller code missing.

### Testing

Go to recycle bin, make sure it's empty. the screen must match the design.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
