### PR TITLE
fix: flaky CommitPendingProposalsGeneratorTests - WPB-23898

### DIFF
--- a/WireDomain/Tests/WireDomainTests/Synchronization/CommitPendingProposalsGeneratorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/CommitPendingProposalsGeneratorTests.swift
@@ -61,8 +61,8 @@ class CommitPendingProposalsGeneratorTests {
     }
 
     @Test(
-        "It generates an item when a conversation with commitPendingProposalDate set is found",
-        arguments: [Date(), Date().addingTimeInterval(0.5)]
+        "It generates an item when a conversation with commitPendingProposalDate set is found", .timeLimit(.minutes(1)),
+        arguments: [Date(), Date().addingTimeInterval(0.5), Date().addingTimeInterval(1)]
     )
     func startGeneratesItem(date: Date) async throws {
         // GIVEN

--- a/WireDomain/Tests/WireDomainTests/Synchronization/CommitPendingProposalsGeneratorTests.swift
+++ b/WireDomain/Tests/WireDomainTests/Synchronization/CommitPendingProposalsGeneratorTests.swift
@@ -72,36 +72,29 @@ class CommitPendingProposalsGeneratorTests {
             proposalDate: date
         )
 
-        var items = [CommitPendingProposalItem]()
+        let (stream, streamContinuation) = AsyncStream.makeStream(of: CommitPendingProposalItem.self)
         commitPendingProposalItemClosure = { item in
-            items.append(item)
+            streamContinuation.yield(item)
         }
+        var iterator = stream.makeAsyncIterator()
+
         // WHEN
         await sut.start()
 
-        // THEN
-        #expect(items.count == 1)
-        #expect(items.first?.conversationID == conversationID)
+        // THEN — properly await the async delivery rather than checking immediately
+        let firstItem = await iterator.next()
+        #expect(firstItem?.conversationID == conversationID)
 
         // WHEN
         let newConversationID = QualifiedID.random()
-        try await confirmation("generator delivers an update for a new conversation") { confirm in
-            self.commitPendingProposalItemClosure = {  item in
-                items.append(item)
-                confirm()
-            }
+        await createPendingMLSConversation(
+            id: newConversationID,
+            proposalDate: date
+        )
 
-            await self.createPendingMLSConversation(
-                id: newConversationID,
-                proposalDate: date
-            )
-
-            try await Task.sleep(for: .seconds(0.5))
-        }
-
-        // THEN
-        #expect(items.count == 2)
-        #expect(items.last?.conversationID == newConversationID)
+        // THEN — await the second delivery (handles future-dated proposals naturally)
+        let secondItem = await iterator.next()
+        #expect(secondItem?.conversationID == newConversationID)
     }
 
     @Test("It does not generate an item on conversation insertion")
@@ -162,7 +155,7 @@ class CommitPendingProposalsGeneratorTests {
                 with: [selfUser],
                 in: context
             )
-            conversation.commitPendingProposalDate = Date()
+            conversation.commitPendingProposalDate = proposalDate
         }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23898" title="WPB-23898" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23898</a>  [iOS] [CI] Flaky tests on CommitPendingProposalsGeneratorTests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Sometimes CommitPendingProposalsGeneratorTests are flaky or even hangs forever on CI.

* rewrite test so it does not rely on time
* add time limit so if test fails it does not hang

### Testing

* run multiple times
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
