### PR TITLE
feat: always show update certificate button in devices list - WPB-23319

### DIFF
--- a/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
@@ -56,24 +56,23 @@ final class DeviceInfoViewModelTests: XCTestCase {
     func test_actionButtonsWhenCertStateIsValid() {
         showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockValid, isFromConversation: false)
     }
-    
-    func test_actionButtonsWhenCertStateIsValidAndFromConversation () {
+
+    func test_actionButtonsWhenCertStateIsValidAndFromConversation() {
         showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockValid, isFromConversation: true)
     }
 
     func test_actionButtonsWhenCertStateIsInvalid() {
         showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockInvalid, isFromConversation: false)
     }
-    
+
     func test_actionButtonsWhenCertStateIsInvalidAndFromConversation() {
         showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockValid, isFromConversation: true)
     }
-    
 
     func test_actionButtonsWhenCertStateNotActivated() {
         showGetWhenIsSelfClient(.mockNotActivated, isFromConversation: false)
     }
-    
+
     func test_actionButtonsWhenCertStateNotActivatedAndFromConversation() {
         showGetWhenIsSelfClient(.mockNotActivated, isFromConversation: false)
     }
@@ -174,6 +173,7 @@ final class DeviceInfoViewModelTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
     fileprivate func showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(
         _ e2eIdentityCertificate: E2eIdentityCertificate,
         isFromConversation: Bool,
@@ -181,14 +181,17 @@ final class DeviceInfoViewModelTests: XCTestCase {
         line: UInt = #line
     ) {
         for isSelfClient in [true, false] {
-            setup(e2eIdentityCertificate: e2eIdentityCertificate,isFromConversation: isFromConversation, isSelfClient: isSelfClient)
+            setup(
+                e2eIdentityCertificate: e2eIdentityCertificate,
+                isFromConversation: isFromConversation,
+                isSelfClient: isSelfClient
+            )
             XCTAssertEqual(deviceInfoViewModel.showCertificateButtonVisible, true)
             XCTAssertEqual(deviceInfoViewModel.getCertificateButtonVisible, false)
             XCTAssertEqual(deviceInfoViewModel.updateCertificateButtonVisible, isSelfClient)
         }
     }
-    
-    
+
     fileprivate func showGetWhenIsSelfClient(
         _ e2eIdentityCertificate: E2eIdentityCertificate,
         isFromConversation: Bool,

--- a/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
@@ -32,6 +32,7 @@ final class DeviceInfoViewModelTests: XCTestCase {
 
     func setup(
         e2eIdentityCertificate: E2eIdentityCertificate,
+        isFromConversation: Bool = false,
         isSelfClient: Bool = false
     ) {
         let userClient = MockUserClient()
@@ -46,35 +47,43 @@ final class DeviceInfoViewModelTests: XCTestCase {
             isSelfClient: isSelfClient,
             gracePeriod: 0,
             mlsCiphersuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
-            isFromConversation: false,
+            isFromConversation: isFromConversation,
             actionsHandler: mockDeviceActionsHandler,
             conversationClientDetailsActions: mockConversationUserClientDetailsActions
         )
     }
 
     func test_actionButtonsWhenCertStateIsValid() {
-        showViewAndUpdate_HideGet(.mockValid)
+        showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockValid, isFromConversation: false)
+    }
+    
+    func test_actionButtonsWhenCertStateIsValidAndFromConversation () {
+        showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockValid, isFromConversation: true)
     }
 
     func test_actionButtonsWhenCertStateIsInvalid() {
-        showViewAndUpdate_HideGet(.mockInvalid)
+        showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockInvalid, isFromConversation: false)
     }
+    
+    func test_actionButtonsWhenCertStateIsInvalidAndFromConversation() {
+        showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockValid, isFromConversation: true)
+    }
+    
 
     func test_actionButtonsWhenCertStateNotActivated() {
-        for isSelfClient in [true, false] {
-            setup(e2eIdentityCertificate: .mockNotActivated, isSelfClient: isSelfClient)
-            XCTAssertEqual(deviceInfoViewModel.showCertificateButtonVisible, false)
-            XCTAssertEqual(deviceInfoViewModel.getCertificateButtonVisible, isSelfClient)
-            XCTAssertEqual(deviceInfoViewModel.updateCertificateButtonVisible, false)
-        }
+        showGetWhenIsSelfClient(.mockNotActivated, isFromConversation: false)
+    }
+    
+    func test_actionButtonsWhenCertStateNotActivatedAndFromConversation() {
+        showGetWhenIsSelfClient(.mockNotActivated, isFromConversation: false)
     }
 
     func test_actionButtonsWhenCertStateIsRevoked() {
-        showViewAndUpdate_HideGet(.mockRevoked)
+        showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockRevoked, isFromConversation: false)
     }
 
     func test_actionButtonsWhenCertStateIsExpired() {
-        showViewAndUpdate_HideGet(.mockExpired)
+        showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(.mockExpired, isFromConversation: false)
     }
 
     func testThatItCallsShowMyDeviceMethodInConversationUserClientDetailsActionsHandler_WhenOnShowMyDeviceTappedIsCalled(
@@ -165,17 +174,32 @@ final class DeviceInfoViewModelTests: XCTestCase {
     }
 
     // MARK: - Helpers
-
-    fileprivate func showViewAndUpdate_HideGet(
+    fileprivate func showViewAlwaysAndUpdateWhenIsSelfClient_HideGetAllways(
         _ e2eIdentityCertificate: E2eIdentityCertificate,
+        isFromConversation: Bool,
         file: StaticString = #file,
         line: UInt = #line
     ) {
         for isSelfClient in [true, false] {
-            setup(e2eIdentityCertificate: e2eIdentityCertificate, isSelfClient: isSelfClient)
+            setup(e2eIdentityCertificate: e2eIdentityCertificate,isFromConversation: isFromConversation, isSelfClient: isSelfClient)
             XCTAssertEqual(deviceInfoViewModel.showCertificateButtonVisible, true)
             XCTAssertEqual(deviceInfoViewModel.getCertificateButtonVisible, false)
             XCTAssertEqual(deviceInfoViewModel.updateCertificateButtonVisible, isSelfClient)
+        }
+    }
+    
+    
+    fileprivate func showGetWhenIsSelfClient(
+        _ e2eIdentityCertificate: E2eIdentityCertificate,
+        isFromConversation: Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        for isSelfClient in [true, false] {
+            setup(e2eIdentityCertificate: .mockNotActivated, isFromConversation: true, isSelfClient: isSelfClient)
+            XCTAssertEqual(deviceInfoViewModel.showCertificateButtonVisible, false)
+            XCTAssertEqual(deviceInfoViewModel.getCertificateButtonVisible, isSelfClient)
+            XCTAssertEqual(deviceInfoViewModel.updateCertificateButtonVisible, false)
         }
     }
 }

--- a/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
+++ b/wire-ios/Wire-iOS UnitTests/DeviceInfoViewModelTests.swift
@@ -27,8 +27,15 @@ final class DeviceInfoViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        setup(e2eIdentityCertificate: .mockExpired)
+    }
+
+    func setup(
+        e2eIdentityCertificate: E2eIdentityCertificate,
+        isSelfClient: Bool = false
+    ) {
         let userClient = MockUserClient()
-        userClient.e2eIdentityCertificate = .mockExpired
+        userClient.e2eIdentityCertificate = e2eIdentityCertificate
         userClient.verified = true
 
         deviceInfoViewModel = DeviceInfoViewModel(
@@ -36,13 +43,38 @@ final class DeviceInfoViewModelTests: XCTestCase {
             addedDate: "",
             proteusID: "",
             userClient: userClient,
-            isSelfClient: false,
+            isSelfClient: isSelfClient,
             gracePeriod: 0,
             mlsCiphersuite: .MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
             isFromConversation: false,
             actionsHandler: mockDeviceActionsHandler,
             conversationClientDetailsActions: mockConversationUserClientDetailsActions
         )
+    }
+
+    func test_actionButtonsWhenCertStateIsValid() {
+        showViewAndUpdate_HideGet(.mockValid)
+    }
+
+    func test_actionButtonsWhenCertStateIsInvalid() {
+        showViewAndUpdate_HideGet(.mockInvalid)
+    }
+
+    func test_actionButtonsWhenCertStateNotActivated() {
+        for isSelfClient in [true, false] {
+            setup(e2eIdentityCertificate: .mockNotActivated, isSelfClient: isSelfClient)
+            XCTAssertEqual(deviceInfoViewModel.showCertificateButtonVisible, false)
+            XCTAssertEqual(deviceInfoViewModel.getCertificateButtonVisible, isSelfClient)
+            XCTAssertEqual(deviceInfoViewModel.updateCertificateButtonVisible, false)
+        }
+    }
+
+    func test_actionButtonsWhenCertStateIsRevoked() {
+        showViewAndUpdate_HideGet(.mockRevoked)
+    }
+
+    func test_actionButtonsWhenCertStateIsExpired() {
+        showViewAndUpdate_HideGet(.mockExpired)
     }
 
     func testThatItCallsShowMyDeviceMethodInConversationUserClientDetailsActionsHandler_WhenOnShowMyDeviceTappedIsCalled(
@@ -130,5 +162,20 @@ final class DeviceInfoViewModelTests: XCTestCase {
         }
         await deviceInfoViewModel.enrollClient()
         await fulfillment(of: [expectation])
+    }
+
+    // MARK: - Helpers
+
+    fileprivate func showViewAndUpdate_HideGet(
+        _ e2eIdentityCertificate: E2eIdentityCertificate,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        for isSelfClient in [true, false] {
+            setup(e2eIdentityCertificate: e2eIdentityCertificate, isSelfClient: isSelfClient)
+            XCTAssertEqual(deviceInfoViewModel.showCertificateButtonVisible, true)
+            XCTAssertEqual(deviceInfoViewModel.getCertificateButtonVisible, false)
+            XCTAssertEqual(deviceInfoViewModel.updateCertificateButtonVisible, isSelfClient)
+        }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/DeviceInfoViewModel.swift
@@ -74,6 +74,21 @@ final class DeviceInfoViewModel: ObservableObject {
             .replacingOccurrences(of: " ", with: ":")
     }
 
+    var showCertificateButtonVisible: Bool {
+        guard let status = e2eIdentityCertificate?.status, status != .notActivated else { return false }
+        return true
+    }
+
+    var getCertificateButtonVisible: Bool {
+        guard let status = e2eIdentityCertificate?.status, status == .notActivated, isSelfClient  else { return false }
+        return true
+    }
+
+    var updateCertificateButtonVisible: Bool {
+        guard let status = e2eIdentityCertificate?.status, status != .notActivated, isSelfClient else { return false }
+        return true
+    }
+
     var showCertificateUpdateSuccess: ((String) -> Void)?
 
     @Published var e2eIdentityCertificate: E2eIdentityCertificate?

--- a/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/DeviceDetailsButtonsView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/DeviceView/Views/Components/DeviceDetailsButtonsView.swift
@@ -70,30 +70,20 @@ struct DeviceDetailsButtonsView: View {
     }
 
     var body: some View {
-        if let status = viewModel.e2eIdentityCertificate?.status {
-            switch status {
-            case .valid:
-                if viewModel.isSelfClient, viewModel.isCertificateExpiringSoon == true {
-                    Divider()
-                    updateCertificateButton.padding()
-                }
+        Group {
+            if viewModel.updateCertificateButtonVisible {
+                Divider()
+                updateCertificateButton.padding()
+            }
+
+            if viewModel.showCertificateButtonVisible {
                 Divider()
                 showCertificateButton.padding()
-            case .notActivated:
-                if !viewModel.isFromConversation, viewModel.isSelfClient {
-                    Divider()
-                    getCertificateButton.padding()
-                }
-            case .revoked, .invalid:
+            }
+
+            if viewModel.getCertificateButtonVisible {
                 Divider()
-                showCertificateButton.padding()
-            case .expired:
-                if !viewModel.isFromConversation, viewModel.isSelfClient {
-                    Divider()
-                    updateCertificateButton.padding()
-                }
-                Divider()
-                showCertificateButton.padding()
+                getCertificateButton.padding()
             }
         }
         Divider()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23319" title="WPB-23319" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23319</a>  [iOS] Always show "Update certificate" button in devices list when E2EI is enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Always show "Update certificate" button in devices list when E2EI is enabled. In parent ticket [WPB-20798](https://wearezeta.atlassian.net/browse/WPB-20798), on comments, it is sumarized the button actions show/hide policy behaviour, agreed in a meeting with PO and Android on 20/2/26. 


### Testing

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-d25e656f-7fff-27b0-f29b-96b7d5889374"><div dir="ltr" style="margin-left:0pt;" align="left">
Cert. status | Show certificate details | Get certificate | Update certificate
-- | -- | -- | --
valid | x |   | x
invalid | x |   | x
not activated |   | x |  
revoked | x |   | x
expired | x |   | x

</div></b>

### Result

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-87987911-7fff-4e5c-a701-4542498d9066"><div dir="ltr" style="margin-left:0pt;" align="left">
Cert. status | Show certificate details
-- | --
valid |  <img width="256" height="208" alt="image" src="https://github.com/user-attachments/assets/7967ed68-ed79-4f9f-a5a9-e186e6f8e765" />
invalid | <img width="257" height="215" alt="image" src="https://github.com/user-attachments/assets/2c396c25-5c94-4044-bd9e-43866d620ca8" />
not activated |  <img width="252" height="189" alt="image" src="https://github.com/user-attachments/assets/38777f21-bd90-463b-a489-e02725e95345" />
revoked | <img width="255" height="214" alt="image" src="https://github.com/user-attachments/assets/365556f9-58b5-43a1-989b-83c01f84197d" />
expired |  <img width="251" height="213" alt="image" src="https://github.com/user-attachments/assets/437ac284-0219-4a2c-882f-2259d574ccea" />


</div></b>

_Optional: attachments like images, videos, etc._

---






### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.


[WPB-20798]: https://wearezeta.atlassian.net/browse/WPB-20798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ