### PR TITLE
fix: infinite sync after MLS got enabled while logged out - WPB-24543

### DIFF
--- a/wire-ios-data-model/Source/Model/Account/Account+Keychain.swift
+++ b/wire-ios-data-model/Source/Model/Account/Account+Keychain.swift
@@ -27,6 +27,7 @@ public extension Account {
         try? Keychain.deleteItem(item)
 
         try? RemoveCoreCryptoKeysUseCase().invoke(userID: userIdentifier)
+        try? RemoveEARKeysUseCase().invoke(accountID: userIdentifier)
     }
 
 }

--- a/wire-ios-data-model/Source/Model/Account/Account+Keychain.swift
+++ b/wire-ios-data-model/Source/Model/Account/Account+Keychain.swift
@@ -27,7 +27,7 @@ public extension Account {
         try? Keychain.deleteItem(item)
 
         try? RemoveCoreCryptoKeysUseCase().invoke(userID: userIdentifier)
-        try? RemoveEARKeysUseCase().invoke(accountID: userIdentifier)
+        RemoveEARKeysUseCase().invoke(accountID: userIdentifier)
     }
 
 }

--- a/wire-ios-data-model/Source/UseCases/RemoveEARKeysUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/RemoveEARKeysUseCase.swift
@@ -23,7 +23,7 @@ import WireLogging
 public protocol RemoveEARKeysUseCaseProtocol {
 
     /// Removes all encryption at rest keys from the keychain for the given account.
-    func invoke(accountID: UUID) throws
+    func invoke(accountID: UUID)
 
 }
 
@@ -39,19 +39,46 @@ public struct RemoveEARKeysUseCase: RemoveEARKeysUseCaseProtocol {
         self.keyRepository = keyRepository
     }
 
-    public func invoke(accountID: UUID) throws {
+    // MARK: - Public interface
+
+    public func invoke(accountID: UUID) {
+        EARKeyDescription.allCases.forEach { key in
+            deleteKey(key, accountID: accountID)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func deleteKey(_ key: EARKeyDescription, accountID: UUID) {
         do {
-            try keyRepository.deletePublicKey(description: .primaryKeyDescription(accountID: accountID))
-            try keyRepository.deletePrivateKey(description: .primaryKeyDescription(accountID: accountID, context: nil))
-            try keyRepository.deletePublicKey(description: .secondaryKeyDescription(accountID: accountID))
-            try keyRepository.deletePrivateKey(description: .secondaryKeyDescription(accountID: accountID))
-            try keyRepository.deleteDatabaseKey(description: .keyDescription(accountID: accountID))
+            switch key {
+            case .primaryPublic:
+                try keyRepository.deletePublicKey(description: .primaryKeyDescription(accountID: accountID))
+            case .primaryPrivate:
+                try keyRepository.deletePrivateKey(description: .primaryKeyDescription(
+                    accountID: accountID,
+                    context: nil
+                ))
+            case .secondaryPublic:
+                try keyRepository.deletePublicKey(description: .secondaryKeyDescription(accountID: accountID))
+            case .secondaryPrivate:
+                try keyRepository.deletePrivateKey(description: .secondaryKeyDescription(accountID: accountID))
+            case .database:
+                try keyRepository.deleteDatabaseKey(description: .keyDescription(accountID: accountID))
+            }
         } catch {
             WireLogger.ear.error(
-                "failed to remove EAR keys for accountID: \(accountID) - error: \(String(describing: error))"
+                "failed to remove \(key.rawValue) key for accountID: \(accountID) - error: \(String(describing: error))"
             )
-            throw error
         }
+    }
+
+    private enum EARKeyDescription: String, CaseIterable {
+        case primaryPublic
+        case primaryPrivate
+        case secondaryPublic
+        case secondaryPrivate
+        case database
     }
 
 }

--- a/wire-ios-data-model/Source/UseCases/RemoveEARKeysUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/RemoveEARKeysUseCase.swift
@@ -1,0 +1,57 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireLogging
+
+// sourcery: AutoMockable
+public protocol RemoveEARKeysUseCaseProtocol {
+
+    /// Removes all encryption at rest keys from the keychain for the given account.
+    func invoke(accountID: UUID) throws
+
+}
+
+public struct RemoveEARKeysUseCase: RemoveEARKeysUseCaseProtocol {
+
+    private let keyRepository: EARKeyRepositoryInterface
+
+    public init() {
+        self.keyRepository = EARKeyRepository()
+    }
+
+    init(keyRepository: EARKeyRepositoryInterface) {
+        self.keyRepository = keyRepository
+    }
+
+    public func invoke(accountID: UUID) throws {
+        do {
+            try keyRepository.deletePublicKey(description: .primaryKeyDescription(accountID: accountID))
+            try keyRepository.deletePrivateKey(description: .primaryKeyDescription(accountID: accountID, context: nil))
+            try keyRepository.deletePublicKey(description: .secondaryKeyDescription(accountID: accountID))
+            try keyRepository.deletePrivateKey(description: .secondaryKeyDescription(accountID: accountID))
+            try keyRepository.deleteDatabaseKey(description: .keyDescription(accountID: accountID))
+        } catch {
+            WireLogger.ear.error(
+                "failed to remove EAR keys for accountID: \(accountID) - error: \(String(describing: error))"
+            )
+            throw error
+        }
+    }
+
+}

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -5659,21 +5659,16 @@ public class MockRemoveEARKeysUseCaseProtocol: RemoveEARKeysUseCaseProtocol {
     // MARK: - invoke
 
     public var invokeAccountID_Invocations: [UUID] = []
-    public var invokeAccountID_MockError: Error?
-    public var invokeAccountID_MockMethod: ((UUID) throws -> Void)?
+    public var invokeAccountID_MockMethod: ((UUID) -> Void)?
 
-    public func invoke(accountID: UUID) throws {
+    public func invoke(accountID: UUID) {
         invokeAccountID_Invocations.append(accountID)
-
-        if let error = invokeAccountID_MockError {
-            throw error
-        }
 
         guard let mock = invokeAccountID_MockMethod else {
             fatalError("no mock for `invokeAccountID`")
         }
 
-        try mock(accountID)
+        mock(accountID)
     }
 
 }

--- a/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-data-model/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -5649,6 +5649,35 @@ public class MockRemoveCoreCryptoKeysUseCaseProtocol: RemoveCoreCryptoKeysUseCas
 
 }
 
+public class MockRemoveEARKeysUseCaseProtocol: RemoveEARKeysUseCaseProtocol {
+
+    // MARK: - Life cycle
+
+    public init() {}
+
+
+    // MARK: - invoke
+
+    public var invokeAccountID_Invocations: [UUID] = []
+    public var invokeAccountID_MockError: Error?
+    public var invokeAccountID_MockMethod: ((UUID) throws -> Void)?
+
+    public func invoke(accountID: UUID) throws {
+        invokeAccountID_Invocations.append(accountID)
+
+        if let error = invokeAccountID_MockError {
+            throw error
+        }
+
+        guard let mock = invokeAccountID_MockMethod else {
+            fatalError("no mock for `invokeAccountID`")
+        }
+
+        try mock(accountID)
+    }
+
+}
+
 public class MockResetBrokenMLSConversationDelegate: ResetBrokenMLSConversationDelegate {
 
     // MARK: - Life cycle

--- a/wire-ios-data-model/Tests/Authentication/EAR/EARKeyRepositoryTests.swift
+++ b/wire-ios-data-model/Tests/Authentication/EAR/EARKeyRepositoryTests.swift
@@ -1,0 +1,166 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WireDataModel
+
+@Suite
+struct EARKeyRepositoryTests {
+
+    let sut: EARKeyRepository
+    let accountID: UUID
+    let keyGenerator: EARKeyGenerator
+
+    let primaryPublicDesc: PublicEARKeyDescription
+    let secondaryPublicDesc: PublicEARKeyDescription
+    let primaryPrivateDesc: PrivateEARKeyDescription
+    let secondaryPrivateDesc: PrivateEARKeyDescription
+    let databaseKeyDesc: DatabaseEARKeyDescription
+
+    init() {
+        self.sut = EARKeyRepository()
+        self.accountID = UUID()
+        self.keyGenerator = EARKeyGenerator()
+
+        self.primaryPublicDesc = .primaryKeyDescription(accountID: accountID)
+        self.secondaryPublicDesc = .secondaryKeyDescription(accountID: accountID)
+        self.primaryPrivateDesc = .primaryKeyDescription(accountID: accountID, context: nil)
+        self.secondaryPrivateDesc = .secondaryKeyDescription(accountID: accountID)
+        self.databaseKeyDesc = .keyDescription(accountID: accountID)
+    }
+
+    // MARK: - Public Key
+
+    @Test("Stores and fetches a public key")
+    func storeAndFetchPublicKey() throws {
+        // Given
+        let (publicKey, _) = try keyGenerator.generatePrimaryPublicPrivateKeyPair(id: "test-primary-\(accountID)")
+        defer { try? sut.deletePublicKey(description: primaryPublicDesc) }
+
+        // When
+        try sut.storePublicKey(description: primaryPublicDesc, key: publicKey)
+        let fetched = try sut.fetchPublicKey(description: primaryPublicDesc)
+
+        // Then
+        #expect(SecKeyCopyExternalRepresentation(fetched, nil) == SecKeyCopyExternalRepresentation(publicKey, nil))
+    }
+
+    @Test("Returns cached public key without hitting keychain again")
+    func fetchPublicKey_returnsFromCache() throws {
+        // Given
+        let (publicKey, _) = try keyGenerator.generatePrimaryPublicPrivateKeyPair(id: "test-cache-\(accountID)")
+        try sut.storePublicKey(description: primaryPublicDesc, key: publicKey)
+
+        // populate cache
+        _ = try sut.fetchPublicKey(description: primaryPublicDesc)
+        // remove from keychain, only cache remains
+        try KeychainManager.deleteItem(primaryPublicDesc)
+
+        // When
+        let fetched = try sut.fetchPublicKey(description: primaryPublicDesc)
+
+        // Then
+        #expect(SecKeyCopyExternalRepresentation(fetched, nil) == SecKeyCopyExternalRepresentation(publicKey, nil))
+    }
+
+    @Test("Throws keyNotFound when public key is absent")
+    func fetchPublicKey_throwsKeyNotFound_whenAbsent() {
+        #expect(throws: EARKeyRepositoryFailure.keyNotFound) {
+            try sut.fetchPublicKey(description: primaryPublicDesc)
+        }
+    }
+
+    @Test("Deletes public key from keychain and cache")
+    func deletePublicKey_removesFromKeychainAndCache() throws {
+        // Given
+        let (publicKey, _) = try keyGenerator.generatePrimaryPublicPrivateKeyPair(id: "test-delete-\(accountID)")
+        try sut.storePublicKey(description: primaryPublicDesc, key: publicKey)
+
+        // populate cache
+        _ = try sut.fetchPublicKey(description: primaryPublicDesc)
+
+        // When
+        try sut.deletePublicKey(description: primaryPublicDesc)
+
+        // Then — cache cleared, keychain cleared
+        #expect(throws: EARKeyRepositoryFailure.keyNotFound) {
+            try sut.fetchPublicKey(description: primaryPublicDesc)
+        }
+    }
+
+    // MARK: - Database Key
+
+    @Test("Stores and fetches a database key")
+    func storeAndFetchDatabaseKey() throws {
+        // Given
+        let databaseKey = Data.randomEncryptionKey()
+        defer { try? sut.deleteDatabaseKey(description: databaseKeyDesc) }
+
+        // When
+        try sut.storeDatabaseKey(description: databaseKeyDesc, key: databaseKey)
+        let fetched = try sut.fetchDatabaseKey(description: databaseKeyDesc)
+
+        // Then
+        #expect(fetched == databaseKey)
+    }
+
+    @Test("Throws keyNotFound when database key is absent")
+    func fetchDatabaseKey_throwsKeyNotFound_whenAbsent() {
+        #expect(throws: EARKeyRepositoryFailure.keyNotFound) {
+            try sut.fetchDatabaseKey(description: databaseKeyDesc)
+        }
+    }
+
+    @Test("Deletes database key from keychain")
+    func deleteDatabaseKey_removesFromKeychain() throws {
+        // Given
+        try sut.storeDatabaseKey(description: databaseKeyDesc, key: .randomEncryptionKey())
+
+        // When
+        try sut.deleteDatabaseKey(description: databaseKeyDesc)
+
+        // Then
+        #expect(throws: EARKeyRepositoryFailure.keyNotFound) {
+            try sut.fetchDatabaseKey(description: databaseKeyDesc)
+        }
+    }
+
+    // MARK: - Cache
+
+    @Test("clearCache forces a keychain refetch on next access")
+    func clearCache_forcesRefetchFromKeychain() throws {
+        // Given
+        let (publicKey, _) = try keyGenerator.generatePrimaryPublicPrivateKeyPair(id: "test-clear-\(accountID)")
+        try sut.storePublicKey(description: primaryPublicDesc, key: publicKey)
+
+        // populate cache
+        _ = try sut.fetchPublicKey(description: primaryPublicDesc)
+        // remove from keychain
+        try KeychainManager.deleteItem(primaryPublicDesc)
+
+        // When
+        sut.clearCache()
+
+        // Then — cache is gone, keychain miss propagates
+        #expect(throws: EARKeyRepositoryFailure.keyNotFound) {
+            try sut.fetchPublicKey(description: primaryPublicDesc)
+        }
+    }
+
+}

--- a/wire-ios-data-model/Tests/Source/Model/AccountTests.swift
+++ b/wire-ios-data-model/Tests/Source/Model/AccountTests.swift
@@ -63,4 +63,37 @@ final class AccountTests: XCTestCase {
         XCTAssertThrowsError(try Keychain.fetchItem(item))
     }
 
+    func test_deleteKeychainItems_removesEARKeysFromKeychain() throws {
+        // Given
+        let accountID = UUID()
+        let account = Account(userName: "", userIdentifier: accountID)
+        let keyGenerator = EARKeyGenerator()
+        let keyRepository = EARKeyRepository()
+
+        let primaryPublicDesc = PublicEARKeyDescription.primaryKeyDescription(accountID: accountID)
+        let secondaryPublicDesc = PublicEARKeyDescription.secondaryKeyDescription(accountID: accountID)
+        let databaseKeyDesc = DatabaseEARKeyDescription.keyDescription(accountID: accountID)
+
+        let (primaryPublicKey, _) = try keyGenerator.generatePrimaryPublicPrivateKeyPair(id: "test-account-primary")
+        let (secondaryPublicKey, _) = try keyGenerator
+            .generateSecondaryPublicPrivateKeyPair(id: "test-account-secondary")
+        try keyRepository.storePublicKey(description: primaryPublicDesc, key: primaryPublicKey)
+        try keyRepository.storePublicKey(description: secondaryPublicDesc, key: secondaryPublicKey)
+        try keyRepository.storeDatabaseKey(description: databaseKeyDesc, key: .randomEncryptionKey())
+
+        // When
+        account.deleteKeychainItems()
+
+        // Then — all EAR keys are gone
+        XCTAssertThrowsError(try keyRepository.fetchPublicKey(description: primaryPublicDesc)) { error in
+            XCTAssertEqual(error as? EARKeyRepositoryFailure, .keyNotFound)
+        }
+        XCTAssertThrowsError(try keyRepository.fetchPublicKey(description: secondaryPublicDesc)) { error in
+            XCTAssertEqual(error as? EARKeyRepositoryFailure, .keyNotFound)
+        }
+        XCTAssertThrowsError(try keyRepository.fetchDatabaseKey(description: databaseKeyDesc)) { error in
+            XCTAssertEqual(error as? EARKeyRepositoryFailure, .keyNotFound)
+        }
+    }
+
 }

--- a/wire-ios-data-model/Tests/UseCases/RemoveEARKeysUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/RemoveEARKeysUseCaseTests.swift
@@ -38,9 +38,9 @@ struct RemoveEARKeysUseCaseTests {
     }
 
     @Test("Deletes all five EAR keys with correct descriptions")
-    func invoke_deletesAllExpectedKeys() throws {
+    func invoke_deletesAllExpectedKeys() {
         // When
-        try sut.invoke(accountID: accountID)
+        sut.invoke(accountID: accountID)
 
         // Then
         let deletedPublicIDs = mockKeyRepository.deletePublicKeyDescription_Invocations.map(\.id)
@@ -58,30 +58,18 @@ struct RemoveEARKeysUseCaseTests {
     }
 
     @Test("Does not delete keys belonging to a different account")
-    func invoke_doesNotDeleteOtherAccountKeys() throws {
+    func invoke_doesNotDeleteOtherAccountKeys() {
         // Given
         let otherAccountID = UUID()
 
         // When
-        try sut.invoke(accountID: accountID)
+        sut.invoke(accountID: accountID)
 
         // Then
         let deletedPublicIDs = mockKeyRepository.deletePublicKeyDescription_Invocations.map(\.id)
         #expect(!deletedPublicIDs.contains(PublicEARKeyDescription.primaryKeyDescription(accountID: otherAccountID).id))
         #expect(!deletedPublicIDs
             .contains(PublicEARKeyDescription.secondaryKeyDescription(accountID: otherAccountID).id))
-    }
-
-    @Test("Propagates repository error")
-    func invoke_propagatesRepositoryError() {
-        // Given
-        struct DeletionError: Error {}
-        mockKeyRepository.deletePublicKeyDescription_MockError = DeletionError()
-
-        // When / Then
-        #expect(throws: DeletionError.self) {
-            try sut.invoke(accountID: accountID)
-        }
     }
 
 }

--- a/wire-ios-data-model/Tests/UseCases/RemoveEARKeysUseCaseTests.swift
+++ b/wire-ios-data-model/Tests/UseCases/RemoveEARKeysUseCaseTests.swift
@@ -1,0 +1,87 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Testing
+@testable import WireDataModel
+@testable import WireDataModelSupport
+
+@Suite
+struct RemoveEARKeysUseCaseTests {
+
+    let sut: RemoveEARKeysUseCase
+    let mockKeyRepository: MockEARKeyRepositoryInterface
+    let accountID: UUID
+
+    init() {
+        self.accountID = UUID()
+        self.mockKeyRepository = MockEARKeyRepositoryInterface()
+        mockKeyRepository.deletePublicKeyDescription_MockMethod = { _ in }
+        mockKeyRepository.deletePrivateKeyDescription_MockMethod = { _ in }
+        mockKeyRepository.deleteDatabaseKeyDescription_MockMethod = { _ in }
+        self.sut = RemoveEARKeysUseCase(keyRepository: mockKeyRepository)
+    }
+
+    @Test("Deletes all five EAR keys with correct descriptions")
+    func invoke_deletesAllExpectedKeys() throws {
+        // When
+        try sut.invoke(accountID: accountID)
+
+        // Then
+        let deletedPublicIDs = mockKeyRepository.deletePublicKeyDescription_Invocations.map(\.id)
+        let deletedPrivateIDs = mockKeyRepository.deletePrivateKeyDescription_Invocations.map(\.id)
+        let deletedDatabaseIDs = mockKeyRepository.deleteDatabaseKeyDescription_Invocations.map(\.id)
+
+        #expect(deletedPublicIDs.contains(PublicEARKeyDescription.primaryKeyDescription(accountID: accountID).id))
+        #expect(deletedPublicIDs.contains(PublicEARKeyDescription.secondaryKeyDescription(accountID: accountID).id))
+        #expect(deletedPrivateIDs.contains(PrivateEARKeyDescription.primaryKeyDescription(
+            accountID: accountID,
+            context: nil
+        ).id))
+        #expect(deletedPrivateIDs.contains(PrivateEARKeyDescription.secondaryKeyDescription(accountID: accountID).id))
+        #expect(deletedDatabaseIDs.contains(DatabaseEARKeyDescription.keyDescription(accountID: accountID).id))
+    }
+
+    @Test("Does not delete keys belonging to a different account")
+    func invoke_doesNotDeleteOtherAccountKeys() throws {
+        // Given
+        let otherAccountID = UUID()
+
+        // When
+        try sut.invoke(accountID: accountID)
+
+        // Then
+        let deletedPublicIDs = mockKeyRepository.deletePublicKeyDescription_Invocations.map(\.id)
+        #expect(!deletedPublicIDs.contains(PublicEARKeyDescription.primaryKeyDescription(accountID: otherAccountID).id))
+        #expect(!deletedPublicIDs
+            .contains(PublicEARKeyDescription.secondaryKeyDescription(accountID: otherAccountID).id))
+    }
+
+    @Test("Propagates repository error")
+    func invoke_propagatesRepositoryError() {
+        // Given
+        struct DeletionError: Error {}
+        mockKeyRepository.deletePublicKeyDescription_MockError = DeletionError()
+
+        // When / Then
+        #expect(throws: DeletionError.self) {
+            try sut.invoke(accountID: accountID)
+        }
+    }
+
+}

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -380,6 +380,9 @@
 		87E2CE312119F6AB0034C2C4 /* ZMClientMessageTests+Cleared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E2CE302119F6AB0034C2C4 /* ZMClientMessageTests+Cleared.swift */; };
 		8807C2282F3DCE2A00396366 /* EARServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807C2272F3DCE2A00396366 /* EARServiceIntegrationTests.swift */; };
 		8807C22A2F3DD66D00396366 /* EARServiceTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807C2292F3DD66D00396366 /* EARServiceTestsBase.swift */; };
+		880A415A2F7D6D8D00446049 /* RemoveEARKeysUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880A41592F7D6D8D00446049 /* RemoveEARKeysUseCase.swift */; };
+		880A44402F7EB47100446049 /* RemoveEARKeysUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880A443F2F7EB47100446049 /* RemoveEARKeysUseCaseTests.swift */; };
+		880A44422F7EB49500446049 /* EARKeyRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880A44412F7EB49500446049 /* EARKeyRepositoryTests.swift */; };
 		882B83592E82F0F9008A50CA /* StaleCoreCryptoKeyTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B83582E82F0F9008A50CA /* StaleCoreCryptoKeyTracker.swift */; };
 		882B85752E83ED7E008A50CA /* StaleCoreCryptoKeysTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B85742E83ED7A008A50CA /* StaleCoreCryptoKeysTrackerTests.swift */; };
 		882B86BC2E843D0C008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882B86BB2E843D05008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift */; };
@@ -1118,6 +1121,9 @@
 		87E2CE302119F6AB0034C2C4 /* ZMClientMessageTests+Cleared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZMClientMessageTests+Cleared.swift"; sourceTree = "<group>"; };
 		8807C2272F3DCE2A00396366 /* EARServiceIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARServiceIntegrationTests.swift; sourceTree = "<group>"; };
 		8807C2292F3DD66D00396366 /* EARServiceTestsBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARServiceTestsBase.swift; sourceTree = "<group>"; };
+		880A41592F7D6D8D00446049 /* RemoveEARKeysUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveEARKeysUseCase.swift; sourceTree = "<group>"; };
+		880A443F2F7EB47100446049 /* RemoveEARKeysUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveEARKeysUseCaseTests.swift; sourceTree = "<group>"; };
+		880A44412F7EB49500446049 /* EARKeyRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EARKeyRepositoryTests.swift; sourceTree = "<group>"; };
 		882B83582E82F0F9008A50CA /* StaleCoreCryptoKeyTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleCoreCryptoKeyTracker.swift; sourceTree = "<group>"; };
 		882B85742E83ED7A008A50CA /* StaleCoreCryptoKeysTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaleCoreCryptoKeysTrackerTests.swift; sourceTree = "<group>"; };
 		882B86BB2E843D05008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveCoreCryptoKeysUseCaseTests.swift; sourceTree = "<group>"; };
@@ -1875,6 +1881,7 @@
 				0667958F2B8C9E4700FF6A25 /* UpdateMLSGroupVerificationStatusUseCase.swift */,
 				638941ED2AF4FD4B0051ABFD /* RemoveLocalConversationUseCase.swift */,
 				882B86BD2E84419A008A50CA /* RemoveCoreCryptoKeysUseCase.swift */,
+				880A41592F7D6D8D00446049 /* RemoveEARKeysUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -1888,6 +1895,7 @@
 				638941F52AF5211D0051ABFD /* RemoveLocalConversationUseCaseTests.swift */,
 				06E2ABBC2B8C9D2C0094F567 /* UpdateMLSGroupVerificationStatusUseCaseTests.swift */,
 				882B86BB2E843D05008A50CA /* RemoveCoreCryptoKeysUseCaseTests.swift */,
+				880A443F2F7EB47100446049 /* RemoveEARKeysUseCaseTests.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -2123,6 +2131,7 @@
 		E6E5044B2BC56EA0004948E7 /* EAR */ = {
 			isa = PBXGroup;
 			children = (
+				880A44412F7EB49500446049 /* EARKeyRepositoryTests.swift */,
 				8807C2292F3DD66D00396366 /* EARServiceTestsBase.swift */,
 				8807C2272F3DCE2A00396366 /* EARServiceIntegrationTests.swift */,
 				E6E5044A2BC56EA0004948E7 /* EARServiceTests.swift */,
@@ -3489,6 +3498,7 @@
 				5E67168E2174B9AF00522E61 /* LoginCredentials.swift in Sources */,
 				069BCC5A2B30945500DF4EC2 /* E2EIClientID.swift in Sources */,
 				63DA335E286C9CF000818C3C /* NSManagedObjectContext+MLSService.swift in Sources */,
+				880A415A2F7D6D8D00446049 /* RemoveEARKeysUseCase.swift in Sources */,
 				CE4EDC0B1D6DC2D2002A20AA /* ConversationMessage+Reaction.swift in Sources */,
 				E6E504422BC542C5004948E7 /* AuthenticationContext.swift in Sources */,
 				EEAAD75A252C6D2700E6A44E /* UnreadMessages.swift in Sources */,
@@ -3914,6 +3924,7 @@
 				F9A7083E1CAEEB7500C2F5FE /* NSFetchRequestTests+ZMRelationshipKeyPaths.m in Sources */,
 				E6E504502BC571BF004948E7 /* AuthenticationContextTests.swift in Sources */,
 				5966D8342BD6ADCA00305BBC /* UserPropertyNormalizerTests.swift in Sources */,
+				880A44422F7EB49500446049 /* EARKeyRepositoryTests.swift in Sources */,
 				D5FA30CB2063ECD400716618 /* BackupMetadataTests.swift in Sources */,
 				EEE83B4A1FBB496B00FC0296 /* ZMMessageTimerTests.swift in Sources */,
 				F9B71F931CB2BF00001DB03F /* ZMMessageTests.m in Sources */,
@@ -4032,6 +4043,7 @@
 				F9DBA5291E29162A00BE23C0 /* MessageObserverTests.swift in Sources */,
 				BF1B980D1EC3410000DE033B /* PermissionsTests.swift in Sources */,
 				63E313D3274D5F57002EAF1D /* ZMConversationTests+Team.swift in Sources */,
+				880A44402F7EB47100446049 /* RemoveEARKeysUseCaseTests.swift in Sources */,
 				069BCC5E2B3094D000DF4EC2 /* E2eIServiceTests.swift in Sources */,
 				63370CF82431F5DE0072C37F /* BaseCompositeMessageTests.swift in Sources */,
 				546D3DE91CE5D24C00A6047F /* RichAssetFileTypeTests.swift in Sources */,

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -101,6 +101,13 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
         setupBindings()
     }
 
+    func tearDown() {
+        delegate = nil
+        Task { [syncAgent = self] in
+            await syncAgent.suspend()
+        }
+    }
+
     // MARK: - API
 
     /// Trigger the appropriate sync depending in the local state.

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -103,8 +103,8 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
 
     func tearDown() {
         delegate = nil
-        Task { [syncAgent = self] in
-            await syncAgent.suspend()
+        Task {
+            await self.suspend()
         }
     }
 

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/ZMUserSession.swift
@@ -759,7 +759,7 @@ public final class ZMUserSession: NSObject {
         appLockController.delegate = nil
         applicationStatusDirectory.clientRegistrationStatus.registrationStatusDelegate = nil
 
-        syncAgent?.delegate = nil
+        syncAgent?.tearDown()
         syncAgent = nil
         syncStrategy?.tearDown()
         syncStrategy = nil

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/SyncAgentTests.swift
@@ -41,6 +41,7 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
     var mainAppPushChannelCoordinator: MockMainAppPushChannelCoordinatorProtocol!
 
     var incrementalSyncDidFinish: XCTestExpectation!
+    var cancellables: Set<AnyCancellable>!
 
     override func setUp() {
         journal = Journal(
@@ -73,6 +74,7 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
         )
 
         incrementalSyncDidFinish = XCTestExpectation(description: "incrementalSyncDidFinish")
+        cancellables = []
     }
 
     override func tearDown() {
@@ -89,6 +91,7 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
         featureConfigRepository = nil
         mainAppPushChannelCoordinator = nil
         incrementalSyncDidFinish = nil
+        cancellables = nil
     }
 
     func provideInitialSync() throws -> any InitialSyncProtocol {
@@ -292,42 +295,62 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
     func testSuspend_Sync_State_Update_To_Suspended_And_Background_Task_Is_Active() async throws {
         // Given
         journal[.isSyncV2Enabled] = true
-        let expectation = XCTestExpectation()
 
         enum Failure: Error {
             case failed
         }
-
-        // Mock
-        incrementalSync.perform_MockMethod = {
-            throw Failure.failed
-        }
+        incrementalSync.perform_MockMethod = { throw Failure.failed }
         lastUpdateEventIDRepository.fetchLastEventID_MockValue = .mockID1
 
-        var cancellable: AnyCancellable?
-
-        cancellable = syncStateSubject
-            .dropFirst()
-            .sink { state in
-                switch state {
-                case .suspended:
-                    // Then
-                    XCTAssertEqual(BackgroundActivityFactory.shared.isActive, true)
-                    expectation.fulfill()
-                default:
-                    XCTFail("Sync should be suspended")
-                }
-            }
+        // Then — assertion fires inside the sink, synchronously during send(.suspended),
+        // before endBackgroundActivity runs.
+        let suspended = expectationForSyncSuspended {
+            XCTAssertEqual(BackgroundActivityFactory.shared.isActive, true)
+        }
 
         // When
         await sut.suspend()
 
-        await fulfillment(of: [expectation])
+        await fulfillment(of: [suspended])
     }
 
-    func provideLiveSync(delegate: any WireDomain.LiveSyncDelegate) throws -> any WireDomain.LiveSyncProtocol {
+    func test_TearDown_NilsDelegate() async {
+        // Given
+        sut.delegate = self
 
-        liveSync
+        let suspended = expectationForSyncSuspended()
+
+        // When
+        sut.tearDown()
+        await fulfillment(of: [suspended])
+
+        // Then
+        XCTAssertNil(sut.delegate)
+    }
+
+    func test_TearDown_SuspendsPushChannel() async throws {
+        // Given
+        journal[.isSyncV2Enabled] = true
+        let pushChannelClosed = expectation(description: "push channel closed")
+
+        incrementalSync.perform_MockMethod = {
+            IncrementalSync.Token(
+                task: Task { try? await Task.sleep(nanoseconds: 10_000_000_000) },
+                closePushChannel: { pushChannelClosed.fulfill() }
+            )
+        }
+
+        let suspended = expectationForSyncSuspended()
+
+        // Start an incremental sync to get an active token with a push channel
+        try await sut.performIncrementalSync()
+
+        // When
+        sut.tearDown()
+
+        // Then — wait for both: push channel closed and suspend() fully completed
+        // (ensures endBackgroundActivity is called before the next test starts)
+        await fulfillment(of: [pushChannelClosed, suspended], timeout: 2)
     }
 
     func testPerformIncrementalSync_V3() async throws {
@@ -349,6 +372,25 @@ final class SyncAgentTests: XCTestCase, InitialSyncProvider, IncrementalSyncProv
 
         // Then
         XCTAssertEqual(liveSync.perform_Invocations.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func expectationForSyncSuspended(onSuspended: (() -> Void)? = nil) -> XCTestExpectation {
+        let suspended = expectation(description: "sync suspended")
+        syncStateSubject
+            .filter { if case .suspended = $0 { true } else { false } }
+            .sink { _ in
+                onSuspended?()
+                suspended.fulfill()
+            }
+            .store(in: &cancellables)
+        return suspended
+    }
+
+    func provideLiveSync(delegate: any WireDomain.LiveSyncDelegate) throws -> any WireDomain.LiveSyncProtocol {
+
+        liveSync
     }
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24543" title="WPB-24543" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24543</a>  [iOS] Infinite sync re-logging in after MLS is enabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
   
After logging out and back in on a team where MLS was enabled while the user was logged out, the incremental sync enters an infinite sync loop because of an error:

```
failedToFetchStoredEvents(
   WireDomain.EAREncryptionHelper.CryptoError.decryptionFailed(
      Error Domain=NSOSStatusErrorDomain Code=-50 "ECIES: Failed to aes-gcm decrypt data (err -69)"
      UserInfo={numberOfErrorsDeep=0, NSDescription=ECIES: Failed to aes-gcm decrypt data (err -69)}
   )
)
```

The sync eventually stops thanks to the `BackoffRetrier` and an alert is shown with the error above. Afterwards we also observe a few EAR decryption errors.

### Causes

**A — Zombie websocket stores events with stale EAR keys.**
`ZMUserSession.tearDown()` set `syncAgent = nil` without calling `suspend()` first. This left the websocket alive after logout. When the user logged back in, a live `user.clientAdd` event arrived on this zombie connection and was encrypted into the event store using EAR public keys that had been fetched at the start of the previous session's `IncrementalSync`.

**B — EAR keys were not deleted on logout.**
`Account.deleteKeychainItems()` removed the app lock passcode and CoreCrypto keys but not EAR keys. On re-login, `clientRegistrationDidSucceed` called `enableEncryptionAtRest`, which deleted the old EAR keys and generated new ones. Any events already stored with the old public key became permanently undecryptable.

**In short:** the zombie websocket stores a freshly arrived event using old EAR keys, then key rotation destroys those keys, leaving the stored event orphaned.

### Solutions

- **Close the websocket on logout** by calling `suspend()` on the sync agent before teardown, ensuring the push channel and its captured EAR public keys are released.
- **Delete EAR keys on account cleanup** by adding `RemoveEARKeysUseCase` to `Account.deleteKeychainItems()`, ensuring no orphaned EAR keys survive in the keychain after logout.

### Changes Made

- **`SyncAgent`**: Added `tearDown()` method that nils the delegate and fires a task to call `suspend()`, which cancels the ongoing sync and closes the push channel.
- **`ZMUserSession.tearDown()`**: Replaced `syncAgent?.delegate = nil` with `syncAgent?.tearDown()`.
- **`RemoveEARKeysUseCase`** *(new)*: Use case that deletes all five EAR keychain entries (primary/secondary public, primary/secondary private, database key) for a given account ID.
- **`Account.deleteKeychainItems()`**: Added `RemoveEARKeysUseCase().invoke(accountID:)` alongside the existing CoreCrypto key cleanup.
- **Tests**: Added `RemoveEARKeysUseCaseTests`, `EARKeyRepositoryTests`, extended `AccountTests` and `SyncAgentTests`.                                                                                                                                    
                
### Testing

- login with proteus user on iOS and any other client
- create some groups and / or 1:1s
- logout the iOS user
- enable MLS for the team
- login the iOS user
- Try to send a message in any conversation or
- try to add the user to a group

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.
