### PR TITLE
fix: display full name instead of username - WPB-23535

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireDrive/Model/WireDriveNodeNetworkModel.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/Model/WireDriveNodeNetworkModel.swift
@@ -88,9 +88,13 @@ package struct WireDriveNodeNetworkModel: Equatable, Hashable, Sendable {
 
 package extension WireDriveNodeNetworkModel {
     func toDomainModel(conversations: [WireDriveConversation]) -> WireDriveNode {
-        WireDriveNode(
+        let conversation = matchingConversation(in: conversations)
+        let ownerUserID = ownerUserId.flatMap { QualifiedID(string: $0) }
+        let owner = conversation?.participants.first(where: { QualifiedID(string: $0.id) == ownerUserID })
+
+        return WireDriveNode(
             uuid: uuid,
-            conversation: matchingConversation(in: conversations),
+            conversation: conversation,
             path: path,
             modified: modified.map { Date(timeIntervalSince1970: Double($0)) },
             size: size,
@@ -103,8 +107,8 @@ package extension WireDriveNodeNetworkModel {
             contentHash: contentHash,
             mimeType: mimeType,
             previews: previews.map { $0.toModel() },
-            ownerUserID: ownerUserId.flatMap { QualifiedID(string: $0) },
-            ownerUserName: ownerUserName,
+            ownerUserID: ownerUserID,
+            ownerUserName: owner?.displayName ?? ownerUserName,
             conversationID: conversationId.flatMap(QualifiedID.init(string:)),
             publicLinkID: publicLinkID.map(WireDrivePublicLinkID.init(string:)),
             downloadURL: downloadURL,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23535" title="WPB-23535" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23535</a>  [iOS] username being shown in place of name in drive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes an issue where we display the username  instead of the user display name (see screenshots)

Before:
<img width="375" height="60" alt="Capture d’écran 2026-04-08 à 11 28 44" src="https://github.com/user-attachments/assets/bf30f222-000e-46dd-9eed-80f49e3a91de" />

After:
<img width="375" height="84" alt="Capture d’écran 2026-04-08 à 11 29 50" src="https://github.com/user-attachments/assets/0d67e020-a24a-490b-b78a-c77cc2de4e5e" />


### Testing

_Describe how to test._

_Optional: attachments like images, videos, etc._

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
