### PR TITLE
fix: Allow call join from the lock screen - WPB-21406

### DIFF
--- a/wire-ios-request-strategy/Sources/Request Strategies/MLS/MLSRequestStrategy.swift
+++ b/wire-ios-request-strategy/Sources/Request Strategies/MLS/MLSRequestStrategy.swift
@@ -60,6 +60,7 @@ public final class MLSRequestStrategy: AbstractRequestStrategy {
         )
 
         configuration = [
+            .allowsRequestsWhileInBackground,
             .allowsRequestsWhileOnline
         ]
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
[[iOS] Can't join call via CallKit from Lock Screen](https://wearezeta.atlassian.net/browse/WPB-21406)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Users cannot join incoming MLS group calls via CallKit from the phone's lock screen, the call gets stuck in "Connecting" state.
`MLSRequestStrategy` only had `.allowsRequestsWhileOnline` configuration, which prevents it from processing requests when the app is in background.

### Solution
Add `.allowsRequestsWhileInBackground` to `MLSRequestStrategy` configuration to allow MLS operations (like fetching subgroups for conference calls) to execute when the app is in background state, such as when accepting an incoming group call with the phone locked.

### Testing
- move the app to the background
- lock the screen
- receive an incoming call
- join the call


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
