### PR TITLE
fix: sent indicator way off on shared file (image/video) - WPB-23929

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/FlowLayout.swift
+++ b/WireMessaging/Sources/WireMessagingUI/FlowLayout.swift
@@ -49,7 +49,7 @@ struct FlowLayout: Layout {
 
     private func layout(subviews: Subviews, containerWidth: CGFloat) -> (items: [CGRect], size: CGSize) {
         let sizes = subviews.map { subview in
-            let size = subview.sizeThatFits(.unspecified)
+            let size = subview.sizeThatFits(ProposedViewSize(width: containerWidth, height: nil))
             return CGSize(width: min(size.width, containerWidth), height: size.height)
         }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23929" title="WPB-23929" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23929</a>  [iOS][Files in conversation] Send indicator appears much below the video in conversation for the sender
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes a layout issue on some shared file (image/video) where the height of the custom `FlowLayout` is not properly computed resulting in a sent indicator looking way off (see screenshots)

**BEFORE**

![Capture d’écran   2026-03-25 à 11 50 22](https://github.com/user-attachments/assets/0264f61a-604b-419c-b776-4cef7ebcffc5)

![Capture d’écran   2026-03-25 à 11 49 50](https://github.com/user-attachments/assets/10e0f1ca-7072-43bc-80af-bd6ce06af1af)

**AFTER**

![Capture d’écran   2026-03-25 à 11 52 46](https://github.com/user-attachments/assets/696b5531-7ac4-49c1-a928-8a34467d8bb5)
![Capture d’écran   2026-03-25 à 11 51 52](https://github.com/user-attachments/assets/fcfc42b0-4e5f-470c-b9b3-b3bf886b27aa)

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
