### PR TITLE
fix(ci): missing app icon build number on beta builds - WPB-23367

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -174,6 +174,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          
+      - name: Install ImageMagick
+        uses: gerlero/brew-install@v1
+        with:
+          packages: imagemagick
+          
       - name: Run setup
         run: sh ./setup.sh
       - name: Configure AWS Credentials


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23367" title="WPB-23367" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23367</a>  [iOS] CI missing build number on beta
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Since this morning, the beta app is missing the build number on the app icon. This is due to a [image update ](https://github.com/cirruslabs/macos-image-templates/releases/tag/26.3-rc) on cirrus-ci that does not explicitly install imagemagick.

* add step to install imagemagick

### Testing

* ~run playground build from this branch~
-> this needs to be merged on develop too
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
