### PR TITLE
feat: allow network failures setting up user session - WPB-24162

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -321,12 +321,7 @@ final class UserSessionLoader {
         // Get new metadata.
         let newMetadata: ResolvedBackendMetadata
         do {
-            let metadata = try await networkStack.resolvedBackendMetadata()
-            newMetadata = ResolvedBackendMetadata(
-                apiVersion: metadata.apiVersion,
-                domain: metadata.domain,
-                isFederationEnabled: metadata.isFederationEnabled
-            )
+            newMetadata = try await networkStack.resolvedBackendMetadata()
         } catch is URLError {
             // To allow offline browsing fallback to previous metadata if possible.
             if let prevMetadata {

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -326,7 +326,6 @@ final class UserSessionLoader {
             // To allow offline browsing fallback to previous metadata if possible.
             if let prevMetadata {
                 newMetadata = prevMetadata
-                // TODO: Schedule fetching the latest backend metadata.
             } else {
                 throw Failure.noResolvedBackendMetadataAvailable
             }
@@ -609,7 +608,6 @@ final class UserSessionLoader {
             MLSAPIError.unsupportedEndpointForAPIVersion,
             MLSAPIError.mlsNotEnabled {
             // Don't block session loading, we'll try again later.
-            // TODO: Schedule trying again later
             return nil
         }
     }

--- a/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/UserSessionLoader.swift
@@ -327,10 +327,11 @@ final class UserSessionLoader {
                 domain: metadata.domain,
                 isFederationEnabled: metadata.isFederationEnabled
             )
-        } catch URLError.notConnectedToInternet, URLError.networkConnectionLost {
+        } catch is URLError {
             // To allow offline browsing fallback to previous metadata if possible.
             if let prevMetadata {
                 newMetadata = prevMetadata
+                // TODO: Schedule fetching the latest backend metadata.
             } else {
                 throw Failure.noResolvedBackendMetadataAvailable
             }
@@ -609,12 +610,11 @@ final class UserSessionLoader {
             let api = MLSAPIBuilder(apiService: apiService).makeAPI(for: apiVersion)
             let keys = try await api.getBackendMLSPublicKeys()
             return keys.removal.isValid
-        } catch
-        URLError.notConnectedToInternet,
-            URLError.networkConnectionLost,
+        } catch is URLError,
             MLSAPIError.unsupportedEndpointForAPIVersion,
             MLSAPIError.mlsNotEnabled {
             // Don't block session loading, we'll try again later.
+            // TODO: Schedule trying again later
             return nil
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24162" title="WPB-24162" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24162</a>  [iOS] Allow any URLError when loading a UserSession
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Currently when loading a UserSession we make a few network requests to fetch backend metadata, determine if MLS is enabled, and check if the build is blacklisted. 

To allow for the situation where the user is offline, we ignore certain network errors - URLError.notConnectedToInternet, URLError.networkConnectionLost. 

However a poor connection can show up as many other types of error such as URLError.timedOut, URLError.secureConnectionFailed etc which causes an error to be shown prompting the user to retry or submit a bug.

As it is not easy to determine a list of poor connection related errors, this PR considers any URLError during session loading as OK (the same as URLError.notConnectedToInternet) and will allow loading of the conversation screen.

This is a temporary measure. In some follow up PRs I hope to remove network requests from loading a user session in most cases. Errors such as a time out means the user is stuck on our launch screen at least 60 seconds which is a horrible UX. 

### Testing

1. Log in to a **staging** account
2. Quit the app.
3. Disable internet
4. Open the app. Confirm that it opens to the conversation list
5. Quit the app & re-enable internet
6. Using proxyman or similar enable a breakpoint for https://staging-nginz-https.zinfra.io/api-version
7. Open the app.
8. The breakpoint in proxyman should trigger. Wait 60 seconds for the request to timeout.
9. Confirm the app opens to the conversation list
10. Repeat with https://staging-nginz-https.zinfra.io/v14/mls/public-keys

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.