### PR TITLE
fix: remove top padding from video and files thumbnails - WPB-23931

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeDocumentPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeDocumentPreviewView.swift
@@ -26,6 +26,7 @@ struct WireDriveLargeDocumentPreviewView: View {
     private static let errorMessage = L10n.Localizable.Conversation.Message.Attachment.previewNotAvailable
     private static let downloadErrorMessage = L10n.Localizable.Conversation.Message.Attachment.unableToDownload
     private static let loadingMessage = L10n.Localizable.Conversation.Message.Attachment.loadingContent
+    private static let previewCornerRadius = 10.0
 
     let headerIcon: Image
     let headerText: String
@@ -42,7 +43,7 @@ struct WireDriveLargeDocumentPreviewView: View {
             progressColor: downloadError
                 ? ColorTheme.Base.error.color : ColorTheme.Base.primary(wireAccentColor).color
         ) {
-            VStack {
+            VStack(spacing: 0) {
                 WireDriveDocumentHeaderView(
                     headerIcon: headerIcon,
                     headerText: headerText,
@@ -65,7 +66,7 @@ struct WireDriveLargeDocumentPreviewView: View {
                         }
                     }
                 }
-            }
+            }.background(ColorTheme.Backgrounds.surfaceVariant.color)
         }
     }
 
@@ -95,7 +96,7 @@ struct WireDriveLargeDocumentPreviewView: View {
             .background(alignment: .top) {
                 content()
             }
-            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: Self.previewCornerRadius))
     }
 
     @ViewBuilder

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/AttachmentsPreviewView/WireDriveLargeVideoPreviewView.swift
@@ -48,7 +48,7 @@ struct WireDriveLargeVideoPreviewView: View {
             progressColor: downloadError
                 ? ColorTheme.Base.error.color : ColorTheme.Base.primary(wireAccentColor).color
         ) {
-            VStack {
+            VStack(spacing: 0) {
                 WireDriveDocumentHeaderView(
                     headerIcon: headerIcon,
                     headerText: headerText,
@@ -76,7 +76,7 @@ struct WireDriveLargeVideoPreviewView: View {
                         durationView(duration: duration)
                     }
                 }
-            }
+            }.background(ColorTheme.Backgrounds.surfaceVariant.color)
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23931" title="WPB-23931" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23931</a>  [iOS][Files in conversation] Remove top padding from video and files thumbnails 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR removes top padding from video and files thumbnails. Also added some corner radius on the large document preview so it is aligned with the large video preview.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
