### PR TITLE
fix: replace attachment menu with alert - WPB-21656

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "conversation.channelHistory.fetchChannelHistoryDepthOptions.error" = "An error occurred while fetching channel history depth options.";
 "conversation.channelHistory.updateHistoryDepth.error" = "An error occurred while updating channel history depth.";
 "conversation.file.preview.open" = "Open preview";
+"conversation.draft.attachmentMenu.errorTitle" = "Unable to load file";
 "conversation.draft.attachmentMenu.retry" = "Retry";
 "conversation.draft.attachmentMenu.remove" = "Remove File";
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsCarousel/AttachmentsCarousel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsCarousel/AttachmentsCarousel.swift
@@ -67,6 +67,8 @@ private struct AttachmentsCarouselItemView: View {
         static let buttonCornerRadius: CGFloat = 24
     }
 
+    @State private var showErrorAlert = false
+
     let item: AttachmentsCarouselItem
     let onTap: () -> Void
     let onRemove: () -> Void
@@ -83,7 +85,15 @@ private struct AttachmentsCarouselItemView: View {
             .padding(.trailing, Constants.trailingPadding)
 
             cornerButton
-        }
+        }.alert(
+            L10n.Localizable.Conversation.Draft.AttachmentMenu.errorTitle,
+            isPresented: $showErrorAlert,
+            actions: {
+                Button(L10n.Localizable.Conversation.Draft.AttachmentMenu.remove, action: { onRemove() })
+                Button(L10n.Localizable.Conversation.Draft.AttachmentMenu.retry, action: { onRetry() })
+
+            }
+        )
     }
 
     @ViewBuilder var content: some View {
@@ -119,9 +129,8 @@ private struct AttachmentsCarouselItemView: View {
                 Spacer()
 
                 if item.state.isFailed {
-                    Menu {
-                        Button(L10n.Localizable.Conversation.Draft.AttachmentMenu.retry, action: onRetry)
-                        Button(L10n.Localizable.Conversation.Draft.AttachmentMenu.remove, action: onRemove)
+                    Button {
+                        showErrorAlert = true
                     } label: {
                         Image(systemName: "ellipsis.circle.fill")
                             .resizable()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21656" title="WPB-21656" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21656</a>  [iOS] Sorting in all files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR replaces the attachment Menu that shows up when a file could not be uploaded as it was introducing a UI bug when the keyboard was showing. As discussed with design team, we prefer to display an alert instead to avoid that bug.

<img width="1206" height="2622" alt="Simulator Screenshot - Snapshots - 2026-02-05 at 15 12 24" src="https://github.com/user-attachments/assets/e07e310b-9913-4b82-a8d2-cb1917445816" />

### Testing

have an attachment uploaded that ends up in error, tap on the "elipsis" button in top right corner of the attachment. Before it was showing a context menu, now it displays an alert, same actions as before (remove file or retry).

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
