### PR TITLE
fix: crash resolving WireDrive backend URL - WPB-24584

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
@@ -35,7 +35,7 @@ final class ZClientControllerBuilder {
     private(set) var trackingManager: TrackingManager?
     let legacyEnvironment: WireTransport.BackendEnvironment
     let newEnvironment: WireNetwork.BackendEnvironment2?
-    private lazy var wireDriveBackendURL: URL? = {
+    private var wireDriveBackendURL: URL? {
         let contextProvider = userSession.contextProvider
         let syncContext = contextProvider.syncContext
         let featureRepository = LegacyFeatureRepository(context: syncContext)
@@ -43,7 +43,7 @@ final class ZClientControllerBuilder {
         return syncContext.performAndWait {
             featureRepository.fetchCellsInternal()?.config.backend.url
         }
-    }()
+    }
 
     init(
         account: Account,

--- a/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/MainController/ZClientControllerBuilder.swift
@@ -37,10 +37,10 @@ final class ZClientControllerBuilder {
     let newEnvironment: WireNetwork.BackendEnvironment2?
     private var wireDriveBackendURL: URL? {
         let contextProvider = userSession.contextProvider
-        let syncContext = contextProvider.syncContext
-        let featureRepository = LegacyFeatureRepository(context: syncContext)
+        let viewContext = contextProvider.viewContext
+        let featureRepository = LegacyFeatureRepository(context: viewContext)
 
-        return syncContext.performAndWait {
+        return viewContext.performAndWait {
             featureRepository.fetchCellsInternal()?.config.backend.url
         }
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24584" title="WPB-24584" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24584</a>  [iOS] Crash when resolving wire drive backend URL
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

From crash log, the mention `doDecrementSlow` indicates there's race condition happening when resolving the wire drive backend URL.

Race condition was reproducible with this debug code which indicates that multiple threads might attempt to initialize the property simultaneously resulting in undefined behavior (crash).

```
while true {
        DispatchQueue.global().async {
            do {
                _ = try driveURLResolver()
            } catch {
                   
            }
        }
}
```

**Root cause:** race condition, lazy var are thread-unsafe
**Solution**: Remove the lazy initialization

### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
