### PR TITLE
fix: missing start worker on fresh install - WPB-24057

### DIFF
--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -681,9 +681,19 @@ public final class ZMUserSession: NSObject {
             WireLogger.session.error("failed to clean up invalid connections: \(String(describing: error))")
         }
 
+        await startWorkAgentAndGenerators()
+    }
+
+    private func startWorkAgentAndGenerators() async {
         guard let clientSessionComponent else {
+            WireLogger.session.warn(
+                "no client session component, skipping startWorkAgentAndGenerators",
+                attributes: .safePublic
+            )
             return
         }
+
+        WireLogger.session.info("start work agent and generators", attributes: .safePublic)
 
         await clientSessionComponent.workAgent.setAutoStartEnabled(true)
         await clientSessionComponent.workAgent.start()
@@ -698,7 +708,6 @@ public final class ZMUserSession: NSObject {
         }.store(in: &cancellables)
         // Initialize the generator to enqueue repair work item if needed
         clientSessionComponent.repairFaultyMLSRemovalKeysGenerator.submitWorkItemIfNeeded()
-
     }
 
     public func migrateToConsumableNotificationsIfNeeded() async throws {
@@ -1401,6 +1410,8 @@ extension ZMUserSession: ZMClientRegistrationStatusDelegate {
             // this is a fresh client so we need an initialSync
             journal[.isInitialSyncRequired] = true
             Task {
+                //
+                await startWorkAgentAndGenerators()
                 WireLogger.sync.debug("Triggering initial sync after client registration")
                 await triggerSync()
             }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -1410,7 +1410,6 @@ extension ZMUserSession: ZMClientRegistrationStatusDelegate {
             // this is a fresh client so we need an initialSync
             journal[.isInitialSyncRequired] = true
             Task {
-                //
                 await startWorkAgentAndGenerators()
                 WireLogger.sync.debug("Triggering initial sync after client registration")
                 await triggerSync()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24057" title="WPB-24057" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24057</a>  [iOS] WorkAgent and Generators not started on fresh install
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

On fresh install, the workAgent and generators are not started following  #4363. This PR fixes it.

### Testing

Install and login make sure work-agent is running in checking logs

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
