### PR TITLE
fix: commit pending proposals recovery strategy - WPB-23159

### DIFF
--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -784,13 +784,7 @@ public final class ClientSessionComponent {
             selfDomain: backendMetadata.domain
         )
     }
-    
-    public func createCommitPendingProposalsUseCase() -> some CommitPendingProposalUseCaseProtocol {
-        CommitPendingProposalUseCase(mlsService: mlsService,
-                                     coreCryptoProvider: coreCryptoProvider,
-                                     context: syncContext
-        )
-    }
+
     // MARK: - Other
 
     public private(set) lazy var conversationProtobufMessageProcessor = ConversationProtobufMessageProcessor(
@@ -834,20 +828,12 @@ public final class ClientSessionComponent {
         selfDomain: backendMetadata.domain
     )
 
-    public lazy var commitPendingProposalsUseCase = CommitPendingProposalUseCase(mlsService: mlsService,
-                                                                                 coreCryptoProvider: coreCryptoProvider,
-                                                                                 context: syncContext)
-    
     public lazy var mlsTransport: any WireCoreCryptoUniffi.MlsTransport = MLSTransportImpl(
         mlsAPI: mlsAPI,
         conversationEventProcessor: conversationEventProcessor
     )
 
-    public lazy var workAgent: WorkAgent = {
-        let scheduler = PriorityOrderWorkItemScheduler()
-        scheduler.subscribe(syncStatePublisher: syncStateSubject.eraseToAnyPublisher())
-        return .init(scheduler: scheduler)
-    }()
+    public lazy var workAgent: WorkAgent = .init(scheduler: PriorityOrderWorkItemScheduler())
 
     public lazy var conversationUpdatesGenerator: IncrementalGeneratorProtocol = ConversationUpdatesGenerator(
         repository: conversationRepository,
@@ -861,7 +847,6 @@ public final class ClientSessionComponent {
     public lazy var commitPendingProposalsGenerator: LiveGeneratorProtocol = CommitPendingProposalsGenerator(
         repository: conversationRepository,
         mlsService: mlsService,
-        commitPendingProposalUseCase: commitPendingProposalsUseCase,
         context: syncContext,
         isMLSGroupBroken: { [weak self] groupID in
             self?.isMLSGroupBroken(groupID: groupID) == true

--- a/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
+++ b/WireDomain/Sources/WireDomain/Components/ClientSessionComponent.swift
@@ -772,6 +772,25 @@ public final class ClientSessionComponent {
         )
     }
 
+    public func createInitiateResetMLSConversationUseCase() -> some InitiateResetMLSConversationUseCaseProtocol {
+        InitiateResetMLSConversationUseCase(
+            api: mlsAPI,
+            mlsService: mlsService,
+            conversationLocalStore: conversationLocalStore,
+            conversationRepository: conversationRepository,
+            lockRepository: ResetMLSConversationLockRepository(
+                userID: selfUserID
+            ),
+            selfDomain: backendMetadata.domain
+        )
+    }
+    
+    public func createCommitPendingProposalsUseCase() -> some CommitPendingProposalUseCaseProtocol {
+        CommitPendingProposalUseCase(mlsService: mlsService,
+                                     coreCryptoProvider: coreCryptoProvider,
+                                     context: syncContext
+        )
+    }
     // MARK: - Other
 
     public private(set) lazy var conversationProtobufMessageProcessor = ConversationProtobufMessageProcessor(
@@ -815,12 +834,20 @@ public final class ClientSessionComponent {
         selfDomain: backendMetadata.domain
     )
 
+    public lazy var commitPendingProposalsUseCase = CommitPendingProposalUseCase(mlsService: mlsService,
+                                                                                 coreCryptoProvider: coreCryptoProvider,
+                                                                                 context: syncContext)
+    
     public lazy var mlsTransport: any WireCoreCryptoUniffi.MlsTransport = MLSTransportImpl(
         mlsAPI: mlsAPI,
         conversationEventProcessor: conversationEventProcessor
     )
 
-    public lazy var workAgent: WorkAgent = .init(scheduler: PriorityOrderWorkItemScheduler())
+    public lazy var workAgent: WorkAgent = {
+        let scheduler = PriorityOrderWorkItemScheduler()
+        scheduler.subscribe(syncStatePublisher: syncStateSubject.eraseToAnyPublisher())
+        return .init(scheduler: scheduler)
+    }()
 
     public lazy var conversationUpdatesGenerator: IncrementalGeneratorProtocol = ConversationUpdatesGenerator(
         repository: conversationRepository,
@@ -834,6 +861,7 @@ public final class ClientSessionComponent {
     public lazy var commitPendingProposalsGenerator: LiveGeneratorProtocol = CommitPendingProposalsGenerator(
         repository: conversationRepository,
         mlsService: mlsService,
+        commitPendingProposalUseCase: commitPendingProposalsUseCase,
         context: syncContext,
         isMLSGroupBroken: { [weak self] groupID in
             self?.isMLSGroupBroken(groupID: groupID) == true

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/LocalStore/ConversationLocalStore.swift
@@ -116,6 +116,7 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
             conversation.mlsStatus = .ready
             conversation.epoch = epoch
             conversation.mlsGroupID = mlsGroupID
+            conversation.commitPendingProposalDate = nil
         }
     }
 
@@ -126,6 +127,7 @@ public final class ConversationLocalStore: ConversationLocalStoreProtocol {
         await context.perform {
             conversation.mlsStatus = .pendingJoinAfterReset
             conversation.mlsGroupID = newMLSGroupID
+            conversation.commitPendingProposalDate = nil
             conversation.epoch = 0
         }
     }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationRepositoryProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationRepositoryProtocol.swift
@@ -198,4 +198,9 @@ public protocol ConversationRepositoryProtocol: Sendable {
     func isSelfAnActiveMember(
         in groupID: WireDataModel.MLSGroupID
     ) async -> Bool
+    
+    /// Reset the pendingProposalDate for the conversation
+    /// - Parameter groupID: mlsGroupID of the conversation
+    func clearPendingProposals(in groupID: WireDataModel.MLSGroupID) async
+
 }

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationRepositoryProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Protocols/ConversationRepositoryProtocol.swift
@@ -198,7 +198,7 @@ public protocol ConversationRepositoryProtocol: Sendable {
     func isSelfAnActiveMember(
         in groupID: WireDataModel.MLSGroupID
     ) async -> Bool
-    
+
     /// Reset the pendingProposalDate for the conversation
     /// - Parameter groupID: mlsGroupID of the conversation
     func clearPendingProposals(in groupID: WireDataModel.MLSGroupID) async

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -389,6 +389,14 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
         }
         return isSelfAnActiveMember
     }
+    
+    public func clearPendingProposals(in groupID: WireDataModel.MLSGroupID) async {
+        await conversationsLocalStore.execute(identifier: groupID) { conversation, context in
+            conversation?.commitPendingProposalDate = nil
+            context.saveOrRollback()
+        }
+    }
+
 
     // MARK: - Private
 

--- a/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Conversations/Repository/ConversationRepository.swift
@@ -389,14 +389,13 @@ public final class ConversationRepository: ConversationRepositoryProtocol {
         }
         return isSelfAnActiveMember
     }
-    
+
     public func clearPendingProposals(in groupID: WireDataModel.MLSGroupID) async {
         await conversationsLocalStore.execute(identifier: groupID) { conversation, context in
             conversation?.commitPendingProposalDate = nil
             context.saveOrRollback()
         }
     }
-
 
     // MARK: - Private
 

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
@@ -136,6 +136,9 @@ public actor WorkAgent {
         task = nil
     }
 
+    public func clearSchedulerQueue() async {
+        await scheduler.clearAllItems()
+    }
 }
 
 extension LogAttributes {

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
@@ -25,8 +25,14 @@ struct CommitPendingProposalItem: WorkItem, CustomStringConvertible {
     private let repository: ConversationRepositoryProtocol
     private let mlsService: MLSServiceInterface
 
+    let _internalID = UUID()
+    
+    var id: String {
+        "commitPendingProposalItem_\(_internalID)_\(groupID)_\(conversationID)"
+    }
+    
     var description: String {
-        "CommitPendingProposalItem: \(id), mlsGroupID: \(groupID), conversationID: \(conversationID)"
+        "CommitPendingProposalItem: \(_internalID), mlsGroupID: \(groupID), conversationID: \(conversationID)"
     }
 
     let id = UUID()

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
@@ -59,7 +59,7 @@ struct CommitPendingProposalItem: WorkItem, CustomStringConvertible {
         let logAttributes: LogAttributes = [.mlsGroupID: groupID.safeForLoggingDescription] + LogAttributes.safePublic
 
         let isSelfAnActiveMember = await repository.isSelfAnActiveMember(in: groupID)
-        
+
         guard isSelfAnActiveMember else {
             logger.info("cancelling commit as the user is no longer a member", attributes: logAttributes)
             return
@@ -70,7 +70,7 @@ struct CommitPendingProposalItem: WorkItem, CustomStringConvertible {
             await repository.clearPendingProposals(in: groupID)
             return
         }
-        
+
         logger.info("committing pending proposals now...", attributes: logAttributes)
         try await mlsService.commitPendingProposals(in: groupID)
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
@@ -59,12 +59,18 @@ struct CommitPendingProposalItem: WorkItem, CustomStringConvertible {
         let logAttributes: LogAttributes = [.mlsGroupID: groupID.safeForLoggingDescription] + LogAttributes.safePublic
 
         let isSelfAnActiveMember = await repository.isSelfAnActiveMember(in: groupID)
-
+        
         guard isSelfAnActiveMember else {
             logger.info("cancelling commit as the user is no longer a member", attributes: logAttributes)
             return
         }
 
+        guard try await mlsService.conversationExists(groupID: groupID) else {
+            logger.warn("mls group does not exist, clearing pending proposal", attributes: logAttributes)
+            await repository.clearPendingProposals(in: groupID)
+            return
+        }
+        
         logger.info("committing pending proposals now...", attributes: logAttributes)
         try await mlsService.commitPendingProposals(in: groupID)
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/CommitPendingProposalItem.swift
@@ -26,16 +26,15 @@ struct CommitPendingProposalItem: WorkItem, CustomStringConvertible {
     private let mlsService: MLSServiceInterface
 
     let _internalID = UUID()
-    
+
     var id: String {
         "commitPendingProposalItem_\(_internalID)_\(groupID)_\(conversationID)"
     }
-    
+
     var description: String {
         "CommitPendingProposalItem: \(_internalID), mlsGroupID: \(groupID), conversationID: \(conversationID)"
     }
 
-    let id = UUID()
     var priority: WorkItemPriority {
         .medium
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/RepairFaultyMLSRemovalKeysWorkItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/RepairFaultyMLSRemovalKeysWorkItem.swift
@@ -30,7 +30,7 @@ struct RepairFaultyMLSRemovalKeysWorkItem: WorkItem {
     var id: String {
         "repairFaultyMLSRemovalKeys_\(UUID().uuidString)"
     }
-    
+
     var priority: WorkItemPriority {
         .low
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/RepairFaultyMLSRemovalKeysWorkItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/RepairFaultyMLSRemovalKeysWorkItem.swift
@@ -27,7 +27,10 @@ import WireLogging
 
 struct RepairFaultyMLSRemovalKeysWorkItem: WorkItem {
 
-    let id = UUID()
+    var id: String {
+        "repairFaultyMLSRemovalKeys_\(UUID().uuidString)"
+    }
+    
     var priority: WorkItemPriority {
         .low
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/UpdateConversationItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/UpdateConversationItem.swift
@@ -24,7 +24,16 @@ import WireNetwork
 struct UpdateConversationItem: WorkItem {
     private let repository: ConversationRepositoryProtocol
 
-    let id = UUID()
+    let _internalID = UUID()
+    
+    var id: String {
+        "updateConversationItem_\(_internalID.uuidString)_\(conversationID)"
+    }
+    
+    var description: String {
+        "UpdateConversationItem: \(_internalID.uuidString), conversationID: \(conversationID)"
+    }
+    
     var priority: WorkItemPriority {
         .medium
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/UpdateConversationItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/UpdateConversationItem.swift
@@ -25,15 +25,15 @@ struct UpdateConversationItem: WorkItem {
     private let repository: ConversationRepositoryProtocol
 
     let _internalID = UUID()
-    
+
     var id: String {
         "updateConversationItem_\(_internalID.uuidString)_\(conversationID)"
     }
-    
+
     var description: String {
         "UpdateConversationItem: \(_internalID.uuidString), conversationID: \(conversationID)"
     }
-    
+
     var priority: WorkItemPriority {
         .medium
     }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/WorkItem.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItem/WorkItem.swift
@@ -27,7 +27,7 @@ protocol WorkItem: Sendable {
 
     /// A unique identifier for this item.
 
-    var id: UUID { get }
+    var id: String { get }
 
     /// The urgency or importance of this ticket.
 

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItemScheduler/PriorityOrderWorkItemScheduler.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItemScheduler/PriorityOrderWorkItemScheduler.swift
@@ -54,4 +54,10 @@ actor PriorityOrderWorkItemScheduler: WorkItemScheduler {
         }
     }
 
+    func clearAllItems() async {
+        blockerQueue.removeAll()
+        highQueue.removeAll()
+        mediumQueue.removeAll()
+        lowQueue.removeAll()
+    }
 }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkItemScheduler/WorkItemScheduler.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkItemScheduler/WorkItemScheduler.swift
@@ -38,4 +38,8 @@ protocol WorkItemScheduler: Sendable {
     /// - Returns: The next available item.
 
     func dequeueNextItem() async -> (any WorkItem)?
+
+    /// Clears all items from queues
+
+    func clearAllItems() async
 }

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -2009,6 +2009,21 @@ public class MockConversationRepositoryProtocol: ConversationRepositoryProtocol,
         }
     }
 
+    // MARK: - clearPendingProposals
+
+    public var clearPendingProposalsIn_Invocations: [WireDataModel.MLSGroupID] = []
+    public var clearPendingProposalsIn_MockMethod: ((WireDataModel.MLSGroupID) async -> Void)?
+
+    public func clearPendingProposals(in groupID: WireDataModel.MLSGroupID) async {
+        clearPendingProposalsIn_Invocations.append(groupID)
+
+        guard let mock = clearPendingProposalsIn_MockMethod else {
+            fatalError("no mock for `clearPendingProposalsIn`")
+        }
+
+        await mock(groupID)
+    }
+
 }
 
 class MockConversationTextMessageNotificationBuilderProtocol: ConversationTextMessageNotificationBuilderProtocol {

--- a/WireDomain/Tests/WireDomainTests/WorkAgent/PriorityOrderWorkSchedulerTests.swift
+++ b/WireDomain/Tests/WireDomainTests/WorkAgent/PriorityOrderWorkSchedulerTests.swift
@@ -121,7 +121,7 @@ struct PriorityOrderWorkItemSchedulerTests {
 
 private struct MockWorkItem: WorkItem, Equatable {
 
-    let id = UUID()
+    let id = UUID().uuidString
     let priority: WorkItemPriority
     func start() async throws {}
 

--- a/WireDomain/Tests/WireDomainTests/WorkAgent/WorkAgentTests.swift
+++ b/WireDomain/Tests/WireDomainTests/WorkAgent/WorkAgentTests.swift
@@ -92,7 +92,7 @@ struct WorkAgentTests {
 
 private actor MockWorkItem: WorkItem {
 
-    let id = UUID()
+    let id = UUID().uuidString
     let priority: WorkItemPriority
 
     var startCalls = 0

--- a/WireDomain/Tests/WireDomainTests/WorkAgent/WorkAgentTests.swift
+++ b/WireDomain/Tests/WireDomainTests/WorkAgent/WorkAgentTests.swift
@@ -88,6 +88,23 @@ struct WorkAgentTests {
         #expect(await item.startCalls == 1)
     }
 
+    @Test("Clear items are removed")
+    func clearItems() async throws {
+        // Given
+        let item = MockWorkItem(priority: .medium)
+        await sut.submitItem(item)
+        await Task.yield()
+
+        #expect(await scheduler.enqueuedItems.count == 1)
+
+        // When
+        await sut.clearSchedulerQueue()
+
+        // Then
+        #expect(await scheduler.items.isEmpty)
+        #expect(await scheduler.enqueuedItems.isEmpty)
+    }
+
 }
 
 private actor MockWorkItem: WorkItem {
@@ -137,4 +154,8 @@ private actor MockScheduler: WorkItemScheduler {
         return item
     }
 
+    func clearAllItems() async {
+        enqueuedItems.removeAll()
+        items.removeAll()
+    }
 }

--- a/WireDomain/Tests/WireDomainTests/WorkAgent/WorkItem/CommitPendingProposalItemTests.swift
+++ b/WireDomain/Tests/WireDomainTests/WorkAgent/WorkItem/CommitPendingProposalItemTests.swift
@@ -39,6 +39,7 @@ class CommitPendingProposalItemTests {
         self.mlsGroupID = .random()
         self.mlsService = .init()
         mlsService.commitPendingProposalsIn_MockMethod = { _ in }
+        mlsService.conversationExistsGroupID_MockValue = true
         repository.isSelfAnActiveMemberIn_MockValue = true
     }
 

--- a/WireDomain/Tests/WireDomainTests/WorkAgent/WorkItem/CommitPendingProposalItemTests.swift
+++ b/WireDomain/Tests/WireDomainTests/WorkAgent/WorkItem/CommitPendingProposalItemTests.swift
@@ -76,6 +76,23 @@ class CommitPendingProposalItemTests {
         #expect(mlsService.commitPendingProposalsIn_Invocations.isEmpty)
     }
 
+    @Test("It does not call commitPendingProposal when mlsGroup does not exist")
+    func startDoesNotCommitWhenMLSGroupDoesNotExist() async throws {
+        // Given
+        repository.clearPendingProposalsIn_MockMethod = { _ in }
+        mlsService.conversationExistsGroupID_MockValue = false
+
+        sut = makeProposalItem()
+
+        // When
+        try await sut.start()
+
+        // Then
+        #expect(mlsService.commitPendingProposalsIn_Invocations.isEmpty)
+        #expect(repository.clearPendingProposalsIn_Invocations.count == 1)
+    }
+
+    
     @Test("It logs properly")
     func loggingDescription() {
         // Given

--- a/WireDomain/Tests/WireDomainTests/WorkAgent/WorkItem/CommitPendingProposalItemTests.swift
+++ b/WireDomain/Tests/WireDomainTests/WorkAgent/WorkItem/CommitPendingProposalItemTests.swift
@@ -92,7 +92,6 @@ class CommitPendingProposalItemTests {
         #expect(repository.clearPendingProposalsIn_Invocations.count == 1)
     }
 
-    
     @Test("It logs properly")
     func loggingDescription() {
         // Given

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -25,7 +25,7 @@ public actor BackoffRetrier {
         _ seconds: Double
     ) async throws -> Void
 
-    enum Failure: Error {
+    public enum Failure: Error {
         case exceededMaxAttempts(latestError: any Error)
     }
 

--- a/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
+++ b/WireFoundation/Sources/WireFoundation/Utilities/BackoffRetry/BackoffRetrier.swift
@@ -36,14 +36,16 @@ public actor BackoffRetrier {
 
     public init(
         policy: BackoffRetryPolicy = .init(),
+        monitoringNetwork: Bool = true,
         sleep: @escaping SleepFunction = { delay in
             try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
         }
     ) {
         self.policy = policy
         self.sleep = sleep
-
-        setupObservers()
+        if monitoringNetwork {
+            setupObservers()
+        }
     }
 
     deinit {

--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -257,7 +257,8 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             } catch {
                 WireLogger.mls
                     .info(
-                        "failed: adding members to group: \(String(describing: error))", attributes: groupID.safeAttributes
+                        "failed: adding members to group: \(String(describing: error))",
+                        attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -277,7 +278,8 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: removing clients from group: \(String(describing: error))", attributes: groupID.safeAttributes
+                        "error: removing clients from group: \(String(describing: error))",
+                        attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -294,7 +296,8 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: updating key material for group: \(String(describing: error))", attributes: groupID.safeAttributes
+                        "error: updating key material for group: \(String(describing: error))",
+                        attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -313,7 +316,8 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: committing pending proposals for group: \(String(describing: error))", attributes: groupID.safeAttributes
+                        "error: committing pending proposals for group: \(String(describing: error))",
+                        attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -342,7 +346,8 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: joining group via external commit: \(String(describing: error))", attributes: groupID.safeAttributes
+                        "error: joining group via external commit: \(String(describing: error))",
+                        attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -421,6 +426,6 @@ extension MLSActionExecutor.Action: CustomDebugStringConvertible {
 
 private extension MLSGroupID {
     var safeAttributes: LogAttributes {
-        [.mlsGroupID: self.safeForLoggingDescription, .public: true]
+        [.mlsGroupID: safeForLoggingDescription, .public: true]
     }
 }

--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -238,7 +238,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func addMembers(_ invitees: [WireDataModel.KeyPackage], to groupID: MLSGroupID) async throws {
         try await performNonReentrant(groupID: groupID) {
             do {
-                WireLogger.mls.info("adding members to group (\(groupID.safeForLoggingDescription))...")
+                WireLogger.mls.info("adding members to group...", attributes: groupID.safeAttributes)
 
                 let crlNewDistributionPoints = try await coreCrypto.perform {
                     try await $0.addClientsToConversation(
@@ -253,11 +253,11 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
                     onNewCRLsDistributionPointsSubject.send(newDistributionPoints)
                 }
 
-                WireLogger.mls.info("success: adding members to group (\(groupID.safeForLoggingDescription))")
+                WireLogger.mls.info("success: adding members to group", attributes: groupID.safeAttributes)
             } catch {
                 WireLogger.mls
                     .info(
-                        "failed: adding members to group (\(groupID.safeForLoggingDescription)): \(String(describing: error))"
+                        "failed: adding members to group: \(String(describing: error))", attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -267,7 +267,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func removeClients(_ clients: [ClientId], from groupID: MLSGroupID) async throws {
         try await performNonReentrant(groupID: groupID) {
             do {
-                WireLogger.mls.info("removing clients from group (\(groupID.safeForLoggingDescription))...")
+                WireLogger.mls.info("removing clients from group...", attributes: groupID.safeAttributes)
                 return try await coreCrypto.perform {
                     try await $0.removeClientsFromConversation(
                         conversationId: groupID.conversationId,
@@ -277,7 +277,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: removing clients from group (\(groupID.safeForLoggingDescription)): \(String(describing: error))"
+                        "error: removing clients from group: \(String(describing: error))", attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -287,14 +287,14 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func updateKeyMaterial(for groupID: MLSGroupID) async throws {
         try await performNonReentrant(groupID: groupID) {
             do {
-                WireLogger.mls.info("updating key material for group (\(groupID.safeForLoggingDescription))...")
+                WireLogger.mls.info("updating key material for group...", attributes: groupID.safeAttributes)
                 return try await coreCrypto.perform {
                     try await $0.updateKeyingMaterial(conversationId: groupID.conversationId)
                 }
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: updating key material for group (\(groupID.safeForLoggingDescription)): \(String(describing: error))"
+                        "error: updating key material for group: \(String(describing: error))", attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -304,16 +304,16 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func commitPendingProposals(in groupID: MLSGroupID) async throws {
         try await performNonReentrant(groupID: groupID) {
             do {
-                WireLogger.mls.info("committing pending proposals for group (\(groupID.safeForLoggingDescription))...")
+                WireLogger.mls.info("committing pending proposals for group", attributes: groupID.safeAttributes)
                 try await coreCrypto.perform {
                     try await $0.commitPendingProposals(conversationId: groupID.conversationId)
                 }
                 WireLogger.mls
-                    .info("success: committing pending proposals for group (\(groupID.safeForLoggingDescription))")
+                    .info("success: committing pending proposals for group", attributes: groupID.safeAttributes)
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: committing pending proposals for group (\(groupID.safeForLoggingDescription)): \(String(describing: error))"
+                        "error: committing pending proposals for group: \(String(describing: error))", attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -323,7 +323,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
     public func joinGroup(_ groupID: MLSGroupID, groupInfo: Data) async throws {
         try await performNonReentrant(groupID: groupID) {
             do {
-                WireLogger.mls.info("joining group (\(groupID.safeForLoggingDescription)) via external commit")
+                WireLogger.mls.info("joining group via external commit", attributes: groupID.safeAttributes)
                 let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
                 let conversationInitBundle = try await coreCrypto.perform {
                     let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: ciphersuite)
@@ -338,11 +338,11 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
                 ) {
                     onNewCRLsDistributionPointsSubject.send(newDistributionPoints)
                 }
-                WireLogger.mls.info("success: joining group (\(groupID.safeForLoggingDescription)) via external commit")
+                WireLogger.mls.info("success: joining group via external commit", attributes: groupID.safeAttributes)
             } catch {
                 WireLogger.mls
                     .info(
-                        "error: joining group (\(groupID.safeForLoggingDescription)) via external commit: \(String(describing: error))"
+                        "error: joining group via external commit: \(String(describing: error))", attributes: groupID.safeAttributes
                     )
                 throw error
             }
@@ -417,4 +417,10 @@ extension MLSActionExecutor.Action: CustomDebugStringConvertible {
         }
     }
 
+}
+
+private extension MLSGroupID {
+    var safeAttributes: LogAttributes {
+        [.mlsGroupID: self.safeForLoggingDescription, .public: true]
+    }
 }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1442,19 +1442,9 @@ public final class MLSService: MLSServiceInterface {
 
     enum RecoveryStrategy: Equatable {
 
-        /// Perform a quick sync, then retry the action in its entirety.
+        /// Retry the action in its entirety.
         ///
-        /// Core Crypto can not automatically recover by itself. It needs
-        /// to process incoming handshake messages then generate a new commit.
-
-        case retryAfterQuickSync
-
-        /// Repair (re-join) the group and retry the action
-        ///
-        /// We may have missed a few commits so we will rejoin the group
-        /// and try again.
-
-        case retryAfterRepairingGroup
+        case retryAfterBackoff
 
         /// Add the missing users to the group, then retry the action in
         /// its entirety.
@@ -1488,10 +1478,8 @@ public final class MLSService: MLSServiceInterface {
             }
 
             switch error {
-            case .mlsClientMismatch, .mlsCommitMissingReferences:
-                self = .retryAfterQuickSync
-            case .mlsStaleMessage:
-                self = .retryAfterRepairingGroup
+            case .mlsClientMismatch, .mlsCommitMissingReferences, .mlsStaleMessage:
+                self = .retryAfterBackoff
             case .mlsInvalidLeafNodeIndex, .mlsInvalidLeafNodeSignature:
                 self = .resetBrokenMLSConversation
             case let .groupOutOfSync(missingUsers):
@@ -1517,48 +1505,15 @@ public final class MLSService: MLSServiceInterface {
             try await operation()
         } catch let CoreCryptoError.Mls(.MessageRejected(reason: reason)) {
             switch RecoveryStrategy(from: reason) {
-            case .retryAfterQuickSync:
-                logger.warn(
-                    "failed to send commit, syncing then retrying operation...",
-                    attributes: logAttributes
-                )
-                try await mlsSyncDelegate?.recoverWithIncrementalSync()
-                logger.info(
-                    "sync finished, retrying operation...",
-                    attributes: logAttributes
-                )
+            case .retryAfterBackoff:
 
-                guard retryCount <= maxRetryAttempts else {
-                    // If MLS conversation reset is DISABLED we quarantine the group to avoid repeated commit attempts
-                    // otherwise assume that things will sort themselves out through conversation reset.
-                    let feature = await featureRepository.fetchAllowedGlobalOperations()
-                    if feature.status == .disabled || feature.config.mlsConversationReset == false {
-                        brokenGroupIDs.insert(groupID)
-                    }
-
-                    throw MLSRetryError.retryLimitReached
+                try await BackoffRetrier(policy: .init(maxRetries: 2)).retry { [logger] in
+                    logger.warn(
+                        "failed to send commit due to \(reason). retrying operation with backoff - attempt: \(retryCount)...",
+                        attributes: logAttributes
+                    )
+                    try await operation()
                 }
-
-                var currentRetryCount = retryCount
-                currentRetryCount += 1
-
-                try await retryOnCommitFailure(for: groupID, operation: operation, retryCount: currentRetryCount)
-
-            case .retryAfterRepairingGroup:
-                logger.warn(
-                    "failed to send commit, repairing group then retrying operation...",
-                    attributes: logAttributes
-                )
-                await fetchAndRepairGroup(
-                    with: groupID,
-                    shouldPerformIncrementalSync: true
-                )
-
-                logger.info(
-                    "repair finished, retrying operation...",
-                    attributes: logAttributes
-                )
-                try await operation()
 
             case let .retryAfterAddingMissingUsers(missingUsers):
                 guard retryCount <= maxRetryAttempts else {

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1401,8 +1401,16 @@ public final class MLSService: MLSServiceInterface {
     // MARK: - Pending proposals
 
     public func commitPendingProposals(in groupID: MLSGroupID) async throws {
-        try await retryOnCommitFailure(for: groupID) { [weak self] in
-            try await self?.internalCommitPendingProposals(in: groupID)
+        try await commitPendingProposals(in: groupID, skipRetry: false)
+    }
+
+    public func commitPendingProposals(in groupID: MLSGroupID, skipRetry: Bool) async throws {
+        if skipRetry {
+            try await internalCommitPendingProposals(in: groupID)
+        } else {
+            try await retryOnCommitFailure(for: groupID) { [weak self] in
+                try await self?.internalCommitPendingProposals(in: groupID)
+            }
         }
     }
 
@@ -1506,7 +1514,7 @@ public final class MLSService: MLSServiceInterface {
             switch RecoveryStrategy(from: reason) {
             case .retryAfterBackoff:
 
-                try await BackoffRetrier(policy: .init(maxRetries: 2)).retry { [logger] in
+                try await BackoffRetrier(policy: .init(maxRetries: 2), monitoringNetwork: false).retry { [logger] in
                     logger.warn(
                         "failed to send commit due to \(reason). retrying operation with backoff - attempt: \(retryCount)...",
                         attributes: logAttributes

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1514,7 +1514,7 @@ public final class MLSService: MLSServiceInterface {
             switch RecoveryStrategy(from: reason) {
             case .retryAfterBackoff:
                 var attempt = 1
-                
+
                 try await BackoffRetrier(policy: .init(maxRetries: 2), monitoringNetwork: false).retry { [logger] in
                     defer {
                         attempt += 1

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -67,7 +67,6 @@ public final class MLSService: MLSServiceInterface {
     private weak var mlsSyncDelegate: (any MLSSyncDelegate)?
     private weak var resetBrokenMLSConversationDelegate: (any ResetBrokenMLSConversationDelegate)?
     private let onEpochChangedSubject = PassthroughSubject<MLSGroupID, Never>()
-    private var brokenGroupIDs: Set<MLSGroupID> = []
     private let localDomain: String?
 
     private var coreCrypto: SafeCoreCryptoProtocol {
@@ -1556,7 +1555,6 @@ public final class MLSService: MLSServiceInterface {
                         "no need to apply recovery strategy for reset broken MLS conversation, FF is OFF",
                         attributes: logAttributes
                     )
-                    brokenGroupIDs.insert(groupID)
                     throw MLSRetryError.nonRecoverableError(reason)
                 }
 
@@ -1569,7 +1567,6 @@ public final class MLSService: MLSServiceInterface {
                     epoch = await fetchConversationInfo(with: groupID, in: context)?.epoch ?? 0
                 }
                 await resetBrokenMLSConversationDelegate?.didCatchBrokenMLSConversation(groupID: groupID, epoch: epoch)
-                brokenGroupIDs.remove(groupID)
 
             case .giveUp:
                 logger.warn(

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -1513,10 +1513,14 @@ public final class MLSService: MLSServiceInterface {
         } catch let CoreCryptoError.Mls(.MessageRejected(reason: reason)) {
             switch RecoveryStrategy(from: reason) {
             case .retryAfterBackoff:
-
+                var attempt = 1
+                
                 try await BackoffRetrier(policy: .init(maxRetries: 2), monitoringNetwork: false).retry { [logger] in
+                    defer {
+                        attempt += 1
+                    }
                     logger.warn(
-                        "failed to send commit due to \(reason). retrying operation with backoff - attempt: \(retryCount)...",
+                        "failed to send commit due to \(reason). retrying operation with backoff - attempt: \(attempt)...",
                         attributes: logAttributes
                     )
                     try await operation()

--- a/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
+++ b/wire-ios-data-model/Source/MLS/MLSServiceInterface.swift
@@ -332,6 +332,14 @@ public protocol MLSServiceInterface: MLSEncryptionServiceInterface, MLSDecryptio
 
     func commitPendingProposals(in groupID: MLSGroupID) async throws
 
+    /// Commits pending proposals for a group.
+    /// - Parameters:
+    ///   - groupID: The group ID to commit pending proposals for
+    ///   - skipRetry: true to skip internal recovery strategy. False otherwise
+    ///
+    /// If skipRetry is false it's up to the caller to handle errors
+    func commitPendingProposals(in groupID: MLSGroupID, skipRetry: Bool) async throws
+
     // MARK: - Key material
 
     /// Updates the key material for all stale groups if it hasn't been done in the past day.

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -4626,6 +4626,26 @@ public class MockMLSServiceInterface: MLSServiceInterface {
         try await mock(groupID)
     }
 
+    // MARK: - commitPendingProposals
+
+    public var commitPendingProposalsInSkipRetry_Invocations: [(groupID: MLSGroupID, skipRetry: Bool)] = []
+    public var commitPendingProposalsInSkipRetry_MockError: Error?
+    public var commitPendingProposalsInSkipRetry_MockMethod: ((MLSGroupID, Bool) async throws -> Void)?
+
+    public func commitPendingProposals(in groupID: MLSGroupID, skipRetry: Bool) async throws {
+        commitPendingProposalsInSkipRetry_Invocations.append((groupID: groupID, skipRetry: skipRetry))
+
+        if let error = commitPendingProposalsInSkipRetry_MockError {
+            throw error
+        }
+
+        guard let mock = commitPendingProposalsInSkipRetry_MockMethod else {
+            fatalError("no mock for `commitPendingProposalsInSkipRetry`")
+        }
+
+        try await mock(groupID, skipRetry)
+    }
+
     // MARK: - updateKeyMaterialForAllStaleGroupsIfNeeded
 
     public var updateKeyMaterialForAllStaleGroupsIfNeeded_Invocations: [Void] = []

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -20,9 +20,9 @@ import Combine
 import Foundation
 import WireCoreCrypto
 import WireFoundation
-import WireNetwork
 import WireTesting
 import XCTest
+@testable import WireNetwork
 
 @testable @preconcurrency import WireDataModel
 @testable import WireDataModelSupport
@@ -1798,17 +1798,11 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             }
         }
 
-        // Mock incremental sync.
-        mockSyncDelegate.recoverWithIncrementalSync_MockMethod = {}
-
         // When
         try await sut.updateKeyMaterial(for: groupID)
 
         // Then it attempted to update key material twice.
         XCTAssertEqual(mockUpdateKeyMaterialCount, 2)
-
-        // Then it performed an incremental sync once.
-        XCTAssertEqual(mockSyncDelegate.recoverWithIncrementalSync_Invocations.count, 1)
     }
 
     func test_RetryOnCommitFailure_MultipleRetries() async throws {
@@ -1840,9 +1834,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Then it attempted to update key material 4 times (3 failed, 1 success).
         XCTAssertEqual(mockUpdateKeyMaterialCount, 4)
-
-        // Then it performed an incremental sync 3 times (for 3 failures).
-        XCTAssertEqual(mockSyncDelegate.recoverWithIncrementalSync_Invocations.count, 3)
     }
 
     func test_RetryOnCommitFailure_Keep_Throwing_Commit_Error_Prevents_Infinite_Loop() async throws {
@@ -1865,15 +1856,13 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             ))
         }
 
-        // Mock incremental sync.
-        mockSyncDelegate.recoverWithIncrementalSync_MockMethod = {}
-
         do {
             // When
             try await sut.updateKeyMaterial(for: groupID)
-        } catch let error as MLSService.MLSRetryError {
+        } catch is BackoffRetrier.Failure {
             // Then, infinite loop is broken after a few attempts, it throws an error
-            XCTAssertEqual(error, .retryLimitReached)
+        } catch {
+            XCTFail("failed with unexpected error: \(error)")
         }
     }
 
@@ -1903,9 +1892,10 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         do {
             // When
             try await sut.updateKeyMaterial(for: groupID)
-        } catch let error as MLSService.MLSRetryError {
+        } catch let error as BackoffRetrier.Failure {
             // Then, infinite loop is broken after a few attempts, it throws an error
-            XCTAssertEqual(error, .retryLimitReached)
+        } catch {
+            XCTFail("failed with unexpected error: \(error)")
         }
     }
 
@@ -1952,9 +1942,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Then it attempted to update key material 4 times (3 failed, 1 success).
         XCTAssertEqual(mockUpdateKeyMaterialCount, 4)
-
-        // Then it performed an incremental sync 5 times (for 2 + 3 failures).
-        XCTAssertEqual(mockSyncDelegate.recoverWithIncrementalSync_Invocations.count, 5)
     }
 
     func test_RetryOnCommitFailure_GroupOutOfSync() async throws {
@@ -2034,9 +2021,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             mockUpdateKeyMaterialCount += 1
         }
 
-        // Mock incremental sync.
-        mockSyncDelegate.recoverWithIncrementalSync_MockMethod = {}
-
         // Mock no subgroup
         mockSubconversationGroupIDRepository.findSubgroupTypeAndParentIDFor_MockMethod = { _ in
             nil
@@ -2050,9 +2034,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Then it attempted to update key material once.
         XCTAssertEqual(mockUpdateKeyMaterialCount, 1)
-
-        // Then it performed an incremental sync once.
-        XCTAssertEqual(mockSyncDelegate.recoverWithIncrementalSync_Invocations.count, 1)
     }
 
     func test_RetryOnCommitFailure_ItGivesUp() async throws {
@@ -2072,9 +2053,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
             ))
         }
 
-        // Mock incremental sync.
-        mockSyncDelegate.recoverWithIncrementalSync_MockMethod = {}
-
         // Then
         await assertItThrows(
             error: try MLSService.MLSRetryError
@@ -2086,9 +2064,6 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
         // Then it attempted to update key material once.
         XCTAssertEqual(mockUpdateKeyMaterialCount, 1)
-
-        // Then it didn't perform an incremental sync.
-        XCTAssertEqual(mockSyncDelegate.recoverWithIncrementalSync_Invocations.count, 0)
     }
 
     func test_UpdateKeyMaterial_ContinuesOnFailureForSomeGroups() async throws {

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSender.swift
@@ -16,6 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
+import WireCoreCrypto
 import WireDataModel
 import WireLogging
 
@@ -398,7 +399,7 @@ public final class MessageSender: MessageSenderInterface {
                 try await mlsService.reEstablishPendingGroup(groupID: groupID)
             }
 
-            try await mlsService.commitPendingProposals(in: groupID)
+            try await mlsService.commitPendingProposals(in: groupID, skipRetry: true)
             let encryptedData = try await encryptMlsMessage(message, groupID: groupID)
 
             // set expiration so request can be expired later
@@ -423,51 +424,84 @@ public final class MessageSender: MessageSenderInterface {
                 message.delivered(with: response)
             }
         } catch let error as SendMLSMessageFailure {
-            switch error {
-            case .mlsStaleMessage:
-                // We should try to repair the conversation for the `mlsStaleMessage` error.
-                // This error indicates that the message was not encrypted in the latest epoch.
-                let operation: () async throws -> Void = { [weak self] in
-                    try await self?.sendMessage(message: message)
-                }
 
-                try await handleMLSStaleMessageError(
+            try await handleSendMLSMessageFailure(error, message: message, groupID: groupID, mlsService: mlsService)
+        } catch let CoreCryptoError.Mls(.MessageRejected(reason: reason)) {
+
+            if let supportedError = SendMLSMessageFailure(from: reason) {
+                try await handleSendMLSMessageFailure(
+                    supportedError,
+                    message: message,
                     groupID: groupID,
-                    mlsService: mlsService,
-                    operation: operation
+                    mlsService: mlsService
                 )
-            case .mlsInvalidLeafNodeIndex, .mlsInvalidLeafNodeSignature:
-                let feature = await featureRepository.fetchAllowedGlobalOperations()
-                guard feature.status == .enabled,
-                      feature.config.mlsConversationReset == true
-                else {
-                    WireLogger.messaging.debug(
-                        "No need to initiate reset broken MLS conversation, FF is OFF"
-                    )
-                    throw error
-                }
+            } else {
+                throw CoreCryptoError.Mls(.MessageRejected(reason: reason))
+            }
 
-                let epoch = await context.perform { message.conversation?.epoch }
+        }
+    }
 
-                await initiateResetMLSConversationUseCase
-                    .invoke(
-                        groupID: groupID,
-                        epoch: epoch ?? 0
-                    )
-            case let .groupOutOfSync(missingUsers):
-                guard retryCount < maxRetryAttempts else {
-                    retryCount = 0
-                    throw error
-                }
+    private func handleSendMLSMessageFailure(
+        _ error: SendMLSMessageFailure,
+        message: any SendableMessage,
+        groupID: MLSGroupID,
+        mlsService: MLSServiceInterface
+    ) async throws {
+        switch error {
+        case .mlsStaleMessage:
+            // We should try to repair the conversation for the `mlsStaleMessage` error.
+            // This error indicates that the message was not encrypted in the latest epoch.
+            let operation: () async throws -> Void = { [weak self] in
+                try await self?.sendMessage(message: message)
+            }
 
-                retryCount += 1
-
-                let users = missingUsers.map { MLSUser($0) }
-                try await mlsService.addMembersToConversation(with: users, for: groupID)
-                try await sendMessage(message: message)
-            default:
+            try await handleMLSStaleMessageError(
+                groupID: groupID,
+                mlsService: mlsService,
+                operation: operation
+            )
+        case .mlsInvalidLeafNodeIndex, .mlsInvalidLeafNodeSignature:
+            let feature = await featureRepository.fetchAllowedGlobalOperations()
+            guard feature.status == .enabled,
+                  feature.config.mlsConversationReset == true
+            else {
+                WireLogger.messaging.debug(
+                    "No need to initiate reset broken MLS conversation, FF is OFF"
+                )
                 throw error
             }
+
+            let epoch = await context.perform { message.conversation?.epoch }
+
+            await initiateResetMLSConversationUseCase
+                .invoke(
+                    groupID: groupID,
+                    epoch: epoch ?? 0
+                )
+        case let .groupOutOfSync(missingUsers):
+            guard retryCount < maxRetryAttempts else {
+                retryCount = 0
+                throw error
+            }
+
+            retryCount += 1
+
+            let users = missingUsers.map { MLSUser($0) }
+            try await mlsService.addMembersToConversation(with: users, for: groupID)
+            try await sendMessage(message: message)
+        case .mlsCommitMissingReferences, .mlsClientMismatch:
+            // here a simple retry is used but as an optim we could use a backoff
+            guard retryCount < maxRetryAttempts else {
+                retryCount = 0
+                throw error
+            }
+
+            retryCount += 1
+
+            try await sendMessage(message: message)
+        default:
+            throw error
         }
     }
 
@@ -531,4 +565,33 @@ private extension Payload.ClientListByQualifiedUserID {
         return qualifiedClientIDs
     }
 
+}
+
+private extension SendMLSMessageFailure {
+
+    init?(from reason: String) {
+        guard let error = try? JSONDecoder().decode(
+            MLSTransportError.self,
+            from: Data(reason.utf8)
+        ) else {
+            return nil
+        }
+
+        switch error {
+        case .mlsClientMismatch:
+            self = .mlsClientMismatch
+        case .mlsCommitMissingReferences:
+            self = .mlsCommitMissingReferences(message: "")
+        case .mlsStaleMessage:
+            self = .mlsStaleMessage
+        case .mlsInvalidLeafNodeIndex:
+            self = .mlsInvalidLeafNodeIndex(message: "")
+        case .mlsInvalidLeafNodeSignature:
+            self = .mlsInvalidLeafNodeSignature(message: "")
+        case let .groupOutOfSync(missingUsers):
+            self = .groupOutOfSync(missingUsers: missingUsers)
+        default:
+            return nil
+        }
+    }
 }

--- a/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
+++ b/wire-ios-request-strategy/Sources/Message Sending/MessageSenderTests.swift
@@ -17,6 +17,7 @@
 //
 
 import GenericMessageProtocol
+import WireCoreCrypto
 import WireTransport
 import XCTest
 
@@ -486,7 +487,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .success((messageSendingStatus, response)))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -526,7 +526,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .success((messageSendingStatus, response)))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -535,7 +534,9 @@ final class MessageSenderTests: MessagingTestBase {
         try await messageSender.sendMessage(message: message)
 
         // then
-        XCTAssertEqual([Arrangement.Scaffolding.groupID], arrangement.mlsService.commitPendingProposalsIn_Invocations)
+        let invocation = try XCTUnwrap(arrangement.mlsService.commitPendingProposalsInSkipRetry_Invocations.first)
+        XCTAssertEqual(Arrangement.Scaffolding.groupID, invocation.groupID)
+        XCTAssertTrue(invocation.skipRetry)
         XCTAssertEqual(arrangement.mlsService.reEstablishPendingGroupGroupID_Invocations.count, 0)
     }
 
@@ -562,7 +563,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .failure(networkError))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -595,7 +595,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .failure(networkError))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -628,7 +627,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .failure(networkError))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -665,7 +663,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withSendMlsMessage(returning: .failure(networkError))
             .withResetMLSConversationsFeatureOff()
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -759,7 +756,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .success((messageSendingStatus, response)))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
         }
@@ -812,7 +808,6 @@ final class MessageSenderTests: MessagingTestBase {
                 .success((messageSendingStatus, response))
             ])
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
@@ -855,7 +850,6 @@ final class MessageSenderTests: MessagingTestBase {
             .withMLServiceConfigured()
             .withSendMlsMessage(returning: .failure(SendMLSMessageFailure.groupOutOfSync(missingUsers: missingUsers)))
             .arrange()
-        arrangement.mlsService.commitPendingProposalsIn_MockMethod = { _ in }
         arrangement.mlsService.addMembersToConversationWithFor_MockMethod = { _, _ in }
         arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
             message + [000]
@@ -872,6 +866,47 @@ final class MessageSenderTests: MessagingTestBase {
             .sendMLSMessageMessageConversationIDExpirationDate_Invocations
         XCTAssertEqual(sendMessageInvocations.count, 4)
         XCTAssertEqual(arrangement.mlsService.addMembersToConversationWithFor_Invocations.count, 3)
+    }
+
+    func testThatWhenSendingMlsMessageCommitMissingReferences_ItRetriesMax3Times() async throws {
+        // Given
+        await syncMOC.performGrouped {
+            self.groupConversation.mlsGroupID = Arrangement.Scaffolding.groupID
+            self.groupConversation.messageProtocol = .mls
+            self.groupConversation.mlsStatus = .ready
+        }
+
+        let message = GenericMessageEntity(
+            message: GenericMessage(content: Text(content: "Hello World")),
+            context: syncMOC,
+            conversation: groupConversation,
+            completionHandler: nil
+        )
+
+        let (arrangement, messageSender) = Arrangement(coreDataStack: coreDataStack)
+            .withIncrementalSyncObserverCompleting()
+            .withMessageDependencyResolverReturning(result: .success(()))
+            .withApiVersionResolving(to: .v13)
+            .withMLServiceConfigured()
+            .arrange()
+        let errorString = try XCTUnwrap(String(
+            data: try JSONEncoder().encode(MLSTransportError.mlsCommitMissingReferences),
+            encoding: .utf8
+        ))
+        arrangement.mlsService.commitPendingProposalsInSkipRetry_MockError = CoreCryptoError
+            .Mls(.MessageRejected(reason: errorString))
+        arrangement.mlsService.encryptMessageFor_MockMethod = { message, _ in
+            message + [000]
+        }
+
+        // When
+        await XCTAssertThrowsErrorAsync {
+            try await messageSender.sendMessage(message: message)
+        }
+
+        // Then
+        // It tried to send the message 4 times (initial + 3 retries)
+        XCTAssertEqual(arrangement.mlsService.commitPendingProposalsInSkipRetry_Invocations.count, 4)
     }
 
     // MARK: - Helpers
@@ -952,6 +987,7 @@ final class MessageSenderTests: MessagingTestBase {
                 config: .init(mlsConversationReset: true)
             )
             mlsService.reEstablishPendingGroupGroupID_MockMethod = { _ in }
+
         }
 
         func withApiVersionResolving(to apiVersion: APIVersion?) -> Arrangement {
@@ -1006,6 +1042,7 @@ final class MessageSenderTests: MessagingTestBase {
             coreDataStack.syncContext.performAndWait {
                 coreDataStack.syncContext.mlsService = mlsService
             }
+            mlsService.commitPendingProposalsInSkipRetry_MockMethod = { _, _ in }
             return self
         }
 

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -38,8 +38,6 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
     public private(set) var requestStrategies: [RequestStrategy]
     public private(set) var contextChangeTrackers: [ZMContextChangeTracker]
     public private(set) var clientContextChangeTrackers: [ZMContextChangeTracker] = []
-    public private(set) var initiateResetMLSConversationUseCaseFactory: (NSManagedObjectContext) -> WireRequestStrategy
-        .InitiateResetMLSConversationUseCaseProtocol
 
     init(
         contextProvider: ContextProvider,
@@ -53,8 +51,6 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         mlsService: MLSServiceInterface,
         coreCryptoProvider: CoreCryptoProviderProtocol,
         searchUsersCache: SearchUsersCache?,
-        initiateResetMLSConversationUseCaseFactory: @escaping (NSManagedObjectContext) -> WireRequestStrategy
-            .InitiateResetMLSConversationUseCaseProtocol,
         metadata: BackendMetadataProvider
     ) {
         self.strategies = Self.buildStrategies(
@@ -71,8 +67,6 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
             searchUsersCache: searchUsersCache,
             metadata: metadata
         )
-        self.initiateResetMLSConversationUseCaseFactory = initiateResetMLSConversationUseCaseFactory
-
         self.requestStrategies = strategies.compactMap { $0 as? RequestStrategy }
         self.contextChangeTrackers = strategies.flatMap { (object: Any) -> [ZMContextChangeTracker] in
             if let source = object as? ZMContextChangeTrackerSource {
@@ -317,6 +311,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         pushMessageHandler: PushMessageHandler,
         flowManager: FlowManagerType,
         incrementalSyncObserver: IncrementalSyncObserverProtocol,
+        initiateResetMLSConversationUseCase: WireRequestStrategy.InitiateResetMLSConversationUseCaseProtocol,
         metadata: BackendMetadataProvider
     ) {
         syncContext.performAndWait {
@@ -337,7 +332,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
                 messageDependencyResolver: messageDependencyResolver,
                 context: syncContext,
                 incrementalSyncObserver: incrementalSyncObserver,
-                initiateResetMLSConversationUseCase: initiateResetMLSConversationUseCaseFactory(syncContext),
+                initiateResetMLSConversationUseCase: initiateResetMLSConversationUseCase,
                 featureRepository: LegacyFeatureRepository(context: syncContext),
                 apiVersion: metadata.apiVersion
             )

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1274,17 +1274,6 @@ extension ZMUserSession: SyncAgentDelegate {
         performPostQuickSyncE2EIActions()
     }
 
-    private func makePullSelfUserClients(context: NSManagedObjectContext) -> PullSelfUserClientsSyncProtocol {
-        guard let clientSessionComponent else {
-            fatalError()
-        }
-
-        return PullSelfUserClientsSync(
-            api: clientSessionComponent.userClientsAPI,
-            store: clientSessionComponent.userClientsLocalStore
-        )
-    }
-
     private func resolveOneOnOneConversationsIfNeeded() async {
         guard let clientSessionComponent, mlsFeature.isEnabled, !didAlreadyResolveAllOneOnOnes else { return }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1274,23 +1274,14 @@ extension ZMUserSession: SyncAgentDelegate {
         performPostQuickSyncE2EIActions()
     }
 
-    private func makeInitiateResetMLSConversationUseCase(
-        context: NSManagedObjectContext,
-        conversationRepository: ConversationRepositoryProtocol
-    ) -> WireRequestStrategy.InitiateResetMLSConversationUseCaseProtocol {
+    private func makePullSelfUserClients(context: NSManagedObjectContext) -> PullSelfUserClientsSyncProtocol {
         guard let clientSessionComponent else {
             fatalError()
         }
 
-        return InitiateResetMLSConversationUseCase(
-            api: clientSessionComponent.mlsAPI,
-            mlsService: mlsService,
-            conversationLocalStore: clientSessionComponent.conversationLocalStore,
-            conversationRepository: clientSessionComponent.conversationRepository,
-            lockRepository: ResetMLSConversationLockRepository(
-                userID: userId
-            ),
-            selfDomain: resolvedBackendMetadata.domain
+        return PullSelfUserClientsSync(
+            api: clientSessionComponent.userClientsAPI,
+            store: clientSessionComponent.userClientsLocalStore
         )
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -431,6 +431,7 @@ public final class ZMUserSession: NSObject {
     private let networkReachability = NetworkReachability()
     private var networkInterfaceSwitchCancellable: AnyCancellable?
     private var isNetworkReachableCancellable: AnyCancellable?
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initialize
 
@@ -667,7 +668,6 @@ public final class ZMUserSession: NSObject {
                 flowManager: flowManager,
                 incrementalSyncObserver: incrementalSyncObserver,
                 initiateResetMLSConversationUseCase: clientSessionComponent.initiateResetMLSConversationUseCase,
-                commitPendingProposalUseCase: clientSessionComponent.commitPendingProposalsUseCase,
                 metadata: resolvedBackendMetadata
             )
             syncStrategy?.updateClientContextChangeTrackers()
@@ -676,7 +676,14 @@ public final class ZMUserSession: NSObject {
             await clientSessionComponent.workAgent.setAutoStartEnabled(true)
             await clientSessionComponent.workAgent.start()
             clientSessionComponent.generatorsDirectory.observeSyncState()
-
+            clientSessionComponent.syncStateSubject.sink { state in
+                if state == .suspended {
+                    Task {
+                        // clear all items, those will be regenerated when sync is resumed
+                        await clientSessionComponent.workAgent.clearSchedulerQueue()
+                    }
+                }
+            }.store(in: &cancellables)
             // Initialize the generator to enqueue repair work item if needed
             clientSessionComponent.repairFaultyMLSRemovalKeysGenerator.submitWorkItemIfNeeded()
         }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -666,6 +666,8 @@ public final class ZMUserSession: NSObject {
                 pushMessageHandler: localNotificationDispatcher,
                 flowManager: flowManager,
                 incrementalSyncObserver: incrementalSyncObserver,
+                initiateResetMLSConversationUseCase: clientSessionComponent.initiateResetMLSConversationUseCase,
+                commitPendingProposalUseCase: clientSessionComponent.commitPendingProposalsUseCase,
                 metadata: resolvedBackendMetadata
             )
             syncStrategy?.updateClientContextChangeTrackers()
@@ -785,16 +787,6 @@ public final class ZMUserSession: NSObject {
             mlsService: mlsService,
             coreCryptoProvider: coreCryptoProvider,
             searchUsersCache: dependencies.caches.searchUsers,
-            initiateResetMLSConversationUseCaseFactory: { [weak self] context in
-                guard let self, let repo = clientSessionComponent?.conversationRepository else {
-                    fatal("userSession not reachable")
-                }
-                // Passing useCase from WireDomain to WireRequestStrategy's MessageSender
-                return makeInitiateResetMLSConversationUseCase(
-                    context: context,
-                    conversationRepository: repo
-                )
-            },
             metadata: resolvedBackendMetadata
         )
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -672,15 +672,16 @@ public final class ZMUserSession: NSObject {
             )
             syncStrategy?.updateClientContextChangeTrackers()
         }
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
             await clientSessionComponent.workAgent.setAutoStartEnabled(true)
             await clientSessionComponent.workAgent.start()
             clientSessionComponent.generatorsDirectory.observeSyncState()
-            clientSessionComponent.syncStateSubject.sink { state in
+            clientSessionComponent.syncStateSubject.sink { [weak clientSessionComponent] state in
                 if state == .suspended {
                     Task {
                         // clear all items, those will be regenerated when sync is resumed
-                        await clientSessionComponent.workAgent.clearSchedulerQueue()
+                        await clientSessionComponent?.workAgent.clearSchedulerQueue()
                     }
                 }
             }.store(in: &cancellables)
@@ -724,6 +725,7 @@ public final class ZMUserSession: NSObject {
         guard !isTornDown else { return }
 
         Task {
+            await clientSessionComponent?.workAgent.clearSchedulerQueue()
             await clientSessionComponent?.workAgent.stop()
         }
         tearDownMLSGroupVerification()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23159" title="WPB-23159" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23159</a>  [iOS] Change Commit Pending Proposals recovery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

* clear commit pending proposal date when mls reset
* change recovery strategy to a backoff retry instead of retryaftersync
* avoid sending commit to non existing groups
* clear scheduled items from workAgent queue when sync is suspended. These will be recreated if needed.
* cleanup setup initiate mls reset use case
* improve debugging workAgent item (changed ids)

### Testing

-
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
