### PR TITLE
fix: crash on critical flows - WPB-20367

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+AccessToken.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+AccessToken.swift
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireLogging
+
+protocol AccessTokenRenewalObserver: AnyObject {
+    func accessTokenRenewalDidSucceed()
+    func accessTokenRenewalDidFail()
+}
+
+protocol AccessTokenRenewing {
+    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver)
+    func renewAccessToken(with clientID: String)
+}
+
+extension ZMUserSession: AccessTokenRenewing {
+
+    func renewAccessToken(with clientID: String) {
+        WireLogger.session.debug("⚠️ renewAccessToken clientID: \(clientID)")
+        transportSession.renewAccessToken(with: clientID)
+    }
+
+    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver) {
+        accessTokenRenewalObserver = observer
+    }
+
+    func transportSessionAccessTokenDidFail(response: ZMTransportResponse) {
+        WireLogger.authentication.error("⚠️ access token renewal failed: response status: \(response.errorInfo)")
+
+        managedObjectContext.performGroupedBlock { [weak self] in
+            guard let self else { return }
+            let selfUser = ZMUser.selfUser(in: managedObjectContext)
+            let error = NSError.userSessionError(
+                code: .accessTokenExpired,
+                userInfo: selfUser.loginCredentials.dictionaryRepresentation
+            )
+            notifyAuthenticationInvalidated(error)
+        }
+
+        accessTokenRenewalObserver?.accessTokenRenewalDidFail()
+        accessTokenRenewalObserver = nil
+    }
+
+    func transportSessionAccessTokenDidSucceed() {
+        WireLogger.authentication.info("⚠️ access token renewal did succeed")
+        accessTokenRenewalObserver?.accessTokenRenewalDidSucceed()
+        accessTokenRenewalObserver = nil
+    }
+}

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+AccessToken.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+AccessToken.swift
@@ -19,11 +19,6 @@
 import Foundation
 import WireLogging
 
-protocol AccessTokenRenewalObserver: AnyObject {
-    func accessTokenRenewalDidSucceed()
-    func accessTokenRenewalDidFail()
-}
-
 protocol AccessTokenRenewing {
     func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver)
     func renewAccessToken(with clientID: String)
@@ -32,16 +27,12 @@ protocol AccessTokenRenewing {
 extension ZMUserSession: AccessTokenRenewing {
 
     func renewAccessToken(with clientID: String) {
-        WireLogger.session.debug("⚠️ renewAccessToken clientID: \(clientID)")
+        WireLogger.session.debug("🎟️🔓 renewAccessToken clientID: \(clientID)")
         transportSession.renewAccessToken(with: clientID)
     }
 
-    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver) {
-        accessTokenRenewalObserver = observer
-    }
-
     func transportSessionAccessTokenDidFail(response: ZMTransportResponse) {
-        WireLogger.authentication.error("⚠️ access token renewal failed: response status: \(response.errorInfo)")
+        WireLogger.authentication.error("🎟️🔓 access token renewal failed: response status: \(response.errorInfo)")
 
         managedObjectContext.performGroupedBlock { [weak self] in
             guard let self else { return }
@@ -52,14 +43,9 @@ extension ZMUserSession: AccessTokenRenewing {
             )
             notifyAuthenticationInvalidated(error)
         }
-
-        accessTokenRenewalObserver?.accessTokenRenewalDidFail()
-        accessTokenRenewalObserver = nil
     }
 
     func transportSessionAccessTokenDidSucceed() {
-        WireLogger.authentication.info("⚠️ access token renewal did succeed")
-        accessTokenRenewalObserver?.accessTokenRenewalDidSucceed()
-        accessTokenRenewalObserver = nil
+        WireLogger.authentication.info("🎟️🔓 access token renewal did succeed")
     }
 }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+AccessToken.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+AccessToken.swift
@@ -20,7 +20,6 @@ import Foundation
 import WireLogging
 
 protocol AccessTokenRenewing {
-    func setAccessTokenRenewalObserver(_ observer: AccessTokenRenewalObserver)
     func renewAccessToken(with clientID: String)
 }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -73,8 +73,6 @@ public final class ZMUserSession: NSObject {
     private(set) var urlActionProcessors: [URLActionProcessor]?
     let debugCommands: [String: DebugCommand]
 
-    var accessTokenRenewalObserver: AccessTokenRenewalObserver?
-
     var recurringActionService: any RecurringActionServiceInterface
 
     private(set) var coreCryptoProvider: CoreCryptoProviderProtocol
@@ -1026,7 +1024,8 @@ public final class ZMUserSession: NSObject {
     // MARK: Access Token
 
     private func renewAccessTokenIfNeeded(for userClient: WireDataModel.UserClient) {
-        WireLogger.session.debug("⚠️ renewAccessTokenIfNeeded")
+        WireLogger.session.debug("🎟️🔓 renewAccessTokenIfNeeded")
+        // apparently it is needed once we got a new userClient so we can send messages
         guard
             let apiVersion = resolvedBackendMetadata.apiVersion,
             apiVersion > .v2,

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -73,6 +73,8 @@ public final class ZMUserSession: NSObject {
     private(set) var urlActionProcessors: [URLActionProcessor]?
     let debugCommands: [String: DebugCommand]
 
+    var accessTokenRenewalObserver: AccessTokenRenewalObserver?
+
     var recurringActionService: any RecurringActionServiceInterface
 
     private(set) var coreCryptoProvider: CoreCryptoProviderProtocol
@@ -777,21 +779,9 @@ public final class ZMUserSession: NSObject {
         transportSession.setAccessTokenRenewalFailureHandler { [weak self] response in
             self?.transportSessionAccessTokenDidFail(response: response)
         }
-    }
-
-    private func transportSessionAccessTokenDidFail(response: ZMTransportResponse) {
-        WireLogger.authentication.error("access token renewal failed: response status: \(response.errorInfo)")
-
-        managedObjectContext.performGroupedBlock { [weak self] in
-            guard let self else { return }
-            let selfUser = ZMUser.selfUser(in: managedObjectContext)
-            let error = NSError.userSessionError(
-                code: .accessTokenExpired,
-                userInfo: selfUser.loginCredentials.dictionaryRepresentation
-            )
-            notifyAuthenticationInvalidated(error)
+        transportSession.setAccessTokenRenewalSuccessHandler { [weak self]  _, _ in
+            self?.transportSessionAccessTokenDidSucceed()
         }
-
     }
 
     private func createStrategyDirectory() -> StrategyDirectoryProtocol {
@@ -1031,6 +1021,19 @@ public final class ZMUserSession: NSObject {
             await conversationEventProcessor.processAndSaveConversationEvents(events)
             completion?()
         }
+    }
+
+    // MARK: Access Token
+
+    private func renewAccessTokenIfNeeded(for userClient: WireDataModel.UserClient) {
+        WireLogger.session.debug("⚠️ renewAccessTokenIfNeeded")
+        guard
+            let apiVersion = resolvedBackendMetadata.apiVersion,
+            apiVersion > .v2,
+            let clientID = userClient.remoteIdentifier
+        else { return }
+
+        renewAccessToken(with: clientID)
     }
 
     // MARK: Perform changes
@@ -1350,6 +1353,7 @@ extension ZMUserSession: ZMClientRegistrationStatusDelegate {
 
     public func didRegisterSelfUserClient(_ userClient: WireDataModel.UserClient) {
         registerCurrentPushToken()
+        renewAccessTokenIfNeeded(for: userClient)
 
         managedObjectContext.performGroupedBlock { [weak self] in
             guard

--- a/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
+++ b/wire-ios-sync-engine/WireSyncEngine.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@
 		EE1108F923D1F945005DC663 /* TypingUsersTimeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1108F823D1F945005DC663 /* TypingUsersTimeout.swift */; };
 		EE1108FB23D2087F005DC663 /* Typing.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1108FA23D2087F005DC663 /* Typing.swift */; };
 		EE13BD8B2BC948FC006561F8 /* ZMUserSession+APIAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE13BD8A2BC948FC006561F8 /* ZMUserSession+APIAdapter.swift */; };
+		63CD5958296434A700385037 /* ZMUserSession+AccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CD59562964346400385037 /* ZMUserSession+AccessToken.swift */; };
 		EE1DEBB323D5A6930087EE1F /* TypingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBB223D5A6930087EE1F /* TypingTests.swift */; };
 		EE1DEBB523D5AEE50087EE1F /* TypingUsersTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBB423D5AEE50087EE1F /* TypingUsersTimeoutTests.swift */; };
 		EE1DEBB723D5B62C0087EE1F /* TypingUsersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1DEBB623D5B62C0087EE1F /* TypingUsersTests.swift */; };
@@ -975,6 +976,7 @@
 		EE1108F823D1F945005DC663 /* TypingUsersTimeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingUsersTimeout.swift; sourceTree = "<group>"; };
 		EE1108FA23D2087F005DC663 /* Typing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typing.swift; sourceTree = "<group>"; };
 		EE13BD8A2BC948FC006561F8 /* ZMUserSession+APIAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+APIAdapter.swift"; sourceTree = "<group>"; };
+		63CD59562964346400385037 /* ZMUserSession+AccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMUserSession+AccessToken.swift"; sourceTree = "<group>"; };
 		EE1DEBB223D5A6930087EE1F /* TypingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingTests.swift; sourceTree = "<group>"; };
 		EE1DEBB423D5AEE50087EE1F /* TypingUsersTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingUsersTimeoutTests.swift; sourceTree = "<group>"; };
 		EE1DEBB623D5B62C0087EE1F /* TypingUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingUsersTests.swift; sourceTree = "<group>"; };
@@ -2111,6 +2113,7 @@
 				166B2B5D23E86522003E8581 /* ZMUserSession.swift */,
 				EE5B851F2CAADB9F00A8ADF7 /* ZMUserSession+AnalyticsUser.swift */,
 				EE13BD8A2BC948FC006561F8 /* ZMUserSession+APIAdapter.swift */,
+				63CD59562964346400385037 /* ZMUserSession+AccessToken.swift */,
 				164EAF9B1F4455FA00B628C4 /* ZMUserSession+Actions.swift */,
 				EEE186B3259CC92D008707CA /* ZMUserSession+AppLock.swift */,
 				16E0FB86232F8933000E3235 /* ZMUserSession+Authentication.swift */,
@@ -2975,6 +2978,7 @@
 				63B1FADB2763A636000766F8 /* ZMUser+AVSIdentifier.swift in Sources */,
 				A95D0B1223F6B75A0057014F /* AVSLogObserver.swift in Sources */,
 				EE13BD8B2BC948FC006561F8 /* ZMUserSession+APIAdapter.swift in Sources */,
+				63CD5958296434A700385037 /* ZMUserSession+AccessToken.swift in Sources */,
 				E9E4D4712C2AD61500364352 /* TeamRole+AnalyticsValue.swift in Sources */,
 				5E8BB8A22147F89000EEA64B /* CallCenterSupport.swift in Sources */,
 				1660AA0D1ECDB0250056D403 /* SearchTask.swift in Sources */,

--- a/wire-ios-transport/Source/Public/ZMTransportSession.h
+++ b/wire-ios-transport/Source/Public/ZMTransportSession.h
@@ -127,6 +127,9 @@ extern NSString * const ZMTransportSessionReachabilityIsEnabled;
 /// Sets the access token failure callback. This can be called only before the first request is fired
 - (void)setAccessTokenRenewalFailureHandler:(ZMCompletionHandlerBlock)handler NS_SWIFT_NAME(setAccessTokenRenewalFailureHandler(_:));
 
+/// Sets the access token success callback
+- (void)setAccessTokenRenewalSuccessHandler:(ZMAccessTokenHandlerBlock)handler NS_SWIFT_NAME(setAccessTokenRenewalSuccessHandler(_:));
+
 /// Renews the access token passing the client ID as query parameter
 - (void)renewAccessTokenWithClientID:(NSString *)clientID NS_SWIFT_NAME(renewAccessToken(with:));
 

--- a/wire-ios-transport/Source/TransportSession/TransportSession.swift
+++ b/wire-ios-transport/Source/TransportSession/TransportSession.swift
@@ -41,6 +41,9 @@ public protocol TransportSessionType: ZMBackgroundable, ZMRequestCancellation, T
     @objc(setAccessTokenRenewalFailureHandler:)
     func setAccessTokenRenewalFailureHandler(_ handler: @escaping ZMCompletionHandlerBlock)
 
+    @objc(setAccessTokenRenewalSuccessHandler:)
+    func setAccessTokenRenewalSuccessHandler(_ handler: @escaping ZMAccessTokenHandlerBlock)
+
     func setNetworkStateDelegate(_ delegate: ZMNetworkStateDelegate?)
 
     @objc(addCompletionHandlerForBackgroundSessionWithIdentifier:handler:)

--- a/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
+++ b/wire-ios-transport/Source/TransportSession/ZMTransportSession.m
@@ -767,6 +767,11 @@ static NSInteger const DefaultMaximumRequests = 6;
     [self.accessTokenHandler setAccessTokenRenewalFailureHandler:handler];
 }
 
+- (void)setAccessTokenRenewalSuccessHandler:(ZMAccessTokenHandlerBlock)handler;
+{
+    [self.accessTokenHandler setAccessTokenRenewalSuccessHandler:handler];
+}
+
 - (void)renewAccessTokenWithClientID:(NSString *)clientID
 {
     [self.accessTokenHandler sendAccessTokenRequestWithURLSession:self.sessionsDirectory.foregroundSession clientID:clientID];

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -200,11 +200,11 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
                 return NSIntersectionRange(linkRange, mentionRange).length > 0
             }
 
-            if !isOverlappingMention {
+            if let link = result.url, !isOverlappingMention {
                 mutableAttributedText.addAttributes([
                     .foregroundColor: detectedLinkForegroundColor,
                     .underlineStyle: NSUnderlineStyle.single.rawValue,
-                    .link: result.url!
+                    .link: link
                 ], range: linkRange)
             }
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-20367" title="WPB-20367" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-20367</a>  [iOS] Mentions in chat bubbles should not be underlined
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following #4294 , there was a forced unwrapped value in code, that made the critical flows crashed.

Following https://github.com/wireapp/wire-ios/pull/4132, the renewAccessToken was removed when the client just registered. This seems to be required to send messages right after

### Testing

- [x] run critical flows https://github.com/wireapp/wire-ios/actions/runs/21942379649
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
