### PR TITLE
fix: create file percent encoding - WPB-23207

### DIFF
--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveCreateFileUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveCreateFileUseCase.swift
@@ -56,7 +56,7 @@ package struct WireDriveCreateFileUseCase: WireDriveCreateFileUseCaseProtocol {
             url.appendingPathComponent("\(name).\(template.fileExtension)")
         }
 
-        let path = targetPath.absoluteString
+        let path = targetPath.absoluteString.removingPercentEncoding ?? targetPath.absoluteString
 
         // Checks whether the path doesn't already exist.
         let preCheckResult = try await nodesRepository.preCheck(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23207" title="WPB-23207" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23207</a>  [iOS] Files and folders with spaces and special characters created on iOS have wrong names on Android and Web
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Removing the percent encoding for the use case of creating a file, just like it's already done for the use case of renaming files.

### Testing

* Create a file from a template and give it a name containing a space, like "test file".
* Check on Android or Web if that file is not percent encoded like "test%20file" but "test file" instead.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
