### PR TITLE
fix: update self-deleting system message - WPB-21395

### DIFF
--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationFileCollaborationSystemMessageCellSnapshotTests/testFileCollaboration_DarkTheme.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationFileCollaborationSystemMessageCellSnapshotTests/testFileCollaboration_DarkTheme.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0d5dd0eab424ed127d043960f4bd0a18ebc638efd4780711fa116c31b404c31
-size 8891
+oid sha256:8cff09ef122031f3d5fb3bcd4a410c639dfd65658027a753f6eda05a35344e0a
+size 8958

--- a/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationFileCollaborationSystemMessageCellSnapshotTests/testFileCollaboration_LightTheme.1.png
+++ b/wire-ios/Wire-iOS Tests/ReferenceImages/ConversationFileCollaborationSystemMessageCellSnapshotTests/testFileCollaboration_LightTheme.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9b00951a69893a104ae9acdcd5883c36406cb06573ea42626c05761d7c37a62
-size 8929
+oid sha256:017b68cb2cbe79f5e4e5e01c70c26cf70fa0bb692f68582541184e432dd8c2e6
+size 8982

--- a/wire-ios/Wire-iOS/Sources/Helpers/DynamicFontLabel.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/DynamicFontLabel.swift
@@ -45,7 +45,21 @@ class DynamicFontLabel: UILabel, DynamicTypeCapable {
         self.adjustsFontForContentSizeCategory = true
     }
 
-    @available(*, deprecated, message: "Use `init(text:style:color)` instead")
+    init(
+        attributedText: NSAttributedString,
+        style: WireTextStyle = .body1,
+        color: UIColor
+    ) {
+        // Not needed when we use a font style.
+        self.onRedrawFont = { nil }
+        super.init(frame: .zero)
+        self.attributedText = attributedText
+        self.textColor = color
+        self.font = .font(for: style)
+        self.adjustsFontForContentSizeCategory = true
+    }
+
+    @available(*, deprecated, message: "Use `init(text:style:color)` or `init(attributedText:style:color)` instead")
     init(
         text: String? = nil,
         fontSpec: FontSpec = .normalRegularFont,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationFileCollaborationSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationFileCollaborationSystemMessageCellDescription.swift
@@ -23,7 +23,7 @@ import WireDesign
 
 final class ConversationFileCollaborationSystemMessageCellDescription: ConversationMessageCellDescription {
 
-    typealias View = ConversationSystemMessageCell<ConversationFileCollaborationSystemMessageCellDescription>
+    typealias View = ConversationWarningSystemMessageCell<ConversationFileCollaborationSystemMessageCellDescription>
     typealias LabelColors = SemanticColors.Label
     typealias IconColors = SemanticColors.Icon
 
@@ -59,7 +59,11 @@ final class ConversationFileCollaborationSystemMessageCellDescription: Conversat
             attributedText.addAttribute(.font, value: UIFont.mediumSemiboldFont, range: nsRange)
         }
 
-        self.configuration = View.Configuration(icon: icon, attributedText: attributedText, showLine: false)
+        self.configuration = View.Configuration(
+            icon: icon,
+            topText: NSAttributedString(string: ""),
+            bottomText: attributedText,
+        )
         self.accessibilityLabel = attributedText.string
         self.actionController = nil
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageTimerSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMessageTimerSystemMessageCellDescription.swift
@@ -23,7 +23,7 @@ import WireDesign
 
 final class ConversationMessageTimerSystemMessageCellDescription: ConversationMessageCellDescription {
 
-    typealias View = ConversationSystemMessageCell<ConversationMessageTimerSystemMessageCellDescription>
+    typealias View = ConversationWarningSystemMessageCell<ConversationMessageTimerSystemMessageCellDescription>
     typealias LabelColors = SemanticColors.Label
     typealias IconColors = SemanticColors.Icon
 
@@ -82,7 +82,11 @@ final class ConversationMessageTimerSystemMessageCellDescription: ConversationMe
 
         typealias LabelColors = SemanticColors.Label
         let icon = StyleKitIcon.hourglass.makeImage(size: 16, color: IconColors.backgroundDefault)
-        self.configuration = View.Configuration(icon: icon, attributedText: updateText, showLine: false)
+        self.configuration = View.Configuration(
+            icon: icon,
+            topText: NSAttributedString(string: ""),
+            bottomText: updateText ?? NSAttributedString(string: "")
+        )
         self.accessibilityLabel = updateText?.string
         self.actionController = nil
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
@@ -28,22 +28,26 @@ final class ConversationWarningSystemMessageCell<
     private typealias IconColors = SemanticColors.Icon
 
     struct Configuration: Equatable {
-        let topText: String
-        let bottomText: String
+        let icon: UIImage?
+        let topText: NSAttributedString
+        let bottomText: NSAttributedString
     }
 
     private let encryptionLabel = DynamicFontLabel(
+        attributedText: NSAttributedString(string: ""),
         style: .subline1,
         color: LabelColors.textDefault
     )
     private let sensitiveInfoLabel = DynamicFontLabel(
+        attributedText: NSAttributedString(string: ""),
         style: .subline1,
         color: LabelColors.textDefault
     )
 
     func configure(with object: Configuration, animated: Bool) {
-        encryptionLabel.text = object.topText
-        sensitiveInfoLabel.text = object.bottomText
+        encryptionLabel.attributedText = object.topText
+        sensitiveInfoLabel.attributedText = object.bottomText
+        imageView.image = object.icon
     }
 
     override func configureSubviews() {
@@ -57,7 +61,6 @@ final class ConversationWarningSystemMessageCell<
         bottomContentView.addSubview(sensitiveInfoLabel)
 
         lineView.isHidden = true
-        imageView.image = .init(resource: .attention)
         imageView.tintColor = IconColors.backgroundDefault
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationWarningSystemMessageCell.swift
@@ -66,8 +66,14 @@ final class ConversationWarningSystemMessageCell<
 
     override func configureConstraints() {
         super.configureConstraints()
-        encryptionLabel.fitIn(view: topContentView)
-        sensitiveInfoLabel.fitIn(view: bottomContentView)
+        let padding: CGFloat = 6.0
+
+        encryptionLabel.fitIn(view: topContentView, insets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding))
+        sensitiveInfoLabel.fitIn(
+            view: bottomContentView,
+            insets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: padding)
+        )
+
         NSLayoutConstraint.activate([
             imageContainer.topAnchor.constraint(equalTo: bottomContentView.topAnchor).withPriority(.required)
         ])


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21395" title="WPB-21395" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21395</a>  [iOS] "Cells" text from system message seems moving to next line when there is space avaiable.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When creating a chat with "Cells" enabled, the self-deleting message was not using the fill width available.

In order to fix that and avoid creating more abstraction or system cells, i've updated DynamicFontLabel to allow to use Attributed String instead of just String (an extra init() was added)

Adding that extra init() we can use it for ConversationWarningSystemMessageCell (updating a bit ConversationEncryptionInfoSystemMessageCellDescription) instead of ConversationSystemMessageCell for ConversationTimerSystemMessageCellDescription.

This will use the full width of the parent view.

As needed extra, padding was added to ConversationWarningSystemMessageCell so text is not showing under the scrollbar.

As a nice to have extra, ConversationFileCollaborationSystemMessageCellDescription was updated to also use ConversationWarningSystemMessageCell so if the text gets too long it will also use the full width properly.

### Testing

Steps to test:
- Create a conversation with Cells enabled
- Observe system message


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
