### PR TITLE
chore: add missing tab bar localization - WPB-22722

### DIFF
--- a/WireUI/Sources/WireMainNavigationUI/Resources/Localization/Localizable.xcstrings
+++ b/WireUI/Sources/WireMainNavigationUI/Resources/Localization/Localizable.xcstrings
@@ -254,20 +254,20 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ملفّات"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Filer"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Dateien"
+            "state" : "translated",
+            "value" : "Drive"
           }
         },
         "en" : {
@@ -278,98 +278,98 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ficheros"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "et" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Failid"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tiedostot"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Fichiers"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Allegati"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "ファイル"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "lt" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Failai"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Bestanden"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Pliki"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Arquivos"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Файлы"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "sl" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Zbirke"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Dosyalar"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Файли"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "文件"
+            "state" : "new",
+            "value" : "Drive"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "檔案"
+            "state" : "new",
+            "value" : "Drive"
           }
         }
       }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22722" title="WPB-22722" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22722</a>  [iOS] Manage release iOS 4.14.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Adds 1 missing localization 😞 for the tab bar.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
