### PR TITLE
fix: occasional deadlock configuring `AVCaptureSession` - WPB-23237

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Camera/CameraController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Camera/CameraController.swift
@@ -46,8 +46,13 @@ final class CameraController {
     init?(camera: SettingsCamera) {
         guard !UIDevice.isSimulator else { return nil }
         self.currentCamera = camera
-        setupSession()
         self.previewLayer = AVCaptureVideoPreviewLayer(session: session)
+
+        // `setupSession()` performs session configuration on a dedicated serial queue. This needs to happen after the
+        // `previewLayer` is created to avoid simultaneous session configuration across different threads as
+        // `AVCaptureVideoPreviewLayer` appears to configure the session internally on the main thread during init.
+        // Configuring the `AVCaptureSession` from multiple threads can lead to a deadlock.
+        setupSession()
     }
 
     // MARK: - Session Management


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23237" title="WPB-23237" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23237</a>  [iOS] Replicated Once - Screen freeze and Crash observed on camera permission
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Sometimes when the camera button is tapped and the preview loads we get a deadlock. I've managed to reproduce this a few times by showing and hiding the camera input repeatably but it can take time to happen. @findms originally found the issue after giving phone permissions.

Looking at the crash report in the jira ticket we see that we have called `beginConfiguration` on the `AVCaptureSession` from two threads (main + background) and that there is a deadlock before any call to `commitConfiguration`. Debugging I found that the main thread call happens internally when instantiating `AVCaptureVideoPreviewLayer`. 

My fix is to first instantiate `AVCaptureVideoPreviewLayer` before doing our own background thread configuration of `AVCaptureSession`. I have observed this leads to the `AVCaptureVideoPreviewLayer` completing it's configuration of the session before we do it.

### Testing

1. Navigate to a conversation
2. Repeatably tap the camera button so the camera input shows and hides
3. Continue for a few minutes 
4. The UI should not freeze. 

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
