### PR TITLE
fix: tags not tappable - WPB-23240

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Filter/FilesFiltersViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/Filter/FilesFiltersViewModel.swift
@@ -74,6 +74,7 @@ package final class FilesFiltersViewModel: ObservableObject {
             if !isRefreshing { isLoading = true }
             defer { isLoading = false }
             let tags = try await fetchTagsUseCase.invoke()
+            if isRefreshing { presentedTags = [] }
             self.tags = tags
                 .filter { !$0.isEmpty }
                 .map { .init(name: $0, isSelected: savedTags.contains($0)) }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23240" title="WPB-23240" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23240</a>  [iOS] Unable to tap a tag on tags filters screen after pulling to refresh
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue in the tags filter screen where after a pull to refresh, the already presented tags are no longer tappable. Issue is that when selecting a tag after a pull to refresh, the selected tag ID no longer finds a match in the "cached" tags model. Solution is to ensure the presented tags are correctly reset when pulling to refresh so tags IDs are correctly in sync.

### Testing

go to Drive tab, open tags filter screen (top right corner), pull to refresh, try to select a tag, then it should select/deselect the tag properly.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
