### PR TITLE
fix: GitHub run number conflict due to artifact name - WPB-23154

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -214,7 +214,7 @@ jobs:
         if: always()
         uses: ./.github/actions/allure-reporting
         with:
-          allure_artifact_name: "html-report-${{ github.run_number }}"
+          allure_artifact_name: "html-report-${{ github.run_number }}-${{ env.SANITIZED_BRANCH }}"
           xcresult_search_path: "artifacts"
 
       - name: Add Allure Report to Job Summary


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

**Nightly run same workflow 3 times for develop, 4.14 and 4.15 and create conflict due to same run number. added branch name to avoid confict.**

### Testing

_Describe how to test._

Observe nightly

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
