### PR TITLE
fix: connecting 1:1 federation - WPB-24066

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -227,7 +227,8 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
                     mlsConversation.ciphersuite = ciphersuite
                     mlsConversation.mlsStatus = .ready
                 }
-
+                WireLogger.mls.info("mls 1-1 conversation established", attributes: .safePublic, [.mlsGroupID: groupID.safeForLoggingDescription])
+                
             } catch {
                 throw Error.failedToEstablishGroup(error)
             }

--- a/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/OneOnOneResolver.swift
@@ -227,8 +227,12 @@ public struct OneOnOneResolver: OneOnOneResolverProtocol {
                     mlsConversation.ciphersuite = ciphersuite
                     mlsConversation.mlsStatus = .ready
                 }
-                WireLogger.mls.info("mls 1-1 conversation established", attributes: .safePublic, [.mlsGroupID: groupID.safeForLoggingDescription])
-                
+                WireLogger.mls.info(
+                    "mls 1-1 conversation established",
+                    attributes: .safePublic,
+                    [.mlsGroupID: groupID.safeForLoggingDescription]
+                )
+
             } catch {
                 throw Error.failedToEstablishGroup(error)
             }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
@@ -137,7 +137,7 @@ public actor WorkAgent {
     }
 
     public func clearSchedulerQueue() async {
-        WireLogger.workAgent.info("⚠️ clear scheduler queue", attributes: .safePublic)
+        WireLogger.workAgent.info("clear scheduler queue", attributes: .safePublic)
         await scheduler.clearAllItems()
     }
 }

--- a/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
+++ b/WireDomain/Sources/WireDomain/WorkAgent/WorkAgent.swift
@@ -137,6 +137,7 @@ public actor WorkAgent {
     }
 
     public func clearSchedulerQueue() async {
+        WireLogger.workAgent.info("⚠️ clear scheduler queue", attributes: .safePublic)
         await scheduler.clearAllItems()
     }
 }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -856,43 +856,48 @@ public final class MLSService: MLSServiceInterface {
             return
         }
 
-        let pendingGroups = try await context.perform {
+        let pendingGroupConversations = try await context.perform {
             try ZMConversation.fetchConversationsWithMLSGroupStatus(
                 mlsGroupStatus: .pendingJoin,
                 in: context
             )
         }
 
-        logger.info("joining \(pendingGroups.count) group(s)")
+        logger.info("joining \(pendingGroupConversations.count) group(s)")
 
         let needToSave = await withTaskGroup(of: Bool.self) { group in
-            for pendingGroup in pendingGroups {
+            for pendingGroupConversation in pendingGroupConversations {
                 group.addTask {
-                    guard let mlsGroupID = await context.perform({ pendingGroup.mlsGroupID }),
-                          let conversationQualifiedID = await context.perform({ pendingGroup.qualifiedID }) else {
+                    let (mlsGroupID, conversationQualifiedID, epoch, isOneOnOne) = await context.perform {
+                        (pendingGroupConversation.mlsGroupID,
+                         pendingGroupConversation.qualifiedID,
+                         pendingGroupConversation.epoch,
+                         pendingGroupConversation.conversationType == .oneOnOne)
+                    }
+                    
+                    guard let mlsGroupID,
+                          let conversationQualifiedID else {
                         return false
                     }
 
                     do {
-                        let epoch = await context.perform {
-                            pendingGroup.epoch
-                        }
                         let conversationExists = try await self.conversationExists(
                             groupID: mlsGroupID
                         )
-                        let shouldEstablishGroup = epoch == 0 && !conversationExists && conversationQualifiedID
-                            .domain == self.localDomain
+                        
+                        let shouldEstablishGroup = (epoch == 0 && !conversationExists) && (isOneOnOne || (!isOneOnOne && conversationQualifiedID
+                            .domain == self.localDomain))
 
                         if shouldEstablishGroup {
                             try await self.internalEstablishPendingGroup(
                                 groupID: mlsGroupID,
-                                pendingGroup: pendingGroup,
+                                pendingGroup: pendingGroupConversation,
                                 context: context
                             )
                             return true
                         } else {
                             try await self.joinByExternalCommit(groupID: mlsGroupID)
-                            return false
+                            return true // save change of ZMConversation
                         }
                     } catch {
                         WireLogger.mls.error(

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -887,11 +887,14 @@ public final class MLSService: MLSServiceInterface {
                             groupID: mlsGroupID
                         )
 
-                        let shouldEstablishGroup = (epoch == 0 && !conversationExists) &&
-                            (isOneOnOne || (!isOneOnOne && conversationQualifiedID
-                                    .domain == self.localDomain))
+                        let shouldEstablish = (epoch == 0 && !conversationExists)
+                        let isLocalGroup = (!isOneOnOne && conversationQualifiedID
+                            .domain == self.localDomain)
 
-                        if shouldEstablishGroup {
+                        // don't establishGroup for federatedGroup
+                        let shouldEstablishMLSGroup = shouldEstablish && (isLocalGroup || isOneOnOne)
+
+                        if shouldEstablishMLSGroup {
                             try await self.internalEstablishPendingGroup(
                                 groupID: mlsGroupID,
                                 pendingGroup: pendingGroupConversation,

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -869,12 +869,14 @@ public final class MLSService: MLSServiceInterface {
             for pendingGroupConversation in pendingGroupConversations {
                 group.addTask {
                     let (mlsGroupID, conversationQualifiedID, epoch, isOneOnOne) = await context.perform {
-                        (pendingGroupConversation.mlsGroupID,
-                         pendingGroupConversation.qualifiedID,
-                         pendingGroupConversation.epoch,
-                         pendingGroupConversation.conversationType == .oneOnOne)
+                        (
+                            pendingGroupConversation.mlsGroupID,
+                            pendingGroupConversation.qualifiedID,
+                            pendingGroupConversation.epoch,
+                            pendingGroupConversation.conversationType == .oneOnOne
+                        )
                     }
-                    
+
                     guard let mlsGroupID,
                           let conversationQualifiedID else {
                         return false
@@ -884,9 +886,10 @@ public final class MLSService: MLSServiceInterface {
                         let conversationExists = try await self.conversationExists(
                             groupID: mlsGroupID
                         )
-                        
-                        let shouldEstablishGroup = (epoch == 0 && !conversationExists) && (isOneOnOne || (!isOneOnOne && conversationQualifiedID
-                            .domain == self.localDomain))
+
+                        let shouldEstablishGroup = (epoch == 0 && !conversationExists) &&
+                            (isOneOnOne || (!isOneOnOne && conversationQualifiedID
+                                    .domain == self.localDomain))
 
                         if shouldEstablishGroup {
                             try await self.internalEstablishPendingGroup(

--- a/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
+++ b/wire-ios-data-model/Source/MLS/OneOnOne/OneOnOneMigrator.swift
@@ -182,7 +182,8 @@ public struct OneOnOneMigrator: OneOnOneMigratorInterface {
             throw MigrateMLSOneOnOneConversationError.missingConversationEpoch
         }
 
-        if epoch == 0, conversationID.domain == mlsService.localDomain {
+        // we only establish oneOnOnes
+        if epoch == 0 {
             try await establishMLSGroupIfNeeded(
                 userID: userID,
                 mlsGroupID: mlsGroupID,

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1007,61 +1007,60 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
 
     func test_PerformPendingJoins_It_JoinsByExternalCommit_DifferentDomain() async throws {
         let groupID = MLSGroupID.random()
-               let conversationID = UUID.create()
-               let domain = localDomain
-               let conversationDomain = "other.domain.local"
-               let conversation = await uiMOC.perform { [uiMOC] in
-                   let conversation = ZMConversation.insertNewObject(in: uiMOC)
-                   conversation.remoteIdentifier = conversationID
-                   conversation.mlsGroupID = groupID
-                   conversation.messageProtocol = .mls
-                   conversation.mlsStatus = .pendingJoin
-                   conversation.conversationType = .group
-                   conversation.domain = conversationDomain
-                   
-                   // Only epoch 0 leads to establishing group
-                   conversation.epoch = 0
+        let conversationID = UUID.create()
+        let domain = localDomain
+        let conversationDomain = "other.domain.local"
+        let conversation = await uiMOC.perform { [uiMOC] in
+            let conversation = ZMConversation.insertNewObject(in: uiMOC)
+            conversation.remoteIdentifier = conversationID
+            conversation.mlsGroupID = groupID
+            conversation.messageProtocol = .mls
+            conversation.mlsStatus = .pendingJoin
+            conversation.conversationType = .group
+            conversation.domain = conversationDomain
 
-                   return conversation
-               }
+            // Only epoch 0 leads to establishing group
+            conversation.epoch = 0
 
-               // mock fetching group info
-               let publicGroupState = Data()
-               mockActionsProvider
-                   .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockValue = publicGroupState
+            return conversation
+        }
 
-               // mock joining group
-               var joinGroupArguments = [(groupID: MLSGroupID, groupState: Data)]()
-               mockMLSActionExecutor.mockJoinGroup = {
-                   joinGroupArguments.append(($0, $1))
-               }
+        // mock fetching group info
+        let publicGroupState = Data()
+        mockActionsProvider
+            .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockValue = publicGroupState
 
-               // mock CC conversation exists
-               mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
+        // mock joining group
+        var joinGroupArguments = [(groupID: MLSGroupID, groupState: Data)]()
+        mockMLSActionExecutor.mockJoinGroup = {
+            joinGroupArguments.append(($0, $1))
+        }
 
-               // When
-               try await sut.performPendingJoins()
+        // mock CC conversation exists
+        mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
 
-               // Then
+        // When
+        try await sut.performPendingJoins()
 
-               // it fetches public group state
-               let groupStateInvocations = mockActionsProvider
-                   .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations
-               XCTAssertEqual(groupStateInvocations.count, 1)
-               XCTAssertEqual(groupStateInvocations.first?.conversationId, conversationID)
-               XCTAssertEqual(groupStateInvocations.first?.domain, conversationDomain)
+        // Then
 
-               // it asks executor to join group
-               XCTAssertEqual(joinGroupArguments.count, 1)
-               XCTAssertEqual(joinGroupArguments.first?.groupID, groupID)
-               XCTAssertEqual(joinGroupArguments.first?.groupState, publicGroupState)
+        // it fetches public group state
+        let groupStateInvocations = mockActionsProvider
+            .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations
+        XCTAssertEqual(groupStateInvocations.count, 1)
+        XCTAssertEqual(groupStateInvocations.first?.conversationId, conversationID)
+        XCTAssertEqual(groupStateInvocations.first?.domain, conversationDomain)
 
-               // it sets conversation state to ready
-               let conversationMLSStatus = await uiMOC.perform { conversation.mlsStatus }
-               XCTAssertEqual(conversationMLSStatus, .ready)
+        // it asks executor to join group
+        XCTAssertEqual(joinGroupArguments.count, 1)
+        XCTAssertEqual(joinGroupArguments.first?.groupID, groupID)
+        XCTAssertEqual(joinGroupArguments.first?.groupState, publicGroupState)
+
+        // it sets conversation state to ready
+        let conversationMLSStatus = await uiMOC.perform { conversation.mlsStatus }
+        XCTAssertEqual(conversationMLSStatus, .ready)
     }
-    
-    
+
     func test_PerformPendingJoins_It_JoinsViaExternalCommit_FederationGroup() async throws {
         // Given
         let groupID = MLSGroupID.random()

--- a/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
+++ b/wire-ios-data-model/Tests/MLS/MLSServiceTests.swift
@@ -1005,6 +1005,63 @@ final class MLSServiceTests: ZMConversationTestsBase, MLSServiceDelegate {
         )
     }
 
+    func test_PerformPendingJoins_It_JoinsByExternalCommit_DifferentDomain() async throws {
+        let groupID = MLSGroupID.random()
+               let conversationID = UUID.create()
+               let domain = localDomain
+               let conversationDomain = "other.domain.local"
+               let conversation = await uiMOC.perform { [uiMOC] in
+                   let conversation = ZMConversation.insertNewObject(in: uiMOC)
+                   conversation.remoteIdentifier = conversationID
+                   conversation.mlsGroupID = groupID
+                   conversation.messageProtocol = .mls
+                   conversation.mlsStatus = .pendingJoin
+                   conversation.conversationType = .group
+                   conversation.domain = conversationDomain
+                   
+                   // Only epoch 0 leads to establishing group
+                   conversation.epoch = 0
+
+                   return conversation
+               }
+
+               // mock fetching group info
+               let publicGroupState = Data()
+               mockActionsProvider
+                   .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_MockValue = publicGroupState
+
+               // mock joining group
+               var joinGroupArguments = [(groupID: MLSGroupID, groupState: Data)]()
+               mockMLSActionExecutor.mockJoinGroup = {
+                   joinGroupArguments.append(($0, $1))
+               }
+
+               // mock CC conversation exists
+               mockCoreCryptoContext.conversationExistsConversationId_MockValue = false
+
+               // When
+               try await sut.performPendingJoins()
+
+               // Then
+
+               // it fetches public group state
+               let groupStateInvocations = mockActionsProvider
+                   .fetchConversationGroupInfoConversationIdDomainSubgroupTypeContext_Invocations
+               XCTAssertEqual(groupStateInvocations.count, 1)
+               XCTAssertEqual(groupStateInvocations.first?.conversationId, conversationID)
+               XCTAssertEqual(groupStateInvocations.first?.domain, conversationDomain)
+
+               // it asks executor to join group
+               XCTAssertEqual(joinGroupArguments.count, 1)
+               XCTAssertEqual(joinGroupArguments.first?.groupID, groupID)
+               XCTAssertEqual(joinGroupArguments.first?.groupState, publicGroupState)
+
+               // it sets conversation state to ready
+               let conversationMLSStatus = await uiMOC.perform { conversation.mlsStatus }
+               XCTAssertEqual(conversationMLSStatus, .ready)
+    }
+    
+    
     func test_PerformPendingJoins_It_JoinsViaExternalCommit_FederationGroup() async throws {
         // Given
         let groupID = MLSGroupID.random()


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24066" title="WPB-24066" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24066</a>  [iOS] Establish group for federated 1-1 conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

In https://github.com/wireapp/wire-ios/pull/4304, we only establish groups for local domain conversations, but this is only needed for groups not 1-1. This PR fixes it:

- Update performJoins to handle 1:1 correctly
- Remove check of localDomain for OneOnOneMigrator because only 1:1 conversations are processed.

### Testing

- [x] Updated tests
- [x] Run critical flow: FederationTests (which was failing) -> https://github.com/wireapp/wire-ios/actions/runs/23153031669

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
