### PR TITLE
fix: stretched video preview - WPB-23930

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
@@ -88,7 +88,7 @@ struct WireDriveLargeVideoPreviewView: View {
             case let .success(image):
                 image
                     .resizable()
-                    .scaledToFill()
+                    .aspectRatio(imageAspectRatio ?? Self.defaultAspectRatio, contentMode: .fit)
                     .overlay {
                         PlayIcon()
                             .disabled(false)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
@@ -36,7 +36,7 @@ struct WireDriveLargeVideoPreviewView: View {
     let progress: Double?
     let downloadError: Bool
     let url: URL?
-    var imageAspectRatio: CGFloat? = defaultAspectRatio
+    var imageAspectRatio: CGFloat = defaultAspectRatio
     let duration: String?
 
     @Environment(\.wireAccentColor) private var wireAccentColor
@@ -88,7 +88,7 @@ struct WireDriveLargeVideoPreviewView: View {
             case let .success(image):
                 image
                     .resizable()
-                    .aspectRatio(imageAspectRatio ?? Self.defaultAspectRatio, contentMode: .fit)
+                    .aspectRatio(imageAspectRatio, contentMode: .fit)
                     .overlay {
                         PlayIcon()
                             .disabled(false)
@@ -105,7 +105,7 @@ struct WireDriveLargeVideoPreviewView: View {
     private func previewContainer(@ViewBuilder content: () -> some View)
         -> some View {
         Color.clear
-            .aspectRatio(imageAspectRatio ?? Self.defaultAspectRatio, contentMode: .fit)
+            .aspectRatio(imageAspectRatio, contentMode: .fit)
             .background(alignment: .top) {
                 content()
             }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23930" title="WPB-23930" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23930</a>  [iOS][File in conversation] Video thumbnails in conversation stretched and distorted 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue on large video previews where the image is stretched and distorted.

Before:
<img width="432" height="699" alt="Screenshot 2026-03-10 at 09 18 49" src="https://github.com/user-attachments/assets/90f7c7f3-478d-4395-a08b-0000c303372b" />

After:

![Capture d’écran   2026-03-10 à 09 30 47](https://github.com/user-attachments/assets/9de4a6be-2099-4184-a738-19e4c2497459)

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
