### PR TITLE
fix: remove no connection bar background on FilesView - WPB-23484

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesView.swift
@@ -62,7 +62,6 @@ package struct FilesView: FilesViewProtocol {
                             if viewModel.shouldShowOfflineBar {
                                 offlineBar
                                     .id(UUID())
-                                    .background(ColorTheme.Backgrounds.surface.color)
                             }
                         }
                 case let .error(isConnectionError):


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23484" title="WPB-23484" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23484</a>  [iOS] No internet banner doesn't stick to the top on Global Drive and Shared Drive screens
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Remove background from no connection bar. 
On 1:1 conversations files list the background of no connection bar was different from the rest of screen, making it look odd.

### Testing

Go to 1:1 conversation Shared Drive screen
Disable internet
When no connection bar shows, background should be same color as the rest of the screen

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
