### PR TITLE
fix: disable video when user left the call - WPB-24188

### DIFF
--- a/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
+++ b/wire-ios-sync-engine/Source/Calling/WireCallCenterV3.swift
@@ -849,7 +849,7 @@ public extension WireCallCenterV3 {
                     shouldRing: false,
                     degraded: isDegraded(conversationId: conversationId)
                 )
-                callSnapshots[conversationId] = previousSnapshot.update(with: callState)
+                callSnapshots[conversationId] = previousSnapshot.update(with: callState).updateVideoState(.stopped)
             } else {
                 callSnapshots[conversationId] = previousSnapshot.update(with: .terminating(reason: reason))
             }

--- a/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Calling/WireCallCenterV3Tests.swift
@@ -1887,6 +1887,52 @@ extension WireCallCenterV3Tests {
         )
     }
 
+    func testThatClosingAGroupCallResetsVideoState() {
+        // given
+        sut.handleIncomingCall(
+            conversationId: groupConversationID.serialized,
+            messageTime: Date(),
+            userId: otherUserID.serialized,
+            clientId: otherUserClientID,
+            isVideoCall: true,
+            shouldRing: true,
+            conversationType: .group
+        )
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        sut.setVideoState(conversationId: groupConversationID, videoState: .started)
+        XCTAssertEqual(sut.videoState(conversationId: groupConversationID), .started)
+
+        // when
+        sut.closeCall(conversationId: groupConversationID)
+
+        // then
+        XCTAssertEqual(sut.videoState(conversationId: groupConversationID), .stopped)
+    }
+
+    func testThatRejoiningGroupCallAfterEnablingVideoStartsWithVideoDisabled() {
+        // given
+        sut.handleIncomingCall(
+            conversationId: groupConversationID.serialized,
+            messageTime: Date(),
+            userId: otherUserID.serialized,
+            clientId: otherUserClientID,
+            isVideoCall: true,
+            shouldRing: true,
+            conversationType: .group
+        )
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+        sut.setVideoState(conversationId: groupConversationID, videoState: .started)
+        sut.closeCall(conversationId: groupConversationID)
+
+        // when
+        sut.handleEstablishedCall(conversationId: groupConversationID.serialized)
+        XCTAssert(waitForAllGroupsToBeEmpty(withTimeout: 0.5))
+
+        // then
+        XCTAssertEqual(sut.videoState(conversationId: groupConversationID), .stopped)
+    }
+
     func testThatItWhenClosingAOneOnOneCallItDoesNotSetTheCallStateToIncomingInactive() {
         // given
         sut.handleIncomingCall(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24188" title="WPB-24188" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24188</a>  [iOS] Video is still enabled when user left the call with video on and joins it again
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When a user has their video enabled, leaves a call and joins again, the video is still enabled on joining the call.

### Solution

Disable video when user left the call.

### Testing


### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
