### PR TITLE
fix: 1:1 call drop - WPB-23904

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -518,11 +518,14 @@ extension WireCallCenterV3 {
         previousParticipants: [AVSCallMember],
         newParticipants: [AVSCallMember]
     ) -> Bool {
-        /// We assume that the 2nd participant is the other user, and if the other user's audio state is connecting, the
-        /// call should end.
+        /// We assume that the 2nd participant is the other user.
+        /// If the other user's audio state changes from `established` to `connecting`,
+        /// it means the call connection was dropped and the call should be ended.
+        ///  https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT
         guard
             previousParticipants.count == 2,
             newParticipants.count == 2,
+            previousParticipants[1].audioState == .established,
             newParticipants[1].audioState == .connecting
         else {
             return false

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -2629,6 +2629,89 @@ extension WireCallCenterV3Tests {
         XCTAssertTrue(mockAVSWrapper.didCallEndCall)
     }
 
+    func test_EndsCall_WhenOtherParticipantDropsFromEstablishedToConnecting() throws {
+        // Given
+        oneOnOneConversation.messageProtocol = .mls
+        conferenceCalling.status = .enabled
+        conferenceCalling.config = try JSONEncoder().encode(
+            Feature.ConferenceCalling.Config(useSFTForOneToOneCalls: true)
+        )
+
+        sut.handleIncomingCall(
+            conversationId: oneOnOneConversationID.serialized,
+            messageTime: Date(),
+            userId: otherUserID.serialized,
+            clientId: otherUserClientID,
+            isVideoCall: false,
+            shouldRing: true,
+            conversationType: .oneToOne
+        )
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID.serialized)
+
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        handleParticipantChange(selfAudioState: .established, otherAudioState: .established)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // When
+        handleParticipantChange(selfAudioState: .established, otherAudioState: .connecting)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // Then
+        XCTAssertTrue(mockAVSWrapper.didCallEndCall)
+    }
+
+    func test_DoesNotEndCall_WhenCallIsNotEstablished() throws {
+        // Given
+        oneOnOneConversation.messageProtocol = .mls
+        conferenceCalling.status = .enabled
+        conferenceCalling.config = try JSONEncoder().encode(
+            Feature.ConferenceCalling.Config(useSFTForOneToOneCalls: true)
+        )
+
+        sut.handleIncomingCall(
+            conversationId: oneOnOneConversationID.serialized,
+            messageTime: Date(),
+            userId: otherUserID.serialized,
+            clientId: otherUserClientID,
+            isVideoCall: false,
+            shouldRing: true,
+            conversationType: .oneToOne
+        )
+
+        // When
+        handleParticipantChange(selfAudioState: .established, otherAudioState: .connecting)
+
+        // Then
+        XCTAssertFalse(mockAVSWrapper.didCallEndCall)
+    }
+
+    func test_DoesNotEndCall_WhenUseSFTForOneToOneCallsIsFalse() throws {
+        // Given
+        oneOnOneConversation.messageProtocol = .mls
+        conferenceCalling.status = .enabled
+        conferenceCalling.config = try JSONEncoder().encode(
+            Feature.ConferenceCalling.Config(useSFTForOneToOneCalls: false)
+        )
+
+        sut.handleIncomingCall(
+            conversationId: oneOnOneConversationID.serialized,
+            messageTime: Date(),
+            userId: otherUserID.serialized,
+            clientId: otherUserClientID,
+            isVideoCall: false,
+            shouldRing: true,
+            conversationType: .oneToOne
+        )
+        sut.handleEstablishedCall(conversationId: oneOnOneConversationID.serialized)
+        handleParticipantChange(selfAudioState: .established, otherAudioState: .established)
+
+        // When
+        handleParticipantChange(selfAudioState: .established, otherAudioState: .connecting)
+
+        // Then
+        XCTAssertFalse(mockAVSWrapper.didCallEndCall)
+    }
+
 }
 
 // MARK: - Helpers
@@ -2647,4 +2730,34 @@ private extension AVSActiveSpeakersChange {
         let encoded = try! JSONEncoder().encode(self)
         return String(decoding: encoded, as: UTF8.self)
     }
+}
+
+private extension WireCallCenterV3Tests {
+
+    func handleParticipantChange(
+        selfAudioState: AudioState,
+        otherAudioState: AudioState
+    ) {
+        let selfMember = AVSParticipantsChange.Member(
+            userid: selfUserID.serialized,
+            clientid: clientID,
+            aestab: selfAudioState,
+            vrecv: .stopped,
+            muted: .unmuted
+        )
+        let otherMember = AVSParticipantsChange.Member(
+            userid: otherUserID.serialized,
+            clientid: otherUserClientID,
+            aestab: otherAudioState,
+            vrecv: .stopped,
+            muted: .unmuted
+        )
+        let change = AVSParticipantsChange(
+            convid: oneOnOneConversationID.serialized,
+            members: [selfMember, otherMember]
+        )
+        let data = String(decoding: try! JSONEncoder().encode(change), as: UTF8.self)
+        sut.handleParticipantChange(conversationId: oneOnOneConversationID.serialized, data: data)
+    }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23904" title="WPB-23904" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23904</a>  [iOS] 1:1 calls keep disconnecting for some environment
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The 1:1 call is disconnected immediately after the connection is established.
In an environment where the "useSFTForOneToOneCalls" feature flag is set to true, we treat 1:1 calls as group calls.
This initial issue and its solution were described [here](https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT) and implemented some time ago.
However, the implementation is missing one step. This PR fixes that missing step.


### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
