### PR TITLE
fix: crash UI freeze - WPB-22990

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Content/Text/ConversationTextMessageCell.swift
@@ -49,7 +49,7 @@ final class ConversationTextMessageCell: UIView, ConversationMessageCell, TextVi
             rhs: ConversationTextMessageCell.Configuration
         ) -> Bool {
             lhs.isObfuscated == rhs.isObfuscated &&
-                lhs.attributedText.description == rhs.attributedText.description &&
+                lhs.attributedText.isEqual(to: rhs.attributedText) &&
                 lhs.mentions.elementsEqual(
                     rhs.mentions,
                     by: {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22990" title="WPB-22990" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22990</a>  [iOS] Wire: specialized closure #8 in AnyConversationMessageCellDescription.init<A>(_:)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following https://wearezeta.atlassian.net/browse/WPB-20367, the fix for https://github.com/wireapp/wire-ios/pull/4190 was reverted on develop. It's correctly set on 4.15, 4.16. This PR restores the fix

### Testing

N/A
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
