### PR TITLE
fix: crash in topIndexPath - WPB-23912

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/ConversationTableViewDataSource.swift
@@ -554,11 +554,8 @@ final class ConversationTableViewDataSource: NSObject {
     }
 
     func index(of message: ZMConversationMessage) -> Int? {
-        if let indexPath = fetchController?.indexPath(forObject: message as! ZMMessage) {
-            indexPath.row
-        } else {
-            nil
-        }
+        guard let nonce = message.nonce else { return nil }
+        return currentSections.firstIndex(where: { $0.model == nonce })
     }
 
     func topIndexPath(for message: ZMConversationMessage) -> IndexPath? {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23912" title="WPB-23912" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23912</a>  [iOS] crash on topIndexPath(for:) ConversationTableViewDataSource.swift:571
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

  The app crashed when scrolling to a specific message (e.g. via push notification or search result) in a long conversation while background sync was active.

  `topIndexPath(for:)` called `tableView.numberOfRows(inSection:)` with a section index derived from the fetch controller. Because calculateSections snapshots allMessages before dispatching to a background thread, the
  fetch controller can gain new objects (via `NSFetchedResultsControllerDelegate`) by the time the result is applied and `reloadData()` is called. This made the fetch controller index exceed the number of sections the
  table view knew about, triggering UIKit's internal assertion.

  The fix changes `index(of:)` to look up the message by nonce in `currentSections` instead of the fetch controller. Since currentSections is always the exact snapshot the table view was last reloaded with, the
  returned index is guaranteed to be in bounds.

 ### Testing

  1. Open a conversation with significantly more than 30 messages.
  2. While the conversation is open and receiving new messages, trigger a scroll to an old message — either by tapping a push notification or using message search and jumping to a result.
  3. Verify the app does not crash and scrolls to the correct message.

  ---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
