### PR TITLE
chore: don't install imagemagick & ghostscript in setup file - WPB-23820

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,9 +3,5 @@ tap "peripheryapp/periphery"
 # Common dependencies for both CI and local development
 brew "git-lfs"
 
-# CI-only dependencies
-brew "imagemagick" if ENV['CI']
-brew "ghostscript" if ENV['CI']
-
 # Development-only dependencies
 brew "periphery" unless ENV['CI'] # no version support for periphery, using the latest


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23820" title="WPB-23820" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23820</a>  [iOS] Broken build number app icon
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR removes installing `imagemagick` & `ghostscript` from `setup.sh` as this is already being done in our workflows using the `gerlero/brew-install@v1` action.

### Testing

Deploy a playtest build and confirm it's icon has the build number overlay (build [here](https://github.com/wireapp/wire-ios/actions/runs/22662267848))

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.