### PR TITLE
fix: missing build number in internal build icons - WPB-23820

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -897,7 +897,7 @@ class Build
             height = Integer(image_height) / 4.0
 
             # Add build number to the icon
-            %x( magick -background '#0008' -fill white -gravity center -size #{width}x#{height} caption:"#{extra_info}" "#{image}" +swap -gravity south -composite "#{image}" )
+            %x( magick -background '#0008' -fill white -font '/System/Library/Fonts/Helvetica.ttc' -gravity center -size #{width}x#{height} caption:"#{extra_info}" "#{image}" +swap -gravity south -composite "#{image}" )
             processed += 1
         end
         UI.important("Processed #{processed} icons in #{iconset_location} by adding '#{extra_info}'")


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23820" title="WPB-23820" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23820</a>  [iOS] Broken build number app icon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

The CI is currently not adding a build number to the beta build (etc) app icons. 

Fixing this confused me. I incorrectly assumed it was because of CI/CD image update that had caused this. But in the end it turned out to be due to changes in the compiled dependencies in the standard version of `imagemagick` installed via brew.

`imagemagick` has had a bunch of dependencies removed from it including `fontconfig` which `imagemagick` depends on to locate fonts on the system. There is a new brew `imagemagick-full` which keeps `fontconfig` but this requires a bit of setup getting it working. 

Instead of making changes above, in this PR I take the simple solution of providing the path to a font `Helvetica` on the system. This would break if Apple stops shipping Helvetica font of if the path of fonts move but I think that change is unlikely to happen.

### Test

[This build](https://github.com/wireapp/wire-ios/actions/runs/22633206272/job/65589094515) should have a build number on the icon.

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.
