### PR TITLE
fix: "no connection" banner not hiding when internet back - WPB-23482

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesBrowserView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesBrowserView.swift
@@ -50,7 +50,7 @@ package struct FilesBrowserView: FilesViewProtocol {
                         .progressViewStyle(.circular)
                 case .received, .pending:
                     VStack {
-                        if viewModel.connectionState == .offline {
+                        if viewModel.shouldShowOfflineBar {
                             Spacer()
                             offlineBar.id(UUID())
                             Spacer()

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
@@ -254,6 +254,10 @@ package final class FilesViewModel: ObservableObject {
         loadMoreTask != nil
     }
 
+    var shouldShowOfflineBar: Bool {
+        connectionState == .offline && !state.items.isEmpty
+    }
+
     enum ConnectionState {
         case offline
         case online
@@ -338,7 +342,7 @@ package final class FilesViewModel: ObservableObject {
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
-                guard let self, !state.items.isEmpty else { return }
+                guard let self else { return }
 
                 switch status {
                 case .connected:

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewModelTests.swift
@@ -559,4 +559,38 @@ final class FilesViewModelTests {
         #expect(sut.alert == expectedAlert)
     }
 
+    @Test
+    func testOfflineBarIsHiddenWhenItemsAreEmpty() {
+        sut.connectionState = .offline
+        sut.state = .received(items: [])
+
+        #expect(sut.shouldShowOfflineBar == false)
+    }
+
+    @Test
+    func testOfflineBarIsShownWhenOfflineWithItems() {
+        let nodeA = WireDriveNode.fixture(path: "foo/aa.xyz")
+        let now = Date()
+
+        sut.connectionState = .offline
+        sut.state = .received(items: [
+            FilesViewItem(
+                id: nodeA.id,
+                eTag: "eTag",
+                kind: .file,
+                name: "aaa.xyz",
+                filePath: "foo/aaa.xyz",
+                ownedBy: nil,
+                modifiedAt: now,
+                icon: .other,
+                tags: [],
+                isEditable: false,
+                publicLinkID: nil,
+                conversationName: nil
+            )
+        ])
+
+        #expect(sut.shouldShowOfflineBar == true)
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23482" title="WPB-23482" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23482</a>  [iOS] When internet off and on No internet banner is still visible on global Drive and Shared Drive screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

"No internet" bar was still showing on a specific use case when user wasn't on File Browser screen when the connection was lost.
The issue was that when internet was going out but list file was empty the network state wasn't getting updated. 

Now that logic was move out from the function in charge of checking for internet changes and updating the connection state so it will always update the state correctly.

UI was updated to show Offline bar base on param that combines both "states" (internet status && list items empty or not) now that internet status will always get updated.

### Testing

Steps to reproduce:
- Open conversation list
- Switch internet off
- Open global Drive
- Open conversation list
- Switch internet on
- Open global Drive

No internet bar should be hidden since internet is back on.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
