### PR TITLE
fix: all files browse view accent color fix - WPB-23200

### DIFF
--- a/WireMessaging/Sources/WireMessagingAssembly/WireMessagingFactory.swift
+++ b/WireMessaging/Sources/WireMessagingAssembly/WireMessagingFactory.swift
@@ -215,7 +215,7 @@ public extension WireMessagingFactory {
                     isBrowsing: true,
                     accentColorProvider: accentColorProvider
                 )
-            )
+            ).environment(\.wireAccentColor, accentColorProvider())
         )
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23200" title="WPB-23200" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23200</a>  [iOS] Create public link switch color shows blue irrespective of profile color 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->

Copy of PR #4250 but the base is `release/cycle-4.15`

### Issue

When opening the Share Link view from the All Files Browser Tab, the color of the toggle was always blue, regardless of the user's profile color.
This PR sets the user profile color as an environment value to that View and this fixes not only the toggle color but also many more views and components where the color was always blue.

### Testing

* Set your user profile color to something other than blue
* Go to the All Files (Browser) tab
* Select "Share" from the menu of a file.
* Check if the Toggle in the Share Link screen is the color of your user profile.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
