### PR TITLE
chore: remove ZMUser.selfUser(inUserSession:) - WPB-20362

### DIFF
--- a/wire-ios-data-model/Source/Model/User/UserType+Federation.swift
+++ b/wire-ios-data-model/Source/Model/User/UserType+Federation.swift
@@ -16,8 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import Foundation
-
 extension UserType {
 
     func isFederating(with otherUser: UserType) -> Bool {

--- a/wire-ios-data-model/Source/Model/User/ZMSearchUser.swift
+++ b/wire-ios-data-model/Source/Model/User/ZMSearchUser.swift
@@ -105,7 +105,7 @@ public class ZMSearchUser: NSObject, UserType {
         user?.objectId ?? remoteIdentifier!
     }
 
-    fileprivate weak var contextProvider: ContextProvider?
+    fileprivate weak var viewContext: NSManagedObjectContext?
     private let searchUsersCache: SearchUsersCache?
 
     fileprivate var internalDomain: String?
@@ -162,16 +162,12 @@ public class ZMSearchUser: NSObject, UserType {
     }
 
     public var isFederated: Bool {
-        guard let contextProvider else {
-            return false
-        }
-
-        return ZMUser.selfUser(inUserSession: contextProvider).isFederating(with: self)
+        guard let viewContext else { return false }
+        return ZMUser.selfUser(in: viewContext).isFederating(with: self)
     }
 
     public var isSelfUser: Bool {
         guard let user else { return false }
-
         return user.isSelfUser
     }
 
@@ -265,8 +261,8 @@ public class ZMSearchUser: NSObject, UserType {
     }
 
     public var oneToOneConversation: ZMConversation? {
-        if isTeamMember, let uiContext = contextProvider?.viewContext {
-            materialize(in: uiContext)?.oneToOneConversation
+        if isTeamMember, let viewContext {
+            materialize(in: viewContext)?.oneToOneConversation
         } else {
             user?.oneToOneConversation
         }
@@ -482,7 +478,7 @@ public class ZMSearchUser: NSObject, UserType {
 
     @objc
     public required init(
-        contextProvider: ContextProvider,
+        viewContext: NSManagedObjectContext,
         name: String,
         handle: String?,
         accentColor: ZMAccentColor?,
@@ -503,10 +499,10 @@ public class ZMSearchUser: NSObject, UserType {
         self.internalDomain = domain
         self.remoteIdentifier = existingUser?.remoteIdentifier ?? remoteIdentifier
         self.teamIdentifier = existingUser?.teamIdentifier ?? teamIdentifier
-        self.contextProvider = contextProvider
+        self.viewContext = viewContext
         self.searchUsersCache = searchUsersCache
 
-        let selfUser = ZMUser.selfUser(inUserSession: contextProvider)
+        let selfUser = ZMUser.selfUser(in: viewContext)
         self.internalIsTeamMember = teamIdentifier != nil && selfUser.teamIdentifier == teamIdentifier
         self.internalIsConnected = internalIsTeamMember
 
@@ -524,7 +520,7 @@ public class ZMSearchUser: NSObject, UserType {
         searchUsersCache: SearchUsersCache?
     ) {
         self.init(
-            contextProvider: contextProvider,
+            viewContext: contextProvider.viewContext,
             name: user.name ?? "",
             handle: user.handle,
             accentColor: user.zmAccentColor,
@@ -556,7 +552,7 @@ public class ZMSearchUser: NSObject, UserType {
         let accentColorRawValue = (payload["accent_id"] as? NSNumber)?.int16Value ?? 0
 
         self.init(
-            contextProvider: contextProvider,
+            viewContext: contextProvider.viewContext,
             name: name,
             handle: handle,
             accentColor: .from(rawValue: accentColorRawValue) ?? .default,
@@ -611,7 +607,7 @@ public class ZMSearchUser: NSObject, UserType {
     }
 
     public func connect(completion: @escaping (Error?) -> Void) {
-        let selfUser = ZMUser.selfUser(inUserSession: contextProvider!)
+        let selfUser = ZMUser.selfUser(in: viewContext!)
         selfUser.sendConnectionRequest(to: self) { [weak self] result in
             switch result {
             case .success:
@@ -628,7 +624,7 @@ public class ZMSearchUser: NSObject, UserType {
     private func updateLocalUser() {
         guard
             let userID = remoteIdentifier,
-            let viewContext = contextProvider?.viewContext
+            let viewContext
         else {
             return
         }
@@ -637,7 +633,7 @@ public class ZMSearchUser: NSObject, UserType {
     }
 
     private func notifySearchUserChanged() {
-        contextProvider?.viewContext.searchUserObserverCenter.notifyUpdatedSearchUser(self)
+        viewContext?.searchUserObserverCenter.notifyUpdatedSearchUser(self)
     }
 
     public func accept(completion: @escaping (Error?) -> Void) {
@@ -671,7 +667,7 @@ public class ZMSearchUser: NSObject, UserType {
 
         if let user {
             user.requestPreviewProfileImage()
-        } else if let notificationContext = contextProvider?.viewContext.notificationContext {
+        } else if let notificationContext = viewContext?.notificationContext {
             NotificationInContext(
                 name: .searchUserDidRequestPreviewAsset,
                 context: notificationContext,
@@ -686,7 +682,7 @@ public class ZMSearchUser: NSObject, UserType {
 
         if let user {
             user.requestCompleteProfileImage()
-        } else if let notificationContext = contextProvider?.viewContext.notificationContext {
+        } else if let notificationContext = viewContext?.notificationContext {
             NotificationInContext(
                 name: .searchUserDidRequestCompleteAsset,
                 context: notificationContext,
@@ -731,7 +727,7 @@ public class ZMSearchUser: NSObject, UserType {
             internalCompleteImageData = imageData
         }
 
-        contextProvider?.viewContext.searchUserObserverCenter.notifyUpdatedSearchUser(self)
+        viewContext?.searchUserObserverCenter.notifyUpdatedSearchUser(self)
     }
 
     public func update(from payload: [String: Any]) {

--- a/wire-ios-data-model/Source/Model/User/ZMUser.m
+++ b/wire-ios-data-model/Source/Model/User/ZMUser.m
@@ -717,17 +717,6 @@ static NSString *const PrimaryKey = @"primaryKey";
 @end
 
 
-@implementation ZMUser (Utilities)
-
-+ (ZMUser<ZMEditableUserType> *)selfUserInUserSession:(id<ZMContextProvider>)session
-{
-    VerifyReturnNil(session != nil);
-    return [self selfUserInContext:session.viewContext];
-}
-
-@end
-
-
 
 
 @implementation ZMUser (Editable)

--- a/wire-ios-data-model/Source/Public/ZMUser.h
+++ b/wire-ios-data-model/Source/Public/ZMUser.h
@@ -83,15 +83,6 @@ typedef NS_ENUM(int16_t, ZMBlockState) {
 @end
 
 
-@protocol ZMEditableUserType;
-
-@interface ZMUser (Utilities)
-
-+ (ZMUser<ZMEditableUserType> *_Nonnull)selfUserInUserSession:(id<ZMContextProvider> _Nonnull)session;
-
-@end
-
-
 
 
 @interface ZMUser (Connections)

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverCenterTests.swift
@@ -170,7 +170,7 @@ final class SearchUserObserverCenterTests: ModelObjectsTests {
         user: ZMUser? = nil
     ) -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: name,
             handle: handle,
             accentColor: accentColor,

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserObserverTests.swift
@@ -137,7 +137,7 @@ final class SearchUserObserverTests: NotificationDispatcherTestBase {
         user: ZMUser? = nil
     ) -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: name,
             handle: name.lowercased(),
             accentColor: .amber,

--- a/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserSnapshotTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/Observer/SearchUserSnapshotTests.swift
@@ -225,7 +225,7 @@ final class SearchUserSnapshotTests: ZMBaseManagedObjectTest {
         user: ZMUser? = nil
     ) -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: name,
             handle: handle,
             accentColor: accentColor,

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+Connections.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+Connections.swift
@@ -24,7 +24,7 @@ final class ZMSearchUserTests_Connections: ModelObjectsTests {
     func testThatConnectSendsAConnectToUserNotification() {
         // given
         let searchUser = ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: "John Doe",
             handle: "johndoe",
             accentColor: .turquoise,

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+ProfileImages.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+ProfileImages.swift
@@ -177,7 +177,7 @@ final class ZMSearchUserTests_ProfileImages: ZMBaseManagedObjectTest {
         user: ZMUser? = nil
     ) -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: name,
             handle: name.lowercased(),
             accentColor: .amber,

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests+TeamUser.swift
@@ -73,7 +73,7 @@ final class ZMSearchUserTests_TeamUser: ModelObjectsTests {
 
     private func makeSearchUser(teamIdentifier: UUID?) -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: "Foo",
             handle: "foo",
             accentColor: .amber,

--- a/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/User/ZMSearchUserTests.m
@@ -49,40 +49,40 @@
     NSUUID *remoteIDA = [NSUUID createUUID];
     NSUUID *remoteIDB = [NSUUID createUUID];
 
-    ZMSearchUser *user1 = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                   name:@"A"
-                                                                 handle:@"a"
-                                                            accentColor:ZMAccentColor.green
-                                                       remoteIdentifier:remoteIDA
-                                                                 domain:nil
-                                                         teamIdentifier:nil
-                                                                   user:nil
-                                                       searchUsersCache:nil];
+    ZMSearchUser *user1 = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                               name:@"A"
+                                                             handle:@"a"
+                                                        accentColor:ZMAccentColor.green
+                                                   remoteIdentifier:remoteIDA
+                                                             domain:nil
+                                                     teamIdentifier:nil
+                                                               user:nil
+                                                   searchUsersCache:nil];
 
     // (1)
-    ZMSearchUser *user2 = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                   name:@"B"
-                                                                 handle:@"b"
-                                                            accentColor:ZMAccentColor.purple
-                                                       remoteIdentifier:remoteIDA
-                                                                 domain:nil
-                                                         teamIdentifier:nil
-                                                                   user:nil
-                                                       searchUsersCache:nil];
+    ZMSearchUser *user2 = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                               name:@"B"
+                                                             handle:@"b"
+                                                        accentColor:ZMAccentColor.purple
+                                                   remoteIdentifier:remoteIDA
+                                                             domain:nil
+                                                     teamIdentifier:nil
+                                                               user:nil
+                                                   searchUsersCache:nil];
 
     XCTAssertEqualObjects(user1, user2);
     XCTAssertEqual(user1.hash, user2.hash);
     
     // (2)
-    ZMSearchUser *user3 = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                   name:@"A"
-                                                                 handle:@"b"
-                                                            accentColor:ZMAccentColor.green
-                                                       remoteIdentifier:remoteIDB
-                                                                 domain:nil
-                                                         teamIdentifier:nil
-                                                                   user:nil
-                                                       searchUsersCache:nil];
+    ZMSearchUser *user3 = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                               name:@"A"
+                                                             handle:@"b"
+                                                        accentColor:ZMAccentColor.green
+                                                   remoteIdentifier:remoteIDB
+                                                             domain:nil
+                                                     teamIdentifier:nil
+                                                               user:nil
+                                                   searchUsersCache:nil];
 
     XCTAssertNotEqualObjects(user1, user3);
 }
@@ -95,15 +95,15 @@
     NSUUID *remoteID = [NSUUID createUUID];
     
     // when
-    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                        name:name
-                                                                      handle:handle
-                                                                 accentColor:ZMAccentColor.green
-                                                            remoteIdentifier:remoteID
-                                                                      domain:nil
-                                                              teamIdentifier:nil
-                                                                        user:nil
-                                                            searchUsersCache:nil];
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                                    name:name
+                                                                  handle:handle
+                                                             accentColor:ZMAccentColor.green
+                                                        remoteIdentifier:remoteID
+                                                                  domain:nil
+                                                          teamIdentifier:nil
+                                                                    user:nil
+                                                        searchUsersCache:nil];
 
     
     // then
@@ -134,15 +134,15 @@
    
     
     // when
-    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                        name:@"Wrong name"
-                                                                      handle:@"not_my_handle"
-                                                                 accentColor:ZMAccentColor.green
-                                                            remoteIdentifier:[NSUUID createUUID]
-                                                                      domain:nil
-                                                              teamIdentifier:nil
-                                                                        user:user
-                                                            searchUsersCache:nil];
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                                    name:@"Wrong name"
+                                                                  handle:@"not_my_handle"
+                                                             accentColor:ZMAccentColor.green
+                                                        remoteIdentifier:[NSUUID createUUID]
+                                                                  domain:nil
+                                                          teamIdentifier:nil
+                                                                    user:user
+                                                        searchUsersCache:nil];
 
     // then
     XCTAssertEqualObjects(searchUser.name, user.name);
@@ -162,15 +162,15 @@
 - (void)testThatItCanBeConnectedIfItIsNotAlreadyConnected
 {
     // given
-    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                        name:@"Hans"
-                                                                      handle:@"hans"
-                                                                 accentColor:ZMAccentColor.green
-                                                            remoteIdentifier:NSUUID.createUUID
-                                                                      domain:nil
-                                                              teamIdentifier:nil
-                                                                        user:nil
-                                                            searchUsersCache:nil];
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                                    name:@"Hans"
+                                                                  handle:@"hans"
+                                                             accentColor:ZMAccentColor.green
+                                                        remoteIdentifier:NSUUID.createUUID
+                                                                  domain:nil
+                                                          teamIdentifier:nil
+                                                                    user:nil
+                                                        searchUsersCache:nil];
 
     
     // then
@@ -181,15 +181,15 @@
 - (void)testThatItCanNotBeConnectedIfItHasNoRemoteIdentifier
 {
     // given
-    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithContextProvider:self.coreDataStack
-                                                                        name:@"Hans"
-                                                                      handle:@"hans"
-                                                                 accentColor:ZMAccentColor.green
-                                                            remoteIdentifier:nil
-                                                                      domain:nil
-                                                              teamIdentifier:nil
-                                                                        user:nil
-                                                            searchUsersCache:nil];
+    ZMSearchUser *searchUser = [[ZMSearchUser alloc] initWithViewContext:self.coreDataStack.viewContext
+                                                                    name:@"Hans"
+                                                                  handle:@"hans"
+                                                             accentColor:ZMAccentColor.green
+                                                        remoteIdentifier:nil
+                                                                  domain:nil
+                                                          teamIdentifier:nil
+                                                                    user:nil
+                                                        searchUsersCache:nil];
 
     // then
     XCTAssertFalse(searchUser.canBeConnected);

--- a/wire-ios-data-model/Tests/Source/Model/UserTypeTests+Materialize.swift
+++ b/wire-ios-data-model/Tests/Source/Model/UserTypeTests+Materialize.swift
@@ -97,7 +97,7 @@ final class UserTypeTests_Materialize: ModelObjectsTests {
         teamIdentifier: UUID?
     ) -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: name.capitalized,
             handle: name.lowercased(),
             accentColor: .amber,

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+Backup.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+Backup.swift
@@ -31,9 +31,9 @@ extension SessionManager {
     public func backupActiveAccount(password: String) async throws -> URL {
         guard
             let userId = accountManager.selectedAccount?.userIdentifier,
-            let clientId = activeUserSession?.selfUserClient?.remoteIdentifier,
-            let handle = activeUserSession.flatMap(ZMUser.selfUser)?.handle,
-            let activeUserSession
+            let activeUserSession,
+            let clientId = activeUserSession.selfUserClient?.remoteIdentifier,
+            let handle = ZMUser.selfUser(in: activeUserSession.viewContext).handle
         else {
             throw CreateLegacyBackupError.noActiveAccountForExport
         }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -1173,7 +1173,7 @@ public final class SessionManager: NSObject, SessionManagerType {
 
     fileprivate func registerObservers(account: Account, session: ZMUserSession) {
 
-        let selfUser = ZMUser.selfUser(inUserSession: session)
+        let selfUser = ZMUser.selfUser(in: session.viewContext)
         let teamObserver = TeamChangeInfo.add(
             observer: self,
             for: nil,

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -469,8 +469,7 @@ final class UserSessionLoader {
             accountID: accountID,
             databaseContexts: [
                 coreDataStack.viewContext,
-                coreDataStack.syncContext,
-                coreDataStack.searchContext
+                coreDataStack.syncContext
             ],
             canPerformKeyMigration: true,
             sharedUserDefaults: sharedUserDefaults,

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -469,7 +469,8 @@ final class UserSessionLoader {
             accountID: accountID,
             databaseContexts: [
                 coreDataStack.viewContext,
-                coreDataStack.syncContext
+                coreDataStack.syncContext,
+                coreDataStack.searchContext
             ],
             canPerformKeyMigration: true,
             sharedUserDefaults: sharedUserDefaults,

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ConnectToBotURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/ConnectToBotURLActionProcessor.swift
@@ -44,7 +44,7 @@ final class ConnectToBotURLActionProcessor: NSObject, URLActionProcessor {
 
         let providerIdentifier = serviceUserData.provider.transportString()
         let serviceUser = ZMSearchUser(
-            contextProvider: contextProvider,
+            viewContext: contextProvider.viewContext,
             name: "",
             handle: nil,
             accentColor: .blue,

--- a/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
+++ b/wire-ios-sync-engine/Source/UserSession/URLActionProcessors/DeepLinkURLActionProcessor.swift
@@ -209,7 +209,6 @@ class DeepLinkURLActionProcessor: URLActionProcessor {
     private func handleOpenUserProfile(id: UUID, domain: String?, delegate: PresentationDelegate?) {
 
         let viewContext = contextProvider.viewContext
-
         if let user = ZMUser.fetch(with: id, domain: domain, in: viewContext) {
             delegate?.showUserProfile(user: user)
         } else {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Authentication.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+Authentication.swift
@@ -98,8 +98,8 @@ extension ZMUserSession {
 
     public func logout(credentials: UserEmailCredentials, _ completion: @escaping (Result<Void, Error>) -> Void) {
         guard
-            let accountID = ZMUser.selfUser(inUserSession: self).remoteIdentifier,
-            let selfClientIdentifier = ZMUser.selfUser(inUserSession: self).selfClient()?.remoteIdentifier,
+            let accountID = ZMUser.selfUser(in: viewContext).remoteIdentifier,
+            let selfClientIdentifier = ZMUser.selfUser(in: viewContext).selfClient()?.remoteIdentifier,
             let apiVersion = resolvedBackendMetadata.apiVersion
         else {
             return

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+UserSession.swift
@@ -123,15 +123,15 @@ extension ZMUserSession: UserSession {
     }
 
     public var selfUser: any UserType {
-        ZMUser.selfUser(inUserSession: self)
+        ZMUser.selfUser(in: viewContext)
     }
 
     public var selfUserLegalHoldSubject: any SelfUserLegalHoldable {
-        ZMUser.selfUser(inUserSession: self)
+        ZMUser.selfUser(in: viewContext)
     }
 
     public var editableSelfUser: any EditableUserType & UserType {
-        ZMUser.selfUser(inUserSession: self)
+        ZMUser.selfUser(in: viewContext)
     }
 
     public func addUserObserver(

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Strategies/SearchUserImageStrategyTests.swift
@@ -55,7 +55,7 @@ final class SearchUserImageStrategyTests: MessagingTest {
 
     func createSearchUser() -> ZMSearchUser {
         ZMSearchUser(
-            contextProvider: coreDataStack,
+            viewContext: coreDataStack.viewContext,
             name: "Foo",
             handle: "foo",
             accentColor: .amber,

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchDirectoryTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchDirectoryTests.swift
@@ -73,7 +73,7 @@ final class SearchDirectoryTests: DatabaseTest {
 
     private func insertSearchUser(remoteIdentifier: UUID) {
         _ = ZMSearchUser(
-            contextProvider: coreDataStack!,
+            viewContext: coreDataStack!.viewContext,
             name: "John Doe",
             handle: "john",
             accentColor: .amber,

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SearchTaskTests.swift
@@ -16,10 +16,10 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-import XCTest
-
 import WireMockTransport
 import WireTransport
+import XCTest
+
 @testable import WireSyncEngine
 
 final class SearchTaskTests: DatabaseTest {

--- a/wire-ios/Wire-iOS/Sources/AuthenticatedRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AuthenticatedRouter.swift
@@ -176,8 +176,8 @@ extension AuthenticatedRouter: AuthenticatedRouterProtocol {
 
     func navigate(to destination: NavigationDestination) {
         switch destination {
-        case let .conversation(converation, message):
-            _zClientViewController?.showConversation(converation, at: message)
+        case let .conversation(conversation, message):
+            _zClientViewController?.showConversation(conversation, at: message)
         case let .connectionRequest(qualifiedID):
             _zClientViewController?.showConnectionRequest(qualifiedID: qualifiedID)
         case .conversationList:

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -456,7 +456,7 @@ final class DeveloperToolsViewModel: ObservableObject {
 
     private var selfUser: ZMUser? {
         guard let userSession else { return nil }
-        return ZMUser.selfUser(inUserSession: userSession)
+        return ZMUser.selfUser(in: userSession.viewContext)
     }
 
     private var selfClient: UserClient? {

--- a/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Self.swift
+++ b/wire-ios/Wire-iOS/Sources/Helpers/syncengine/ZMUser+Self.swift
@@ -39,7 +39,7 @@ import WireSyncEngine
             } else {
                 guard let session = ZMUserSession.shared() else { return nil }
 
-                return ZMUser.selfUser(inUserSession: session)
+                return ZMUser.selfUser(in: session.viewContext)
             }
         }
     }
@@ -52,7 +52,7 @@ import WireSyncEngine
         static func selfUser() -> ZMUser? {
             guard let session = ZMUserSession.shared() else { return nil }
 
-            return ZMUser.selfUser(inUserSession: session)
+            return ZMUser.selfUser(in: session.viewContext)
         }
     }
 #endif

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation Options/Conversation+OptionsConfiguration.swift
@@ -65,7 +65,7 @@ extension ZMConversation {
         }
 
         var isConversationFromSelfTeam: Bool {
-            let selfUser = ZMUser.selfUser(inUserSession: userSession)
+            let selfUser = ZMUser.selfUser(in: userSession.viewContext)
 
             return conversation.teamRemoteIdentifier == selfUser.teamIdentifier
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ShowContentDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientViewController+ShowContentDelegate.swift
@@ -30,7 +30,7 @@ extension ZClientViewController {
     }
 
     func showConnectionRequest(qualifiedID: QualifiedID) {
-        let searchUserViewConroller = SearchUserViewController(
+        let searchUserViewController = SearchUserViewController(
             qualifiedID: qualifiedID,
             profileViewControllerDelegate: self,
             userSession: userSession,
@@ -39,8 +39,8 @@ extension ZClientViewController {
             conversationCreationRepository: conversationCreationRepository
         )
 
-        Task {
-            await wrapInNavigationControllerAndPresent(viewController: searchUserViewConroller)
+        Task { @MainActor in
+            await wrapInNavigationControllerAndPresent(viewController: searchUserViewController)
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -288,8 +288,7 @@ final class SelfProfileViewController: UIViewController {
     private func onTeamCreationBannerInteraction(
         apiVersion: WireNetwork.APIVersion
     ) {
-        let sessionContextProvider = userSession.contextProvider
-        let user = ZMUser.selfUser(inUserSession: sessionContextProvider)
+        let user = ZMUser.selfUser(in: userSession.contextProvider.viewContext)
         guard let userName = user.normalizedName,
               let useCase = SessionManager.shared?.activeUserSession?
               .createIndividualToTeamMigrationUseCase() else {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/DebugActions.swift
@@ -166,7 +166,7 @@ enum DebugActions {
             return
         }
 
-        let selfUser = ZMUser.selfUser(inUserSession: userSession)
+        let selfUser = ZMUser.selfUser(in: userSession.viewContext)
 
         let alert = UIAlertController(
             title: "Analytics identifier",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20362" title="WPB-20362" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-20362</a>  [iOS/Integration] - Searching for Apps specifically
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR removes some unnecessary complexity by replacing `ZMUser.selfUser(inUserSession:)`.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
