### PR TITLE
chore: update github action notify on Wire - WPB-24093

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -19,6 +19,11 @@ on:
       run_critical_flows:
         type: boolean
         required: true
+      notify:
+        type: string
+        required: true
+        default: 'failure' # values: always | failure | never
+
     secrets:
       ZENKINS_USERNAME:
         required: true
@@ -267,10 +272,10 @@ jobs:
             echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
             echo "commit_message=$(git log -1 --pretty=format:"%s")" >> $GITHUB_ENV
 
-      - name: Notify on Wire for iOS Nightly 🤖
+      - name: Always Notify on Wire
         uses: 8398a7/action-slack@v3
         continue-on-error: true
-        if: ${{ inputs.all && always() }}
+        if:  ${{ inputs.notify == 'always'  && always() }}
         with:
           status: ${{ job.status }}
           text: |
@@ -281,10 +286,10 @@ jobs:
             **Triggered by:** ${{ github.triggering_actor }}
             **Build log:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       
-      - name: Notify on Wire for iOS CI
+      - name: Only Notify on Wire failures
         uses: 8398a7/action-slack@v3
         continue-on-error: true
-        if: ${{ !inputs.all && failure() }}
+        if: ${{ inputs.notify == 'failure' && failure() }}
         with:
           status: ${{ job.status }}
           text: |

--- a/.github/workflows/critical_flows.yaml
+++ b/.github/workflows/critical_flows.yaml
@@ -21,4 +21,5 @@ jobs:
       notify_secret: WIRE_IOS_QA_WEBHOOK
       test_dependencies: false
       run_critical_flows: true
+      notify: always
     secrets: inherit

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -14,4 +14,5 @@ jobs:
       all: true
       notify_secret: WIRE_IOS_CI_WEBHOOK
       run_critical_flows: true
+      notify: always
     secrets: inherit

--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -21,4 +21,5 @@ jobs:
       branch: ${{ matrix.branch }}
       notify_secret: WIRE_IOS_NIGHTLY_WEBHOOK
       run_critical_flows: true
+      notify: always
     secrets: inherit

--- a/.github/workflows/test_pr_changes.yml
+++ b/.github/workflows/test_pr_changes.yml
@@ -103,4 +103,5 @@ jobs:
       notify_secret: WIRE_IOS_CI_WEBHOOK
       test_dependencies: ${{ github.event_name != 'pull_request' || startsWith(github.base_ref, 'release/cycle') }} # run on merge_queue or release branch PRs
       run_critical_flows: false # separare workflow
+      notify: failure
     secrets: inherit


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Currently it's hard to know when critical flows are passed on Wire channel. This PR changes a bit the conditions when we get a notifications:

Always notify (failure or success):
- Nightly on **iOS Nightly**
- Critical flows on **iOS Critical flows**

Notify only failures:
- PRs or Merge queue on **iOS CI**

### Testing

TBD

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
