### PR TITLE
fix: background fetch tasks accumulate & interfere with sync - WPB-23451

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/ApplicationStatusDirectory.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/ApplicationStatusDirectory.swift
@@ -85,7 +85,7 @@ public final class ApplicationStatusDirectory: NSObject, ApplicationStatus {
         switch operationStatus.operationState {
         case .foreground:
             .foreground
-        case .background, .backgroundCall, .backgroundFetch, .backgroundTask:
+        case .background, .backgroundCall, .backgroundTask:
             .background
         }
     }

--- a/wire-ios-sync-engine/Source/UserSession/OperationStatus.swift
+++ b/wire-ios-sync-engine/Source/UserSession/OperationStatus.swift
@@ -19,8 +19,6 @@
 import Foundation
 import WireLogging
 
-public typealias BackgroundFetchHandler = (_ fetchResult: UIBackgroundFetchResult) -> Void
-
 public typealias BackgroundTaskHandler = (_ taskResult: BackgroundTaskResult) -> Void
 
 private let zmLog = ZMSLog(tag: "OperationStatus")
@@ -49,10 +47,6 @@ public enum SyncEngineOperationState: UInt, CustomStringConvertible {
 
     case backgroundCall
 
-    /// The app is active in the background to perform a background fetch.
-
-    case backgroundFetch
-
     /// The app is active in the background to perform a background task.
 
     case backgroundTask
@@ -69,9 +63,6 @@ public enum SyncEngineOperationState: UInt, CustomStringConvertible {
         case .backgroundCall:
             "backgroundCall"
 
-        case .backgroundFetch:
-            "backgroundFetch"
-
         case .backgroundTask:
             "backgroundTask"
 
@@ -86,14 +77,7 @@ public class OperationStatus: NSObject {
 
     public weak var delegate: OperationStatusDelegate?
 
-    private var backgroundFetchTimer: Timer?
     private var backgroundTaskTimer: Timer?
-
-    private var backgroundFetchHandler: BackgroundFetchHandler? {
-        didSet {
-            updateOperationState()
-        }
-    }
 
     private var backgroundTaskHandler: BackgroundTaskHandler? {
         didSet {
@@ -119,29 +103,6 @@ public class OperationStatus: NSObject {
         }
     }
 
-    public func startBackgroundFetch(withCompletionHandler completionHandler: @escaping BackgroundFetchHandler) {
-        startBackgroundFetch(timeout: 30.0, withCompletionHandler: completionHandler)
-    }
-
-    public func startBackgroundFetch(
-        timeout: TimeInterval,
-        withCompletionHandler completionHandler: @escaping BackgroundFetchHandler
-    ) {
-        guard backgroundFetchHandler == nil else {
-            return completionHandler(.failed)
-        }
-
-        backgroundFetchHandler = completionHandler
-        backgroundFetchTimer = Timer.scheduledTimer(
-            timeInterval: timeout,
-            target: self,
-            selector: #selector(backgroundFetchTimeout),
-            userInfo: nil,
-            repeats: false
-        )
-        RequestAvailableNotification.notifyNewRequestsAvailable(self)
-    }
-
     public func startBackgroundTask(withCompletionHandler completionHandler: @escaping BackgroundTaskHandler) {
         startBackgroundTask(timeout: 30.0, withCompletionHandler: completionHandler)
     }
@@ -164,22 +125,8 @@ public class OperationStatus: NSObject {
         )
     }
 
-    func backgroundFetchTimeout() {
-        finishBackgroundFetch(withFetchResult: .failed)
-    }
-
     func backgroundTaskTimeout() {
         finishBackgroundTask(withTaskResult: .failed)
-    }
-
-    public func finishBackgroundFetch(withFetchResult result: UIBackgroundFetchResult) {
-        backgroundFetchTimer?.invalidate()
-        backgroundFetchTimer = nil
-        DispatchQueue.main.async {
-            WireLogger.appState.info("end background fetch", attributes: .safePublic)
-            self.backgroundFetchHandler?(result)
-            self.backgroundFetchHandler = nil
-        }
     }
 
     public func finishBackgroundTask(withTaskResult result: BackgroundTaskResult) {
@@ -206,10 +153,6 @@ public class OperationStatus: NSObject {
 
             if hasOngoingCall {
                 return .backgroundCall
-            }
-
-            if backgroundFetchHandler != nil {
-                return .backgroundFetch
             }
 
             if backgroundTaskHandler != nil {

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+LifeCycle.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession+LifeCycle.swift
@@ -30,32 +30,6 @@ public extension ZMUserSession {
 
     func application(
         _ application: ZMApplication,
-        performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
-    ) {
-        // TODO: [WPB-17583] re-enable background fetch for new sync.
-        guard !journal[.isSyncV2Enabled] else {
-            WireLogger.sync.debug("background fetch is triggered")
-            Task {
-                WireLogger.sync.debug("Sync already running: \(syncAgent?.syncRunning ?? false)")
-                await self.syncAgent?.suspend()
-                WireLogger.sync.debug("Sync suspended")
-                completionHandler(.noData)
-            }
-            // disable background fetch
-            application.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalNever)
-            return
-        }
-
-        BackgroundActivityFactory.shared.resume()
-
-        syncManagedObjectContext.performGroupedBlock {
-            self.applicationStatusDirectory.operationStatus
-                .startBackgroundFetch(withCompletionHandler: completionHandler)
-        }
-    }
-
-    func application(
-        _ application: ZMApplication,
         handleEventsForBackgroundURLSession identifier: String,
         completionHandler: @escaping () -> Void
     ) {

--- a/wire-ios-sync-engine/Tests/Source/UserSession/OperationStatusTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/OperationStatusTests.swift
@@ -84,29 +84,6 @@ final class OperationStatusTests: MessagingTest {
         XCTAssertEqual(sut.operationState, .background)
     }
 
-    func testThatBackgroundFetchIsUpdatingOperationState() {
-
-        // given
-        sut.isInBackground = true
-        let handlerCalled = customExpectation(description: "background fetch handler called")
-
-        // when
-        sut.startBackgroundFetch(withCompletionHandler: { _ in
-            handlerCalled.fulfill()
-        })
-
-        // then
-        XCTAssertEqual(sut.operationState, .backgroundFetch)
-        wait(for: [XCTestExpectation().inverted()], timeout: 0.05)
-
-        // when
-        sut.finishBackgroundFetch(withFetchResult: .noData)
-        wait(for: [XCTestExpectation().inverted()], timeout: 0.05)
-
-        // then
-        XCTAssertEqual(sut.operationState, .background)
-    }
-
     func testThatStartingMultipleBackgroundTasksFail() {
 
         let successHandler = customExpectation(description: "background task handler called with success result")
@@ -131,52 +108,11 @@ final class OperationStatusTests: MessagingTest {
         sut.finishBackgroundTask(withTaskResult: .finished)
     }
 
-    func testThatStartingMultipleBackgroundFetchesFail() {
-
-        let successHandler = customExpectation(description: "background fetch handler called with success result")
-        let failureHandler = customExpectation(description: "background fetch handler called with failure result")
-
-        // given
-        sut.startBackgroundFetch(withCompletionHandler: { result in
-            // expect
-            if result == UIBackgroundFetchResult.noData {
-                successHandler.fulfill()
-            }
-        })
-
-        // when
-        sut.startBackgroundFetch(withCompletionHandler: { result in
-            // expect
-            if result == UIBackgroundFetchResult.failed {
-                failureHandler.fulfill()
-            }
-        })
-
-        sut.finishBackgroundFetch(withFetchResult: .noData)
-    }
-
     func testBackgroundTaskFailAfterTimeout() {
         let failureHandler = customExpectation(description: "background task handler called with failure result")
 
         // given
         sut.startBackgroundTask(timeout: 1.0) { result in
-            if result == .failed {
-                failureHandler.fulfill()
-            }
-        }
-
-        // when
-        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
-
-        // then
-        XCTAssertEqual(sut.operationState, .background)
-    }
-
-    func testBackgroundFetchFailAfterTimeout() {
-        let failureHandler = customExpectation(description: "background fetch handler called with failure result")
-
-        // given
-        sut.startBackgroundFetch(timeout: 1.0) { result in
             if result == .failed {
                 failureHandler.fulfill()
             }

--- a/wire-ios/Wire-iOS/Sources/AppDelegate.swift
+++ b/wire-ios/Wire-iOS/Sources/AppDelegate.swift
@@ -345,23 +345,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(
         _ application: UIApplication,
-        performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
-    ) {
-        WireLogger.appDelegate.info("application:performFetchWithCompletionHandler:", attributes: .safePublic)
-
-        guard let appRootRouter else {
-            WireLogger.appDelegate.info("no appRouter, calling completionHandler", attributes: .safePublic)
-            completionHandler(.noData)
-            return
-        }
-
-        appRootRouter.performWhenAuthenticated {
-            ZMUserSession.shared()?.application(application, performFetchWithCompletionHandler: completionHandler)
-        }
-    }
-
-    func application(
-        _ application: UIApplication,
         handleEventsForBackgroundURLSession identifier: String,
         completionHandler: @escaping () -> Void
     ) {

--- a/wire-ios/Wire-iOS/Wire-Info.plist
+++ b/wire-ios/Wire-iOS/Wire-Info.plist
@@ -135,7 +135,6 @@
 		<string>audio</string>
 		<string>voip</string>
 		<string>remote-notification</string>
-		<string>fetch</string>
 	</array>
 	<key>UIDesignRequiresCompatibility</key>
 	<true/>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23451" title="WPB-23451" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23451</a>  [iOS] Background fetch tasks accumulate and run in foreground
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Background fetch was been softly disabled with the introduction of sync v2, but the app still wakes periodically and runs some code, including starting a Swift `Task` that suspends any ongoing sync. These tasks have been observed to accumulate, meaning they don't start until the app comes to the foreground and then all run at once. In the logs, this appears as many as 20 or 30 "suspending sync" messages.

Since background fetch shouldn't run (yet) with sync v2, the solution here is to simply remove background fetch support entirely. When we add it back, we should do so with the [BackgroundTasks framework](https://developer.apple.com/documentation/UIKit/using-background-tasks-to-update-your-app).

### Testing
I don't think there's any direct way we can test this, but we should monitor how the app behaves when left in the background for extended periods of time.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
