### PR TITLE
fix: Incorrect text content is read aloud - WPB-14760

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptor.swift
@@ -234,6 +234,7 @@ final class SettingsGroupCellDescriptor: SettingsInternalGroupCellDescriptorType
         if let cell = cell as? SettingsTableCell {
             cell.showDisclosureIndicatorAccessoryView()
             cell.accessibilityIdentifier = settingsTopLevelMenuItem?.accessibilityID
+            cell.accessibilityTraits = .button
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCopyButtonCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCopyButtonCellDescriptor.swift
@@ -39,6 +39,7 @@ final class SettingsCopyButtonCellDescriptor: SettingsCellDescriptorType {
     func featureCell(_ cell: SettingsCellType) {
         if let iconActionCell = cell as? IconActionCell {
             delegate = iconActionCell
+            iconActionCell.accessibilityTraits = .button
             iconActionCell.configure(with: copyInProgress ? copiedLink : copyLink)
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -135,6 +135,8 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
             tableCell.accessibilityIdentifier = settingsTopLevelMenuItem?.accessibilityID
             tableCell.valueLabel.accessibilityIdentifier = title + "Field"
             tableCell.valueLabel.isAccessibilityElement = true
+            tableCell.accessibilityTraits = .keyboardKey
+            
         }
 
         if let previewGenerator {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsExternalScreenCellDescriptor.swift
@@ -135,8 +135,6 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
             tableCell.accessibilityIdentifier = settingsTopLevelMenuItem?.accessibilityID
             tableCell.valueLabel.accessibilityIdentifier = title + "Field"
             tableCell.valueLabel.isAccessibilityElement = true
-            tableCell.accessibilityTraits = .keyboardKey
-            
         }
 
         if let previewGenerator {
@@ -149,8 +147,10 @@ class SettingsExternalScreenCellDescriptor: SettingsGroupCellDescriptorType, Set
             case .automatic:
                 if presentationStyle == .modal {
                     groupCell.hideAccessoryView()
+                    groupCell.accessibilityTraits = .button
                 } else {
                     groupCell.showDisclosureIndicatorAccessoryView()
+                    groupCell.accessibilityTraits = .button
                 }
             case .disclosureIndicator:
                 groupCell.showDisclosureIndicatorAccessoryView()

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsProfileLinkCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsProfileLinkCellDescriptor.swift
@@ -28,6 +28,7 @@ final class SettingsProfileLinkCellDescriptor: SettingsCellDescriptorType {
 
         linkCell.linkText = link && .lineSpacing(8)
         linkCell.titleText = title
+        linkCell.setupAccessibility()
     }
 
     // MARK: - SettingsCellDescriptorType

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -48,13 +48,16 @@ final class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescrip
         if settingsProperty.enabled {
             textCell.textInput.accessibilityTraits.remove(.staticText)
             textCell.textInput.accessibilityIdentifier = title + "Field"
+            textCell.accessibilityTraits.insert(.keyboardKey)
         } else {
+            textCell.accessibilityTraits.remove(.keyboardKey)
             textCell.textInput.accessibilityTraits.insert(.staticText)
             textCell.textInput.accessibilityIdentifier = title + "FieldDisabled"
         }
 
         textCell.textInput.isEnabled = settingsProperty.enabled
-        textCell.textInput.isAccessibilityElement = true
+
+        textCell.setupAccessibility()
     }
 
     func select(_ value: SettingsPropertyValue, sender: UIView) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyTextValueCellDescriptor.swift
@@ -48,9 +48,7 @@ final class SettingsPropertyTextValueCellDescriptor: SettingsPropertyCellDescrip
         if settingsProperty.enabled {
             textCell.textInput.accessibilityTraits.remove(.staticText)
             textCell.textInput.accessibilityIdentifier = title + "Field"
-            textCell.accessibilityTraits.insert(.keyboardKey)
         } else {
-            textCell.accessibilityTraits.remove(.keyboardKey)
             textCell.textInput.accessibilityTraits.insert(.staticText)
             textCell.textInput.accessibilityIdentifier = title + "FieldDisabled"
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsPropertyToggleCellDescriptor.swift
@@ -60,6 +60,11 @@ final class SettingsPropertyToggleCellDescriptor: SettingsPropertyCellDescriptor
             toggleCell.switchView.isOn = boolValue
             toggleCell.switchView.accessibilityLabel = identifier
             toggleCell.switchView.isEnabled = settingsProperty.enabled
+            if #available(iOS 17.0, *) {
+                toggleCell.accessibilityTraits = .toggleButton
+            } else {
+                toggleCell.accessibilityTraits = .button
+            }
         }
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsAppearanceCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsAppearanceCell.swift
@@ -82,16 +82,19 @@ final class SettingsAppearanceCell: SettingsTableCell, CellConfigurationConfigur
                 iconImageView.backgroundColor = UIColor.clear
                 subtitleLabel.text = nil
                 titleLabelToIconInset.isActive = true
+                accessibilityTraits = [.button]
             case let .color(color):
                 iconImageView.backgroundColor = color
                 iconImageView.image = .none
                 subtitleLabel.text = AccentColor.current.name
                 titleLabelToIconInset.isActive = true
+                accessibilityTraits = [.button]
             default:
                 subtitleLabel.text = nil
                 iconImageView.backgroundColor = UIColor.clear
                 iconImageView.image = .none
                 titleLabelToIconInset.isActive = false
+                accessibilityTraits = []
             }
             layoutIfNeeded()
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -194,6 +194,8 @@ class SettingsTableCell: SettingsTableCellProtocol {
         super.prepareForReuse()
         preview = .none
         accessibilityIdentifier = nil
+        accessibilityTraits = .none
+        accessibilityElements = nil
     }
 
     func setup() {
@@ -259,7 +261,6 @@ class SettingsTableCell: SettingsTableCellProtocol {
 
     func setupAccessibility() {
         isAccessibilityElement = true
-        accessibilityTraits = .button
         accessibilityValue = valueLabel.text
         let badgeValue = badgeLabel.text ?? ""
         accessibilityHint = badgeValue.isEmpty ? "" : L10n.Accessibility.Settings.DeviceCount.hint("\(badgeValue)")

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsCell.swift
@@ -194,7 +194,7 @@ class SettingsTableCell: SettingsTableCellProtocol {
         super.prepareForReuse()
         preview = .none
         accessibilityIdentifier = nil
-        accessibilityTraits = .none
+        accessibilityTraits = []
         accessibilityElements = nil
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsLinkTableCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsLinkTableCell.swift
@@ -109,7 +109,7 @@ final class SettingsLinkTableCell: SettingsTableCellProtocol {
         ])
     }
 
-     func setupAccessibility() {
+    func setupAccessibility() {
         isAccessibilityElement = true
         accessibilityValue = cellLinkLabel.text
         accessibilityTraits = .staticText

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsLinkTableCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/SettingsLinkTableCell.swift
@@ -109,8 +109,9 @@ final class SettingsLinkTableCell: SettingsTableCellProtocol {
         ])
     }
 
-    private func setupAccessibility() {
+     func setupAccessibility() {
         isAccessibilityElement = true
+        accessibilityValue = cellLinkLabel.text
         accessibilityTraits = .staticText
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-14760" title="WPB-14760" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-14760</a>  [iOS] Incorrect text content is read aloud #53
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Instead of the profile name the screen reader reads the team name

Instead of the team name the screen reader reads the profile name

The domain name and username were correct

Report says: In addition, "key" is read here, although you can't edit anything here. – Those are read as buttons as users can edit the name, username and email.

fix: 1. Profile name and team name are now corrected. 
      2. Wrong Accessibility traits for all the fields inside account settings are removed and relevant accessibility traits are added
      3. Value of profile link will also be announced by voice over 

_Optional: reference dependencies to other pull requests etc._

### Testing

Test below issues inside Account Settings :  
      1. Profile name and team name are now corrected. 
      2. Wrong Accessibility traits for all the fields inside account settings are removed and relevant accessibility traits are added
      3. Value of profile link will also be announced by voice over 

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
