### PR TITLE
chore: add missing translation - WPB-23133

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/de.lproj/Localizable.strings
@@ -215,6 +215,7 @@
 "conversation.wireCells.shareLink.on" = "EIN";
 "conversation.wireCells.shareLink.expired" = "ABGELAUFEN";
 "conversation.wireCells.shareLink.linkExpiredOn" = "Link ist am %@ abgelaufen";
+"conversation.wireCells.shareLink.sharedMessage" = "Öffnen Sie diesen Link, um die angehängten Dateien anzuzeigen: %@";
 
 // MARK: - Share Link Password View
 "conversation.wireCells.shareLink.password.title" = "Passwort";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23133" title="WPB-23133" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23133</a>  [iOS] Manage release iOS 4.15.0
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds the one remaining missing translation for Wire drive.

### Testing

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
