### PR TITLE
fix: Nightly test runs cancelled when one branch fails in matrix strategy - WPB-24537

### DIFF
--- a/.github/workflows/test_develop.yml
+++ b/.github/workflows/test_develop.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   trigger_tests:
     strategy:
+      fail-fast: false # prevents a branch to cancel other branches on failure
       matrix:
         branch: [develop, release/cycle-4.16, release/cycle-4.17]  # List other branches here
     uses: ./.github/workflows/_reusable_run_tests.yml


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24537" title="WPB-24537" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24537</a>  [iOS] Nightly test runs cancelled when one branch fails in matrix strategy
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The nightly test workflow (.github/workflows/test_develop.yml) uses a matrix strategy to run tests across multiple branches. When one branch's test run fails, GitHub Actions' default fail-fast: true behavior
cancels all other in-progress matrix jobs, preventing results from being collected for the remaining branches.

### Testing
N/A

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
