### PR TITLE
fix: filling critical flow for open connection Request page - WPB-23970

### DIFF
--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -123,17 +123,16 @@ class ConversationsPage: PageModel {
 
     func openPendingRequest() throws -> ConnectionRequestsPage {
         try letTheSyncFinish()
-        XCTAssertTrue(conversationCell.waitForExistence(timeout: 5), "Conversation cell did not appear")
 
         let maxDuration: TimeInterval = 10
         let start = Date()
 
         while !connectionsRequestCell.exists, Date().timeIntervalSince(start) < maxDuration {
-            if conversationCell.isHittable {
-                conversationCell.tap()
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
         }
+
+        XCTAssertTrue(connectionsRequestCell.exists, "Connection request cell did not appear within \(maxDuration) seconds")
+        connectionsRequestCell.tap()
         return try ConnectionRequestsPage()
     }
 

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -131,7 +131,10 @@ class ConversationsPage: PageModel {
             RunLoop.current.run(until: Date().addingTimeInterval(0.5))
         }
 
-        XCTAssertTrue(connectionsRequestCell.exists, "Connection request cell did not appear within \(maxDuration) seconds")
+        XCTAssertTrue(
+            connectionsRequestCell.exists,
+            "Connection request cell did not appear within \(maxDuration) seconds"
+        )
         connectionsRequestCell.tap()
         return try ConnectionRequestsPage()
     }

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -125,16 +125,11 @@ class ConversationsPage: PageModel {
         try letTheSyncFinish()
 
         let maxDuration: TimeInterval = 10
-        let start = Date()
-
-        while !connectionsRequestCell.exists, Date().timeIntervalSince(start) < maxDuration {
-            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        guard connectionsRequestCell.waitForExistence(timeout: maxDuration) else {
+            XCTFail("Connection request cell did not appear within \(maxDuration) seconds")
+            return try ConnectionRequestsPage()
         }
 
-        XCTAssertTrue(
-            connectionsRequestCell.exists,
-            "Connection request cell did not appear within \(maxDuration) seconds"
-        )
         connectionsRequestCell.tap()
         return try ConnectionRequestsPage()
     }

--- a/wire-ios/WireUITests/Pages/ConversationsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationsPage.swift
@@ -126,8 +126,7 @@ class ConversationsPage: PageModel {
 
         let maxDuration: TimeInterval = 10
         guard connectionsRequestCell.waitForExistence(timeout: maxDuration) else {
-            XCTFail("Connection request cell did not appear within \(maxDuration) seconds")
-            return try ConnectionRequestsPage()
+            throw Error.connectionRequestsCellNotFound
         }
 
         connectionsRequestCell.tap()
@@ -189,5 +188,9 @@ class ConversationsPage: PageModel {
         filterConversationsButton.tap()
         filterByOneOnOneConversation.tap()
         return self
+    }
+
+    enum Error: Swift.Error {
+        case connectionRequestsCellNotFound
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23970" title="WPB-23970" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23970</a>  [iOS] fix connection request page failure in ciritical flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Critical flow failure due to a logic issue**

https://app.datadoghq.eu/ci/test/runs?query=test_level%3Atest%20%40test.service%3A%28wire-ios-mono%29%20%40test.suite%3AWireUITests%2A%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZzZsTebXjshZQAAABhBWnpac1RlYkFBQ2w1bGVUcm1PdzJPcm8AAAAkMTE5Y2Q5YjgtOWFiOS00NTQzLWJiOWEtNDllNjMxMGI3YzQyAAAZiQ&fromUser=false&index=citest&testId=AwAAAZzZsTebXjshZQAAABhBWnpac1RlYkFBQ2w1bGVUcm1PdzJPcm8AAAAkMTE5Y2Q5YjgtOWFiOS00NTQzLWJiOWEtNDllNjMxMGI3YzQyAAAZiQ&trace=AwAAAZzZsTebXjshZQAAABhBWnpac1RlYkFBQ2w1bGVUcm1PdzJPcm8AAAAkMTE5Y2Q5YjgtOWFiOS00NTQzLWJiOWEtNDllNjMxMGI3YzQyAAAZiQ&viz=stream&start=1773135893891&end=1773222293891&paused=false

### Testing

Locally ran and worked fine

<img width="1134" height="882" alt="image" src="https://github.com/user-attachments/assets/8ab4ef08-2bd2-4c30-8887-76d53e4fe7ea" />


---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
