### PR TITLE
fix: disallow clipboard - WPB-24299

### DIFF
--- a/WireUI/Sources/WireDesign/Appearance/ClipboardRestrictedTextFieldDelegate.swift
+++ b/WireUI/Sources/WireDesign/Appearance/ClipboardRestrictedTextFieldDelegate.swift
@@ -85,14 +85,13 @@ public final class ClipboardRestrictedTextFieldDelegate: NSObject, UITextFieldDe
     ) -> ClipboardRestrictedTextFieldDelegate? {
         guard !isContextMenuAllowed else { return nil }
         let textField = searchBar.searchTextField
-        let restricted: ClipboardRestrictedTextFieldDelegate
-        if let original = textField.delegate {
-            restricted = ClipboardRestrictedTextFieldDelegate(
+        let restricted = if let original = textField.delegate {
+            ClipboardRestrictedTextFieldDelegate(
                 isContextMenuAllowed: false,
                 forwardingTo: original
             )
         } else {
-            restricted = ClipboardRestrictedTextFieldDelegate(isContextMenuAllowed: false)
+            ClipboardRestrictedTextFieldDelegate(isContextMenuAllowed: false)
         }
         textField.delegate = restricted
         return restricted

--- a/WireUI/Sources/WireDesign/Appearance/ClipboardRestrictedTextFieldDelegate.swift
+++ b/WireUI/Sources/WireDesign/Appearance/ClipboardRestrictedTextFieldDelegate.swift
@@ -1,0 +1,100 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import UIKit
+
+/// A `UITextFieldDelegate` that restricts the edit menu (copy/paste/cut) on
+/// system-created text fields that cannot be subclassed, such as those inside
+/// `UIAlertController` or `UISearchBar`.
+///
+/// Supports two modes:
+/// - **Standalone**: for text fields with no existing delegate.
+/// - **Proxy**: for text fields with an internal delegate (e.g. `UISearchBar.searchTextField`);
+///   transparently forwards all non-overridden delegate methods to the original delegate.
+public final class ClipboardRestrictedTextFieldDelegate: NSObject, UITextFieldDelegate {
+
+    private let isContextMenuAllowed: Bool
+    private weak var forwardingDelegate: (any UITextFieldDelegate)?
+
+    /// Creates a standalone delegate with no forwarding.
+    public init(isContextMenuAllowed: Bool) {
+        self.isContextMenuAllowed = isContextMenuAllowed
+    }
+
+    /// Creates a proxy delegate that intercepts clipboard actions
+    /// and forwards everything else to the original delegate.
+    public init(isContextMenuAllowed: Bool, forwardingTo delegate: any UITextFieldDelegate) {
+        self.isContextMenuAllowed = isContextMenuAllowed
+        self.forwardingDelegate = delegate
+    }
+
+    // MARK: - Edit Menu Restriction
+
+    public func textField(
+        _ textField: UITextField,
+        editMenuForCharactersIn range: NSRange,
+        suggestedActions: [UIMenuElement]
+    ) -> UIMenu? {
+        if !isContextMenuAllowed {
+            return UIMenu(children: [])
+        }
+        return forwardingDelegate?.textField?(
+            textField,
+            editMenuForCharactersIn: range,
+            suggestedActions: suggestedActions
+        )
+    }
+
+    // MARK: - Forwarding
+
+    public override func responds(to aSelector: Selector!) -> Bool {
+        if super.responds(to: aSelector) { return true }
+        return forwardingDelegate?.responds(to: aSelector) ?? false
+    }
+
+    public override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        if forwardingDelegate?.responds(to: aSelector) == true {
+            return forwardingDelegate
+        }
+        return super.forwardingTarget(for: aSelector)
+    }
+
+    // MARK: - Convenience
+
+    /// Applies clipboard restriction to a `UISearchBar`'s internal search text field.
+    /// Returns the delegate instance which **must be stored with a strong reference**.
+    /// Returns `nil` if clipboard is allowed (no restriction needed).
+    public static func restrictSearchBarIfNeeded(
+        _ searchBar: UISearchBar,
+        isContextMenuAllowed: Bool
+    ) -> ClipboardRestrictedTextFieldDelegate? {
+        guard !isContextMenuAllowed else { return nil }
+        let textField = searchBar.searchTextField
+        let restricted: ClipboardRestrictedTextFieldDelegate
+        if let original = textField.delegate {
+            restricted = ClipboardRestrictedTextFieldDelegate(
+                isContextMenuAllowed: false,
+                forwardingTo: original
+            )
+        } else {
+            restricted = ClipboardRestrictedTextFieldDelegate(isContextMenuAllowed: false)
+        }
+        textField.delegate = restricted
+        return restricted
+    }
+}

--- a/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ConversationSelectionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ConversationSelectionViewController.swift
@@ -18,6 +18,7 @@
 
 import UIKit
 import WireCommonComponents
+import WireDesign
 import WireShareEngine
 
 private let cellReuseIdentifier = "ConversationCell"
@@ -30,6 +31,7 @@ final class ConversationSelectionViewController: UITableViewController {
     var selectionHandler: ((_ conversation: Conversation) -> Void)?
 
     private let searchController = UISearchController(searchResultsController: nil)
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
 
     init(conversations: [Conversation]) {
         self.allConversations = conversations
@@ -59,6 +61,11 @@ final class ConversationSelectionViewController: UITableViewController {
         searchController.searchResultsUpdater = self
         let searchBar = searchController.searchBar
         tableView.tableHeaderView = searchBar
+
+        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+            searchBar,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/Giphy/GiphySearchViewController.swift
@@ -50,6 +50,8 @@ final class GiphySearchViewController: VerticalColumnCollectionViewController {
         return controller
     }()
 
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
+
     private let noResultsLabel = DynamicFontLabel(
         text: Giphy.Error.noResult,
         style: .body1,
@@ -165,6 +167,11 @@ final class GiphySearchViewController: VerticalColumnCollectionViewController {
         searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self
         definesPresentationContext = true
+
+        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+            searchController.searchBar,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
     }
 
     private func setupNoResultLabel() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Components/TextView/TextView.swift
@@ -171,9 +171,14 @@ class TextView: UITextView {
     }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+
         if action == #selector(paste(_:)) {
-            let pasteboard = UIPasteboard.general
-            return pasteboard.hasImages || pasteboard.hasStrings
+            if isContextMenuAllowed {
+                let pasteboard = UIPasteboard.general
+                return pasteboard.hasImages || pasteboard.hasStrings
+            } else {
+                return false
+            }
         }
 
         return super.canPerformAction(action, withSender: sender)

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/CompleteReactionPicker/CompleteReactionPickerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/CompleteReactionPicker/CompleteReactionPickerViewController.swift
@@ -51,7 +51,7 @@ final class CompleteReactionPickerViewController: UIViewController {
         setupViews()
         createConstraints()
 
-        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+        self.clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
             searchBar,
             isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
         )

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/CompleteReactionPicker/CompleteReactionPickerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/MessageActions/CompleteReactionPicker/CompleteReactionPickerViewController.swift
@@ -31,6 +31,7 @@ final class CompleteReactionPickerViewController: UIViewController {
     private let collectionView = ReactionsCollectionView()
     private lazy var sectionViewController = ReactionSectionViewController(types: emojiDataSource.sectionTypes)
     private let searchBar = UISearchBar()
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
     private let selectedReactions: Set<Emoji.ID>
 
     private var deleting = false
@@ -49,6 +50,11 @@ final class CompleteReactionPickerViewController: UIViewController {
         sectionViewController.sectionDelegate = self
         setupViews()
         createConstraints()
+
+        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+            searchBar,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
 
         NotificationCenter.default.addObserver(
             self,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/ConversationList/Container/ConversationListViewController.swift
@@ -44,6 +44,7 @@ final class ConversationListViewController: UIViewController {
 
     private static let contentControllerBottomInset: CGFloat = 16
     private var userDefaultsObservation: NSKeyValueObservation?
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
 
     private lazy var filterContainerView = UIView()
 
@@ -491,6 +492,11 @@ final class ConversationListViewController: UIViewController {
         navigationItem.searchController = searchController
         navigationItem.preferredSearchBarPlacement = .stacked
         navigationItem.hidesSearchBarWhenScrolling = false
+
+        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+            searchController.searchBar,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
     }
 
     /// Adjusts the navigation item appearance based on the `splitViewControllerMode` value.

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupParticipantsDetail/GroupParticipantsDetailViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import WireCommonComponents
 import WireDataModel
 import WireDesign
 import WireMainNavigationUI
@@ -53,6 +54,8 @@ final class GroupParticipantsDetailViewController: UIViewController {
         collection.translatesAutoresizingMaskIntoConstraints = false
         return collection
     }()
+
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
 
     // State tracking
     private var isFirstLayout = true
@@ -136,6 +139,11 @@ final class GroupParticipantsDetailViewController: UIViewController {
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         definesPresentationContext = true
+
+        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+            searchController.searchBar,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
 
         view.addSubview(collectionView)
         collectionViewController.collectionView = collectionView

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/RequestPasswordController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Helpers/RequestPasswordController.swift
@@ -17,6 +17,8 @@
 //
 
 import UIKit
+import WireCommonComponents
+import WireDesign
 
 final class RequestPasswordController {
 
@@ -36,6 +38,7 @@ final class RequestPasswordController {
     private let callback: Callback
     private let inputValidation: InputValidation?
     private weak var okAction: UIAlertAction?
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
     weak var passwordTextField: UITextField?
 
     init(
@@ -104,6 +107,12 @@ final class RequestPasswordController {
             )
 
             self.passwordTextField = textField
+
+            let delegate = ClipboardRestrictedTextFieldDelegate(
+                isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+            )
+            textField.delegate = delegate
+            self.clipboardDelegate = delegate
         }
 
         let okAction = UIAlertAction(title: okTitle, style: okActionStyle) { [weak self] _ in

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/ChangingDetails/ChangeHandleViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import WireCommonComponents
 import WireDesign
 import WireReusableUIComponents
 import WireSettingsUI
@@ -52,8 +53,11 @@ final class ChangeHandleTableViewCell: UITableViewCell, UITextFieldDelegate {
         return label
     }()
 
-    let handleTextField: UITextField = {
-        let textField = UITextField()
+    let handleTextField: ContextMenuControllableUITextField = {
+        let textField = ContextMenuControllableUITextField(
+            frame: .zero,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
         textField.font = .normalFont
         textField.textColor = SemanticColors.Label.textDefault
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/StartUI/StartUI/StartUIViewController.swift
@@ -40,6 +40,7 @@ final class StartUIViewController: UIViewController {
     weak var delegate: StartUIDelegate?
 
     let searchController = UISearchController(searchResultsController: nil)
+    private var clipboardDelegate: ClipboardRestrictedTextFieldDelegate?
 
     let groupSelector = SearchGroupSelector()
 
@@ -244,6 +245,11 @@ final class StartUIViewController: UIViewController {
         navigationItem.searchController = searchController
         navigationItem.preferredSearchBarPlacement = .stacked
         navigationItem.hidesSearchBarWhenScrolling = false
+
+        clipboardDelegate = ClipboardRestrictedTextFieldDelegate.restrictSearchBarIfNeeded(
+            searchController.searchBar,
+            isContextMenuAllowed: SecurityFlags.clipboard.isEnabled
+        )
     }
 
     private func configGroupSelector() {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24299" title="WPB-24299" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24299</a>  [iOS] WireAuthentication textfields should not allow copy/paste on C1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Apply clipboard restrictions to search views and password text fields

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

