### PR TITLE
fix: Banner Text content is not read aloud merge in to release branch - WPB-14755

### DIFF
--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -282,4 +282,10 @@ public enum Locators {
         case continueButton = "Continue"
     }
 
+    public enum SecurityLevelView: String {
+
+        case classificationBanner = "ClassificationBanner"
+
+    }
+
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/UserProfile/Views/SecurityLevelView.swift
@@ -20,6 +20,7 @@ import SwiftUI
 import WireCommonComponents
 import WireDataModel
 import WireDesign
+import WireLocators
 import WireSyncEngine
 
 final class SecurityLevelView: UIView {
@@ -76,7 +77,9 @@ final class SecurityLevelView: UIView {
             levelText
         ].joined(separator: " ")
 
-        accessibilityIdentifier = "ClassificationBanner" + classification.accessibilitySuffix
+        accessibilityIdentifier = Locators.SecurityLevelView.classificationBanner.rawValue + classification
+            .accessibilitySuffix
+        accessibilityLabel = securityLevelLabel.text
     }
 
     func configure(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14755" title="WPB-14755" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14755</a>  [iOS] Banner: Text content is not read aloud #8
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Issue: The banner "SICHERHEITSNIVEAU:VS-NfD" is not read by the screen reader.

Solution: Added accessibility label for securityLevelLabel as it is a custom UIView

Note: Grouped Accessibility Strings for better maintenance and gave unique name to Accessibility Identifier. Changed this value as this value is currently not used in any UI tests

### Testing

When Accessibility is turned on for voice over, the banner text is read out loudly and we can also see accessibility label value when inspected in Accessibility Inspector

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
