### PR TITLE
fix: skipping the rename request if the name didn't change - WPB-22329

### DIFF
--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Rename/FileRenameViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/Rename/FileRenameViewModel.swift
@@ -120,14 +120,21 @@ final class FileRenameViewModel: ObservableObject {
             let nodeID = model.nodeID
             let nodeFilePath = model.filepath
 
-            try await renameNodeUseCase.invoke(
-                nodeID: nodeID,
-                nodeFilepath: nodeFilePath,
-                newFilename: trimmedInput(filenameInput),
-                isFolder: kind == .folder
-            )
+            let originalFilename = URL(fileURLWithPath: model.filename).deletingPathExtension().lastPathComponent
 
-            didRename = true
+            // The backend doesn't allow to only change the case so we consider case changes as no changes.
+            let fileNameChanged = originalFilename.caseInsensitiveCompare(filenameInput) != .orderedSame
+
+            if fileNameChanged {
+                try await renameNodeUseCase.invoke(
+                    nodeID: nodeID,
+                    nodeFilepath: nodeFilePath,
+                    newFilename: trimmedInput(filenameInput),
+                    isFolder: kind == .folder
+                )
+
+                didRename = true
+            }
 
             return true
 

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.file-dark.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.file-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fde32e946663802b5c839f03ef544d5a6cf49c4c4b999227c2f85f84b93dc72
-size 78656
+oid sha256:414ab214e04be4407e8ade86d55e22f5fd257dbdd3a11524b35ec5568e7dd7bf
+size 81068

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.file-light.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.file-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b0f88dcd60c4cce140268db4cf977ff62cc7f392c6de97ddbd82760a6bba4d1d
-size 79307
+oid sha256:53ce6a24f03810d66d0144235b3b0a8ee1f844a4785597c6e01aa68b056e8188
+size 81824

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.folder-dark.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.folder-dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:197cd918f3ae8f41f0de3b31f97ae6eba7d0061cc0d907e9c174e89cd9e332e0
-size 84638
+oid sha256:5cabe66ab884a8182b1158008aa227135ca257088f53336115fc1a43b730e809
+size 84556

--- a/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.folder-light.png
+++ b/WireMessaging/Tests/WireMessagingTests/Resources/ReferenceImages/FileRenameViewTests/testFileRenameView_AlreadyExistsError.folder-light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a7d176263521fefee4cc103ee128e4e3f9ee475178bab62d364bc18c17a042e
-size 85179
+oid sha256:2e32c3c0402558733348dcc043d0a06de9542585e543a17f6b67ad96e0801d08
+size 85129

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FileRenameViewTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FileRenameViewTests.swift
@@ -132,6 +132,7 @@ final class FileRenameViewTests: XCTestCase {
             let (viewModel, view) = makeView(kind: kind)
             renameNodeUseCase.invokeNodeIDNodeFilepathNewFilenameIsFolder_MockError = WireDriveRenameNodeError
                 .fileAlreadyExists
+            viewModel.filenameInput = "new name"
             _ = await viewModel.save()
             let name = kind == .file ? ".file." : ".folder."
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22329" title="WPB-22329" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22329</a>  [iOS] Error when user does not change the name in Renaming flow
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

When renaming a file or a folder, I added a check if the name has changed.
If it didn't change, the rename BE request is skipped.
The result is that no error message appears.

### Testing

* Go to a Drive enabled conversation
* Select a file or folder for renaming
* don't change the name and press Save
* the screen should close immediately