### PR TITLE
fix: mls decrypted messages not shown in NSE - WPB-23426

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationEventNotificationBuilder.swift
@@ -24,7 +24,7 @@ import WireNetwork
 protocol ConversationEventNotificationBuilderProtocol {
     func buildContent(
         event: ConversationEvent
-    ) async throws -> UserNotification?
+    ) async throws -> [UserNotification]?
 }
 
 struct ConversationEventNotificationBuilder: ConversationEventNotificationBuilderProtocol {
@@ -39,7 +39,7 @@ struct ConversationEventNotificationBuilder: ConversationEventNotificationBuilde
 
     func buildContent(
         event: ConversationEvent
-    ) async throws -> UserNotification? {
+    ) async throws -> [UserNotification]? {
         let canDisplayNotification = await validator.validate(
             conversationID: event.conversationID,
             senderID: event.senderID,
@@ -65,33 +65,38 @@ struct ConversationEventNotificationBuilder: ConversationEventNotificationBuilde
 
         case let .memberLeave(memberLeaveEvent):
 
-            return await conversationMemberLeaveEventNotificationBuilder.buildContent(
+            let notification = await conversationMemberLeaveEventNotificationBuilder.buildContent(
                 event: memberLeaveEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .memberJoin(memberJoinEvent):
 
-            return await conversationMemberJoinEventNotificationBuilder.buildContent(
+            let notification = await conversationMemberJoinEventNotificationBuilder.buildContent(
                 event: memberJoinEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .create(conversationCreateEvent):
 
-            return await conversationCreateEventNotificationBuilder.buildContent(
+            let notification = await conversationCreateEventNotificationBuilder.buildContent(
                 event: conversationCreateEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .delete(conversationDeleteEvent):
 
-            return await conversationDeleteEventNotificationBuilder.buildContent(
+            let notification = await conversationDeleteEventNotificationBuilder.buildContent(
                 event: conversationDeleteEvent
             )
+            return notification.flatMap { [$0] }
 
         case let .messageTimerUpdate(messageTimerUpdateEvent):
 
-            return await conversationMessageTimerUpdateEventNotificationBuilder.buildContent(
+            let notification = await conversationMessageTimerUpdateEventNotificationBuilder.buildContent(
                 event: messageTimerUpdateEvent
             )
+            return notification.flatMap { [$0] }
 
         default:
             return nil

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationMessageAddEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationMessageAddEventNotificationBuilder.swift
@@ -50,35 +50,47 @@ struct ConversationMessageAddEventNotificationBuilder: ConversationMessageAddEve
     let conversationVideoMessageNotificationBuilder: any ConversationVideoMessageNotificationBuilderProtocol
     let conversationTextMessageNotificationBuilder: any ConversationTextMessageNotificationBuilderProtocol
 
-    func buildContent(
-        event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
-    ) async throws -> UserNotification? {
-
+    
+    struct MessageContent {
         var message: GenericMessage
         var senderID: UserID
         var conversationID: ConversationID
         var timestamp: Date?
-
+    }
+    
+    func buildContent(
+        event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
+    ) async throws -> [UserNotification]? {
         switch event {
         case let .left(mlsMessageEvent):
-            guard let decryptedMessage = mlsMessageEvent.decryptedMessages.first else {
-                // TODO: [WPB-23426] get all messages
-                // The event may have contained only mls protocol messages so it's not
-                // unexpected to find no decrypted application messages.
-                return nil
+            var userNotifications = [UserNotification]()
+            
+            for decryptedMessage in mlsMessageEvent.decryptedMessages {
+                do {
+                    let message = try extractMessageContent(from: decryptedMessage.message)
+                    
+                    let messageContent =
+                        MessageContent(message: message,
+                              senderID: mlsMessageEvent.senderID,
+                              conversationID: mlsMessageEvent.conversationID,
+                              timestamp: mlsMessageEvent.timestamp)
+                    
+                    if let userNotification = try await buildUserNotification(for: messageContent) {
+                        userNotifications.append(userNotification)
+                    }
+                } catch {
+                    WireLogger.sync.error("Failed to build notification for message", attributes: [.conversationId: mlsMessageEvent.conversationID.id.safeForLoggingDescription])
+                }
             }
-
-            message = try extractMessageContent(from: decryptedMessage.message)
-            senderID = mlsMessageEvent.senderID
-            conversationID = mlsMessageEvent.conversationID
-            timestamp = mlsMessageEvent.timestamp
-
+            
+            return userNotifications.isEmpty ? nil : userNotifications
+            
         case let .right(proteusMessageEvent):
             guard let decryptedMessage = proteusMessageEvent.message.decryptedMessage else {
                 throw Failure.proteusMessageMissing
             }
 
-            message = try extractMessageContent(from: decryptedMessage)
+            var message = try extractMessageContent(from: decryptedMessage)
 
             // Extra large proteus messages (many recipients) are contained
             // in external data.
@@ -93,23 +105,29 @@ struct ConversationMessageAddEventNotificationBuilder: ConversationMessageAddEve
                 )
             }
 
-            senderID = proteusMessageEvent.senderID
-            conversationID = proteusMessageEvent.conversationID
-            timestamp = proteusMessageEvent.timestamp
+            let messageContent = MessageContent(message: message,
+                           senderID: proteusMessageEvent.senderID,
+                           conversationID: proteusMessageEvent.conversationID,
+                           timestamp: proteusMessageEvent.timestamp)
+            let userNotification = try await buildUserNotification(for: messageContent)
+            return userNotification.flatMap { [$0] }
         }
-
+    }
+    
+    private func buildUserNotification(for content: MessageContent) async throws -> UserNotification? {
+        
         if let callingNotification = await conversationCallingEventNotificationBuilder.buildContent(
-            calling: message.calling,
-            at: timestamp,
-            conversationID: conversationID,
-            senderID: senderID
+            calling: content.message.calling,
+            at: content.timestamp,
+            conversationID: content.conversationID,
+            senderID: content.senderID
         ) {
             return callingNotification
         } else {
             return await buildMessageContentNotification(
-                message: message,
-                senderID: senderID,
-                conversationID: conversationID
+                message: content.message,
+                senderID: content.senderID,
+                conversationID: content.conversationID
             )
         }
     }

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationMessageAddEventNotificationBuilder.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Conversation/ConversationMessageAddEventNotificationBuilder.swift
@@ -50,41 +50,45 @@ struct ConversationMessageAddEventNotificationBuilder: ConversationMessageAddEve
     let conversationVideoMessageNotificationBuilder: any ConversationVideoMessageNotificationBuilderProtocol
     let conversationTextMessageNotificationBuilder: any ConversationTextMessageNotificationBuilderProtocol
 
-    
     struct MessageContent {
         var message: GenericMessage
         var senderID: UserID
         var conversationID: ConversationID
         var timestamp: Date?
     }
-    
+
     func buildContent(
         event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
     ) async throws -> [UserNotification]? {
         switch event {
         case let .left(mlsMessageEvent):
             var userNotifications = [UserNotification]()
-            
+
             for decryptedMessage in mlsMessageEvent.decryptedMessages {
                 do {
                     let message = try extractMessageContent(from: decryptedMessage.message)
-                    
+
                     let messageContent =
-                        MessageContent(message: message,
-                              senderID: mlsMessageEvent.senderID,
-                              conversationID: mlsMessageEvent.conversationID,
-                              timestamp: mlsMessageEvent.timestamp)
-                    
+                        MessageContent(
+                            message: message,
+                            senderID: mlsMessageEvent.senderID,
+                            conversationID: mlsMessageEvent.conversationID,
+                            timestamp: mlsMessageEvent.timestamp
+                        )
+
                     if let userNotification = try await buildUserNotification(for: messageContent) {
                         userNotifications.append(userNotification)
                     }
                 } catch {
-                    WireLogger.sync.error("Failed to build notification for message", attributes: [.conversationId: mlsMessageEvent.conversationID.id.safeForLoggingDescription])
+                    WireLogger.sync.error(
+                        "Failed to build notification for message",
+                        attributes: [.conversationId: mlsMessageEvent.conversationID.id.safeForLoggingDescription]
+                    )
                 }
             }
-            
+
             return userNotifications.isEmpty ? nil : userNotifications
-            
+
         case let .right(proteusMessageEvent):
             guard let decryptedMessage = proteusMessageEvent.message.decryptedMessage else {
                 throw Failure.proteusMessageMissing
@@ -105,26 +109,28 @@ struct ConversationMessageAddEventNotificationBuilder: ConversationMessageAddEve
                 )
             }
 
-            let messageContent = MessageContent(message: message,
-                           senderID: proteusMessageEvent.senderID,
-                           conversationID: proteusMessageEvent.conversationID,
-                           timestamp: proteusMessageEvent.timestamp)
+            let messageContent = MessageContent(
+                message: message,
+                senderID: proteusMessageEvent.senderID,
+                conversationID: proteusMessageEvent.conversationID,
+                timestamp: proteusMessageEvent.timestamp
+            )
             let userNotification = try await buildUserNotification(for: messageContent)
             return userNotification.flatMap { [$0] }
         }
     }
-    
+
     private func buildUserNotification(for content: MessageContent) async throws -> UserNotification? {
-        
+
         if let callingNotification = await conversationCallingEventNotificationBuilder.buildContent(
             calling: content.message.calling,
             at: content.timestamp,
             conversationID: content.conversationID,
             senderID: content.senderID
         ) {
-            return callingNotification
+            callingNotification
         } else {
-            return await buildMessageContentNotification(
+            await buildMessageContentNotification(
                 message: content.message,
                 senderID: content.senderID,
                 conversationID: content.conversationID

--- a/WireDomain/Sources/WireDomain/Notifications/Builders/Protocols/ConversationMessageAddEventNotificationBuilderProtocol.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Builders/Protocols/ConversationMessageAddEventNotificationBuilderProtocol.swift
@@ -23,5 +23,5 @@ import WireNetwork
 protocol ConversationMessageAddEventNotificationBuilderProtocol {
     func buildContent(
         event: Either<ConversationMLSMessageAddEvent, ConversationProteusMessageAddEvent>
-    ) async throws -> UserNotification?
+    ) async throws -> [UserNotification]?
 }

--- a/WireDomain/Sources/WireDomain/Notifications/GenerateNotificationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/GenerateNotificationUseCase.swift
@@ -79,10 +79,9 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
         switch event {
         case let .conversation(conversationEvent):
             do {
-                let notifications = try await conversationEventBuilder.buildContent(
+                return try await conversationEventBuilder.buildContent(
                     event: conversationEvent
                 )
-                return notifications
             } catch ConversationMessageAddEventNotificationBuilder.Failure.unknownMessageContent {
                 // Can't show notifications for unknown message types,
                 // so just ignore.

--- a/WireDomain/Sources/WireDomain/Notifications/GenerateNotificationUseCase.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/GenerateNotificationUseCase.swift
@@ -51,7 +51,7 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
         updateEvents: AsyncStream<[UpdateEvent]>
     ) async throws -> [UserNotification] {
 
-        var notifications = [UserNotification]()
+        var allNotifications = [UserNotification]()
 
         for await events in updateEvents {
             logger.info(
@@ -60,28 +60,29 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
             )
 
             for event in events {
-                if let notification = await generateNotification(for: event) {
+                if let notifications = await generateNotification(for: event) {
                     logger.info(
-                        "Generated a notification from an event",
+                        "Generated \(notifications.count) notifications from an event",
                         attributes: .newNSE, .safePublic
                     )
-                    notifications.append(notification)
+                    allNotifications.append(contentsOf: notifications)
                 }
             }
         }
 
-        return notifications
+        return allNotifications
     }
 
     private func generateNotification(
         for event: UpdateEvent
-    ) async -> UserNotification? {
+    ) async -> [UserNotification]? {
         switch event {
         case let .conversation(conversationEvent):
             do {
-                return try await conversationEventBuilder.buildContent(
+                let notifications = try await conversationEventBuilder.buildContent(
                     event: conversationEvent
                 )
+                return notifications
             } catch ConversationMessageAddEventNotificationBuilder.Failure.unknownMessageContent {
                 // Can't show notifications for unknown message types,
                 // so just ignore.
@@ -99,9 +100,10 @@ struct GenerateNotificationUseCase: GenerateNotificationUseCaseProtocol {
             }
 
         case let .user(userEvent):
-            return await userEventBuilder.buildContent(
+            let notification = await userEventBuilder.buildContent(
                 event: userEvent
             )
+            return notification.flatMap { [$0] }
 
         default:
             var attributes = LogAttributes.newNSE

--- a/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
+++ b/WireDomain/Sources/WireDomainSupport/Sourcery/generated/AutoMockable.generated.swift
@@ -447,10 +447,10 @@ class MockConversationEventNotificationBuilderProtocol: ConversationEventNotific
 
     var buildContentEvent_Invocations: [ConversationEvent] = []
     var buildContentEvent_MockError: Error?
-    var buildContentEvent_MockMethod: ((ConversationEvent) async throws -> UserNotification?)?
-    var buildContentEvent_MockValue: UserNotification??
+    var buildContentEvent_MockMethod: ((ConversationEvent) async throws -> [UserNotification]?)?
+    var buildContentEvent_MockValue: [UserNotification]??
 
-    func buildContent(event: ConversationEvent) async throws -> UserNotification? {
+    func buildContent(event: ConversationEvent) async throws -> [UserNotification]? {
         buildContentEvent_Invocations.append(event)
 
         if let error = buildContentEvent_MockError {

--- a/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationMessageAddEventNotificationBuilderTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/Conversations/ConversationMessageAddEventNotificationBuilderTests.swift
@@ -121,6 +121,30 @@ final class ConversationMessageAddEventNotificationBuilderTests: XCTestCase {
         XCTAssertEqual(conversationTextNotificationBuilder.buildContentTextConversationIDSenderID_Invocations.count, 1)
     }
 
+    func testGenerateNotifications_Multiple_MLS_Text_Message_Content_It_Invokes_Text_Notification_Builder(
+    ) async throws {
+
+        // Mock
+        let conversation = await context.perform { [self] in
+            modelHelper.createGroupConversation(in: context)
+        }
+        conversationCallingEventNotificationBuilder.buildContentCallingAtConversationIDSenderID_MockValue = .some(nil)
+        conversationTextNotificationBuilder
+            .buildContentTextConversationIDSenderID_MockValue = .text(UNMutableNotificationContent())
+        conversationLocalStore.fetchOrCreateConversationIdDomain_MockValue = conversation
+        conversationLocalStore.isMessageSilencedSenderIDConversation_MockValue = false
+        conversationLocalStore.shouldHideNotification_MockValue = false
+
+        // When
+
+        _ = try await sut.buildContent(
+            event: .left(Scaffolding.mlsTextMessageEvents)
+        )
+
+        // Then
+        XCTAssertEqual(conversationTextNotificationBuilder.buildContentTextConversationIDSenderID_Invocations.count, 2)
+    }
+
     func testGenerateNotification_MLS_Does_Not_Fail_If_No_Messages_Found() async throws {
         // When
         let result = try await sut.buildContent(
@@ -191,6 +215,24 @@ final class ConversationMessageAddEventNotificationBuilderTests: XCTestCase {
                 message: Scaffolding.base64EncodedString, // text content
                 senderClientID: UUID.mockID1.uuidString
             )]
+        )
+
+        static let mlsTextMessageEvents = ConversationMLSMessageAddEvent(
+            conversationID: conversationID,
+            senderID: userID,
+            subconversation: "",
+            message: messageContent,
+            timestamp: .now,
+            decryptedMessages: [
+                .init(
+                    message: Scaffolding.base64EncodedString, // text content
+                    senderClientID: UUID.mockID1.uuidString
+                ),
+                .init(
+                    message: Scaffolding.base64EncodedString, // text content
+                    senderClientID: UUID.mockID1.uuidString
+                )
+            ]
         )
 
         static let proteusTextMessageEvent = ConversationProteusMessageAddEvent(

--- a/WireDomain/Tests/WireDomainTests/Notifications/GenerateNotificationUseCaseTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Notifications/GenerateNotificationUseCaseTests.swift
@@ -50,7 +50,7 @@ final class GenerateNotificationUseCaseTests: XCTestCase {
     func testProcess_It_Invokes_Notification_Content_Handler() async throws {
         // Mock
 
-        conversationEventBuilder.buildContentEvent_MockValue = .text(UNMutableNotificationContent())
+        conversationEventBuilder.buildContentEvent_MockValue = [.text(UNMutableNotificationContent())]
         userEventBuilder.buildContentEvent_MockValue = .text(UNMutableNotificationContent())
 
         let asyncStream = AsyncStream<[UpdateEvent]> {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23426" title="WPB-23426" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23426</a>  [iOS] mls decrypted messages not shown in NSE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Generates a notification for all decrypted messages returned from a mls message add event, not only the first one.

### Testing

* update unit tests

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
