### PR TITLE
chore: disable Datadog RUM features - WPB-23905

### DIFF
--- a/WireAnalytics/Sources/WireDatadog/WireDatadog.swift
+++ b/WireAnalytics/Sources/WireDatadog/WireDatadog.swift
@@ -21,9 +21,7 @@ public import WireLogging
 
 import CryptoKit
 import DatadogCore
-import DatadogCrashReporting
 import DatadogLogs
-import DatadogRUM
 import DatadogTrace
 import UIKit
 
@@ -67,8 +65,6 @@ public final class WireDatadog {
             trackingConsent: .granted
         )
 
-        CrashReporting.enable()
-
         let logsConfiguration = Logs.Configuration()
         Logs.enable(with: logsConfiguration)
 
@@ -86,15 +82,6 @@ public final class WireDatadog {
             networkInfoEnabled: true
         )
         Trace.enable(with: traceConfiguration)
-
-        let rumConfiguration = RUM.Configuration(
-            applicationID: applicationID,
-            sessionSampleRate: 100,
-            uiKitViewsPredicate: DefaultUIKitRUMViewsPredicate(),
-            uiKitActionsPredicate: DefaultUIKitRUMActionsPredicate(),
-            trackBackgroundEvents: true
-        )
-        RUM.enable(with: rumConfiguration)
 
         Datadog.setUserInfo(id: userIdentifier)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,7 +182,6 @@ platform :ios do
     lane :development do |options|
         options[:build_type] = "Development"
         options[:upload_testflight] = true
-        options[:upload_dsyms_to_datadog] = true
         options[:extra_distribution_groups] = ["Wire Employees"]
         options[:produce_debug_builds] = true
         options[:countly_api_key] = ENV['COUNTLY_INTERNAL_KEY']
@@ -195,7 +194,6 @@ platform :ios do
     lane :playground do |options|
         options[:build_type] = "Playground"
         options[:upload_testflight] = true
-        options[:upload_dsyms_to_datadog] = true
         options[:extra_distribution_groups] = ["Wire Employees", "Externals - Non Wire Employees"]
         options[:produce_debug_builds] = true
         options[:countly_api_key] = ENV['COUNTLY_INTERNAL_KEY']
@@ -208,7 +206,6 @@ platform :ios do
     lane :testflight_beta do |options|
         options[:build_type] = "Beta"
         options[:upload_testflight] = true
-        options[:upload_dsyms_to_datadog] = true
         options[:produce_debug_builds] = true
         options[:countly_api_key] = ENV['COUNTLY_INTERNAL_KEY']
         options[:extra_distribution_groups] = ["Wire Employees", "Externals - Non Wire Employees"]
@@ -356,10 +353,6 @@ platform :ios do
         sha256(options)
         upload_s3(options)
         save_changelog_to_env(options)
-       
-        if options[:upload_dsyms_to_datadog] || false
-            upload_dsyms_to_datadog(options)
-        end
     end
 
     def save_app_name(name)
@@ -706,19 +699,6 @@ platform :ios do
         build = Build.new(options: options)
         changelog = changelog(build)
         `export TEMP='RELEASE_NOTES=#{Base64.strict_encode64(changelog)}' && echo $TEMP >> ./.post_build/.env`
-    end
-
-    # Upload dsyms to Datadog
-    def upload_dsyms_to_datadog(options)
-        build = Build.new(options: options)
-        
-        upload_symbols_to_datadog(
-            api_key: ENV["DATADOG_API_KEY"],
-            dsym_paths: [
-                "#{build.artifact_path(with_filename: true)}.app.dSYM.zip"
-            ],
-            site: "datadoghq.eu"
-        )
     end
 end
 

--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperToolsViewModel.swift
@@ -238,8 +238,7 @@ final class DeveloperToolsViewModel: ObservableObject {
             sections.append(Section(
                 header: "Datadog",
                 items: [
-                    .text(TextItem(title: "User ID", value: datadogUserIdentifier)),
-                    .button(.init(title: "Crash Report Test", action: { fatal("crash app") }))
+                    .text(TextItem(title: "User ID", value: datadogUserIdentifier))
                 ]
             ))
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23905" title="WPB-23905" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23905</a>  [iOS] Disable Datadog RUM features
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
Datadog's RUM feature has been disabled. In this PR, we also disable the feature (including crash reporting).

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
