### PR TITLE
fix: learn more link not underlined - WPB-22531

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesInfoView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesInfoView.swift
@@ -152,10 +152,12 @@ struct FilesInfoView: View {
         case .recycleBin:
             Strings.RecycleBin.NoData.learnMore
         }
-
-        return Link(linkTitle, destination: scope.learnMoreURL)
-            .foregroundColor(SemanticColors.Label.baseSecondaryText.color)
-            .underline()
+        
+        return Link(destination: scope.learnMoreURL) {
+            Text(linkTitle)
+                .foregroundColor(SemanticColors.Label.baseSecondaryText.color)
+                .underline()
+        }
     }
 
     private var reloadButton: some View {

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesInfoView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesInfoView.swift
@@ -152,7 +152,7 @@ struct FilesInfoView: View {
         case .recycleBin:
             Strings.RecycleBin.NoData.learnMore
         }
-        
+
         return Link(destination: scope.learnMoreURL) {
             Text(linkTitle)
                 .foregroundColor(SemanticColors.Label.baseSecondaryText.color)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22531" title="WPB-22531" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22531</a>  [iOS] Add support link to - Empty state screen in files tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue where the "learn more.." link is not underlined on real device (works fine on simulator though).

### Testing

- have empty files screen (whether in "Drive" tab, recycle bin or files conversation), "learn more.." link should be underlined

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
