### PR TITLE
fix(ci): C build github action failing on changelog - WPB-23941

### DIFF
--- a/.github/workflows/beta_app_release.yml
+++ b/.github/workflows/beta_app_release.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       distribute_externals:
         type: boolean
-        description: 'Distribute externally'
+        description: 'Distribute externally: Wire Employees and Externals - Non Wire Employees (Public Beta)'
         default: false
 permissions: 
   checks: write

--- a/.github/workflows/c1_c2_c3_app_release_restricted.yml
+++ b/.github/workflows/c1_c2_c3_app_release_restricted.yml
@@ -21,6 +21,11 @@ on:
         description: 'Skip security tests'
         type: boolean
         default: false
+      distribute_externals:
+        type: boolean
+        description: 'Distribute externally: Wire Employees'
+        default: true
+      
 permissions: 
   checks: write
 
@@ -35,6 +40,7 @@ jobs:
       datadog_enabled: ${{ inputs.datadog_enabled }}
       skip_security_tests: ${{ inputs.skip_security_tests }}
       notify_secret: WIRE_IOS_BUILD_WEBHOOK
+      distribute_externals: ${{ inputs.distribute_externals }}
     secrets: inherit
 
   column_2_restricted:
@@ -47,6 +53,7 @@ jobs:
       datadog_enabled: ${{ inputs.datadog_enabled }}
       skip_security_tests: ${{ inputs.skip_security_tests }}
       notify_secret: WIRE_IOS_BUILD_WEBHOOK
+      distribute_externals: ${{ inputs.distribute_externals }}
     secrets: inherit
 
   column_3_restricted:
@@ -59,4 +66,5 @@ jobs:
       datadog_enabled: ${{ inputs.datadog_enabled }}
       skip_security_tests: ${{ inputs.skip_security_tests }}
       notify_secret: WIRE_IOS_BUILD_WEBHOOK
+      distribute_externals: ${{ inputs.distribute_externals }}
     secrets: inherit

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,7 +35,7 @@ jobs:
           if [ "true" == "${IS_CLOUD_BUILD}" ]; then
             echo "regex='appstore/[0-9]+\.[0-9]+\.[0-9]*'" >> $GITHUB_ENV
           else
-            echo "regex='bk_build/[0-9]+\.[0-9]+\.[0-9]*'" >> $GITHUB_ENV
+            echo "regex='build/bk_[0-9]+\.[0-9]+\.[0-9]*'" >> $GITHUB_ENV
           fi
         env:
           IS_CLOUD_BUILD: ${{ inputs.is_cloud_build }}

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -5,8 +5,8 @@ on:
     inputs:
       distribute_externals:
         type: boolean
-        description: 'Distribute externally'
-        default: false
+        description: 'Distribute externally: Wire Employees and Externals - Non Wire Employees'
+        default: true
 
 permissions: 
   checks: write

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -233,6 +233,7 @@ platform :ios do
         options[:s3_subfolder] = ENV['C1_S3_SUBFOLDER_RESTRICTED']
         options[:upload_testflight] = true
         options[:produce_debug_builds] = true
+        options[:extra_distribution_groups] = ["Wire Employees"]
         save_app_name('Column 1 Restricted')
         build_and_upload_app(options)
     end
@@ -244,6 +245,7 @@ platform :ios do
         options[:s3_subfolder] = ENV['C2_S3_SUBFOLDER_RESTRICTED']
         options[:upload_testflight] = true
         options[:produce_debug_builds] = true
+        options[:extra_distribution_groups] = ["Wire Employees"]
         save_app_name('Column 2 Restricted')
         build_and_upload_app(options)
     end
@@ -255,6 +257,7 @@ platform :ios do
         options[:s3_subfolder] = ENV['C3_S3_SUBFOLDER_RESTRICTED']
         options[:upload_testflight] = true
         options[:produce_debug_builds] = true
+        options[:extra_distribution_groups] = ["Wire Employees"]
         save_app_name('Column 3 Restricted')
         build_and_upload_app(options)
     end


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23941" title="WPB-23941" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23941</a>  [iOS] C build github action failing on changelog
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

* Fix the C builds tags for changelog
* Add default distribution option for C build to be available to Wire employees
* Add more description about distribute externally

### Testing

N/A

<img width="319" height="344" alt="Screenshot 2026-03-10 at 09 27 04" src="https://github.com/user-attachments/assets/6c183e30-b096-4287-a0d5-cc26a0e53695" />

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
