### PR TITLE
chore: add logging to help investigate hang - WPB-22986

### DIFF
--- a/WireLogging/Sources/WireLogging/LogAttributes.swift
+++ b/WireLogging/Sources/WireLogging/LogAttributes.swift
@@ -48,6 +48,7 @@ public enum LogAttributesKey: String, Comparable, Sendable {
     case syncType = "sync_type"
     case syncVersion = "sync_version"
     case workItemID = "work_item_id"
+    case isNewClient = "is_new_client"
 
     public static func < (lhs: LogAttributesKey, rhs: LogAttributesKey) -> Bool {
         lhs.rawValue < rhs.rawValue

--- a/WireLogging/Sources/WireLogging/WireLogger+MessageTime.swift
+++ b/WireLogging/Sources/WireLogging/WireLogger+MessageTime.swift
@@ -25,16 +25,9 @@ public extension WireLogger {
         attributes: LogAttributes = [:],
         block: () async throws -> T
     ) async throws -> T {
-        let startMessage = "starting \(label)"
-        info(startMessage, attributes: attributes)
-        let start = Date.now
+        let context = measureTimeStart(label: label)
         let result = try await block()
-        let durationInSeconds = start.timeIntervalSinceNow.magnitude
-        var updatedAttributes = attributes
-        let formattedDuration = String(format: "%.2f", durationInSeconds)
-        updatedAttributes[.duration] = formattedDuration
-        let completedMessage = "completed \(label)"
-        info(completedMessage, attributes: updatedAttributes)
+        measureTimeEnd(context: context)
         return result
     }
 
@@ -43,17 +36,36 @@ public extension WireLogger {
         attributes: LogAttributes = [:],
         block: () throws(E) -> T
     ) throws(E) -> T {
+        let context = measureTimeStart(label: label)
+        let result = try block()
+        measureTimeEnd(context: context)
+        return result
+    }
+
+    // MARK: - Helpers
+
+    private struct Context {
+        let start: Date
+        let label: String
+        let attributes: LogAttributes
+    }
+
+    private func measureTimeStart(
+        label: String,
+        attributes: LogAttributes = [:]
+    ) -> Context {
         let startMessage = "starting \(label)"
         info(startMessage, attributes: attributes)
-        let start = Date.now
-        let result = try block()
-        let durationInSeconds = start.timeIntervalSinceNow.magnitude
-        var updatedAttributes = attributes
+        return Context(start: Date.now, label: label, attributes: attributes)
+    }
+
+    private func measureTimeEnd(context: Context) {
+        let durationInSeconds = context.start.timeIntervalSinceNow.magnitude
+        var updatedAttributes = context.attributes
         let formattedDuration = String(format: "%.2f", durationInSeconds)
         updatedAttributes[.duration] = formattedDuration
-        let completedMessage = "completed \(label)"
+        let completedMessage = "completed \(context.label)"
         info(completedMessage, attributes: updatedAttributes)
-        return result
     }
 
 }

--- a/WireLogging/Sources/WireLogging/WireLogger+MessageTime.swift
+++ b/WireLogging/Sources/WireLogging/WireLogger+MessageTime.swift
@@ -25,7 +25,7 @@ public extension WireLogger {
         attributes: LogAttributes = [:],
         block: () async throws -> T
     ) async throws -> T {
-        let context = measureTimeStart(label: label)
+        let context = measureTimeStart(label: label, attributes: attributes)
         let result = try await block()
         measureTimeEnd(context: context)
         return result
@@ -36,7 +36,7 @@ public extension WireLogger {
         attributes: LogAttributes = [:],
         block: () throws(E) -> T
     ) throws(E) -> T {
-        let context = measureTimeStart(label: label)
+        let context = measureTimeStart(label: label, attributes: attributes)
         let result = try block()
         measureTimeEnd(context: context)
         return result
@@ -52,7 +52,7 @@ public extension WireLogger {
 
     private func measureTimeStart(
         label: String,
-        attributes: LogAttributes = [:]
+        attributes: LogAttributes
     ) -> Context {
         let startMessage = "starting \(label)"
         info(startMessage, attributes: attributes)

--- a/WireLogging/Sources/WireLogging/WireLogger+MessageTime.swift
+++ b/WireLogging/Sources/WireLogging/WireLogger+MessageTime.swift
@@ -38,4 +38,22 @@ public extension WireLogger {
         return result
     }
 
+    func measureTime<T, E: Error>(
+        label: String,
+        attributes: LogAttributes = [:],
+        block: () throws(E) -> T
+    ) throws(E) -> T {
+        let startMessage = "starting \(label)"
+        info(startMessage, attributes: attributes)
+        let start = Date.now
+        let result = try block()
+        let durationInSeconds = start.timeIntervalSinceNow.magnitude
+        var updatedAttributes = attributes
+        let formattedDuration = String(format: "%.2f", durationInSeconds)
+        updatedAttributes[.duration] = formattedDuration
+        let completedMessage = "completed \(label)"
+        info(completedMessage, attributes: updatedAttributes)
+        return result
+    }
+
 }

--- a/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/StrategyDirectory.swift
@@ -310,7 +310,7 @@ public class StrategyDirectory: NSObject, StrategyDirectoryProtocol {
         ]
     }
 
-    func makeClientRelatedStategies(
+    func makeClientRelatedStrategies(
         applicationStatusDirectory: ApplicationStatusDirectory,
         syncContext: NSManagedObjectContext,
         transportSession: TransportSessionType,

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -659,15 +659,19 @@ public final class ZMUserSession: NSObject {
                 syncAgent: syncAgent,
                 notificationContext: notificationContext
             )
-            strategyDirectory.makeClientRelatedStategies(
-                applicationStatusDirectory: applicationStatusDirectory,
-                syncContext: syncContext,
-                transportSession: transportSession,
-                pushMessageHandler: localNotificationDispatcher,
-                flowManager: flowManager,
-                incrementalSyncObserver: incrementalSyncObserver,
-                metadata: resolvedBackendMetadata
-            )
+
+            // TODO: [WPB-22986] Remove logging - added this logging temporarily to investigate a hang.
+            WireLogger.session.measureTime(label: "make client strategies") {
+                strategyDirectory.makeClientRelatedStrategies(
+                    applicationStatusDirectory: applicationStatusDirectory,
+                    syncContext: syncContext,
+                    transportSession: transportSession,
+                    pushMessageHandler: localNotificationDispatcher,
+                    flowManager: flowManager,
+                    incrementalSyncObserver: incrementalSyncObserver,
+                    metadata: resolvedBackendMetadata
+                )
+            }
             syncStrategy?.updateClientContextChangeTrackers()
         }
         Task {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -612,12 +612,12 @@ public final class ZMUserSession: NSObject {
 
             // Create and perform sync if there is a self client.
             if let selfClientID = selfUserClient.remoteIdentifier {
-                setUpSyncAgent(clientID: selfClientID)
+                setUpSyncAgent(clientID: selfClientID, isNewClient: false)
             }
         }
     }
 
-    func setUpSyncAgent(clientID: String) {
+    func setUpSyncAgent(clientID: String, isNewClient: Bool) {
         let clientSessionComponent = userSessionComponent.clientSessionComponent(
             clientID: clientID,
             completionHandlers: .init(
@@ -661,7 +661,7 @@ public final class ZMUserSession: NSObject {
             )
 
             // TODO: [WPB-22986] Remove logging - added this logging temporarily to investigate a hang.
-            WireLogger.session.measureTime(label: "make client strategies") {
+            WireLogger.session.measureTime(label: "make client strategies", attributes: [.isNewClient: isNewClient]) {
                 strategyDirectory.makeClientRelatedStrategies(
                     applicationStatusDirectory: applicationStatusDirectory,
                     syncContext: syncContext,
@@ -1393,7 +1393,7 @@ extension ZMUserSession: ZMClientRegistrationStatusDelegate {
         // The client was just registered and still needs to perform the
         // initial sync.
         if let selfClientID = userClient.remoteIdentifier {
-            setUpSyncAgent(clientID: selfClientID)
+            setUpSyncAgent(clientID: selfClientID, isNewClient: true)
             // no migration needed from last sync system as it's a new client
             if userClient.isConsumableNotificationsCapable {
                 // activate new sync with consumable notifications

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests.swift
@@ -419,7 +419,7 @@ final class ZMUserSessionTests: ZMUserSessionTestsBase {
             sut.didRegisterSelfUserClient(selfUserClient)
             syncMOC.saveOrRollback()
 
-            sut.setUpSyncAgent(clientID: selfUserClient.remoteIdentifier!)
+            sut.setUpSyncAgent(clientID: selfUserClient.remoteIdentifier!, isNewClient: false)
 
             // WHEN
             sut.didFinishIncrementalSync(isRecovering: false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22986" title="WPB-22986" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22986</a>  [iOS] WireSyncEngine: ZMUserSession.setUpSyncAgent(clientID:)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

One of our common hangs is one which takes place in `ZMUserSession.setUpSyncAgent(clientID:)` due to a call to `NSManagedObjectContext.performAndWait(_:)` - see ticket for more details.

I'm unable to reproduce any issue here so with this PR I'm just adding some logging. My hope is to catch incidences of a hang in Beta so that I can investigate better what is happening via beta logs.

In this PR I also made some changes to `WireLogger.measureTime` to allow for working with non async code.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
