### PR TITLE
feat: add accessibility identifiers to wire drive - WPB-23902

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Create/CreateFileView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Create/CreateFileView.swift
@@ -95,7 +95,7 @@ private extension CreateFileView {
                 Text(L10n.Localizable.General.cancel)
             }
         )
-        .accessibilityIdentifier(Locators.WireDrive.CreateFilePage.cancelButton.rawValue)
+        .accessibilityIdentifier(Locators.WireDrive.CreateFilePage.cancelButton)
     }
 
     @ViewBuilder var createButton: some View {
@@ -111,7 +111,7 @@ private extension CreateFileView {
                 }
             )
             .disabled(viewModel.isCreateDisabled)
-            .accessibilityIdentifier(Locators.WireDrive.CreateFilePage.createButton.rawValue)
+            .accessibilityIdentifier(Locators.WireDrive.CreateFilePage.createButton)
         }
     }
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Create/CreateFileView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Create/CreateFileView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import WireDesign
+import WireLocators
 import WireReusableUIComponents
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
@@ -94,7 +95,7 @@ private extension CreateFileView {
                 Text(L10n.Localizable.General.cancel)
             }
         )
-        .accessibilityIdentifier("cancelButton")
+        .accessibilityIdentifier(Locators.WireDrive.CreateFilePage.cancelButton.rawValue)
     }
 
     @ViewBuilder var createButton: some View {
@@ -110,7 +111,7 @@ private extension CreateFileView {
                 }
             )
             .disabled(viewModel.isCreateDisabled)
-            .accessibilityIdentifier("createButton")
+            .accessibilityIdentifier(Locators.WireDrive.CreateFilePage.createButton.rawValue)
         }
     }
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Edit/EditFileView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Edit/EditFileView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import WebKit
+import WireLocators
 
 // MARK: - EditFileView
 
@@ -79,7 +80,7 @@ struct EditFileView<ViewModel>: View where ViewModel: EditFileViewModelProtocol 
                     .frame(width: 44, height: 44, alignment: .trailing)
             }
         )
-        .accessibilityIdentifier("close")
+        .accessibilityIdentifier(Locators.WireDrive.EditFilePage.close.rawValue)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Edit/EditFileView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Edit/EditFileView.swift
@@ -80,7 +80,7 @@ struct EditFileView<ViewModel>: View where ViewModel: EditFileViewModelProtocol 
                     .frame(width: 44, height: 44, alignment: .trailing)
             }
         )
-        .accessibilityIdentifier(Locators.WireDrive.EditFilePage.close.rawValue)
+        .accessibilityIdentifier(Locators.WireDrive.EditFilePage.close)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesContentView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesContentView.swift
@@ -190,7 +190,7 @@ private extension FilesContentView {
 
     var confirmButton: some View {
         Button(L10n.Localizable.General.confirm, action: {})
-            .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.confirm.rawValue)
+            .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.confirm)
     }
 }
 
@@ -237,7 +237,7 @@ private extension FilesContentView {
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: Strings.Files.Search.title
         )
-        .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.search.rawValue)
+        .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.search)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesContentView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesContentView.swift
@@ -18,6 +18,7 @@
 
 package import SwiftUI
 import WireDesign
+import WireLocators
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
 private typealias Accessibility = L10n.Accessibility.Conversation.WireCells
@@ -148,6 +149,7 @@ private extension FilesContentView {
             itemRow(index: index)
                 .onAppear { loadMoreIfNeededTask(index: index) }
                 .onTapGesture { Task { await viewModel.openItem(item: item) } }
+                .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.fileItem(index))
         }
     }
 
@@ -178,7 +180,7 @@ private extension FilesContentView {
     }
 
     var loadMoreRow: some View {
-        LoadMoreView(isLoading: viewModel.isLoading, onLoadMore: loadMore)
+        LoadMoreView(isLoading: viewModel.isLoading, onLoadMore: loadMoreTask)
     }
 }
 
@@ -188,6 +190,7 @@ private extension FilesContentView {
 
     var confirmButton: some View {
         Button(L10n.Localizable.General.confirm, action: {})
+            .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.confirm.rawValue)
     }
 }
 
@@ -203,7 +206,7 @@ private extension FilesContentView {
         Task { await viewModel.loadMoreIfNeeded(index: index) }
     }
 
-    func loadMore() {
+    func loadMoreTask() {
         let lastRowIndex = viewModel.state.items.count - 1
         Task { await viewModel.loadMoreIfNeeded(index: lastRowIndex) }
     }
@@ -234,6 +237,7 @@ private extension FilesContentView {
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: Strings.Files.Search.title
         )
+        .accessibilityIdentifier(Locators.WireDrive.FilesContentPage.search.rawValue)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesInfoView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesInfoView.swift
@@ -210,7 +210,7 @@ struct FilesInfoView: View {
                 )
         }
         .accessibilityLabel(Strings.Files.Error.retry)
-        .accessibilityIdentifier(Locators.WireDrive.FilesInfoPage.retryButton.rawValue)
+        .accessibilityIdentifier(Locators.WireDrive.FilesInfoPage.retryButton)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesInfoView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesInfoView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import WireDesign
+import WireLocators
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
 private typealias Accessibility = L10n.Accessibility.Conversation.WireCells
@@ -110,23 +111,26 @@ struct FilesInfoView: View {
         }
 
         var accessibilityIdentifiers: (title: String, message: String) {
+            typealias Identifiers = Locators.WireDrive.FilesInfoPage
+
             switch self {
             case .preparingFiles:
-                ("preparing-files-title", "preparing-files-message")
+                return (Identifiers.preparingFilesTitle.rawValue, Identifiers.preparingFilesMessage.rawValue)
             case let .noFilesFound(scope, isSearch):
                 if isSearch {
-                    (
-                        "no-files-search-title",
-                        "no-files-search-message"
+                    return (
+                        Identifiers.noFilesSearchTitle.rawValue,
+                        Identifiers.noFilesSearchMessage.rawValue
                     )
                 } else {
-                    (
-                        "no-files-title",
-                        scope == .allConversations ? "no-files-all-conversations-message" : "no-files-message"
+                    return (
+                        Identifiers.noFilesTitle.rawValue,
+                        scope == .allConversations ? Identifiers.noFilesAllConversationsMessage.rawValue : Identifiers
+                            .noFilesMessage.rawValue
                     )
                 }
             case .error:
-                ("error-title", "error-message")
+                return (Identifiers.errorTitle.rawValue, Identifiers.errorMessage.rawValue)
             }
         }
     }
@@ -206,9 +210,8 @@ struct FilesInfoView: View {
                 )
         }
         .accessibilityLabel(Strings.Files.Error.retry)
-        .accessibilityIdentifier("filesBrowser.retryButton")
+        .accessibilityIdentifier(Locators.WireDrive.FilesInfoPage.retryButton.rawValue)
     }
-
 }
 
 #Preview("no files found - single conversation") {
@@ -239,7 +242,7 @@ struct LoadMoreView: View {
             } else {
                 Button(Strings.Files.LoadMore.title, action: onLoadMore)
                     .accessibilityLabel(Accessibility.Files.LoadMore.title)
-                    .accessibilityIdentifier("load-more")
+                    .accessibilityIdentifier(Locators.WireDrive.FilesInfoPage.loadMore.rawValue)
                     .buttonStyle(.borderless)
                     .font(for: .body3)
                     .foregroundStyle(ColorTheme.Buttons.Secondary.onEnabled.color)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesView.swift
@@ -21,6 +21,7 @@ import QuickLook
 package import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 import WireReusableUIComponents
 
@@ -114,7 +115,7 @@ private extension FilesView {
             }
         )
         .accessibilityLabel(Accessibility.Files.close)
-        .accessibilityIdentifier("close")
+        .accessibilityIdentifier(Locators.WireDrive.FilesPage.close.rawValue)
         .tint(ColorTheme.Base.primary(accentColor).color)
     }
 
@@ -130,6 +131,7 @@ private extension FilesView {
                         .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
                 }
             }
+            .accessibilityIdentifier(Locators.WireDrive.FilesPage.createFolder.rawValue)
 
             Menu {
                 ForEach(viewModel.templates, id: \.self) { template in
@@ -153,6 +155,7 @@ private extension FilesView {
                         .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
                 }
             }
+            .accessibilityIdentifier(Locators.WireDrive.FilesPage.createFile.rawValue)
 
             Button {
                 onOpenRecycleBin()
@@ -164,6 +167,7 @@ private extension FilesView {
                         .tint(SemanticColors.Icon.foregroundDefaultBlack.color)
                 }
             }
+            .accessibilityIdentifier(Locators.WireDrive.FilesPage.recycleBin.rawValue)
         } label: {
             Image(systemName: "ellipsis.circle")
         }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -35,7 +35,7 @@ final class FilesItemViewModel: ObservableObject {
     private let localAssetRepository: any WireDriveLocalAssetRepositoryProtocol
     private var cancellables = Set<AnyCancellable>()
 
-    enum ItemAction {
+    enum ItemAction: String {
         case open
         case showVersionHistory
         case edit

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -273,6 +273,7 @@ struct FilesItemView: View {
     ) -> some View {
         if viewModel.menuActions.contains(itemAction) {
             menuItem(itemAction)
+                .accessibilityIdentifier(itemAction.rawValue)
         }
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -273,7 +273,7 @@ struct FilesItemView: View {
     ) -> some View {
         if viewModel.menuActions.contains(itemAction) {
             menuItem(itemAction)
-                .accessibilityIdentifier(itemAction.rawValue)
+                .accessibilityIdentifier("fileMenu.\(itemAction)")
         }
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Rename/FileRenameView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Rename/FileRenameView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import WireDesign
+import WireLocators
 import WireReusableUIComponents
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells
@@ -95,7 +96,7 @@ private extension FileRenameView {
             }
         )
         .accessibilityLabel(L10n.Accessibility.General.cancel)
-        .accessibilityIdentifier("cancel")
+        .accessibilityIdentifier(Locators.WireDrive.FileRenamePage.cancel.rawValue)
     }
 
     var saveButton: some View {
@@ -113,7 +114,7 @@ private extension FileRenameView {
                 )
                 .disabled(viewModel.isSaveDisabled)
                 .accessibilityLabel(L10n.Accessibility.General.save)
-                .accessibilityIdentifier("save")
+                .accessibilityIdentifier(Locators.WireDrive.FileRenamePage.save.rawValue)
             }
         }
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Rename/FileRenameView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Rename/FileRenameView.swift
@@ -96,7 +96,7 @@ private extension FileRenameView {
             }
         )
         .accessibilityLabel(L10n.Accessibility.General.cancel)
-        .accessibilityIdentifier(Locators.WireDrive.FileRenamePage.cancel.rawValue)
+        .accessibilityIdentifier(Locators.WireDrive.FileRenamePage.cancel)
     }
 
     var saveButton: some View {
@@ -114,7 +114,7 @@ private extension FileRenameView {
                 )
                 .disabled(viewModel.isSaveDisabled)
                 .accessibilityLabel(L10n.Accessibility.General.save)
-                .accessibilityIdentifier(Locators.WireDrive.FileRenamePage.save.rawValue)
+                .accessibilityIdentifier(Locators.WireDrive.FileRenamePage.save)
             }
         }
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkPasswordView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkPasswordView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 import WireMessagingDomainSupport
 
@@ -165,6 +166,7 @@ struct ShareLinkPasswordView: View {
             RoundedRectangle(cornerRadius: 10)
                 .foregroundStyle(ColorTheme.Buttons.Secondary.enabled.color)
         }
+        .accessibilityIdentifier(Locators.WireDrive.ShareLinkPasswordPage.togglePassword.rawValue)
     }
 
     @ViewBuilder
@@ -279,6 +281,7 @@ struct ShareLinkPasswordView: View {
             }
         }
         .tint(.primaryText)
+        .accessibilityIdentifier(Locators.WireDrive.ShareLinkPasswordPage.sharePassword.rawValue)
     }
 
     @ViewBuilder
@@ -308,6 +311,7 @@ struct ShareLinkPasswordView: View {
             }
         }
         .tint(.primaryText)
+        .accessibilityIdentifier(Locators.WireDrive.ShareLinkPasswordPage.resetPassword.rawValue)
     }
 
     @ToolbarContentBuilder
@@ -340,6 +344,7 @@ struct ShareLinkPasswordView: View {
                 }
             }
             .disabled(!viewModel.canSave)
+            .accessibilityIdentifier(Locators.WireDrive.ShareLinkPasswordPage.savePassword.rawValue)
         }
     }
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 import WireMessagingDomainSupport
 
@@ -220,6 +221,7 @@ struct ShareLinkView: View {
                         .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
                 }
             }
+            .accessibilityIdentifier(Locators.WireDrive.ShareLinkPage.sharePassword.rawValue)
         }
         .padding(.horizontal)
         .padding(.bottom, 8)
@@ -233,6 +235,7 @@ struct ShareLinkView: View {
                 ShareLink(item: Strings.ShareLink.sharedMessage(link.absoluteString)) {
                     shareLinkContent()
                 }
+                .accessibilityIdentifier(Locators.WireDrive.ShareLinkPage.shareLink.rawValue)
             } else {
                 shareLinkContent()
             }

--- a/WireUI/Sources/WireLocators/Locators+accessibilityIdentifier.swift
+++ b/WireUI/Sources/WireLocators/Locators+accessibilityIdentifier.swift
@@ -1,0 +1,53 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import SwiftUI
+
+public extension View {
+
+    /// Adds an accessibility identifier to a view for testing purposes. To be used with `Locators.swift'
+    ///
+    /// This method allows you to specify a testable ID for SwiftUI views, which is particularly useful in automated
+    /// testing scenarios such as XCUITest. It accepts any `RawRepresentable` type whose `RawValue` is a `String`,
+    /// providing flexibility in how you pass the identifier.
+    ///
+    /// - Parameter id: A value conforming to `RawRepresentable` where the `RawValue` is a `String`. For example, you
+    /// can pass a simple `String`, or an `Enum` with a `String` raw value.
+    /// - Returns: A view with the accessibility identifier set.
+    ///
+    /// ### Usage Examples
+    ///
+    /// ```swift
+    /// // Using a plain string
+    /// Text("Hello")
+    ///     .accessibilityIdentifier("greeting")
+    ///
+    /// // Using an enum with raw values
+    /// Button(action: { /* ... */ }) {
+    ///     Text("Submit")
+    /// }
+    /// .accessibilityIdentifier(TestId.submitButton)
+    ///
+    /// enum TestId: String {
+    ///     case submitButton = "submitButton"
+    /// }
+    /// ```
+    func accessibilityIdentifier<T: RawRepresentable>(_ id: T) -> some View where T.RawValue == String {
+        accessibilityIdentifier(id.rawValue)
+    }
+}

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -357,5 +357,33 @@ public enum Locators {
             case createFile
             case recycleBin
         }
+
+        public enum FilesInfoPage: String {
+            case preparingFilesTitle
+            case preparingFilesMessage
+            case noFilesSearchTitle
+            case noFilesSearchMessage
+            case noFilesTitle
+            case noFilesAllConversationsMessage
+            case noFilesMessage
+            case errorTitle
+            case errorMessage
+            case retryButton
+            case loadMore
+        }
+
+        public enum EditFilePage: String {
+            case close
+        }
+
+        public enum CreateFilePage: String {
+            case cancelButton
+            case createButton
+        }
+
+        public enum FileRenamePage: String {
+            case cancel
+            case save
+        }
     }
 }

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -329,5 +329,33 @@ public enum Locators {
             case cancelButton
             case removeFilterButton
         }
+
+        public enum ShareLinkPasswordPage: String {
+            case togglePassword
+            case sharePassword
+            case resetPassword
+            case savePassword
+        }
+
+        public enum ShareLinkPage: String {
+            case sharePassword
+            case shareLink
+        }
+
+        public enum FilesContentPage: String {
+            case confirm
+            case search
+
+            public static func fileItem(_ index: Int) -> String {
+                "fileItem\(index)"
+            }
+        }
+
+        public enum FilesPage: String {
+            case close
+            case createFolder
+            case createFile
+            case recycleBin
+        }
     }
 }

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -23,7 +23,7 @@ import Foundation
 // because the current UI tests depend on these exact values.
 // We are keeping them as-is for now to avoid breaking existing tests.
 //
-// TODO: [WPB-21952] Replace these explicit string values with properly camel-cased,
+// TODO: [WPB-21952] Replace these explicit string values with properly camelCased,
 // non-UI-text-based identifiers (e.g., accessibility identifiers) to have this
 // unform format and reduce test fragility.
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23902" title="WPB-23902" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23902</a>  [iOS] Add missing accessibility elements in Wire drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Wire Drive was missing some identifiers that we could use for testing.

This PR adds some identifiers like:
- One for each Files menu item (Open, share, version history, renaming, tags, delete)
- One for each file (fileX, "X" being the index of the file on the list)
- SearchView
- Create folder
- Create File
- Recycle Bin
- Toggle Password
- Share Password
- Reset Password
- Save Password
- Share Link

On this PR some existing identifiers were updated to follow the same convention as the others (camelCase) to make it easier to implement tests and have a common naming for all the identifiers.

Some updated identifiers on FilesInfoView where:
- preparing-files-title -> preparingFilesTitle
- preparing-files-message -> preparingFilesMessage
- no-files-search-title -> noFilesSearchTitle
- no-files-search-message -> noFilesSearchMessage
- no-files-title -> noFilesTitle
- no-files-all-conversation-message -> noFilesAllConversationMessage
- no-files-message -> noFilesMessage
- error-title -> errorTitle
- error-message -> errorMessage
- filesBrowser.retryButton -> retryButton
- load-more -> loadMore

**Feedback is welcome to know if i'm missing some identifiers that could be useful to have or i might added some that are not need it 😃**

### Testing

Some old test using the existing identifiers might need to get updated in order to use the new camelCase naming.
This PR can't be test it manually with the app since it only adds identifiers for automated test. No change was made on the code so everything should works as in develop.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
