### PR TITLE
fix: search not working in recycle bin - WPB-23202

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -483,15 +483,27 @@ private extension WireCellsGetNodesRequest {
                 root: RestNodeLocator(root)
             )
         case let .recycleBinView(root: root):
+            let lookupFilterTextSearch: LookupFilterTextSearch? = if let searchTerm {
+                LookupFilterTextSearch(searchIn: .baseName, term: searchTerm)
+            } else {
+                nil
+            }
+
+            if searchTerm != nil {
+                request.sortField = "mtime"
+                request.sortDirDesc = true
+            }
+            
             request.filters = RestLookupFilter(
                 status: LookupFilterStatusFilter(
                     deleted: .only,
                     isDraft: false // Backend filtering is not available; filtering is handled on the client side.
                 ),
+                text: lookupFilterTextSearch,
                 type: .unknown // .unknown includes files (leafs) & folders (collections)
             )
             request.scope = RestLookupScope(
-                recursive: false,
+                recursive: searchTerm?.isEmpty == false,
                 root: RestNodeLocator(root)
             )
         case .filesBrowserView:

--- a/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireCells/NodesAPI/RestAPI.swift
@@ -493,7 +493,7 @@ private extension WireCellsGetNodesRequest {
                 request.sortField = "mtime"
                 request.sortDirDesc = true
             }
-            
+
             request.filters = RestLookupFilter(
                 status: LookupFilterStatusFilter(
                     deleted: .only,

--- a/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireCells/Components/Files/FilesView.swift
@@ -189,7 +189,7 @@ private extension FilesView {
                 Label {
                     Text(Strings.Files.List.createFolder)
                 } icon: {
-                    Image(systemName: "folder")
+                    Image(systemName: "folder.badge.plus")
                         .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
                 }
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23202" title="WPB-23202" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23202</a>  [iOS] Search doesn't work in file recycle bin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue where the search is not working in the recycle bin view. This PR adds the missing code to enable search in the API request.

### Testing

go to recycle bin, try to search something, files / folders should be filtered accordingly

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
