### PR TITLE
feat: add accessibility identifiers on files Tags, Sort, Filters & Versioning - WPB-24200

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FileVersioning/FileVersionItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FileVersioning/FileVersionItemView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 import WireReusableUIComponents
 
@@ -105,6 +106,7 @@ struct FileVersionItemView: View {
 
             }
         )
+        .accessibilityIdentifier(Locators.WireDrive.FileVersioningPage.restoreButton)
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FileVersioning/FileVersioningView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FileVersioning/FileVersioningView.swift
@@ -137,7 +137,7 @@ private extension FileVersioningView {
             }
         )
         .accessibilityLabel(Accessibility.Files.close)
-        .accessibilityIdentifier(Locators.FileVersioningPage.closeButton.rawValue)
+        .accessibilityIdentifier(Locators.WireDrive.FileVersioningPage.closeButton)
     }
 }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Item/FilesViewItemView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 import WireMessagingDomainSupport
 
@@ -352,6 +353,7 @@ private extension View {
                     role: .destructive,
                     action: confirm
                 )
+                .accessibilityIdentifier(Locators.WireDrive.FilesItemPage.confirmDeleteButton)
             }
         )
     }
@@ -372,6 +374,7 @@ private extension View {
                     buttonText,
                     action: confirm
                 )
+                .accessibilityIdentifier(Locators.WireDrive.FilesItemPage.confirmRestoreButton)
             }
         )
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesFilteringView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesFilteringView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import WireDesign
+import WireLocators
 import WireMessagingDomain
 import WireMessagingDomainSupport
 
@@ -69,6 +70,7 @@ struct FilesFilteringView: View {
                             .opacity(isEnabled ? 1 : 0.5)
                     }
                     .disabled(!isEnabled)
+                    .accessibilityIdentifier(Locators.WireDrive.FilesFilteringPage.filter(filter.rawValue))
                 }
 
                 if shouldShowRemoveFilters {
@@ -80,6 +82,7 @@ struct FilesFilteringView: View {
                             .foregroundStyle(ColorTheme.Base.primary(accentColor).color)
                             .fontWeight(.semibold)
                     }
+                    .accessibilityIdentifier(Locators.WireDrive.FilesFilteringPage.removeAllFiltersButton)
                 }
             }
             .padding(.horizontal)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesFilteringViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesFilteringViewModel.swift
@@ -23,7 +23,7 @@ private typealias Strings = L10n.Localizable.Conversation.WireCells.Filtering
 
 final class FilesFilteringViewModel: ObservableObject {
 
-    enum Filtering: CaseIterable {
+    enum Filtering: String, CaseIterable {
         case tags
         case type
         case conversation

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesSortingView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesSortingView.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import WireDesign
+import WireLocators
 
 private typealias Strings = L10n.Localizable.Conversation.WireCells.Sorting
 
@@ -55,6 +56,7 @@ struct FilesSortingView: View {
                             systemImage: selectionIconName(isSelected: isSelected)
                         )
                     }
+                    .accessibilityIdentifier(Locators.WireDrive.FilesSortingPage.sortKey(sortingKey.rawValue))
                 }
 
                 Divider()
@@ -70,6 +72,7 @@ struct FilesSortingView: View {
                             systemImage: selectionIconName(isSelected: isSelected)
                         )
                     }
+                    .accessibilityIdentifier(Locators.WireDrive.FilesSortingPage.sortOrder(sortingOrder.rawValue))
                 }
 
             } label: {
@@ -82,6 +85,7 @@ struct FilesSortingView: View {
                 }
             }
             .foregroundStyle(.primary)
+            .accessibilityIdentifier(Locators.WireDrive.FilesSortingPage.menuButton)
 
             Spacer()
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesSortingViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/SortAndFilter/FilesSortingViewModel.swift
@@ -23,7 +23,7 @@ private typealias Strings = L10n.Localizable.Conversation.WireCells.Sorting
 
 final class FilesSortingViewModel: ObservableObject {
 
-    enum SortingOrder: CaseIterable {
+    enum SortingOrder: String, CaseIterable {
         case ascending
         case descending
 
@@ -48,7 +48,7 @@ final class FilesSortingViewModel: ObservableObject {
         }
     }
 
-    enum SortingKey: CaseIterable {
+    enum SortingKey: String, CaseIterable {
         case date
         case name
         case size

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Tags/TagsEditView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Tags/TagsEditView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 import WireDesign
 import WireFoundation
+import WireLocators
 import WireMessagingDomain
 import WireMessagingDomainSupport
 
@@ -57,6 +58,7 @@ struct TagsEditView: View {
                         } label: {
                             Text(L10n.Localizable.General.close)
                         }
+                        .accessibilityIdentifier(Locators.WireDrive.TagsEditPage.closeButton)
                     }
 
                     ToolbarItem(placement: .topBarTrailing) {
@@ -74,6 +76,7 @@ struct TagsEditView: View {
                                     .bold()
                             }
                             .disabled(!viewModel.isSaveEnabled)
+                            .accessibilityIdentifier(Locators.WireDrive.TagsEditPage.saveButton)
                         }
                     }
 
@@ -222,6 +225,7 @@ struct TagsEditView: View {
             .font(for: .body1)
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityIdentifier(Locators.WireDrive.TagsEditPage.textInputField)
     }
 
     @ViewBuilder
@@ -266,6 +270,7 @@ struct TagsEditView: View {
             }
         }
         .accessibilityLabel(Text(Accessibility.Tags.removeTag.replacingOccurrences(of: "{0}", with: tag)))
+        .accessibilityIdentifier(Locators.WireDrive.TagsEditPage.currentTag(tag))
         .foregroundStyle(ColorTheme.Base.primary(wireAccentColor).color)
     }
 
@@ -296,6 +301,7 @@ struct TagsEditView: View {
             .padding(.vertical, 1)
         }
         .accessibilityLabel(Text(Accessibility.Tags.addTag.replacingOccurrences(of: "{0}", with: tag)))
+        .accessibilityIdentifier(Locators.WireDrive.TagsEditPage.suggestedTag(tag))
         .foregroundStyle(.primary)
     }
 }

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -303,11 +303,6 @@ public enum Locators {
         case resetPassword = "Reset password"
     }
 
-    public enum FileVersioningPage: String {
-
-        case closeButton
-    }
-
     public enum ShareExtensionPage: String {
 
         case imageTile = "PXGGridLayout-Info"
@@ -345,6 +340,14 @@ public enum Locators {
             case saveButton
             case cancelButton
             case removeFilterButton
+        }
+
+        public enum FilesFilteringPage: String {
+            case removeAllFiltersButton
+
+            public static func filter(_ filter: String) -> String {
+                "filter.\(filter)"
+            }
         }
 
         public enum ShareLinkPasswordPage: String {
@@ -401,6 +404,39 @@ public enum Locators {
         public enum FileRenamePage: String {
             case cancel
             case save
+        }
+
+        public enum FileVersioningPage: String {
+
+            case closeButton
+            case restoreButton
+        }
+
+        public enum TagsEditPage: String {
+
+            case closeButton
+            case saveButton
+            case textInputField
+
+            public static func currentTag(_ tag: String) -> String {
+                "currentTag.\(tag)"
+            }
+
+            public static func suggestedTag(_ tag: String) -> String {
+                "suggestedTag.\(tag)"
+            }
+        }
+
+        public enum FilesSortingPage: String {
+            case menuButton
+
+            public static func sortOrder(_ order: String) -> String {
+                "sortOrder.\(order)"
+            }
+
+            public static func sortKey(_ key: String) -> String {
+                "sortKey.\(key)"
+            }
         }
     }
 }

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -438,5 +438,10 @@ public enum Locators {
                 "sortKey.\(key)"
             }
         }
+
+        public enum FilesItemPage: String {
+            case confirmDeleteButton
+            case confirmRestoreButton
+        }
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24200" title="WPB-24200" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24200</a>  [iOS] Add identifiers to Sort, Filter, Tags and File Versioning
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

Added some missing identifiers on the following Wire Drive screens:
- FileVersionItemView: "restoreButton"
- FilesFilteringView: 
    - For each filter: "filter._filterName_"
    - To remove all filters: "removeAllFiltersButton"
- FilesSortingView:
    - For each sorting key: "sortKey._sortKeyName_"
    - For each order: "sortOrder._sortOrderName_"
    - To open Sorting menu: "menuButton"
- TagsEditView:
    - "closeButton"
    - "saveButton"
    - "textInputField"
    - Each tag button have an identifiers "currentTag._tagName_" or "sugestedTag._tagName_" so it can be added or removed
- FilesViewItemView:
    - "confirmDeleteButton"
    - "confirmRestoreButton"
    - Cancel button should be possible to select using something like `app.buttons["Cancel"].tap()`

### Testing

This PR adds identifiers that will be used later for test automation.
So aside from making sure nothing breaks, this PR is not really testable.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
