### PR TITLE
fix: EAR Security Tests - WPB-23474

### DIFF
--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
@@ -155,7 +155,7 @@ final class NSEUserScope: Component<NSEUserScopeDependency> {
             throw Failure.mainAppRequired(message: "no self client id")
         }
 
-        let earService = await EARService(
+        let earService = await EARServiceFactory().createEARService(
             accountID: accountID,
             coreDataStack: coreDataStack,
             sharedUserDefaults: dependency.sharedUserDefaults,

--- a/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
+++ b/WireDomain/Sources/WireDomain/Notifications/Components/NSEUserScope.swift
@@ -155,7 +155,7 @@ final class NSEUserScope: Component<NSEUserScopeDependency> {
             throw Failure.mainAppRequired(message: "no self client id")
         }
 
-        let earService = await EARServiceFactory().createEARService(
+        let earService = await EARServiceFactory.createEARService(
             accountID: accountID,
             coreDataStack: coreDataStack,
             sharedUserDefaults: dependency.sharedUserDefaults,

--- a/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
@@ -50,40 +50,6 @@ public class EARService: EARServiceInterface {
 
     // MARK: - Life cycle
 
-    /// Create a new `EARService`.
-    ///
-    /// - Parameters:
-    ///   - accountID: The id of the self user.
-    ///   - coreDataStack: The core data stack on which the message encryption service will be set.
-    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when
-    /// the service is running in app extensions.
-    ///   - sharedUserDefaults: The shared user defaults in which to keep track of whether EAR is enabled.
-    ///   - authenticationContext: The authentication context used to access encryption keys.
-
-    public convenience init(
-        accountID: UUID,
-        coreDataStack: CoreDataStackProtocol,
-        canPerformKeyMigration: Bool = false,
-        sharedUserDefaults: UserDefaults,
-        authenticationContext: any AuthenticationContextProtocol
-    ) {
-        let earStorage = EARStorage(userID: accountID, sharedUserDefaults: sharedUserDefaults)
-        let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
-        let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
-
-        self.init(
-            accountID: accountID,
-            keyRepository: EARKeyRepository(),
-            keyEncryptor: EARKeyEncryptor(),
-            coreDataStack: coreDataStack,
-            canPerformKeyMigration: canPerformKeyMigration,
-            earStorage: earStorage,
-            messageEncryptionService: messageEncryptionService,
-            migrator: migrator,
-            authenticationContext: authenticationContext
-        )
-    }
-
     init(
         accountID: UUID,
         keyRepository: EARKeyRepositoryInterface = EARKeyRepository(),
@@ -116,7 +82,7 @@ public class EARService: EARServiceInterface {
         }
     }
 
-    public func setupDatabaseContexts(databaseContexts: [NSManagedObjectContext]) async {
+    func setupDatabaseContexts(databaseContexts: [NSManagedObjectContext]) async {
         for context in databaseContexts {
             await context.perform { [service = earMessageEncryptionService] in
                 context.earMessageEncryptionService = service

--- a/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
@@ -49,34 +49,31 @@ public class EARService: EARServiceInterface {
     private let authenticationContext: any AuthenticationContextProtocol
 
     // MARK: - Life cycle
-
+    
     /// Create a new `EARService`.
     ///
     /// - Parameters:
     ///   - accountID: The id of the self user.
-    ///   - databaseContexts: A list of database contexts that require access to the database key.
-    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when
-    /// the service is running in app extensions.
+    ///   - coreDataStack: The core data stack on which the message encryption service will be set.
+    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when the service is running in app extensions.
     ///   - sharedUserDefaults: The shared user defaults in which to keep track of whether EAR is enabled.
     ///   - authenticationContext: The authentication context used to access encryption keys.
-
+   
     public convenience init(
         accountID: UUID,
-        databaseContexts: [NSManagedObjectContext] = [],
         coreDataStack: CoreDataStackProtocol,
         canPerformKeyMigration: Bool = false,
         sharedUserDefaults: UserDefaults,
         authenticationContext: any AuthenticationContextProtocol
-    ) async {
+    ) {
         let earStorage = EARStorage(userID: accountID, sharedUserDefaults: sharedUserDefaults)
         let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
         let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
 
-        await self.init(
+        self.init(
             accountID: accountID,
             keyRepository: EARKeyRepository(),
             keyEncryptor: EARKeyEncryptor(),
-            databaseContexts: databaseContexts,
             coreDataStack: coreDataStack,
             canPerformKeyMigration: canPerformKeyMigration,
             earStorage: earStorage,
@@ -85,19 +82,18 @@ public class EARService: EARServiceInterface {
             authenticationContext: authenticationContext
         )
     }
-
+    
     init(
         accountID: UUID,
         keyRepository: EARKeyRepositoryInterface = EARKeyRepository(),
         keyEncryptor: EARKeyEncryptorInterface = EARKeyEncryptor(),
-        databaseContexts: [NSManagedObjectContext],
         coreDataStack: CoreDataStackProtocol,
         canPerformKeyMigration: Bool,
         earStorage: EARStorage,
         messageEncryptionService: EARMessageEncryptionServiceProtocol,
         migrator: EARMigratorProtocol,
         authenticationContext: AuthenticationContextProtocol
-    ) async {
+    ) {
         self.accountID = accountID
         self.keyRepository = keyRepository
         self.keyEncryptor = keyEncryptor
@@ -114,14 +110,16 @@ public class EARService: EARServiceInterface {
 
         coreDataStack.setEARMessageEncryptionService(messageEncryptionService)
 
-        for context in databaseContexts {
-            await context.perform {
-                context.earMessageEncryptionService = messageEncryptionService
-            }
-        }
-
         if canPerformKeyMigration {
             migrateKeysIfNeeded()
+        }
+    }
+    
+    public func setupDatabaseContexts(databaseContexts: [NSManagedObjectContext]) async {
+        for context in databaseContexts {
+            await context.perform { [service = earMessageEncryptionService] in
+                context.earMessageEncryptionService = service
+            }
         }
     }
 

--- a/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARService.swift
@@ -49,16 +49,17 @@ public class EARService: EARServiceInterface {
     private let authenticationContext: any AuthenticationContextProtocol
 
     // MARK: - Life cycle
-    
+
     /// Create a new `EARService`.
     ///
     /// - Parameters:
     ///   - accountID: The id of the self user.
     ///   - coreDataStack: The core data stack on which the message encryption service will be set.
-    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when the service is running in app extensions.
+    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when
+    /// the service is running in app extensions.
     ///   - sharedUserDefaults: The shared user defaults in which to keep track of whether EAR is enabled.
     ///   - authenticationContext: The authentication context used to access encryption keys.
-   
+
     public convenience init(
         accountID: UUID,
         coreDataStack: CoreDataStackProtocol,
@@ -82,7 +83,7 @@ public class EARService: EARServiceInterface {
             authenticationContext: authenticationContext
         )
     }
-    
+
     init(
         accountID: UUID,
         keyRepository: EARKeyRepositoryInterface = EARKeyRepository(),
@@ -114,7 +115,7 @@ public class EARService: EARServiceInterface {
             migrateKeysIfNeeded()
         }
     }
-    
+
     public func setupDatabaseContexts(databaseContexts: [NSManagedObjectContext]) async {
         for context in databaseContexts {
             await context.perform { [service = earMessageEncryptionService] in

--- a/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
@@ -20,6 +20,18 @@ public struct EARServiceFactory {
 
     public init() {}
 
+    /// Create a new `EARService`.
+    ///
+    /// - Parameters:
+    ///   - accountID: The id of the self user.
+    ///   - databaseContexts: The managed object contexts on which to set the `EARMessageEncryptionService`
+    ///   - coreDataStack: The core data stack on which the `EARMessageEncryptionService` will be set.
+    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when
+    /// the service is running in app extensions.
+    ///   - sharedUserDefaults:  The shared user defaults in which to keep track of whether EAR is enabled.
+    ///   - authenticationContext: The authentication context used to access encryption keys.
+    /// - Returns: a newly created `EARService` instance
+    ///
     public func createEARService(
         accountID: UUID,
         databaseContexts: [NSManagedObjectContext] = [],
@@ -52,5 +64,63 @@ public struct EARServiceFactory {
 
         return earService
     }
+    
+    #if DEBUG
+    
+    /// Synchronously creates an `EARService` instance
+    ///
+    /// - Parameters:
+    ///   - accountID: The id of the self user.
+    ///   - coreDataStack: The core data stack on which the `EARMessageEncryptionService` will be set.
+    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when
+    /// the service is running in app extensions.
+    ///   - sharedUserDefaults: The shared user defaults in which to keep track of whether EAR is enabled.
+    ///   - authenticationContext:  The authentication context used to access encryption keys.
+    /// - Returns: a newly created `EARService` instance
+    ///
+    public func createEARService(
+        accountID: UUID,
+        coreDataStack: CoreDataStackProtocol,
+        canPerformKeyMigration: Bool = false,
+        sharedUserDefaults: UserDefaults,
+        authenticationContext: any AuthenticationContextProtocol
+    ) -> EARService {
+        let earStorage = EARStorage(userID: accountID, sharedUserDefaults: sharedUserDefaults)
+        let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
+        let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
+
+        let earService = EARService(
+            accountID: accountID,
+            keyRepository: EARKeyRepository(),
+            keyEncryptor: EARKeyEncryptor(),
+            coreDataStack: coreDataStack,
+            canPerformKeyMigration: canPerformKeyMigration,
+            earStorage: earStorage,
+            messageEncryptionService: messageEncryptionService,
+            migrator: migrator,
+            authenticationContext: authenticationContext
+        )
+
+        return earService
+    }
+    
+    
+    /// Sets the `EARMessageEncryptionService` on the given managed object contexts
+    ///
+    /// - Parameters:
+    ///   - databaseContexts: The managed object contexts on which to set the `EARMessageEncryptionService`
+    ///   - earService: The `EARService` instance to setup
+    ///
+    public func setupDatabaseContexts(
+        databaseContexts: [NSManagedObjectContext],
+        onEARService earService: EARService
+    ) async {
+        guard !databaseContexts.isEmpty else { return }
+        
+        await earService.setupDatabaseContexts(
+            databaseContexts: databaseContexts
+        )
+    }
+    #endif
 
 }

--- a/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
@@ -17,9 +17,9 @@
 //
 
 public struct EARServiceFactory {
-    
+
     public init() {}
-    
+
     public func createEARService(
         accountID: UUID,
         databaseContexts: [NSManagedObjectContext] = [],
@@ -43,13 +43,13 @@ public struct EARServiceFactory {
             migrator: migrator,
             authenticationContext: authenticationContext
         )
-        
+
         if !databaseContexts.isEmpty {
             await earService.setupDatabaseContexts(
                 databaseContexts: databaseContexts
             )
         }
-        
+
         return earService
     }
 

--- a/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
@@ -16,9 +16,9 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
-public struct EARServiceFactory {
+public enum EARServiceFactory {
 
-    public init() {}
+    // MARK: - Public Interface
 
     /// Create a new `EARService`.
     ///
@@ -32,7 +32,7 @@ public struct EARServiceFactory {
     ///   - authenticationContext: The authentication context used to access encryption keys.
     /// - Returns: a newly created `EARService` instance
     ///
-    public func createEARService(
+    public static func createEARService(
         accountID: UUID,
         databaseContexts: [NSManagedObjectContext] = [],
         coreDataStack: CoreDataStackProtocol,
@@ -56,14 +56,15 @@ public struct EARServiceFactory {
             authenticationContext: authenticationContext
         )
 
-        if !databaseContexts.isEmpty {
-            await earService.setupDatabaseContexts(
-                databaseContexts: databaseContexts
-            )
-        }
+        await internalSetupDatabaseContexts(
+            databaseContexts: databaseContexts,
+            onEARService: earService
+        )
 
         return earService
     }
+
+    // MARK: - Tests Interface
 
     #if DEBUG
 
@@ -79,7 +80,7 @@ public struct EARServiceFactory {
         ///   - authenticationContext:  The authentication context used to access encryption keys.
         /// - Returns: a newly created `EARService` instance
         ///
-        public func createEARService(
+        public static func createEARService(
             accountID: UUID,
             coreDataStack: CoreDataStackProtocol,
             canPerformKeyMigration: Bool = false,
@@ -103,23 +104,34 @@ public struct EARServiceFactory {
             )
         }
 
-
         /// Sets the `EARMessageEncryptionService` on the given managed object contexts
         ///
         /// - Parameters:
         ///   - databaseContexts: The managed object contexts on which to set the `EARMessageEncryptionService`
         ///   - earService: The `EARService` instance to setup
         ///
-        public func setupDatabaseContexts(
+        public static func setupDatabaseContexts(
             databaseContexts: [NSManagedObjectContext],
             onEARService earService: EARService
         ) async {
-            guard !databaseContexts.isEmpty else { return }
-
-            await earService.setupDatabaseContexts(
-                databaseContexts: databaseContexts
+            await internalSetupDatabaseContexts(
+                databaseContexts: databaseContexts,
+                onEARService: earService
             )
         }
+
     #endif
 
+    // MARK: - Private Helpers
+
+    private static func internalSetupDatabaseContexts(
+        databaseContexts: [NSManagedObjectContext],
+        onEARService earService: EARService
+    ) async {
+        guard !databaseContexts.isEmpty else { return }
+
+        await earService.setupDatabaseContexts(
+            databaseContexts: databaseContexts
+        )
+    }
 }

--- a/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
@@ -1,0 +1,56 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+public struct EARServiceFactory {
+    
+    public init() {}
+    
+    public func createEARService(
+        accountID: UUID,
+        databaseContexts: [NSManagedObjectContext] = [],
+        coreDataStack: CoreDataStackProtocol,
+        canPerformKeyMigration: Bool = false,
+        sharedUserDefaults: UserDefaults,
+        authenticationContext: any AuthenticationContextProtocol
+    ) async -> EARServiceInterface {
+        let earStorage = EARStorage(userID: accountID, sharedUserDefaults: sharedUserDefaults)
+        let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
+        let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
+
+        let earService = EARService(
+            accountID: accountID,
+            keyRepository: EARKeyRepository(),
+            keyEncryptor: EARKeyEncryptor(),
+            coreDataStack: coreDataStack,
+            canPerformKeyMigration: canPerformKeyMigration,
+            earStorage: earStorage,
+            messageEncryptionService: messageEncryptionService,
+            migrator: migrator,
+            authenticationContext: authenticationContext
+        )
+        
+        if !databaseContexts.isEmpty {
+            await earService.setupDatabaseContexts(
+                databaseContexts: databaseContexts
+            )
+        }
+        
+        return earService
+    }
+
+}

--- a/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
+++ b/wire-ios-data-model/Source/Authentication/EAR/EARServiceFactory.swift
@@ -64,63 +64,62 @@ public struct EARServiceFactory {
 
         return earService
     }
-    
+
     #if DEBUG
-    
-    /// Synchronously creates an `EARService` instance
-    ///
-    /// - Parameters:
-    ///   - accountID: The id of the self user.
-    ///   - coreDataStack: The core data stack on which the `EARMessageEncryptionService` will be set.
-    ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed when
-    /// the service is running in app extensions.
-    ///   - sharedUserDefaults: The shared user defaults in which to keep track of whether EAR is enabled.
-    ///   - authenticationContext:  The authentication context used to access encryption keys.
-    /// - Returns: a newly created `EARService` instance
-    ///
-    public func createEARService(
-        accountID: UUID,
-        coreDataStack: CoreDataStackProtocol,
-        canPerformKeyMigration: Bool = false,
-        sharedUserDefaults: UserDefaults,
-        authenticationContext: any AuthenticationContextProtocol
-    ) -> EARService {
-        let earStorage = EARStorage(userID: accountID, sharedUserDefaults: sharedUserDefaults)
-        let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
-        let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
 
-        let earService = EARService(
-            accountID: accountID,
-            keyRepository: EARKeyRepository(),
-            keyEncryptor: EARKeyEncryptor(),
-            coreDataStack: coreDataStack,
-            canPerformKeyMigration: canPerformKeyMigration,
-            earStorage: earStorage,
-            messageEncryptionService: messageEncryptionService,
-            migrator: migrator,
-            authenticationContext: authenticationContext
-        )
+        /// Synchronously creates an `EARService` instance
+        ///
+        /// - Parameters:
+        ///   - accountID: The id of the self user.
+        ///   - coreDataStack: The core data stack on which the `EARMessageEncryptionService` will be set.
+        ///   - canPerformKeyMigration: Whether key migration can be performed. Key migration should not be performed
+        /// when
+        /// the service is running in app extensions.
+        ///   - sharedUserDefaults: The shared user defaults in which to keep track of whether EAR is enabled.
+        ///   - authenticationContext:  The authentication context used to access encryption keys.
+        /// - Returns: a newly created `EARService` instance
+        ///
+        public func createEARService(
+            accountID: UUID,
+            coreDataStack: CoreDataStackProtocol,
+            canPerformKeyMigration: Bool = false,
+            sharedUserDefaults: UserDefaults,
+            authenticationContext: any AuthenticationContextProtocol
+        ) -> EARService {
+            let earStorage = EARStorage(userID: accountID, sharedUserDefaults: sharedUserDefaults)
+            let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
+            let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
 
-        return earService
-    }
-    
-    
-    /// Sets the `EARMessageEncryptionService` on the given managed object contexts
-    ///
-    /// - Parameters:
-    ///   - databaseContexts: The managed object contexts on which to set the `EARMessageEncryptionService`
-    ///   - earService: The `EARService` instance to setup
-    ///
-    public func setupDatabaseContexts(
-        databaseContexts: [NSManagedObjectContext],
-        onEARService earService: EARService
-    ) async {
-        guard !databaseContexts.isEmpty else { return }
-        
-        await earService.setupDatabaseContexts(
-            databaseContexts: databaseContexts
-        )
-    }
+            return EARService(
+                accountID: accountID,
+                keyRepository: EARKeyRepository(),
+                keyEncryptor: EARKeyEncryptor(),
+                coreDataStack: coreDataStack,
+                canPerformKeyMigration: canPerformKeyMigration,
+                earStorage: earStorage,
+                messageEncryptionService: messageEncryptionService,
+                migrator: migrator,
+                authenticationContext: authenticationContext
+            )
+        }
+
+
+        /// Sets the `EARMessageEncryptionService` on the given managed object contexts
+        ///
+        /// - Parameters:
+        ///   - databaseContexts: The managed object contexts on which to set the `EARMessageEncryptionService`
+        ///   - earService: The `EARService` instance to setup
+        ///
+        public func setupDatabaseContexts(
+            databaseContexts: [NSManagedObjectContext],
+            onEARService earService: EARService
+        ) async {
+            guard !databaseContexts.isEmpty else { return }
+
+            await earService.setupDatabaseContexts(
+                databaseContexts: databaseContexts
+            )
+        }
     #endif
 
 }

--- a/wire-ios-data-model/Tests/Authentication/EAR/EARServiceIntegrationTests.swift
+++ b/wire-ios-data-model/Tests/Authentication/EAR/EARServiceIntegrationTests.swift
@@ -67,11 +67,10 @@ final class EARServiceIntegrationTests: EARServiceTestsBase, @MainActor EARServi
         canPerformMigration: Bool = false,
         contexts: [NSManagedObjectContext]? = nil
     ) async -> EARService {
-        let sut = await EARService(
+        let sut = EARService(
             accountID: userID,
             keyRepository: keyRepository,
             keyEncryptor: keyEncryptor,
-            databaseContexts: contexts ?? [uiMOC, syncMOC],
             coreDataStack: coreDataStack,
             canPerformKeyMigration: canPerformMigration,
             earStorage: earStorage,
@@ -79,7 +78,9 @@ final class EARServiceIntegrationTests: EARServiceTestsBase, @MainActor EARServi
             migrator: migrator,
             authenticationContext: MockAuthenticationContextProtocol()
         )
-
+        await sut.setupDatabaseContexts(
+            databaseContexts: contexts ?? [uiMOC, syncMOC]
+        )
         sut.delegate = self
         return sut
     }
@@ -391,11 +392,10 @@ final class EARServiceIntegrationTests: EARServiceTestsBase, @MainActor EARServi
         let messageEncryptionService = EARMessageEncryptionService(earStorage: earStorage)
         let migrator = EARMigrator(messageEncryptionService: messageEncryptionService)
 
-        let sut = await EARService(
+        let sut = EARService(
             accountID: userID,
             keyRepository: EARKeyRepository(),  // Real keychain access
             keyEncryptor: EARKeyEncryptor(),    // Real crypto
-            databaseContexts: [uiMOC],
             coreDataStack: coreDataStack,
             canPerformKeyMigration: false,
             earStorage: earStorage,
@@ -403,6 +403,7 @@ final class EARServiceIntegrationTests: EARServiceTestsBase, @MainActor EARServi
             migrator: migrator,
             authenticationContext: MockAuthenticationContextProtocol()
         )
+        await sut.setupDatabaseContexts(databaseContexts: [uiMOC])
         sut.delegate = self
 
         let oldDatabaseKey = try sut.generateKeys()

--- a/wire-ios-data-model/Tests/Authentication/EAR/EARServiceTests.swift
+++ b/wire-ios-data-model/Tests/Authentication/EAR/EARServiceTests.swift
@@ -61,11 +61,10 @@ final class EARServiceTests: EARServiceTestsBase, @MainActor EARServiceDelegate 
     func createSUT(
         canPerformMigration: Bool = false
     ) async -> EARService {
-        let sut = await EARService(
+        let sut = EARService(
             accountID: userID,
             keyRepository: keyRepository,
             keyEncryptor: keyEncryptor,
-            databaseContexts: [uiMOC, syncMOC],
             coreDataStack: coreDataStack,
             canPerformKeyMigration: canPerformMigration,
             earStorage: earStorage,
@@ -74,6 +73,9 @@ final class EARServiceTests: EARServiceTestsBase, @MainActor EARServiceDelegate 
             authenticationContext: MockAuthenticationContextProtocol()
         )
 
+        await sut.setupDatabaseContexts(
+            databaseContexts: [uiMOC, syncMOC]
+        )
         sut.delegate = self
         return sut
     }

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		882B86BE2E8441AA008A50CA /* RemoveCoreCryptoKeysUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B86BD2E84419A008A50CA /* RemoveCoreCryptoKeysUseCase.swift */; };
 		8838CFA42EC4CB1B00495012 /* NSManagedObjectContext+AccountDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8838CFA32EC4CB0D00495012 /* NSManagedObjectContext+AccountDirectory.swift */; };
 		884371662EB8E9F3003DA083 /* store2-132-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 884371652EB8E9F3003DA083 /* store2-132-0.wiredatabase */; };
+		885B4BC12F6062B9001D7D72 /* EARServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 885B4BC02F6062B4001D7D72 /* EARServiceFactory.swift */; };
 		88A80B632F320E9200F7E372 /* EARMessageEncryptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A80B622F320E7500F7E372 /* EARMessageEncryptionService.swift */; };
 		88A80B652F3381ED00F7E372 /* EARMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88A80B642F3381DF00F7E372 /* EARMigrator.swift */; };
 		88B81BD62EC232C600248D7A /* store2-133-0.wiredatabase in Resources */ = {isa = PBXBuildFile; fileRef = 88B81BD52EC232C600248D7A /* store2-133-0.wiredatabase */; };
@@ -1123,6 +1124,7 @@
 		882B86BD2E84419A008A50CA /* RemoveCoreCryptoKeysUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveCoreCryptoKeysUseCase.swift; sourceTree = "<group>"; };
 		8838CFA32EC4CB0D00495012 /* NSManagedObjectContext+AccountDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+AccountDirectory.swift"; sourceTree = "<group>"; };
 		884371652EB8E9F3003DA083 /* store2-132-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-132-0.wiredatabase"; sourceTree = "<group>"; };
+		885B4BC02F6062B4001D7D72 /* EARServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARServiceFactory.swift; sourceTree = "<group>"; };
 		88A80B622F320E7500F7E372 /* EARMessageEncryptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARMessageEncryptionService.swift; sourceTree = "<group>"; };
 		88A80B642F3381DF00F7E372 /* EARMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARMigrator.swift; sourceTree = "<group>"; };
 		88B81BD52EC232C600248D7A /* store2-133-0.wiredatabase */ = {isa = PBXFileReference; lastKnownFileType = file; path = "store2-133-0.wiredatabase"; sourceTree = "<group>"; };
@@ -2088,6 +2090,7 @@
 				E6E504282BC542C5004948E7 /* EARPrivateKeys.swift */,
 				E6E504292BC542C5004948E7 /* EARPublicKeys.swift */,
 				E6E5042A2BC542C5004948E7 /* EARService.swift */,
+				885B4BC02F6062B4001D7D72 /* EARServiceFactory.swift */,
 				E6E5042B2BC542C5004948E7 /* EARServiceDelegate.swift */,
 				E6E5042C2BC542C5004948E7 /* EARServiceFailure.swift */,
 				E6E5042D2BC542C5004948E7 /* EARStorage.swift */,
@@ -3572,6 +3575,7 @@
 				16CDEBFB2209D13B00E74A41 /* ZMMessage+Quotes.swift in Sources */,
 				EE997A1425062295008336D2 /* Logging.swift in Sources */,
 				F9331C841CB4191B00139ECC /* NSPredicate+ZMSearch.m in Sources */,
+				885B4BC12F6062B9001D7D72 /* EARServiceFactory.swift in Sources */,
 				BFCD502D21511D58008CD845 /* DraftMessage.swift in Sources */,
 				63B1336B29A503D100009D84 /* MLSGroupStatus.swift in Sources */,
 				EE3EFE9725305A84009499E5 /* ModifiedObjects+Mergeable.swift in Sources */,

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -244,7 +244,8 @@ public final class SharingSession {
             featureRepository: featureRepository
         )
         let contextStorage = LAContextStorage()
-        let earService = await EARService(
+        
+        let earService = await EARServiceFactory().createEARService(
             accountID: accountIdentifier,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -244,7 +244,7 @@ public final class SharingSession {
             featureRepository: featureRepository
         )
         let contextStorage = LAContextStorage()
-        
+
         let earService = await EARServiceFactory().createEARService(
             accountID: accountIdentifier,
             databaseContexts: [

--- a/wire-ios-share-engine/Sources/SharingSession.swift
+++ b/wire-ios-share-engine/Sources/SharingSession.swift
@@ -245,7 +245,7 @@ public final class SharingSession {
         )
         let contextStorage = LAContextStorage()
 
-        let earService = await EARServiceFactory().createEARService(
+        let earService = await EARServiceFactory.createEARService(
             accountID: accountIdentifier,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -318,7 +318,7 @@ public struct SharingSessionLoader {
             transportSession: transportSession
         )
         let contextStorage = LAContextStorage()
-        let earService = await EARServiceFactory().createEARService(
+        let earService = await EARServiceFactory.createEARService(
             accountID: accountID,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-share-engine/Sources/SharingSessionLoader.swift
+++ b/wire-ios-share-engine/Sources/SharingSessionLoader.swift
@@ -318,7 +318,7 @@ public struct SharingSessionLoader {
             transportSession: transportSession
         )
         let contextStorage = LAContextStorage()
-        let earService = await EARService(
+        let earService = await EARServiceFactory().createEARService(
             accountID: accountID,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
@@ -176,7 +176,7 @@ class BaseTest: ZMTBaseTest {
     }
 
     func createSharingSession() async throws -> SharingSession {
-        let earService = await EARServiceFactory().createEARService(
+        let earService = await EARServiceFactory.createEARService(
             accountID: accountIdentifier,
             databaseContexts: [coreDataStack.viewContext, coreDataStack.syncContext],
             coreDataStack: coreDataStack,

--- a/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
+++ b/wire-ios-share-engine/WireShareEngineTests/BaseSharingSessionTests.swift
@@ -176,7 +176,7 @@ class BaseTest: ZMTBaseTest {
     }
 
     func createSharingSession() async throws -> SharingSession {
-        let earService = await EARService(
+        let earService = await EARServiceFactory().createEARService(
             accountID: accountIdentifier,
             databaseContexts: [coreDataStack.viewContext, coreDataStack.syncContext],
             coreDataStack: coreDataStack,

--- a/wire-ios-sync-engine/Source/SessionManager/SessionFactories.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionFactories.swift
@@ -118,7 +118,7 @@ open class AuthenticatedSessionFactory {
             localDomain: BackendInfo.domain
         )
         let contextStorage = LAContextStorage()
-        let earService = await EARServiceFactory().createEARService(
+        let earService = await EARServiceFactory.createEARService(
             accountID: coreDataStack.account.userIdentifier,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-sync-engine/Source/SessionManager/SessionFactories.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionFactories.swift
@@ -118,7 +118,7 @@ open class AuthenticatedSessionFactory {
             localDomain: BackendInfo.domain
         )
         let contextStorage = LAContextStorage()
-        let earService = await EARService(
+        let earService = await EARServiceFactory().createEARService(
             accountID: coreDataStack.account.userIdentifier,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -161,7 +161,7 @@ final class UserSessionLoader {
 
         let contextStorage = LAContextStorage()
 
-        let earService = await EARService(
+        let earService = await EARServiceFactory().createEARService(
             accountID: accountID,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -161,7 +161,7 @@ final class UserSessionLoader {
 
         let contextStorage = LAContextStorage()
 
-        let earService = await EARServiceFactory().createEARService(
+        let earService = await EARServiceFactory.createEARService(
             accountID: accountID,
             databaseContexts: [
                 coreDataStack.viewContext,

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
@@ -19,24 +19,16 @@
 import Foundation
 import LocalAuthentication
 import WireDataModelSupport
-@testable import WireSyncEngine
-
-// TODO: [WPB-23474] Fix the tests setup
-// The test class has been removed from the test plan
+@testable @preconcurrency import WireSyncEngine
 
 final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase {
 
     var userSessionDelegate: MockUserSessionDelegate!
-    private var activityManager: MockBackgroundActivityManager!
-    private var factory: BackgroundActivityFactory!
     private var setEncryptionAtRestExpectation: XCTestExpectation?
+    private var earService: EARService!
 
     private var account: Account {
         coreDataStack.account
-    }
-
-    private var userSession: ZMUserSession {
-        sut
     }
 
     override func setUp() {
@@ -44,9 +36,6 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
 
         super.setUp()
 
-        activityManager = MockBackgroundActivityManager()
-        factory = BackgroundActivityFactory.shared
-        factory.activityManager = activityManager
         setEncryptionAtRestExpectation = nil
     }
 
@@ -54,13 +43,9 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     /// that the `managedObjectContext` is changed.
     /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
     /// a real instance of `EARService`.
-    func createSut() async -> ZMUserSession {
-        let earService = await EARService(
+    override func createSut() -> ZMUserSession {
+        let earService = EARService(
             accountID: coreDataStack.account.userIdentifier,
-            databaseContexts: [
-                coreDataStack.viewContext,
-                coreDataStack.syncContext
-            ],
             coreDataStack: coreDataStack,
             canPerformKeyMigration: true,
             sharedUserDefaults: sharedUserDefaults,
@@ -75,87 +60,93 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
             self.setEncryptionAtRestExpectation?.fulfill()
         }
 
+        self.earService = earService
+        
         return session
     }
 
     override func tearDown() {
-        factory = nil
-        activityManager = nil
-
         try? sut.setEncryptionAtRest(enabled: false, skipMigration: true)
 
         super.tearDown()
         userSessionDelegate = nil
+        earService = nil
     }
 
-    private func setEncryptionAtRest(enabled: Bool, file: StaticString = #filePath, line: UInt = #line) {
-        try? sut.setEncryptionAtRest(enabled: true, skipMigration: true)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
+    private func setupDatabaseContexts() async {
+        await self.earService.setupDatabaseContexts(
+            databaseContexts: [
+                coreDataStack.viewContext,
+                coreDataStack.syncContext
+            ]
+        )
     }
 
-    private func login() {
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
+    private func login() async {
+        await simulateLoggedInUser()
+        
+        await syncMOC.perform { [syncMOC] in
             ModelHelper().createSelfClient(in: syncMOC)
             syncMOC.saveOrRollback()
         }
-        userSession.viewContext.saveOrRollback()
     }
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDatabaseIsMigrated_WhenEncryptionAtRestIsEnabled() throws {
+    @MainActor
+    func testThatDatabaseIsMigrated_WhenEncryptionAtRestIsEnabled() async throws {
         // given
-        login()
+        await setupDatabaseContexts()
+        await login()
 
-        XCTAssertFalse(userSession.encryptMessagesAtRest)
+        XCTAssertFalse(sut.encryptMessagesAtRest)
 
         let expectedText = "Hello World"
-        var groupConversation: ZMConversation!
-        userSession.perform {
-            groupConversation = ModelHelper().createGroupConversation(in: self.userSession.managedObjectContext)
-            try! groupConversation.appendText(content: expectedText)
+        let groupConversation = try await uiMOC.perform { [uiMOC] in
+            let groupConversation = ModelHelper().createGroupConversation(in: uiMOC)
+            try groupConversation.appendText(content: expectedText)
+            return groupConversation
         }
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
         setEncryptionAtRestExpectation = expectation(description: "wait for setEncryptionAtRest")
-        try userSession.setEncryptionAtRest(enabled: true)
-        self.wait(for: [setEncryptionAtRestExpectation!], timeout: 0.5)
+        try sut.setEncryptionAtRest(enabled: true)
+        await fulfillment(of: [setEncryptionAtRestExpectation!], timeout: 0.5)
 
         // then
-        XCTAssertTrue(userSession.encryptMessagesAtRest)
+        XCTAssertTrue(sut.encryptMessagesAtRest)
 
-        try userSession.unlockDatabase()
-        let clientMessage = groupConversation?.lastMessage as? ZMClientMessage
+        try sut.unlockDatabase()
+        let clientMessage = groupConversation.lastMessage as? ZMClientMessage
         XCTAssertEqual(clientMessage?.messageText, expectedText)
     }
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDatabaseIsMigrated_WhenEncryptionAtRestIsDisabled() throws {
+    @MainActor
+    func testThatDatabaseIsMigrated_WhenEncryptionAtRestIsDisabled() async throws {
         // given
-        login()
+        await setupDatabaseContexts()
+        await login()
 
         let expectedText = "Hello World"
 
-        try userSession.setEncryptionAtRest(enabled: true, skipMigration: true)
-        XCTAssertTrue(userSession.encryptMessagesAtRest)
+        try sut.setEncryptionAtRest(enabled: true, skipMigration: true)
+        XCTAssertTrue(sut.encryptMessagesAtRest)
 
-        var groupConversation: ZMConversation!
-        userSession.perform {
-            groupConversation = ModelHelper().createGroupConversation(in: self.userSession.managedObjectContext)
-            try! groupConversation.appendText(content: expectedText)
+        let groupConversation = try await uiMOC.perform { [uiMOC] in
+            let groupConversation = ModelHelper().createGroupConversation(in: uiMOC)
+            try groupConversation.appendText(content: expectedText)
+            return groupConversation
         }
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
         setEncryptionAtRestExpectation = expectation(description: "wait for setEncryptionAtRest")
-        try userSession.setEncryptionAtRest(enabled: false)
-        self.wait(for: [setEncryptionAtRestExpectation!], timeout: 0.5)
+        try sut.setEncryptionAtRest(enabled: false)
+        await fulfillment(of: [setEncryptionAtRestExpectation!], timeout: 0.5)
 
         // then
-        XCTAssertFalse(userSession.encryptMessagesAtRest)
+        XCTAssertFalse(sut.encryptMessagesAtRest)
 
-        let clientMessage = groupConversation?.lastMessage as? ZMClientMessage
+        let clientMessage = groupConversation.lastMessage as? ZMClientMessage
         XCTAssertEqual(clientMessage?.messageText, expectedText)
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
@@ -26,6 +26,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     var userSessionDelegate: MockUserSessionDelegate!
     private var setEncryptionAtRestExpectation: XCTestExpectation?
     private var earService: EARService!
+    private let earServiceFactory: EARServiceFactory = .init()
 
     private var account: Account {
         coreDataStack.account
@@ -44,7 +45,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
     /// a real instance of `EARService`.
     override func createSut() -> ZMUserSession {
-        let earService = EARService(
+        let earService = earServiceFactory.createEARService(
             accountID: coreDataStack.account.userIdentifier,
             coreDataStack: coreDataStack,
             canPerformKeyMigration: true,
@@ -74,11 +75,12 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     }
 
     private func setupDatabaseContexts() async {
-        await earService.setupDatabaseContexts(
+        await earServiceFactory.setupDatabaseContexts(
             databaseContexts: [
                 coreDataStack.viewContext,
                 coreDataStack.syncContext
-            ]
+            ],
+            onEARService: earService
         )
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
@@ -61,7 +61,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
         }
 
         self.earService = earService
-        
+
         return session
     }
 
@@ -74,7 +74,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     }
 
     private func setupDatabaseContexts() async {
-        await self.earService.setupDatabaseContexts(
+        await earService.setupDatabaseContexts(
             databaseContexts: [
                 coreDataStack.viewContext,
                 coreDataStack.syncContext
@@ -84,7 +84,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
 
     private func login() async {
         await simulateLoggedInUser()
-        
+
         await syncMOC.perform { [syncMOC] in
             ModelHelper().createSelfClient(in: syncMOC)
             syncMOC.saveOrRollback()

--- a/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/SessionManagerEncryptionAtRestMigrationTests.swift
@@ -26,7 +26,6 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     var userSessionDelegate: MockUserSessionDelegate!
     private var setEncryptionAtRestExpectation: XCTestExpectation?
     private var earService: EARService!
-    private let earServiceFactory: EARServiceFactory = .init()
 
     private var account: Account {
         coreDataStack.account
@@ -45,7 +44,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
     /// a real instance of `EARService`.
     override func createSut() -> ZMUserSession {
-        let earService = earServiceFactory.createEARService(
+        let earService = EARServiceFactory.createEARService(
             accountID: coreDataStack.account.userIdentifier,
             coreDataStack: coreDataStack,
             canPerformKeyMigration: true,
@@ -75,7 +74,7 @@ final class SessionManagerEncryptionAtRestMigrationTests: ZMUserSessionTestsBase
     }
 
     private func setupDatabaseContexts() async {
-        await earServiceFactory.setupDatabaseContexts(
+        await EARServiceFactory.setupDatabaseContexts(
             databaseContexts: [
                 coreDataStack.viewContext,
                 coreDataStack.syncContext

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -26,7 +26,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     private var activityManager: MockBackgroundActivityManager!
     private var factory: BackgroundActivityFactory!
     private var earService: EARService!
-    
+
     private var account: Account {
         coreDataStack.account
     }
@@ -51,7 +51,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
             sharedUserDefaults: sharedUserDefaults,
             authenticationContext: MockAuthenticationContextProtocol()
         )
-        
+
         self.earService = earService
 
         return createSut(earService: earService)
@@ -80,13 +80,13 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
             ]
         )
     }
-    
+
     private func isDatabaseLocked() async -> Bool {
         await uiMOC.perform { [sut] in
             sut.isDatabaseLocked
         }
     }
-    
+
     // MARK: - Database migration
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
@@ -94,7 +94,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         let userSessionDelegate = MockUserSessionDelegate()
         sut.delegate = userSessionDelegate
 
@@ -110,7 +110,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
         let userSessionDelegate = MockUserSessionDelegate()
         sut.delegate = userSessionDelegate
@@ -154,7 +154,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
@@ -170,7 +170,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
         sut.applicationDidEnterBackground(nil)
 
@@ -188,7 +188,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
@@ -204,7 +204,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
@@ -222,7 +222,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
@@ -246,7 +246,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         let earMessageEncryptionService = try await uiMOC.perform { [uiMOC] in
             try uiMOC.getEarMessageEncryptionService()
         }
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
@@ -272,7 +272,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // expect
@@ -297,7 +297,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: true, skipMigration: true)
         sut.applicationDidEnterBackground(nil)
 
@@ -345,7 +345,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // then
         XCTAssertTrue(sut.isDatabaseLocked)
         XCTAssertEqual(sut.lock, .database)
-        
+
         // cleanup
         token = nil
     }
@@ -355,7 +355,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         // given
         await setupDatabaseContexts()
         await simulateLoggedInUser()
-        
+
         try await setEncryptionAtRest(enabled: false, skipMigration: true)
         let locked = await isDatabaseLocked()
         XCTAssertFalse(locked)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -26,7 +26,6 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     private var activityManager: MockBackgroundActivityManager!
     private var factory: BackgroundActivityFactory!
     private var earService: EARService!
-    private let earServiceFactory: EARServiceFactory = .init()
 
     private var account: Account {
         coreDataStack.account
@@ -45,7 +44,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
     /// a real instance of `EARService`.
     override func createSut() -> ZMUserSession {
-        let earService = earServiceFactory.createEARService(
+        let earService = EARServiceFactory.createEARService(
             accountID: coreDataStack.account.userIdentifier,
             coreDataStack: coreDataStack,
             canPerformKeyMigration: true,
@@ -74,7 +73,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     }
 
     private func setupDatabaseContexts() async {
-        await earServiceFactory.setupDatabaseContexts(
+        await EARServiceFactory.setupDatabaseContexts(
             databaseContexts: [
                 coreDataStack.viewContext,
                 coreDataStack.syncContext

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -19,16 +19,14 @@
 import Foundation
 import LocalAuthentication
 import WireDataModelSupport
-@testable import WireSyncEngine
-
-// TODO: [WPB-23474] Fix the tests setup
-// The test class has been removed from the test plan
+@testable @preconcurrency import WireSyncEngine
 
 final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     private var activityManager: MockBackgroundActivityManager!
     private var factory: BackgroundActivityFactory!
-
+    private var earService: EARService!
+    
     private var account: Account {
         coreDataStack.account
     }
@@ -45,23 +43,22 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     /// that the `managedObjectContext` is changed.
     /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
     /// a real instance of `EARService`.
-    func createSut() async -> ZMUserSession {
-        let earService = await EARService(
+    override func createSut() -> ZMUserSession {
+        let earService = EARService(
             accountID: coreDataStack.account.userIdentifier,
-            databaseContexts: [
-                coreDataStack.viewContext,
-                coreDataStack.syncContext
-            ],
             coreDataStack: coreDataStack,
             canPerformKeyMigration: true,
             sharedUserDefaults: sharedUserDefaults,
             authenticationContext: MockAuthenticationContextProtocol()
         )
+        
+        self.earService = earService
 
         return createSut(earService: earService)
     }
 
     override func tearDown() {
+        earService = nil
         factory = nil
         activityManager = nil
         try? sut.setEncryptionAtRest(enabled: false, skipMigration: true)
@@ -69,43 +66,57 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
         super.tearDown()
     }
 
-    private func setEncryptionAtRest(enabled: Bool, file: StaticString = #filePath, line: UInt = #line) {
-        try? sut.setEncryptionAtRest(enabled: true, skipMigration: true)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5), file: file, line: line)
+    private func setEncryptionAtRest(enabled: Bool, skipMigration: Bool) async throws {
+        try await uiMOC.perform { [sut] in
+            try sut.setEncryptionAtRest(enabled: enabled, skipMigration: skipMigration)
+        }
     }
 
+    private func setupDatabaseContexts() async {
+        await self.earService.setupDatabaseContexts(
+            databaseContexts: [
+                coreDataStack.viewContext,
+                coreDataStack.syncContext
+            ]
+        )
+    }
+    
+    private func isDatabaseLocked() async -> Bool {
+        await uiMOC.perform { [sut] in
+            sut.isDatabaseLocked
+        }
+    }
+    
     // MARK: - Database migration
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDelegateIsCalled_WhenEncryptionAtRestIsEnabled() throws {
+    func testThatDelegateIsCalled_WhenEncryptionAtRestIsEnabled() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
         let userSessionDelegate = MockUserSessionDelegate()
         sut.delegate = userSessionDelegate
 
         // when
-        try sut.setEncryptionAtRest(enabled: true)
+        try await setEncryptionAtRest(enabled: true, skipMigration: false)
 
         // then
         XCTAssertEqual(userSessionDelegate.prepareForMigration_Invocations, [account])
     }
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDelegateIsCalled_WhenEncryptionAtRestIsDisabled() throws {
+    func testThatDelegateIsCalled_WhenEncryptionAtRestIsDisabled() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
         let userSessionDelegate = MockUserSessionDelegate()
         sut.delegate = userSessionDelegate
 
         // when
-        try sut.setEncryptionAtRest(enabled: false)
+        try await setEncryptionAtRest(enabled: false, skipMigration: false)
 
         // then
         XCTAssertEqual(userSessionDelegate.prepareForMigration_Invocations, [account])
@@ -113,138 +124,140 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
     // MARK: - Database locking/unlocking
 
-    func testThatDatabaseIsUnlocked_WhenEncryptionAtRestIsDisabled() {
+    func testThatDatabaseIsUnlocked_WhenEncryptionAtRestIsDisabled() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
 
         // when
-        setEncryptionAtRest(enabled: false)
+        try await setEncryptionAtRest(enabled: false, skipMigration: true)
 
         // then
-        XCTAssertFalse(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertFalse(locked)
     }
 
-    func testThatDatabaseIsUnlocked_AfterActivatingEncryptionAtRest() {
+    func testThatDatabaseIsUnlocked_AfterActivatingEncryptionAtRest() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
 
         // when
-        setEncryptionAtRest(enabled: true)
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // then
-        XCTAssertFalse(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertFalse(locked)
     }
 
-    func testThatDatabaseIsUnlocked_AfterDeactivatingEncryptionAtRest() {
+    func testThatDatabaseIsUnlocked_AfterDeactivatingEncryptionAtRest() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
-        setEncryptionAtRest(enabled: false)
+        try await setEncryptionAtRest(enabled: false, skipMigration: true)
 
         // then
-        XCTAssertFalse(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertFalse(locked)
     }
 
-    func testThatDatabaseIsUnlocked_AfterUnlockingDatabase() throws {
+    @MainActor
+    func testThatDatabaseIsUnlocked_AfterUnlockingDatabase() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
         sut.applicationDidEnterBackground(nil)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // when
         try sut.unlockDatabase()
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertFalse(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertFalse(locked)
     }
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDatabaseIsLocked_AfterEnteringBackground() throws {
+    @MainActor
+    func testThatDatabaseIsLocked_AfterEnteringBackground() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
         sut.applicationDidEnterBackground(nil)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertTrue(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertTrue(locked)
     }
 
-    func testThatDatabaseIsLocked_AfterBackgroundTaskCompletesInTheBackground() throws {
+    @MainActor
+    func testThatDatabaseIsLocked_AfterBackgroundTaskCompletesInTheBackground() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
         let activity = factory.startBackgroundActivity(name: "Activity 1")!
         application.simulateApplicationDidEnterBackground()
         factory.endBackgroundActivity(activity)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertTrue(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertTrue(locked)
     }
 
-    func testThatDatabaseIsNotLocked_IfThereIsAnActiveBackgroundTask() throws {
+    @MainActor
+    func testThatDatabaseIsNotLocked_IfThereIsAnActiveBackgroundTask() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
         let activity = factory.startBackgroundActivity(name: "Activity 1")!
         application.simulateApplicationDidEnterBackground()
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // then
-        XCTAssertFalse(sut.isDatabaseLocked)
+        let locked = await isDatabaseLocked()
+        XCTAssertFalse(locked)
         factory.endBackgroundActivity(activity)
     }
 
     // @SF.Locking @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDatabaseIsLocked_WhenTheCustomTimeoutHasExpiredInTheBackground() throws {
+    @MainActor
+    func testThatDatabaseIsLocked_WhenTheCustomTimeoutHasExpiredInTheBackground() async throws {
         // given
-        let earMessageEncryptionService = try XCTUnwrap(sut.managedObjectContext.getEarMessageEncryptionService())
-
         factory.backgroundTaskTimeout = 2
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+
+        let earMessageEncryptionService = try await uiMOC.perform { [uiMOC] in
+            try uiMOC.getEarMessageEncryptionService()
         }
-        setEncryptionAtRest(enabled: true)
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // when
-        _ = factory.startBackgroundActivity(name: "Activity 1")!
+        let expectation = XCTestExpectation(description: "The expiration handler is called")
+        _ = factory.startBackgroundActivity(name: "Activity 1", expirationHandler: {
+            expectation.fulfill()
+        })!
         application.simulateApplicationDidEnterBackground()
         XCTAssertNotNil(earMessageEncryptionService.getDatabaseKey())
 
-        _ = XCTWaiter.wait(for: [XCTestExpectation(description: "The expiration handler is called.")], timeout: 4.0)
+        await fulfillment(of: [expectation], timeout: 4)
 
         // then
         XCTAssertTrue(sut.isDatabaseLocked)
@@ -254,16 +267,16 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // MARK: - Database lock handler/observer
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatDatabaseLockedHandlerIsCalled_AfterDatabaseIsLocked() throws {
+    @MainActor
+    func testThatDatabaseLockedHandlerIsCalled_AfterDatabaseIsLocked() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
 
         // expect
-        let databaseIsLocked = customExpectation(description: "database is locked")
+        let databaseIsLocked = XCTestExpectation(description: "database is locked")
         var token: Any? = sut.registerDatabaseLockedHandler { isDatabaseLocked in
             if isDatabaseLocked {
                 databaseIsLocked.fulfill()
@@ -273,25 +286,23 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
         // when
         sut.applicationDidEnterBackground(nil)
-        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        await fulfillment(of: [databaseIsLocked], timeout: 0.5)
 
         // cleanup
         token = nil
     }
 
-    func testThatDatabaseLockedHandlerIsCalled_AfterUnlockingDatabase() throws {
+    @MainActor
+    func testThatDatabaseLockedHandlerIsCalled_AfterUnlockingDatabase() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: true)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
         sut.applicationDidEnterBackground(nil)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
 
         // expect
-        let databaseIsUnlocked = customExpectation(description: "database is unlocked")
+        let databaseIsUnlocked = XCTestExpectation(description: "database is unlocked")
         var token: Any? = sut.registerDatabaseLockedHandler { isDatabaseLocked in
             if !isDatabaseLocked {
                 databaseIsUnlocked.fulfill()
@@ -301,8 +312,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
 
         // when
         try sut.unlockDatabase()
-        XCTAssertTrue(waitForCustomExpectations(withTimeout: 0.5))
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        await fulfillment(of: [databaseIsUnlocked], timeout: 0.5)
 
         // cleanup
         token = nil
@@ -311,31 +321,44 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     // MARK: - Misc
 
     // @SF.Storage @TSFI.UserInterface @S0.1 @S0.2
-    func testThatIfDatabaseIsLocked_ThenUserSessionLockIsSet() throws {
+    @MainActor
+    func testThatIfDatabaseIsLocked_ThenUserSessionLockIsSet() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+
+        try await setEncryptionAtRest(enabled: true, skipMigration: true)
+
+        // expect
+        let databaseIsLocked = XCTestExpectation(description: "isDatabaseLocked becomes true")
+        var token: Any? = sut.registerDatabaseLockedHandler { isDatabaseLocked in
+            if isDatabaseLocked {
+                databaseIsLocked.fulfill()
+            }
         }
-        setEncryptionAtRest(enabled: true)
+        XCTAssertNotNil(token)
 
+        // when
         sut.applicationDidEnterBackground(nil)
-        XCTAssertTrue(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
-
-        XCTAssertTrue(sut.isDatabaseLocked)
+        await fulfillment(of: [databaseIsLocked], timeout: 0.5)
 
         // then
+        XCTAssertTrue(sut.isDatabaseLocked)
         XCTAssertEqual(sut.lock, .database)
+        
+        // cleanup
+        token = nil
     }
 
-    func testThatIfDatabaseIsNotLocked_ThenUserSessionLockIsNotSet() throws {
+    @MainActor
+    func testThatIfDatabaseIsNotLocked_ThenUserSessionLockIsNotSet() async throws {
         // given
-        syncMOC.performAndWait {
-            simulateLoggedInUser()
-            syncMOC.saveOrRollback()
-        }
-        setEncryptionAtRest(enabled: false)
-        XCTAssertFalse(sut.isDatabaseLocked)
+        await setupDatabaseContexts()
+        await simulateLoggedInUser()
+        
+        try await setEncryptionAtRest(enabled: false, skipMigration: true)
+        let locked = await isDatabaseLocked()
+        XCTAssertFalse(locked)
 
         // then
         XCTAssertNotEqual(sut.lock, .database)

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTests+EncryptionAtRest.swift
@@ -26,6 +26,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     private var activityManager: MockBackgroundActivityManager!
     private var factory: BackgroundActivityFactory!
     private var earService: EARService!
+    private let earServiceFactory: EARServiceFactory = .init()
 
     private var account: Account {
         coreDataStack.account
@@ -44,7 +45,7 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     /// To remove this workaround, delete this override  and the `mockEARService` should be used instead of
     /// a real instance of `EARService`.
     override func createSut() -> ZMUserSession {
-        let earService = EARService(
+        let earService = earServiceFactory.createEARService(
             accountID: coreDataStack.account.userIdentifier,
             coreDataStack: coreDataStack,
             canPerformKeyMigration: true,
@@ -73,11 +74,12 @@ final class ZMUserSessionTests_EncryptionAtRest: ZMUserSessionTestsBase {
     }
 
     private func setupDatabaseContexts() async {
-        await self.earService.setupDatabaseContexts(
+        await earServiceFactory.setupDatabaseContexts(
             databaseContexts: [
                 coreDataStack.viewContext,
                 coreDataStack.syncContext
-            ]
+            ],
+            onEARService: earService
         )
     }
 

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -220,6 +220,14 @@ class ZMUserSessionTestsBase: MessagingTest {
             cookieStorage.authenticationCookieData = validCookie
         }
     }
+    
+    func simulateLoggedInUser() async {
+        await syncMOC.perform { [syncMOC] in
+            syncMOC.setPersistentStoreMetadata("clientID", key: ZMPersistedClientIdKey)
+            ZMUser.selfUser(in: syncMOC).remoteIdentifier = UUID.create()
+        }
+        cookieStorage.authenticationCookieData = validCookie
+    }
 
     private func clearCache() {
         let cachesURL = FileManager.default.cachesURLForAccount(

--- a/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
+++ b/wire-ios-sync-engine/Tests/Source/UserSession/ZMUserSessionTestsBase.swift
@@ -220,7 +220,7 @@ class ZMUserSessionTestsBase: MessagingTest {
             cookieStorage.authenticationCookieData = validCookie
         }
     }
-    
+
     func simulateLoggedInUser() async {
         await syncMOC.perform { [syncMOC] in
             syncMOC.setPersistentStoreMetadata("clientID", key: ZMPersistedClientIdKey)

--- a/wire-ios-sync-engine/Tests/TestsPlans/AllTests.xctestplan
+++ b/wire-ios-sync-engine/Tests/TestsPlans/AllTests.xctestplan
@@ -50,25 +50,9 @@
       "skippedTests" : [
         "AvailabilityTests",
         "EventProcessingPerformanceTests",
-        "SessionManagerEncryptionAtRestMigrationTests",
         "SessionManagerTests\/testThatSessionManagerSetsUpAPNSEnvironmentOnLaunch()",
         "ZMMissingUpdateEventsTranscoderTests",
-        "ZMUserSessionTests\/testItSlowSyncsAfterRegisteringMLSClient()",
-        "ZMUserSessionTests_EncryptionAtRest",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsLocked_AfterBackgroundTaskCompletesInTheBackground()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsLocked_AfterEnteringBackground()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsLocked_WhenTheCustomTimeoutHasExpiredInTheBackground()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsNotLocked_IfThereIsAnActiveBackgroundTask()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsUnlocked_AfterActivatingEncryptionAtRest()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsUnlocked_AfterDeactivatingEncryptionAtRest()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsUnlocked_AfterUnlockingDatabase()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsUnlocked_WhenEncryptionAtRestIsDisabled()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseLockedHandlerIsCalled_AfterDatabaseIsLocked()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseLockedHandlerIsCalled_AfterUnlockingDatabase()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDelegateIsCalled_WhenEncryptionAtRestIsDisabled()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatDelegateIsCalled_WhenEncryptionAtRestIsEnabled()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatIfDatabaseIsLocked_ThenUserSessionLockIsSet()",
-        "ZMUserSessionTests_EncryptionAtRest\/testThatIfDatabaseIsNotLocked_ThenUserSessionLockIsNotSet()"
+        "ZMUserSessionTests\/testItSlowSyncsAfterRegisteringMLSClient()"
       ],
       "target" : {
         "containerPath" : "container:WireSyncEngine.xcodeproj",

--- a/wire-ios-sync-engine/Tests/TestsPlans/SecurityTests.xctestplan
+++ b/wire-ios-sync-engine/Tests/TestsPlans/SecurityTests.xctestplan
@@ -21,6 +21,14 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "SessionManagerEncryptionAtRestMigrationTests\/testThatDatabaseIsMigrated_WhenEncryptionAtRestIsDisabled()",
+        "SessionManagerEncryptionAtRestMigrationTests\/testThatDatabaseIsMigrated_WhenEncryptionAtRestIsEnabled()",
+        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsLocked_AfterEnteringBackground()",
+        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseIsLocked_WhenTheCustomTimeoutHasExpiredInTheBackground()",
+        "ZMUserSessionTests_EncryptionAtRest\/testThatDatabaseLockedHandlerIsCalled_AfterDatabaseIsLocked()",
+        "ZMUserSessionTests_EncryptionAtRest\/testThatDelegateIsCalled_WhenEncryptionAtRestIsDisabled()",
+        "ZMUserSessionTests_EncryptionAtRest\/testThatDelegateIsCalled_WhenEncryptionAtRestIsEnabled()",
+        "ZMUserSessionTests_EncryptionAtRest\/testThatIfDatabaseIsLocked_ThenUserSessionLockIsSet()",
         "ZMUserSessionTests_EncryptionAtRest\/testThatOldEncryptionKeysAreReplaced_AfterActivatingEncryptionAtRest()"
       ],
       "target" : {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23474" title="WPB-23474" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23474</a>  [iOS] Fix EAR user session security tests
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In  https://github.com/wireapp/wire-ios/pull/4299 I disabled some of the tests covering the `EARService` integration in the `ZMUserSession` because the asynchronous init of `EARService` wasn't compatible with the synchronous setup methods of `SessionManagerEncryptionAtRestMigrationTests` and `ZMUserSessionTests_EncryptionAtRest`.

To solve this issue, I've introduced a `EARServiceFactory` that keeps the capability of creating a `EARService` instance in an `async` manner for production code, while adding an interface that allows tests to create an `EARService` instance synchronously, coupled with a subsequent `async` setup method. This allows the synchronous setup methods to create the service.
 
---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

