### PR TITLE
fix: crash + keyboard issue on iPad - WPB-21539

### DIFF
--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
@@ -532,6 +532,11 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
             splitViewController.conversationUI != nil
         }
     }
+
+    public func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
+        guard .oneOverSecondary == displayMode else { return }
+        splitViewController.view.endEditing(true)
+    }
 }
 
 // MARK: - MainSidebarMenuItem + MainConversationFilter

--- a/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
+++ b/WireUI/Sources/WireMainNavigationUI/Coordinator/MainCoordinator.swift
@@ -533,8 +533,11 @@ public final class MainCoordinator<Dependencies>: NSObject, MainCoordinatorProto
         }
     }
 
-    public func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
-        guard .oneOverSecondary == displayMode else { return }
+    public func splitViewController(
+        _ svc: UISplitViewController,
+        willChangeTo displayMode: UISplitViewController.DisplayMode
+    ) {
+        guard displayMode == .oneOverSecondary else { return }
         splitViewController.view.endEditing(true)
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21539" title="WPB-21539" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-21539</a>  [iOS/iPad] Keyboard remain open on switching from conversation to Files view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue where the keyboard remains open when switching to the "All" files section (in sidebar) on iPad.
This wrong keyboard behavior is also causing a weird UI issue and eventually ends up with a crash which is most likely related to that [Jira ticket](https://wearezeta.atlassian.net/browse/WPB-22075), specifically:

- Go to conversations, have the keyboard open
- Open the side bar, tap on "Folders" then tap again to dismiss the folders view.
- Observe that the "All" button from the "Files" section is being replaced by "Settings" and "Support" ones
- Go to settings then open the side bar again, "All" button is back under the Files section.
- Go to "All" conversations, then back to the "All" files -> This is causing a crash reproducible every single time.

Note: Doing the exact same STR without having the keyboard open is working fine.

The solution to avoid these is to make sure the keyboard is always hidden when we open the side bar (aka the split view is changing to an expanded state). This fixes the crash, the weird UI issue mentioned above and also avoids having a weird UX where the "Settings" and "Support" sections are hidden by the keyboard.

### Testing

See STR in description

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
