### PR TITLE
fix: update sorting localization - WPB-21656

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -298,8 +298,8 @@
 "conversation.wireCells.sorting.key.size" = "Size";
 "conversation.wireCells.sorting.order.date.recentFirst" = "Newest first";
 "conversation.wireCells.sorting.order.date.oldestFirst" = "Oldest first";
-"conversation.wireCells.sorting.order.name.az" = "A-Z";
-"conversation.wireCells.sorting.order.name.za" = "Z-A";
+"conversation.wireCells.sorting.order.name.az" = "A to Z";
+"conversation.wireCells.sorting.order.name.za" = "Z to A";
 "conversation.wireCells.sorting.order.size.smallestFirst" = "Smallest first";
 "conversation.wireCells.sorting.order.size.largestFirst" = "Largest first";
 "conversation.wireCells.sorting.results" = "Results in Shared Drive";


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-21656" title="WPB-21656" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-21656</a>  [iOS] Sorting in all files
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR updates some localizable related to drive files sorting

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
