### PR TITLE
chore: remove `release/cycle-4.14` from nightly tests - WPB-22722

### DIFF
--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -14,7 +14,7 @@ jobs:
   trigger_tests:
     strategy:
       matrix:
-        branch: [develop, release/cycle-4.14, release/cycle-4.15]  # List other branches here
+        branch: [develop, release/cycle-4.15]  # List other branches here
     uses: ./.github/workflows/_reusable_run_tests.yml
     with:
       all: true


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR removes `release/cycle-4.14` from nightly tests as 4.14 release is cancelled.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
