### PR TITLE
fix: crash loading multiple user session for same account concurrently - WPB-22928

### DIFF
--- a/WireDomain/Sources/WireDomain/Utilities/NonReentrantTaskManager.swift
+++ b/WireDomain/Sources/WireDomain/Utilities/NonReentrantTaskManager.swift
@@ -24,7 +24,7 @@ import Foundation
 /// at any given time, regardless how many times the block is enqueued.
 /// Repeated invocations don't result in repeated executions.
 
-public actor NonReentrantTaskManager<Success, Failure>: Sendable where Success: Sendable, Failure: Error {
+public actor NonReentrantTaskManager<Success, Failure> where Success: Sendable, Failure: Error {
 
     private var state: TaskState = .idle
 

--- a/WireDomain/Sources/WireDomain/Utilities/NonReentrantTaskManager.swift
+++ b/WireDomain/Sources/WireDomain/Utilities/NonReentrantTaskManager.swift
@@ -39,6 +39,11 @@ public actor NonReentrantTaskManager<Success, Failure> where Success: Sendable, 
 
 }
 
+// MARK: - Public API
+
+/// Due to limitations of `Task` - initializers are constrained to either `any Error` or `Never` type Failures - we need
+/// to provide two separate APIs for throwing and non-throwing implementations.
+
 public extension NonReentrantTaskManager where Failure == any Error {
 
     /// Perform a non-reentrant async block that cannot throw.

--- a/WireDomain/Sources/WireDomain/Utilities/NonReentrantTaskManager.swift
+++ b/WireDomain/Sources/WireDomain/Utilities/NonReentrantTaskManager.swift
@@ -24,13 +24,30 @@ import Foundation
 /// at any given time, regardless how many times the block is enqueued.
 /// Repeated invocations don't result in repeated executions.
 
-public actor NonReentrantTaskManager {
+public actor NonReentrantTaskManager<Success, Failure>: Sendable where Success: Sendable, Failure: Error {
 
     private var state: TaskState = .idle
 
     public init() {}
 
-    public func performIfNeeded(block: @escaping @Sendable () async throws -> Void) async throws {
+    private enum TaskState {
+
+        case idle
+        case inFlight(Task<Success, Failure>)
+
+    }
+
+}
+
+public extension NonReentrantTaskManager where Failure == any Error {
+
+    /// Perform a non-reentrant async block that cannot throw.
+    ///
+    /// - Parameter block: The async block to perform.
+    /// - Returns: The result of the async block.
+    /// - Throws: Rethrows any error thrown by the async block.
+
+    func performIfNeeded(block: @escaping @Sendable () async throws -> Success) async throws -> Success {
         defer {
             state = .idle
         }
@@ -38,7 +55,7 @@ public actor NonReentrantTaskManager {
         switch state {
         case let .inFlight(task):
             // Wait for existing task.
-            try await task.value
+            return try await task.value
 
         case .idle:
             // Create a new task.
@@ -47,15 +64,38 @@ public actor NonReentrantTaskManager {
             }
 
             state = .inFlight(task)
-            try await task.value
+            return try await task.value
         }
     }
 
-    private enum TaskState {
+}
 
-        case idle
-        case inFlight(Task<Void, any Error>)
+public extension NonReentrantTaskManager where Failure == Never {
 
+    /// Perform a non-reentrant async block that cannot throw.
+    ///
+    /// - Parameter block: The async block to perform.
+    /// - Returns: The result of the async block.
+
+    func performIfNeeded(block: @escaping @Sendable () async -> Success) async -> Success {
+        defer {
+            state = .idle
+        }
+
+        switch state {
+        case let .inFlight(task):
+            // Wait for existing task.
+            return await task.value
+
+        case .idle:
+            // Create a new task.
+            let task = Task {
+                await block()
+            }
+
+            state = .inFlight(task)
+            return await task.value
+        }
     }
 
 }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
@@ -40,7 +40,7 @@ public actor WorkAgent {
 
     private var task: Task<Void, Never>?
     private let scheduler: any WorkItemScheduler
-    private let nonReentrantTaskManager = NonReentrantTaskManager()
+    private let nonReentrantTaskManager = NonReentrantTaskManager<Void, any Error>()
 
     init(scheduler: any WorkItemScheduler) {
         self.scheduler = scheduler

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -381,6 +381,13 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     private let sharedUserDefaults: UserDefaults
 
+    /// Currently active `Tasks` loading sessions by user ID
+    ///
+    /// Used by `withSession(for:newEnvironment:notifyAboutMigration:)` to avoid creating & loading multiple sessions
+    /// for the same account concurrently.
+    @MainActor
+    private var inFlightWithSessionTasks: [UUID: Task<ZMUserSession?, Never>] = [:]
+
     // MARK: - Life cycle
 
     public override init() {
@@ -985,13 +992,6 @@ public final class SessionManager: NSObject, SessionManagerType {
         guard session.lock == .none else { return }
         processPendingURLActionRequiresAuthentication()
     }
-
-    /// Currently active `Tasks` loading sessions by user ID
-    ///
-    /// Used by `withSession(for:newEnvironment:notifyAboutMigration:)` to avoid creating & loading multiple sessions
-    /// for the same account concurrently.
-    @MainActor
-    private var inFlightWithSessionTasks: [UUID: Task<ZMUserSession?, Never>] = [:]
 
     @MainActor
     func withSession(

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -986,6 +986,13 @@ public final class SessionManager: NSObject, SessionManagerType {
         processPendingURLActionRequiresAuthentication()
     }
 
+    /// Currently active `Tasks` loading sessions by user ID
+    ///
+    /// Used by `withSession(for:newEnvironment:notifyAboutMigration:)` to avoid creating & loading multiple sessions
+    /// for the same account concurrently.
+    @MainActor
+    private var inFlightWithSessionTasks: [UUID: Task<ZMUserSession?, Never>] = [:]
+
     @MainActor
     func withSession(
         for account: Account,
@@ -993,109 +1000,122 @@ public final class SessionManager: NSObject, SessionManagerType {
         notifyAboutMigration: Bool = false
     ) async -> ZMUserSession? {
         WireLogger.sessionManager.debug("Request to load session for \(account)")
-        if let session = backgroundUserSessions[account.userIdentifier] {
-            WireLogger.sessionManager.debug("Session for \(account) is already loaded")
-            return session
-        } else {
-            do {
-                let loader = try UserSessionLoader(
-                    account: account,
-                    accountManager: accountManager,
-                    sharedContainerURL: sharedContainerURL,
-                    legacyEnvironment: environment,
-                    minTLSVersion: minTLSVersion,
-                    dispatchGroup: dispatchGroup,
-                    sharedUserDefaults: sharedUserDefaults,
-                    application: application,
-                    appVersion: currentAppVersion,
-                    buildNumber: currentBuildNumber,
-                    mediaManager: authenticatedSessionFactory.mediaManager,
-                    flowManager: authenticatedSessionFactory.flowManager,
-                    logFilesProvider: logFilesProvider,
-                    isDeveloperModeEnabled: isDeveloperModeEnabled,
-                    faultyMLSRemovalKeysByDomain: configuration.faultyMLSRemovalKeysByDomain
-                )
 
-                let userSession = try await loader.load(newEnvironment: newEnvironment)
-                finishSettingUpUserSession(
-                    account: account,
-                    newSession: userSession,
-                    coreDataStack: userSession.coreDataStack
-                )
-                return userSession
+        if let inFlightTask = inFlightWithSessionTasks[account.userIdentifier] {
+            WireLogger.sessionManager.debug("There is already a task loading session for \(account), awaiting it")
+            return await inFlightTask.value
+        }
 
-            } catch UserSessionLoader.Failure.buildIsBlacklisted {
-                WireLogger.sessionManager.warn(
-                    "build is blacklisted: \(currentBuildNumber)",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .buildIsBlacklisted
-                )
-                return nil
-            } catch NetworkStackError.backendAPIVersionObsolete {
-                WireLogger.sessionManager.warn(
-                    "backend API version is obsolete",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .backendIsObsolete
-                )
-                return nil
-            } catch NetworkStackError.clientAPIVersionObsolete {
-                WireLogger.sessionManager.warn(
-                    "client API version is obsolete",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .clientIsObsolete
-                )
-                return nil
-            } catch let error as URLError {
-                WireLogger.sessionManager.error(
-                    "failed to load user session due to url error code: \(error.errorCode)",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .networkError(code: error.errorCode)
-                )
-                return nil
-            } catch let UserSessionLoader.Failure.failedToLoadPersistenceStack(error) {
-                WireLogger.sessionManager.error(
-                    "failed to load user session: \(String(describing: error))",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .databaseError(error)
-                )
-                return nil
-            } catch let error as SafeForLoggingStringConvertible {
-                WireLogger.sessionManager.error(
-                    "failed to load user session: \(error.safeForLoggingDescription)",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .genericError
-                )
-                return nil
-            } catch {
-                WireLogger.sessionManager.error(
-                    "failed to load user session",
-                    attributes: .safePublic
-                )
-                delegate?.sessionManagerDidFailToLoadSession(
-                    for: account,
-                    error: .genericError
-                )
-                return nil
+        let task = Task<ZMUserSession?, Never> { @MainActor in
+            if let session = backgroundUserSessions[account.userIdentifier] {
+                WireLogger.sessionManager.debug("Session for \(account) is already loaded")
+                return session
+            } else {
+                do {
+                    let loader = try UserSessionLoader(
+                        account: account,
+                        accountManager: accountManager,
+                        sharedContainerURL: sharedContainerURL,
+                        legacyEnvironment: environment,
+                        minTLSVersion: minTLSVersion,
+                        dispatchGroup: dispatchGroup,
+                        sharedUserDefaults: sharedUserDefaults,
+                        application: application,
+                        appVersion: currentAppVersion,
+                        buildNumber: currentBuildNumber,
+                        mediaManager: authenticatedSessionFactory.mediaManager,
+                        flowManager: authenticatedSessionFactory.flowManager,
+                        logFilesProvider: logFilesProvider,
+                        isDeveloperModeEnabled: isDeveloperModeEnabled,
+                        faultyMLSRemovalKeysByDomain: configuration.faultyMLSRemovalKeysByDomain
+                    )
+
+                    let userSession = try await loader.load(newEnvironment: newEnvironment)
+                    finishSettingUpUserSession(
+                        account: account,
+                        newSession: userSession,
+                        coreDataStack: userSession.coreDataStack
+                    )
+                    return userSession
+
+                } catch UserSessionLoader.Failure.buildIsBlacklisted {
+                    WireLogger.sessionManager.warn(
+                        "build is blacklisted: \(currentBuildNumber)",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .buildIsBlacklisted
+                    )
+                    return nil
+                } catch NetworkStackError.backendAPIVersionObsolete {
+                    WireLogger.sessionManager.warn(
+                        "backend API version is obsolete",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .backendIsObsolete
+                    )
+                    return nil
+                } catch NetworkStackError.clientAPIVersionObsolete {
+                    WireLogger.sessionManager.warn(
+                        "client API version is obsolete",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .clientIsObsolete
+                    )
+                    return nil
+                } catch let error as URLError {
+                    WireLogger.sessionManager.error(
+                        "failed to load user session due to url error code: \(error.errorCode)",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .networkError(code: error.errorCode)
+                    )
+                    return nil
+                } catch let UserSessionLoader.Failure.failedToLoadPersistenceStack(error) {
+                    WireLogger.sessionManager.error(
+                        "failed to load user session: \(String(describing: error))",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .databaseError(error)
+                    )
+                    return nil
+                } catch let error as SafeForLoggingStringConvertible {
+                    WireLogger.sessionManager.error(
+                        "failed to load user session: \(error.safeForLoggingDescription)",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .genericError
+                    )
+                    return nil
+                } catch {
+                    WireLogger.sessionManager.error(
+                        "failed to load user session",
+                        attributes: .safePublic
+                    )
+                    delegate?.sessionManagerDidFailToLoadSession(
+                        for: account,
+                        error: .genericError
+                    )
+                    return nil
+                }
             }
         }
+
+        inFlightWithSessionTasks[account.userIdentifier] = task
+        let userSession = await task.value
+        inFlightWithSessionTasks[account.userIdentifier] = nil
+        return userSession
     }
 
     public func retryStart() {

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1001,114 +1001,114 @@ public final class SessionManager: NSObject, SessionManagerType {
     ) async -> ZMUserSession? {
         WireLogger.sessionManager.debug("Request to load session for \(account)")
 
+        if let session = backgroundUserSessions[account.userIdentifier] {
+            WireLogger.sessionManager.debug("Session for \(account) is already loaded")
+            return session
+        }
+
         if let inFlightTask = inFlightWithSessionTasks[account.userIdentifier] {
-            WireLogger.sessionManager.debug("There is already a task loading session for \(account), awaiting it")
+            WireLogger.sessionManager.debug("Session is already loading for \(account), awaiting it")
             return await inFlightTask.value
         }
 
         let task = Task<ZMUserSession?, Never> { @MainActor in
-            if let session = backgroundUserSessions[account.userIdentifier] {
-                WireLogger.sessionManager.debug("Session for \(account) is already loaded")
-                return session
-            } else {
-                do {
-                    let loader = try UserSessionLoader(
-                        account: account,
-                        accountManager: accountManager,
-                        sharedContainerURL: sharedContainerURL,
-                        legacyEnvironment: environment,
-                        minTLSVersion: minTLSVersion,
-                        dispatchGroup: dispatchGroup,
-                        sharedUserDefaults: sharedUserDefaults,
-                        application: application,
-                        appVersion: currentAppVersion,
-                        buildNumber: currentBuildNumber,
-                        mediaManager: authenticatedSessionFactory.mediaManager,
-                        flowManager: authenticatedSessionFactory.flowManager,
-                        logFilesProvider: logFilesProvider,
-                        isDeveloperModeEnabled: isDeveloperModeEnabled,
-                        faultyMLSRemovalKeysByDomain: configuration.faultyMLSRemovalKeysByDomain
-                    )
+            do {
+                let loader = try UserSessionLoader(
+                    account: account,
+                    accountManager: accountManager,
+                    sharedContainerURL: sharedContainerURL,
+                    legacyEnvironment: environment,
+                    minTLSVersion: minTLSVersion,
+                    dispatchGroup: dispatchGroup,
+                    sharedUserDefaults: sharedUserDefaults,
+                    application: application,
+                    appVersion: currentAppVersion,
+                    buildNumber: currentBuildNumber,
+                    mediaManager: authenticatedSessionFactory.mediaManager,
+                    flowManager: authenticatedSessionFactory.flowManager,
+                    logFilesProvider: logFilesProvider,
+                    isDeveloperModeEnabled: isDeveloperModeEnabled,
+                    faultyMLSRemovalKeysByDomain: configuration.faultyMLSRemovalKeysByDomain
+                )
 
-                    let userSession = try await loader.load(newEnvironment: newEnvironment)
-                    finishSettingUpUserSession(
-                        account: account,
-                        newSession: userSession,
-                        coreDataStack: userSession.coreDataStack
-                    )
-                    return userSession
+                let userSession = try await loader.load(newEnvironment: newEnvironment)
+                finishSettingUpUserSession(
+                    account: account,
+                    newSession: userSession,
+                    coreDataStack: userSession.coreDataStack
+                )
+                return userSession
 
-                } catch UserSessionLoader.Failure.buildIsBlacklisted {
-                    WireLogger.sessionManager.warn(
-                        "build is blacklisted: \(currentBuildNumber)",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .buildIsBlacklisted
-                    )
-                    return nil
-                } catch NetworkStackError.backendAPIVersionObsolete {
-                    WireLogger.sessionManager.warn(
-                        "backend API version is obsolete",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .backendIsObsolete
-                    )
-                    return nil
-                } catch NetworkStackError.clientAPIVersionObsolete {
-                    WireLogger.sessionManager.warn(
-                        "client API version is obsolete",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .clientIsObsolete
-                    )
-                    return nil
-                } catch let error as URLError {
-                    WireLogger.sessionManager.error(
-                        "failed to load user session due to url error code: \(error.errorCode)",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .networkError(code: error.errorCode)
-                    )
-                    return nil
-                } catch let UserSessionLoader.Failure.failedToLoadPersistenceStack(error) {
-                    WireLogger.sessionManager.error(
-                        "failed to load user session: \(String(describing: error))",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .databaseError(error)
-                    )
-                    return nil
-                } catch let error as SafeForLoggingStringConvertible {
-                    WireLogger.sessionManager.error(
-                        "failed to load user session: \(error.safeForLoggingDescription)",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .genericError
-                    )
-                    return nil
-                } catch {
-                    WireLogger.sessionManager.error(
-                        "failed to load user session",
-                        attributes: .safePublic
-                    )
-                    delegate?.sessionManagerDidFailToLoadSession(
-                        for: account,
-                        error: .genericError
-                    )
-                    return nil
-                }
+            } catch UserSessionLoader.Failure.buildIsBlacklisted {
+                WireLogger.sessionManager.warn(
+                    "build is blacklisted: \(currentBuildNumber)",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .buildIsBlacklisted
+                )
+                return nil
+            } catch NetworkStackError.backendAPIVersionObsolete {
+                WireLogger.sessionManager.warn(
+                    "backend API version is obsolete",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .backendIsObsolete
+                )
+                return nil
+            } catch NetworkStackError.clientAPIVersionObsolete {
+                WireLogger.sessionManager.warn(
+                    "client API version is obsolete",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .clientIsObsolete
+                )
+                return nil
+            } catch let error as URLError {
+                WireLogger.sessionManager.error(
+                    "failed to load user session due to url error code: \(error.errorCode)",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .networkError(code: error.errorCode)
+                )
+                return nil
+            } catch let UserSessionLoader.Failure.failedToLoadPersistenceStack(error) {
+                WireLogger.sessionManager.error(
+                    "failed to load user session: \(String(describing: error))",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .databaseError(error)
+                )
+                return nil
+            } catch let error as SafeForLoggingStringConvertible {
+                WireLogger.sessionManager.error(
+                    "failed to load user session: \(error.safeForLoggingDescription)",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .genericError
+                )
+                return nil
+            } catch {
+                WireLogger.sessionManager.error(
+                    "failed to load user session",
+                    attributes: .safePublic
+                )
+                delegate?.sessionManagerDidFailToLoadSession(
+                    for: account,
+                    error: .genericError
+                )
+                return nil
             }
         }
 

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -381,12 +381,9 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     private let sharedUserDefaults: UserDefaults
 
-    /// Currently active `Tasks` loading sessions by user ID
-    ///
     /// Used by `withSession(for:newEnvironment:notifyAboutMigration:)` to avoid creating & loading multiple sessions
     /// for the same account concurrently.
-    @MainActor
-    private var inFlightWithSessionTasks: [UUID: Task<ZMUserSession?, Never>] = [:]
+    private let withSessionTaskManager = NonReentrantTaskManager<ZMUserSession?, Never>()
 
     // MARK: - Life cycle
 
@@ -1006,12 +1003,7 @@ public final class SessionManager: NSObject, SessionManagerType {
             return session
         }
 
-        if let inFlightTask = inFlightWithSessionTasks[account.userIdentifier] {
-            WireLogger.sessionManager.debug("Session is already loading for \(account), awaiting it")
-            return await inFlightTask.value
-        }
-
-        let task = Task<ZMUserSession?, Never> { @MainActor in
+        return await withSessionTaskManager.performIfNeeded { @MainActor [self] in
             do {
                 let loader = try UserSessionLoader(
                     account: account,
@@ -1111,11 +1103,6 @@ public final class SessionManager: NSObject, SessionManagerType {
                 return nil
             }
         }
-
-        inFlightWithSessionTasks[account.userIdentifier] = task
-        let userSession = await task.value
-        inFlightWithSessionTasks[account.userIdentifier] = nil
-        return userSession
     }
 
     public func retryStart() {

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -62,8 +62,8 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
     private let featureConfigRepository: any FeatureConfigRepositoryProtocol
     private let pushChannelCoordinator: any MainAppPushChannelCoordinatorProtocol
     private let networkStatePublisher: AnyPublisher<NetworkState, Never>
-    private let incrementalSyncTaskManager = NonReentrantTaskManager()
-    private let initialSyncTaskManager = NonReentrantTaskManager()
+    private let incrementalSyncTaskManager = NonReentrantTaskManager<Void, any Error>()
+    private let initialSyncTaskManager = NonReentrantTaskManager<Void, any Error>()
     private var incrementalSyncToken: IncrementalSync.Token?
     private var ongoingSyncTask: Task<Void, Never>?
     private var cancellables: Set<AnyCancellable> = .init()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22928" title="WPB-22928" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22928</a>  [iOS] WireSystem: fatal(_:file:line:)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

There is a crash caused by multiple concurrent calls to `SessionManager.withSession(for:newEnvironment:notifyAboutMigration:)` with the same Account when there is no existing session in `backgroundUserSession` for that account.

Each successive call may cause a new `ZMUserSession` to be created and associated with an Account in the session manager. `SessionManager.configure(session:for:)` is called before the session is returned. It contains a precondition that no session is already loaded for that account. This is the crash. Specifically:

1. `SessionManager.withSession(for:newEnvironment:notifyAboutMigration:)` is called which starts creating a new session for the given account.
2. `SessionManager.withSession(for:newEnvironment:notifyAboutMigration:)` is called again before  `1` completes and also starts setting up a new session for the same account.
3. `1` completes and return the new session.
4. `2` creates a new session but crashes when it tries to configure it because there is already an existing session for that account.

There are likely many situations where `SessionManager.withSession(for:newEnvironment:notifyAboutMigration:)` can be called for the same account currently. In the specific case I looked into there was:

1. One call after app instantiation.
2. 5 seconds later one kicked off by `SessionManager.lookupConversationAndProcessPendingCallEvents(by:completionHandler:)`

Perhaps this happened when receiving a call on bad internet?

#### Fix

The fix is to put the user session loading code into a Task and have concurrent calls wait on the task to get a session.

### Testing

I'm not sure of a good way of testing this. I never managed to reproduce the crash. Anyone have any ideas?

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
