### PR TITLE
feat: update accessibility labels on drive - WPB-24201

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Accessibility.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Accessibility.strings
@@ -28,7 +28,7 @@
 "conversation.creationForm.channelHistory.upgradeBanner.close" = "Close upgrade now banner";
 
 // MARK: Conversation Files View
-"conversation.wireCells.files.close" = "Close files";
+"conversation.wireCells.files.close" = "Close";
 "conversation.wireCells.files.loadMore.title" = "Load more";
 "conversation.wireCells.files.noData.title" = "There are no files or folders yet";
 "conversation.wireCells.files.noData.message" = "You'll find all files and folders shared in this conversation here";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Accessibility.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Accessibility.strings
@@ -54,3 +54,18 @@
 // MARK: - Share Link View
 "conversation.wireCells.shareLink.hidePassword" = "Hide password";
 "conversation.wireCells.shareLink.showPassword" = "Show password";
+
+// MARK: - Accessibility File Icon Labels
+"conversation.wireCells.files.filetype" = "File type, {0}";
+"conversation.wireCells.files.archive" = "Archive";
+"conversation.wireCells.files.audio" = "Audio";
+"conversation.wireCells.files.code" = "Code";
+"conversation.wireCells.files.document" = "Document";
+"conversation.wireCells.files.image" = "Image";
+"conversation.wireCells.files.other" = "Other";
+"conversation.wireCells.files.pdf" = "Pdf";
+"conversation.wireCells.files.presentation" = "Presentation";
+"conversation.wireCells.files.spreadsheet" = "Spreadsheet";
+"conversation.wireCells.files.video" = "Video";
+"conversation.wireCells.files.folder" = "Folder";
+"conversation.wireCells.files.text" = "Text";

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/WireDriveFileType.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/WireDriveFileType.swift
@@ -21,6 +21,8 @@ public import SwiftUI
 public import UniformTypeIdentifiers
 public import WireMessagingDomain
 
+private typealias Accessibility = L10n.Accessibility.Conversation.WireCells
+
 extension WireDriveFileType {
 
     // MARK: - Factory
@@ -128,4 +130,41 @@ extension WireDriveFileType {
         UIImage(resource: imageResource)
     }
 
+    // MARK: - Accessibility File Icon Label
+
+    var accessibilityIconLabel: String {
+        // Folder is a special case that doesn't use the "File type" prefix
+        if self == .folder {
+            return Accessibility.Files.folder
+        }
+
+        let typeName: String = switch self {
+        case .archive:
+            Accessibility.Files.archive
+        case .audio:
+            Accessibility.Files.audio
+        case .code:
+            Accessibility.Files.code
+        case .document:
+            Accessibility.Files.document
+        case .image:
+            Accessibility.Files.image
+        case .other:
+            Accessibility.Files.other
+        case .pdf:
+            Accessibility.Files.pdf
+        case .presentation:
+            Accessibility.Files.presentation
+        case .spreadsheet:
+            Accessibility.Files.spreadsheet
+        case .video:
+            Accessibility.Files.video
+        case .text:
+            Accessibility.Files.text
+        case .folder:
+            "" // Unreachable due to the check above, but required for exhaustiveness
+        }
+
+        return Accessibility.Files.filetype.replacingOccurrences(of: "{0}", with: typeName)
+    }
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -167,6 +167,7 @@ struct FilesItemView: View {
             .padding(.horizontal, iconHorizontalPadding)
             .frame(minWidth: iconSpaceWidth)
             .frame(height: iconSpaceHeight)
+            .accessibilityLabel(viewModel.icon.accessibilityIconLabel)
     }
 
     @ViewBuilder

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -42,7 +42,7 @@ struct FilesItemView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                icon()
+                icon().accessibilitySortPriority(3)
 
                 VStack(alignment: .leading, spacing: 5) {
                     Text(viewModel.fileName)
@@ -82,6 +82,8 @@ struct FilesItemView: View {
                             .foregroundStyle(ColorTheme.Base.secondaryText.color)
                     }
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilitySortPriority(2)
 
                 Spacer()
 
@@ -95,6 +97,7 @@ struct FilesItemView: View {
                 }
                 .tint(nil)
                 .menuOrder(.fixed)
+                .accessibilitySortPriority(1)
                 .deletionConfirmationDialog( // delete file to recycle bin
                     isPresented: $viewModel.isPresentingDeleteFileToRecycleBinConfirmation,
                     title: Strings.Files.Item.DeleteFileConfirmation.title(viewModel.fileName),

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkView.swift
@@ -53,6 +53,7 @@ struct ShareLinkView: View {
                     .padding()
                     .padding(.bottom, 80) // Space for the bottom button
                 }
+                .accessibilitySortPriority(1)
 
                 VStack {
                     if viewModel.isPasswordEnabled, let password = viewModel.getPassword() {

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/ShareLink/ShareLinkView.swift
@@ -124,6 +124,8 @@ struct ShareLinkView: View {
             }
             .tint(wireAccentColor.color)
             .disabled(!viewModel.isLinkToggleEnabled)
+            // We need this so VoiceOver reads the correct state AFTER it changes!
+            .accessibilityAddTraits(.updatesFrequently)
         }
     }
 

--- a/WireUI/Sources/WireReusableUIComponents/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireUI/Sources/WireReusableUIComponents/Resources/Localization/en.lproj/Localizable.strings
@@ -21,3 +21,5 @@
 "passwordtextfield.preview.passwordrules" = "Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.";
 "passwordtextfield.hide_password" = "Hide password";
 "passwordtextfield.show_password" = "Show password";
+
+"validationTextField.removeEntry" = "Remove entry";

--- a/WireUI/Sources/WireReusableUIComponents/ValidationTextField/ValidationTextField.swift
+++ b/WireUI/Sources/WireReusableUIComponents/ValidationTextField/ValidationTextField.swift
@@ -82,6 +82,7 @@ public struct ValidationTextField: View {
                         .frame(width: 16, height: 16)
                         .padding(16)
                 })
+                .accessibilityLabel(L10n.ValidationTextField.removeEntry)
             }
             .padding(.leading, 16)
             .frame(height: fieldHeight)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24201" title="WPB-24201" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24201</a>  [iOS] Add/update accessibility labels on Wire Drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Added or updated some missing or wrong accessibility labels on Drive.

- FilesView will now use different accessibility label for Close (X) button depending on what screen the user is on:
    - Files list
    - Recycle Bin
    - File Versioning
- Update Files list text on Close (X) button from "Close files" to "Close shared drive"
- Add accessibility label to ValidationTextField for "x" (to remove text input). This is used on files/folder creation.

P.D. There are still some accessibility labels that need to be updated or added on. I will update the PR with new commit or most probably make a child PR for the rest.

### Testing

Test updated screens with VoiceOver:
- File creation
- Folder creation
- File Versioning
- 1 to 1 files list
- Files browser

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
