### PR TITLE
fix: incorrect empty search state - WPB-23034

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Accessibility.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Accessibility.strings
@@ -32,6 +32,8 @@
 "conversation.wireCells.files.loadMore.title" = "Load more";
 "conversation.wireCells.files.noData.title" = "There are no files or folders yet";
 "conversation.wireCells.files.noData.message" = "You'll find all files and folders shared in this conversation here";
+"conversation.wireCells.files.noSearchResults.title" = "No results found";
+"conversation.wireCells.files.noSearchResults.message" = "Try adjusting your search.";
 "conversation.wireCells.files.pendingCells.title" = "Files are loading";
 "conversation.wireCells.files.pendingCells.message" = "Your documents and media files will be available here once we've uploaded all files and folders.";
 "conversation.wireCells.allFiles.noData.message" = "You'll find all files and folders shared across your conversations here.";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -139,6 +139,8 @@
 "conversation.wireCells.allFiles.noData.title" = "There are no files yet";
 "conversation.wireCells.allFiles.noData.message" = "For conversations that use shared Drive, you'll find all files here.";
 "conversation.wireCells.allFiles.noData.learnMore" = "Learn more";
+"conversation.wireCells.files.noSearchResults.title" = "No results found";
+"conversation.wireCells.files.noSearchResults.message" = "Try adjusting your search.";
 "conversation.wireCells.files.pendingCells.title" = "Files are loading";
 "conversation.wireCells.files.pendingCells.message" = "Your documents and media files will be available here once we've uploaded all files and folders.";
 "conversation.wireCells.files.error.title" = "Can't load files";

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesInfoView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesInfoView.swift
@@ -27,7 +27,7 @@ struct FilesInfoView: View {
 
     enum Info: Equatable {
         case preparingFiles
-        case noFilesFound(scope: Scope)
+        case noFilesFound(scope: Scope, isSearch: Bool)
         case error(isConnectionError: Bool)
 
         enum Scope: Equatable {
@@ -47,19 +47,27 @@ struct FilesInfoView: View {
             }
         }
 
-        func textForScope(_ scope: Scope) -> String {
-            switch scope {
-            case .allConversations: Strings.AllFiles.NoData.message
-            case .oneConversation: Strings.Files.NoData.message
-            case .recycleBin: Strings.RecycleBin.NoData.message
+        func textFor(scope: Scope, isSearch: Bool) -> String {
+            if isSearch {
+                Strings.Files.NoSearchResults.message
+            } else {
+                switch scope {
+                case .allConversations: Strings.AllFiles.NoData.message
+                case .oneConversation: Strings.Files.NoData.message
+                case .recycleBin: Strings.RecycleBin.NoData.message
+                }
             }
         }
 
-        func accessibilityTextForScope(_ scope: Scope) -> String {
-            switch scope {
-            case .allConversations: Accessibility.AllFiles.NoData.message
-            case .oneConversation: Accessibility.Files.NoData.message
-            case .recycleBin: Accessibility.RecycleBin.NoData.message
+        func accessibilityTextFor(scope: Scope, isSearch: Bool) -> String {
+            if isSearch {
+                Accessibility.Files.NoSearchResults.message
+            } else {
+                switch scope {
+                case .allConversations: Accessibility.AllFiles.NoData.message
+                case .oneConversation: Accessibility.Files.NoData.message
+                case .recycleBin: Accessibility.RecycleBin.NoData.message
+                }
             }
         }
 
@@ -67,11 +75,12 @@ struct FilesInfoView: View {
             switch self {
             case .preparingFiles:
                 (Strings.Files.PendingCells.title, Strings.Files.PendingCells.message)
-            case let .noFilesFound(scope):
+            case let .noFilesFound(scope, isSearch):
                 (
-                    scope == .oneConversation || scope == .recycleBin ?
+                    isSearch ? Strings.Files.NoSearchResults.title :
+                        scope == .oneConversation || scope == .recycleBin ?
                         Strings.Files.NoData.title : Strings.AllFiles.NoData.title,
-                    textForScope(scope)
+                    textFor(scope: scope, isSearch: isSearch)
                 )
             case let .error(isConnectionError):
                 if isConnectionError {
@@ -86,10 +95,10 @@ struct FilesInfoView: View {
             switch self {
             case .preparingFiles:
                 (Accessibility.Files.PendingCells.title, Accessibility.Files.PendingCells.message)
-            case let .noFilesFound(scope):
+            case let .noFilesFound(scope, isSearch):
                 (
                     Accessibility.Files.NoData.title,
-                    accessibilityTextForScope(scope)
+                    accessibilityTextFor(scope: scope, isSearch: isSearch)
                 )
             case let .error(isConnectionError):
                 if isConnectionError {
@@ -104,11 +113,18 @@ struct FilesInfoView: View {
             switch self {
             case .preparingFiles:
                 ("preparing-files-title", "preparing-files-message")
-            case let .noFilesFound(scope):
-                (
-                    "no-files-title",
-                    scope == .allConversations ? "no-files-all-conversations-message" : "no-files-message"
-                )
+            case let .noFilesFound(scope, isSearch):
+                if isSearch {
+                    (
+                        "no-files-search-title",
+                        "no-files-search-message"
+                    )
+                } else {
+                    (
+                        "no-files-title",
+                        scope == .allConversations ? "no-files-all-conversations-message" : "no-files-message"
+                    )
+                }
             case .error:
                 ("error-title", "error-message")
             }
@@ -138,8 +154,10 @@ struct FilesInfoView: View {
                 .accessibilityIdentifier(info.accessibilityIdentifiers.message)
 
             switch info {
-            case let .noFilesFound(scope):
-                learnMoreLink(scope: scope)
+            case let .noFilesFound(scope, isSearch):
+                if !isSearch {
+                    learnMoreLink(scope: scope)
+                }
             case .error:
                 retryButton
             default:
@@ -194,15 +212,19 @@ struct FilesInfoView: View {
 }
 
 #Preview("no files found - single conversation") {
-    FilesInfoView(info: .noFilesFound(scope: .oneConversation))
+    FilesInfoView(info: .noFilesFound(scope: .oneConversation, isSearch: false))
 }
 
 #Preview("no files found - all conversations") {
-    FilesInfoView(info: .noFilesFound(scope: .allConversations))
+    FilesInfoView(info: .noFilesFound(scope: .allConversations, isSearch: false))
 }
 
 #Preview("no files found - recycle bin") {
-    FilesInfoView(info: .noFilesFound(scope: .recycleBin))
+    FilesInfoView(info: .noFilesFound(scope: .recycleBin, isSearch: false))
+}
+
+#Preview("no files found via search - all conversations") {
+    FilesInfoView(info: .noFilesFound(scope: .allConversations, isSearch: true))
 }
 
 struct LoadMoreView: View {

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewProtocol.swift
@@ -65,8 +65,11 @@ extension FilesViewProtocol {
     @ViewBuilder private var listBackgroundView: some View {
         switch viewModel.state {
         case let .received(items) where items.isEmpty:
-            FilesInfoView(info: .noFilesFound(
-                scope: viewModel.isRecycleBin ? .recycleBin : isBrowsing ? .allConversations : .oneConversation)
+            FilesInfoView(
+                info: .noFilesFound(
+                    scope: viewModel.isRecycleBin ? .recycleBin : isBrowsing ? .allConversations : .oneConversation,
+                    isSearch: !viewModel.searchText.isEmpty
+                )
             )
         case .pending:
             FilesInfoView(info: .preparingFiles)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23034" title="WPB-23034" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23034</a>  [iOS] Incorrect empty state displayed when search returns no results
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Added an `isSearch` parameter and new text strings for the "no search results" state.

### Testing

Go to a Files list and search for a file.
When there are no search results, the new empty search state should be visible.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
