### PR TITLE
feat: add button action for file offline availability (UI only) - WPB-23967

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -176,6 +176,8 @@
 "conversation.wireCells.files.renameFile.placeholder" = "Enter file name";
 "conversation.wireCells.files.renameFolder.placeholder" = "Enter folder name";
 "conversation.wireCells.files.openRecycleBin" = "Open recycle bin";
+"conversation.wireCells.files.availableOffline" = "Make available offline";
+"conversation.wireCells.files.unavailableOffline" = "Remove available offline";
 "conversation.wireCells.recycleBin.navigationTitle" = "Recycle Bin";
 "conversation.wireCells.recycleBin.noData.learnMore" = "Learn more about Recycle Bin";
 "conversation.wireCells.recycleBin.noData.message" = "You'll find all deleted files and folders here.";

--- a/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/WireMessaging/Sources/WireMessagingUI/Resources/Localization/en.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "conversation.wireCells.files.item.menu.addOrRemoveTags" = "Add or remove tags";
 "conversation.wireCells.files.item.menu.delete" = "Delete Permanently";
 "conversation.wireCells.files.item.menu.versionHistory" = "Version history";
+"conversation.wireCells.files.item.menu.makeAvailableOffline" = "Make available offline";
+"conversation.wireCells.files.item.menu.removeAvailableOffline" = "Remove available offline";
 "conversation.wireCells.files.item.deleteConfirmation.title" = "This will permanently delete the file %@ for all participants. Everyone will lose access and there is no way to recover the file.";
 "conversation.wireCells.files.item.deleteConfirmation.deletePermanently" = "Delete Permanently";
 "conversation.wireCells.files.item.menu.delete" = "Delete";
@@ -176,8 +178,6 @@
 "conversation.wireCells.files.renameFile.placeholder" = "Enter file name";
 "conversation.wireCells.files.renameFolder.placeholder" = "Enter folder name";
 "conversation.wireCells.files.openRecycleBin" = "Open recycle bin";
-"conversation.wireCells.files.availableOffline" = "Make available offline";
-"conversation.wireCells.files.unavailableOffline" = "Remove available offline";
 "conversation.wireCells.recycleBin.navigationTitle" = "Recycle Bin";
 "conversation.wireCells.recycleBin.noData.learnMore" = "Learn more about Recycle Bin";
 "conversation.wireCells.recycleBin.noData.message" = "You'll find all deleted files and folders here.";

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
@@ -449,6 +449,9 @@ package final class FilesViewModel: ObservableObject {
                     sheetNavigation = .versionHistory(view: makeFileVersioningView(item: item))
                 case .edit:
                     isEditing = item
+                case .makeAvailableOffline, .removeAvailableOffline:
+                    // TODO: [WPB-23967] - Call use cases
+                    break
                 }
             },
             isBrowsing: isBrowsing,

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -367,8 +367,10 @@ final class FilesItemViewModel: ObservableObject {
             actions.insert(.open)
             actions.insert(.shareLink)
         }
-
-        actions.insert(isAvailableOffline ? .removeAvailableOffline : .makeAvailableOffline)
+        
+        if !isEditable {
+            actions.insert(isAvailableOffline ? .removeAvailableOffline : .makeAvailableOffline)
+        }
 
         if !isBrowsing {
             if isInRecycleBin {

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -46,6 +46,8 @@ final class FilesItemViewModel: ObservableObject {
         case restore
         case deleteToRecycleBin
         case deletePermanently
+        case makeAvailableOffline
+        case removeAvailableOffline
     }
 
     let onItemAction: (ItemAction, FilesViewItem) async -> Void
@@ -366,6 +368,8 @@ final class FilesItemViewModel: ObservableObject {
             actions.insert(.shareLink)
         }
 
+        actions.insert(isAvailableOffline ? .removeAvailableOffline : .makeAvailableOffline)
+
         if !isBrowsing {
             if isInRecycleBin {
                 actions.insert(.restore)
@@ -386,6 +390,11 @@ final class FilesItemViewModel: ObservableObject {
         }
 
         return actions
+    }
+
+    var isAvailableOffline: Bool {
+        // TODO: [WPB-24208] When PR merged, uncomment code
+        Bool.random() // localAssetRepository.asset(nodeID: nodeID).isAvailableOffline
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesItemViewModel.swift
@@ -367,7 +367,7 @@ final class FilesItemViewModel: ObservableObject {
             actions.insert(.open)
             actions.insert(.shareLink)
         }
-        
+
         if !isEditable {
             actions.insert(isAvailableOffline ? .removeAvailableOffline : .makeAvailableOffline)
         }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -196,6 +196,19 @@ struct FilesItemView: View {
             }
         }
 
+        menuItem(
+            viewModel.isAvailableOffline ? .removeAvailableOffline : .makeAvailableOffline) { item in
+                Button {
+                    viewModel.performMenuAction(item)
+                } label: {
+                    Label(
+                        viewModel.isAvailableOffline ? Strings.Files.unavailableOffline : Strings.Files
+                            .availableOffline,
+                        systemImage: viewModel.isAvailableOffline ? "xmark.circle" : "arrow.down.circle"
+                    )
+                }
+            }
+
         menuItem(.showVersionHistory) { item in
             Button {
                 viewModel.performMenuAction(item)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -201,7 +201,7 @@ struct FilesItemView: View {
                 viewModel.performMenuAction(item)
             } label: {
                 Label(
-                    Strings.Files.Item.Menu.availableOffline,
+                    Strings.Files.Item.Menu.makeAvailableOffline,
                     systemImage: "arrow.down.circle"
                 )
             }
@@ -212,7 +212,7 @@ struct FilesItemView: View {
                 viewModel.performMenuAction(item)
             } label: {
                 Label(
-                    Strings.Files.Item.Menu.unavailableOffline,
+                    Strings.Files.Item.Menu.removeAvailableOffline,
                     systemImage: "xmark.circle"
                 )
             }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -206,7 +206,7 @@ struct FilesItemView: View {
                 )
             }
         }
-        
+
         menuItem(.removeAvailableOffline) { item in
             Button {
                 viewModel.performMenuAction(item)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -196,18 +196,27 @@ struct FilesItemView: View {
             }
         }
 
-        menuItem(
-            viewModel.isAvailableOffline ? .removeAvailableOffline : .makeAvailableOffline) { item in
-                Button {
-                    viewModel.performMenuAction(item)
-                } label: {
-                    Label(
-                        viewModel.isAvailableOffline ? Strings.Files.unavailableOffline : Strings.Files
-                            .availableOffline,
-                        systemImage: viewModel.isAvailableOffline ? "xmark.circle" : "arrow.down.circle"
-                    )
-                }
+        menuItem(.makeAvailableOffline) { item in
+            Button {
+                viewModel.performMenuAction(item)
+            } label: {
+                Label(
+                    Strings.Files.Item.Menu.availableOffline,
+                    systemImage: "arrow.down.circle"
+                )
             }
+        }
+        
+        menuItem(.removeAvailableOffline) { item in
+            Button {
+                viewModel.performMenuAction(item)
+            } label: {
+                Label(
+                    Strings.Files.Item.Menu.unavailableOffline,
+                    systemImage: "xmark.circle"
+                )
+            }
+        }
 
         menuItem(.showVersionHistory) { item in
             Button {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23967" title="WPB-23967" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-23967</a>  [iOS] Make files available offline 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR adds context button action for file availability - UI only. 
Snapshots will be updated in a follow-up PR.

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
