### PR TITLE
fix: Skipping testServices step for 4.16 and 4.17 - WPB-24541

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -158,7 +158,7 @@ jobs:
           bundle exec fastlane generate_env
           
       - name: Setup Kalium Testservice
-        if: ${{ inputs.run_critical_flows }}
+        if: ${{ inputs.run_critical_flows && inputs.branch != 'release/cycle-4.16' && inputs.branch != 'release/cycle-4.17' }}
         uses: ./.github/actions/kalium-testservice/setup
         with:
           kalium_ref: ${{ inputs.kalium_ref }}
@@ -169,7 +169,7 @@ jobs:
           bundle exec fastlane run_uitests
 
       - name: Stop Kalium Testservice
-        if: ${{ always() && inputs.run_critical_flows }}
+        if: ${{ always() && inputs.run_critical_flows && inputs.branch != 'release/cycle-4.16' && inputs.branch != 'release/cycle-4.17' }}
         uses: ./.github/actions/kalium-testservice/stop
         with:
           print_logs_on_failure: ${{ job.status != 'success' }}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24541" title="WPB-24541" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24541</a>  [iOS] Shared _reusable_run_tests.yml workflow trying to run kalium steps for previous versions
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

testServices setup/stop was being executed for 4.16 & 4.17 because the reusable workflow is resolved from develop, As a temporary workaround, Kalium testServices steps are  skipped for 4.16 and 4.17. Cutting new branch 4.18 from develop also run this by doing this.

**Need to be reverted when these branches are no longer in picture.**

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._


