### PR TITLE
fix: files percent encoding - WPB-23207

### DIFF
--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsRenameNodeUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsRenameNodeUseCase.swift
@@ -67,10 +67,12 @@ package struct WireCellsRenameNodeUseCase: WireCellsRenameNodeUseCaseProtocol {
             let directory = url.deletingLastPathComponent()
             targetPath = directory.appendingPathComponent("\(newFilename).\(pathExtension)")
         }
+        
+        let path = targetPath.absoluteString.removingPercentEncoding ?? targetPath.absoluteString
 
         // Checks whether the path doesn't already exist.
         let preCheckResult = try await nodesRepository.preCheck(
-            nodePath: targetPath.absoluteString,
+            nodePath: path,
             findAvailablePath: false
         )
 
@@ -81,7 +83,7 @@ package struct WireCellsRenameNodeUseCase: WireCellsRenameNodeUseCaseProtocol {
         // Renames the file on the server.
         let didRenameFile = try await nodesRepository.renameNode(
             nodeID: nodeID,
-            targetPath: targetPath.absoluteString
+            targetPath: path
         )
 
         guard didRenameFile else {

--- a/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsRenameNodeUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireCells/UseCases/WireCellsRenameNodeUseCase.swift
@@ -67,7 +67,7 @@ package struct WireCellsRenameNodeUseCase: WireCellsRenameNodeUseCaseProtocol {
             let directory = url.deletingLastPathComponent()
             targetPath = directory.appendingPathComponent("\(newFilename).\(pathExtension)")
         }
-        
+
         let path = targetPath.absoluteString.removingPercentEncoding ?? targetPath.absoluteString
 
         // Checks whether the path doesn't already exist.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23207" title="WPB-23207" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23207</a>  [iOS] Files and folders with spaces and special characters created on iOS have wrong names on Android and Web
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Renaming files was adding percent encoding like `%20` for space ` `.
This was because the file path was wrapped into a URL and then was converted to a String using `.absoluteString`.
I fixed that by calling `.removingPercentEncoding` before that string is used.

The percent encoding isn't visible in iOS but you can check it in the web app.

I also tested creating folders, moving folders and uploading drafts. None of those cases have that issue in 4.14, so no code needs to be changed there.

We should also test if creating new files for Collabora (templates) is affected, but that feature is not in 4.14.

### Testing

Creating, moving and renaming files and folders should not cause the file names to have percent encodings. Percent encodings are only visible in the web app (and probably Android)

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
