### PR TITLE
fix: moving cacheKey generation to a single place - WPB-24133

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireDrive/Model/WireDriveLocalAsset+CacheKey.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/Model/WireDriveLocalAsset+CacheKey.swift
@@ -26,7 +26,7 @@ extension WireDriveLocalAsset {
     /// The file name of the URL path will be shown as the title in the QuickLook preview when the file os opened,
     /// so it's important to make it readable and correspond to the actual file name, rather than a generated id.
     static func cacheKey(nodeID: UUID, eTag: String, path: String) -> String {
-        let filename = path.split(separator: "/").last.flatMap(String.init) ?? "-"
+        let filename = URL(fileURLWithPath: path).lastPathComponent
         return "\(nodeID.uuidString)-\(eTag)/\(filename)"
     }
 

--- a/WireMessaging/Sources/WireMessagingData/WireDrive/Model/WireDriveLocalAsset+CacheKey.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/Model/WireDriveLocalAsset+CacheKey.swift
@@ -21,12 +21,13 @@ import WireMessagingDomain
 
 extension WireDriveLocalAsset {
 
+    /// Builds a key that acts as an identifier for the particular version of the downloaded file.
+    /// This cache key is also used to build the URL which points to the downloaded file.
+    /// The file name of the URL path will be shown as the title in the QuickLook preview when the file os opened,
+    /// so it's important to make it readable and correspond to the actual file name, rather than a generated id.
     static func cacheKey(nodeID: UUID, eTag: String, path: String) -> String {
-        var result = "\(nodeID.uuidString)-\(eTag)"
-        if let pathExtension = URL(string: path)?.pathExtension, !pathExtension.isEmpty {
-            result.append(".\(pathExtension)")
-        }
-        return result
+        let filename = path.split(separator: "/").last.flatMap(String.init) ?? "-"
+        return "\(nodeID.uuidString)-\(eTag)/\(filename)"
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetRepository.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetRepository.swift
@@ -130,24 +130,12 @@ package final class WireDriveLocalAssetRepository: WireDriveLocalAssetRepository
             }
 
             let (tempURL, _) = try await download.value
-
-            let filename = node.path.split(separator: "/").last.flatMap(String.init) ?? "-"
-
-            var asset = try verifyAsset(nodeID: nodeID, eTag: eTag)
-
-            let extensionComponents = asset.cacheKey.split(separator: ".")
-            let pathWithoutExtension: String = if extensionComponents.count > 1 {
-                String(extensionComponents.dropLast().joined(separator: "."))
-            } else {
-                asset.cacheKey
-            }
-
-            let key = pathWithoutExtension + "/" + filename
-
+            let key = WireDriveLocalAsset.cacheKey(nodeID: nodeID, eTag: eTag, path: node.path)
             try await fileCache.saveFile(at: tempURL, key: key)
 
-            asset = try verifyAsset(nodeID: nodeID, eTag: eTag)
+            var asset = try verifyAsset(nodeID: nodeID, eTag: eTag)
             asset.downloadState = .downloaded(cacheKey: key)
+
             try store.upsertAsset(asset)
         } catch {
             // We don't care about the eTag when setting download state to failed.


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24133" title="WPB-24133" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24133</a>  [iOS] Downloaded files need download again after app restart
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a Drive file, which was already downloaded is tapped after an app restart, it starts downloading again.

This is caused by the fact that the cacheKey is being built differently in two places.
Those two places diverged after WPB-23112.
With this PR I moved to logic into one single place and added a doc comment.

### Testing

* tap on a Drive file to start the download
* wait for the download to finish
* force close the app (not just background mode)
* open app again
* tap on the previously downloaded file to open it

Old behaviour before fix:
* The file starts downloading again

New behaviour after fix:
* The file opens
