### PR TITLE
fix: add character restriction when uploading drive file - WPB-23633

### DIFF
--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/UploadDraftUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/UploadDraftUseCase.swift
@@ -38,7 +38,7 @@ package struct UploadDraftUseCase: WireDriveUploadDraftUseCaseProtocol, WireDriv
     private let intermediaryFilesDirectory: URL
     private let filenameGenerator: FilenameGenerator
 
-    package let charactersToReplace: [Character] = ["\\", "\""]
+    package let charactersToReplace: [Character] = ["/", "\\", "\""]
 
     package init(
         cellName: String,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23633" title="WPB-23633" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23633</a>  [iOS] Prevent Invalid File Names at upload to avoid Android Crash and app issues
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds an invalid filename character when uploading a file.

### Testing

on a Drive conversation, try to upload a file with a / in the name, this should trigger the alert

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
