### PR TITLE
fix: leave conversation as an admin - WPB-24661

### DIFF
--- a/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
+++ b/WireAuthentication/Sources/WireAuthenticationUI/Views/Login/LoginViaEmail/LoginViaEmailView.swift
@@ -145,7 +145,7 @@ package struct LoginViaEmailView: View {
             passwordRules: "",
             isValidPassword: viewModel.isPasswordValid
         )
-        .accessibilityIdentifier(String(describing: Locators.LoginPage.passwordSecureTextField))
+        .accessibilityIdentifier(Locators.LoginPage.passwordSecureTextField.rawValue)
     }
 
     @ViewBuilder private var submitButton: some View {
@@ -160,7 +160,7 @@ package struct LoginViaEmailView: View {
         .wireButtonStyle(.primary)
         .bold()
         .disabled(!viewModel.canSubmitCredentials)
-        .accessibilityIdentifier(String(describing: Locators.LoginPage.nextButton))
+        .accessibilityIdentifier(Locators.LoginPage.nextButton.rawValue)
     }
 
     @ViewBuilder private var forgotPasswordButton: some View {
@@ -208,7 +208,7 @@ package struct LoginViaEmailView: View {
                     .cornerRadius(12)
             }
         }
-        .accessibilityIdentifier(String(describing: Locators.LoginPage.createAccountLink.rawValue))
+        .accessibilityIdentifier(Locators.LoginPage.createAccountLink.rawValue)
     }
 
     @ViewBuilder private var proxyCredentials: some View {

--- a/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
+++ b/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2026 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+protocol AutoPrefixedEnum: RawRepresentable, CaseIterable where RawValue == String {}
+
+extension AutoPrefixedEnum {
+    public var rawValue: String { "\(Self.self).\(self)" }
+    
+    public init?(rawValue: String) {
+        guard let match = Self.allCases.first(where: { $0.rawValue == rawValue }) else { return nil }
+        self = match
+    }
+}

--- a/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
+++ b/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
@@ -20,7 +20,7 @@ protocol AutoPrefixedEnum: RawRepresentable, CaseIterable where RawValue == Stri
 
 extension AutoPrefixedEnum {
     public var rawValue: String { "\(Self.self).\(self)" }
-    
+
     public init?(rawValue: String) {
         guard let match = Self.allCases.first(where: { $0.rawValue == rawValue }) else { return nil }
         self = match

--- a/WireUI/Sources/WireLocators/Locators.swift
+++ b/WireUI/Sources/WireLocators/Locators.swift
@@ -29,14 +29,14 @@ import Foundation
 
 public enum Locators {
 
-    public enum WelcomePage: String {
+    public enum WelcomePage: AutoPrefixedEnum {
 
         case emailTextField
         case nextButton
         case onPremInfoButton
     }
 
-    public enum LoginPage: String {
+    public enum LoginPage: AutoPrefixedEnum {
 
         case emailTextField
         case passwordSecureTextField
@@ -65,6 +65,8 @@ public enum Locators {
         case blockOptionOnContextMenu = "Block…"
         case clearOptionOnContextMenu = "Clear Content…"
         case clearButtonOnBottomSheet
+        case leaveButtonOnBottomSheet
+        case leaveAndClearButtonOnBottomSheet
         case blockButtonOnBottomSheet
         case bottomBarArchivedButton
         case accountProfileImageView
@@ -78,9 +80,10 @@ public enum Locators {
         case textFilteredByFavourites = "Filtered by Favorites"
         case textFilteredByOneOnOne = "Filtered by 1:1 Conversations"
         case connectionRequestsCell
+        case useLeftSystemMessage
     }
 
-    public enum SettingsPage: String {
+    public enum SettingsPage: AutoPrefixedEnum {
 
         case accountCell
         case optionsCell
@@ -125,7 +128,7 @@ public enum Locators {
         case browse = "Browse"
     }
 
-    public enum CreatingBackupPage: String {
+    public enum CreatingBackupPage: AutoPrefixedEnum {
 
         case creatingBackupPageLabel
         case progressView
@@ -133,15 +136,15 @@ public enum Locators {
         case exportBackupButton
     }
 
-    public enum ConnectionRequestsPage: String {
+    public enum ConnectionRequestsPage: AutoPrefixedEnum {
 
         case connectRequestButton
         case ignoreRequestButton
         case username
     }
 
-    public enum ConversationDetailsPage: String {
-
+    public enum ConversationDetailsPage: AutoPrefixedEnum {
+        case title
         case addParticipantsButton
         case moreOptionsButton
         case userCellName
@@ -149,12 +152,13 @@ public enum Locators {
 
     }
 
-    public enum ConversationDetailsActions: String {
+    public enum ConversationDetailsActions: AutoPrefixedEnum {
         case archive
         case clearContent
+        case leaveConversation
     }
 
-    public enum UserProfilePage: String {
+    public enum UserProfilePage: AutoPrefixedEnum {
 
         case name
         case qrCodeButton
@@ -166,7 +170,7 @@ public enum Locators {
         case userProfilePicture
     }
 
-    public enum CreateGroupPage: String {
+    public enum CreateGroupPage: AutoPrefixedEnum {
 
         case groupNameField
         case newGroupNextButton
@@ -181,7 +185,7 @@ public enum Locators {
         case acceptTermsOfUse = "Accept"
     }
 
-    public enum EmailUpdatePage: String {
+    public enum EmailUpdatePage: AutoPrefixedEnum {
 
         case emailField
         case newGroupNextButton
@@ -215,7 +219,7 @@ public enum Locators {
         case saveToFiles = "Save to Files"
     }
 
-    public enum SelectParticipantsPage: String {
+    public enum SelectParticipantsPage: AutoPrefixedEnum {
 
         case done
         case skip
@@ -227,7 +231,7 @@ public enum Locators {
         case proceedButton = "Proceed"
     }
 
-    public enum SetPasscodePage: String {
+    public enum SetPasscodePage: AutoPrefixedEnum {
 
         case passcodeField
         case createPasscodeButton
@@ -244,13 +248,13 @@ public enum Locators {
 
     }
 
-    public enum SetUsernamePage: String {
+    public enum SetUsernamePage: AutoPrefixedEnum {
 
         case usernameTextField
         case confirmUsernameButton
     }
 
-    public enum TeamSetupStepsPage: String {
+    public enum TeamSetupStepsPage: AutoPrefixedEnum {
 
         case checkbox
         case confirmUsernameButton
@@ -268,7 +272,7 @@ public enum Locators {
         case removeFromConversation = "Remove From Conversation…"
     }
 
-    public enum VerificationCodePage: String {
+    public enum VerificationCodePage: AutoPrefixedEnum {
 
         case verificationCodeTextField
         case confirmButton
@@ -284,7 +288,7 @@ public enum Locators {
         case resetPassword = "Reset password"
     }
 
-    public enum FileVersioningPage: String {
+    public enum FileVersioningPage: AutoPrefixedEnum {
 
         case closeButton
     }

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Participants.swift
@@ -272,7 +272,6 @@ public extension ZMConversation {
 
         if !removedUsers.isEmpty {
             let removedSelf = removedUsers.contains(where: \.isSelfUser)
-            checkIfArchivedStatusChanged(removedSelfUser: removedSelf, initiatingUser: initiatingUser)
             checkIfVerificationLevelChanged(removedUsers: removedUsers)
         }
     }

--- a/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.m
+++ b/wire-ios-data-model/Tests/Source/Model/Conversation/ZMConversationTests.m
@@ -2140,7 +2140,7 @@
 
 #pragma mark - Archiving
 
-- (void)testThatLeavingAConversationMarksItAsArchived
+- (void)testThatLeavingAConversationDoesNotMarkItAsArchived
 {
     // given
     ZMConversation *conversation = [ZMConversation insertNewObjectInManagedObjectContext:self.uiMOC];
@@ -2155,7 +2155,7 @@
     WaitForAllGroupsToBeEmpty(0.5f);
     
     // then
-    XCTAssertTrue(conversation.isArchived);
+    XCTAssertFalse(conversation.isArchived);
 }
 
 - (void)testThatAppendingATextMessageInAnArchivedConversationUnarchivesIt

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationParticipantsChangedSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationParticipantsChangedSystemMessageCellDescription.swift
@@ -34,7 +34,7 @@ final class ConversationParticipantsChangedSystemMessageCellDescription: Convers
 
     let containsHighlightableContent: Bool = false
 
-    let accessibilityIdentifier: String? = nil
+    let accessibilityIdentifier: String?
     let accessibilityLabel: String?
 
     init(message: ZMConversationMessage, data: ZMSystemMessageData) {
@@ -57,6 +57,7 @@ final class ConversationParticipantsChangedSystemMessageCellDescription: Convers
         )
 
         self.accessibilityLabel = model.attributedTitle()?.string
+        self.accessibilityIdentifier = model.accessibilityIdentifier
         self.actionController = nil
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/ConversationMessageCell.swift
@@ -257,6 +257,7 @@ extension ConversationMessageCellDescription {
             // so re-set message from main context to avoid crash
             actionController?.message = message
         }
+        cell.accessibilityIdentifier = accessibilityIdentifier
         cell.accessibilityCustomActions = actionController?.makeAccessibilityActions()
         return cell
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCellViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCellViewModel.swift
@@ -264,7 +264,7 @@ final class ParticipantsCellViewModel {
             nil
         }
     }
-    
+
     func warning() -> String? {
         guard showServiceUserWarning else { return nil }
         return L10n.Localizable.Content.System.Apps.warning

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCellViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ParticipantsCellViewModel.swift
@@ -20,6 +20,7 @@ import UIKit
 import WireCommonComponents
 import WireDataModel
 import WireDesign
+import WireLocators
 
 enum ConversationActionType {
 
@@ -255,6 +256,15 @@ final class ParticipantsCellViewModel {
         }
     }
 
+    var accessibilityIdentifier: String? {
+        switch action {
+        case .left:
+            Locators.ConversationsPage.useLeftSystemMessage.rawValue
+        default:
+            nil
+        }
+    }
+    
     func warning() -> String? {
         guard showServiceUserWarning else { return nil }
         return L10n.Localizable.Content.System.Apps.warning

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationAction.swift
@@ -189,6 +189,7 @@ extension ZMConversation.Action {
         switch self {
         case .archive: Locators.ConversationDetailsActions.archive.rawValue
         case .clearContent: Locators.ConversationDetailsActions.clearContent.rawValue
+        case .leave: Locators.ConversationDetailsActions.leaveConversation.rawValue
         default: nil
         }
     }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireDataModel
+import WireLocators
 
 enum LeaveResult: AlertResultConfiguration {
     case leave(delete: Bool)
@@ -37,7 +38,23 @@ enum LeaveResult: AlertResultConfiguration {
     }
 
     func action(_ handler: @escaping (LeaveResult) -> Void) -> UIAlertAction {
-        .init(title: title, style: style) { _ in handler(self) }
+        let action = UIAlertAction(title: title, style: style) { _ in handler(self) }
+        let identifier: String?
+        switch self {
+        case .leave(delete: true):
+            identifier = Locators.ConversationsPage.leaveAndClearButtonOnBottomSheet.rawValue
+            
+        case .leave(delete: false):
+            identifier = Locators.ConversationsPage.leaveButtonOnBottomSheet.rawValue
+        case .cancel:
+            identifier = nil
+        }
+        
+        if let identifier {
+            action.setValue(identifier, forKey: "accessibilityIdentifier")
+        }
+        return action
+        
     }
 
     static var title: String {
@@ -52,7 +69,7 @@ enum LeaveResult: AlertResultConfiguration {
 extension ConversationActionController {
 
     func handleLeaveResult(_ result: LeaveResult, for conversation: ZMConversation) {
-        guard  case let .leave(delete: delete) = result else { return }
+        guard  case let .leave(delete: clearContent) = result else { return }
         guard let user = SelfUser.provider?.providedSelfUser else {
             assertionFailure("expected available 'user'!")
             return
@@ -65,13 +82,12 @@ extension ConversationActionController {
         }
 
         Task {
-            await useCase.invoke()
-            if delete {
-                await ZClientViewController.shared?.transitionToList()
-                await MainActor.run {
-                    userSession.enqueue {
-                        conversation.removeOrShowError(participant: user)
-                    }
+            if clearContent {
+                await useCase.invoke()
+            }
+            await MainActor.run {
+                userSession.enqueue {
+                    conversation.removeOrShowError(participant: user)
                 }
             }
         }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/ConversationActions/ConversationActionController+Leave.swift
@@ -39,22 +39,22 @@ enum LeaveResult: AlertResultConfiguration {
 
     func action(_ handler: @escaping (LeaveResult) -> Void) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style) { _ in handler(self) }
-        let identifier: String?
-        switch self {
+        let identifier: String? = switch self {
         case .leave(delete: true):
-            identifier = Locators.ConversationsPage.leaveAndClearButtonOnBottomSheet.rawValue
-            
+            Locators.ConversationsPage.leaveAndClearButtonOnBottomSheet.rawValue
+
         case .leave(delete: false):
-            identifier = Locators.ConversationsPage.leaveButtonOnBottomSheet.rawValue
+            Locators.ConversationsPage.leaveButtonOnBottomSheet.rawValue
+
         case .cancel:
-            identifier = nil
+            nil
         }
-        
+
         if let identifier {
             action.setValue(identifier, forKey: "accessibilityIdentifier")
         }
         return action
-        
+
     }
 
     static var title: String {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -20,13 +20,13 @@ import SwiftUI
 import UIKit
 import WireDesign
 import WireDomain
+import WireLocators
 import WireLogging
 import WireMainNavigationUI
 import WireMessagingAssembly
 import WireMessagingDomain
 import WireNetwork
 import WireSyncEngine
-import WireLocators
 
 final class GroupDetailsViewController: UIViewController, ZMConversationObserver, GroupDetailsFooterViewDelegate {
 
@@ -150,11 +150,11 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
             self?.presentingViewController?.dismiss(animated: true)
         }, accessibilityLabel: L10n.Accessibility.ConversationDetails.CloseButton.description)
         closeButton.accessibilityIdentifier = Locators.ConversationDetailsPage.close.rawValue
-        
+
         navigationItem.rightBarButtonItem = closeButton
         navigationItem.backBarButtonItem?.accessibilityLabel = L10n.Accessibility.Profile.BackButton.description
         navigationItem.backButtonDisplayMode = .minimal
-        
+
         navigationItem.titleView?.accessibilityIdentifier = Locators.ConversationDetailsPage.title.rawValue
     }
 

--- a/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/GroupDetails/GroupDetailsViewController.swift
@@ -26,6 +26,7 @@ import WireMessagingAssembly
 import WireMessagingDomain
 import WireNetwork
 import WireSyncEngine
+import WireLocators
 
 final class GroupDetailsViewController: UIViewController, ZMConversationObserver, GroupDetailsFooterViewDelegate {
 
@@ -145,12 +146,16 @@ final class GroupDetailsViewController: UIViewController, ZMConversationObserver
 
         titleView.addInteraction(UILargeContentViewerInteraction())
         navigationItem.titleView = titleView
-        navigationItem.rightBarButtonItem = UIBarButtonItem.closeButton(action: UIAction { [weak self] _ in
+        let closeButton = UIBarButtonItem.closeButton(action: UIAction { [weak self] _ in
             self?.presentingViewController?.dismiss(animated: true)
         }, accessibilityLabel: L10n.Accessibility.ConversationDetails.CloseButton.description)
-
+        closeButton.accessibilityIdentifier = Locators.ConversationDetailsPage.close.rawValue
+        
+        navigationItem.rightBarButtonItem = closeButton
         navigationItem.backBarButtonItem?.accessibilityLabel = L10n.Accessibility.Profile.BackButton.description
         navigationItem.backButtonDisplayMode = .minimal
+        
+        navigationItem.titleView?.accessibilityIdentifier = Locators.ConversationDetailsPage.title.rawValue
     }
 
     override func viewDidLoad() {

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -80,4 +80,33 @@ final class ConversationTests: WireUITestCase {
         XCTAssertTrue(activeConversationPage.userLeftSystemMessage.exists, "the system message is missing")
     }
 
+    @MainActor
+    func testLeaveAndClearGroup() async throws {
+        let stagingTeam = try await userHelper.registerTeam(withMemberCount: 2)
+        let userA = try XCTUnwrap(stagingTeam.teamOwner)
+        let userB = try XCTUnwrap(stagingTeam.teamMembers.last)
+
+        let conversationsPage = try await loginToBackend(user: userA)
+
+        // WHEN
+        let activeConversationPage = try conversationsPage
+            .tapPlusButtonToCreateGroup()
+            .tapNewGroupButton()
+            .enterGroupName("test")
+            .tapMemberCells(withLabelPrefixes: [userB.name])
+            .doneSelectingMembers()
+            .sendMessage("test")
+            .openConversationDetails()
+            .moreOptionsConversationDetails()
+            .leaveOptionsConversationDetails()
+            .leaveAndClearConversation()
+            .closeConversationDetails()
+        
+        // THEN
+        let userMessages = try XCTUnwrap(activeConversationPage.fetchMessages())
+        XCTAssertEqual(userMessages.count, 0)
+        
+        XCTAssertFalse(activeConversationPage.userLeftSystemMessage.exists, "the system message has not been removed")
+    }
+
 }

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -50,4 +50,34 @@ final class ConversationTests: WireUITestCase {
         XCTAssertTrue(sentMessages.isEmpty)
     }
 
+    
+    @MainActor
+    func testLeaveGroup_TC_8861() async throws {
+        let stagingTeam = try await userHelper.registerTeam(withMemberCount: 2)
+        let userA = try XCTUnwrap(stagingTeam.teamOwner)
+        let userB = try XCTUnwrap(stagingTeam.teamMembers.last)
+
+        let conversationsPage = try await loginToBackend(user: userA)
+
+        // WHEN
+        let activeConversationPage = try conversationsPage
+            .tapPlusButtonToCreateGroup()
+            .tapNewGroupButton()
+            .enterGroupName("test")
+            .tapMemberCells(withLabelPrefixes: [userB.name])
+            .doneSelectingMembers()
+            .sendMessage("test")
+            .openConversationDetails()
+            .moreOptionsConversationDetails()
+            .leaveOptionsConversationDetails()
+            .leaveConversation()
+            .closeConversationDetails()
+        
+        // THEN
+        let userMessages = try XCTUnwrap(activeConversationPage.fetchMessages())
+        XCTAssertEqual(userMessages.count, 1)
+        
+        XCTAssertTrue(activeConversationPage.userLeftSystemMessage.exists, "the system message is missing")
+    }
+
 }

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -50,7 +50,6 @@ final class ConversationTests: WireUITestCase {
         XCTAssertTrue(sentMessages.isEmpty)
     }
 
-    
     @MainActor
     func testLeaveGroup_TC_8861() async throws {
         let stagingTeam = try await userHelper.registerTeam(withMemberCount: 2)
@@ -72,16 +71,16 @@ final class ConversationTests: WireUITestCase {
             .leaveOptionsConversationDetails()
             .leaveConversation()
             .closeConversationDetails()
-        
+
         // THEN
         let userMessages = try XCTUnwrap(activeConversationPage.fetchMessages())
         XCTAssertEqual(userMessages.count, 1)
-        
+
         XCTAssertTrue(activeConversationPage.userLeftSystemMessage.exists, "the system message is missing")
     }
 
     @MainActor
-    func testLeaveAndClearGroup() async throws {
+    func testLeaveAndClearGroup_TC_10525() async throws {
         let stagingTeam = try await userHelper.registerTeam(withMemberCount: 2)
         let userA = try XCTUnwrap(stagingTeam.teamOwner)
         let userB = try XCTUnwrap(stagingTeam.teamMembers.last)
@@ -101,11 +100,11 @@ final class ConversationTests: WireUITestCase {
             .leaveOptionsConversationDetails()
             .leaveAndClearConversation()
             .closeConversationDetails()
-        
+
         // THEN
         let userMessages = try XCTUnwrap(activeConversationPage.fetchMessages())
         XCTAssertEqual(userMessages.count, 0)
-        
+
         XCTAssertFalse(activeConversationPage.userLeftSystemMessage.exists, "the system message has not been removed")
     }
 

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage .swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage .swift
@@ -68,8 +68,7 @@ class ActiveConversationPage: PageModel {
     var imageCell: XCUIElement {
         app.otherElements[Locators.ActiveConversationPage.imageCell.rawValue]
     }
-    
-    
+
     var userLeftSystemMessage: XCUIElement {
         app.descendants(matching: .any)[Locators.ConversationsPage.useLeftSystemMessage.rawValue]
     }

--- a/wire-ios/WireUITests/Pages/ActiveConversationPage .swift
+++ b/wire-ios/WireUITests/Pages/ActiveConversationPage .swift
@@ -22,7 +22,7 @@ import XCTest
 class ActiveConversationPage: PageModel {
 
     override var pageMainElement: XCUIElement {
-        videoCallButton
+        conversationTitleButton
     }
 
     var videoCallButton: XCUIElement {
@@ -67,6 +67,11 @@ class ActiveConversationPage: PageModel {
 
     var imageCell: XCUIElement {
         app.otherElements[Locators.ActiveConversationPage.imageCell.rawValue]
+    }
+    
+    
+    var userLeftSystemMessage: XCUIElement {
+        app.descendants(matching: .any)[Locators.ConversationsPage.useLeftSystemMessage.rawValue]
     }
 
     func fetchMessages() -> [String] {

--- a/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
@@ -107,6 +107,12 @@ class ConversationDetailsPage: PageModel {
         leaveConversationButtonOnBottomSheet.waitAndTap()
         return try ConversationDetailsPage()
     }
+    
+    @discardableResult
+    func leaveAndClearConversation() throws -> ConversationDetailsPage {
+        leaveAndClearConversationButtonOnBottomSheet.waitAndTap()
+        return try ConversationDetailsPage()
+    }
 
     var clearButtonOnBottomSheet: XCUIElement {
         app.buttons[Locators.ConversationsPage.clearButtonOnBottomSheet.rawValue].firstMatch
@@ -116,4 +122,8 @@ class ConversationDetailsPage: PageModel {
         app.buttons[Locators.ConversationsPage.leaveButtonOnBottomSheet.rawValue].firstMatch
     }
 
+    var leaveAndClearConversationButtonOnBottomSheet: XCUIElement {
+        app.buttons[Locators.ConversationsPage.leaveAndClearButtonOnBottomSheet.rawValue].firstMatch
+    }
+    
 }

--- a/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
@@ -28,7 +28,7 @@ class ConversationDetailsPage: PageModel {
     var navigationTitleView: XCUIElement {
         app.descendants(matching: .any)[Locators.ConversationDetailsPage.title.rawValue].firstMatch
     }
-    
+
     var addParticipantsButton: XCUIElement {
         app.descendants(matching: .button)[Locators.ConversationDetailsPage.addParticipantsButton.rawValue].firstMatch
     }
@@ -50,9 +50,10 @@ class ConversationDetailsPage: PageModel {
     }
 
     var leaveConversationOptionConversationDetailsButton: XCUIElement {
-        app.buttons.matching(identifier: Locators.ConversationDetailsActions.leaveConversation.rawValue).element(boundBy: 0)
+        app.buttons.matching(identifier: Locators.ConversationDetailsActions.leaveConversation.rawValue)
+            .element(boundBy: 0)
     }
-    
+
     var userCells: XCUIElementQuery {
         app.staticTexts.matching(identifier: Locators.ConversationDetailsPage.userCellName.rawValue)
     }
@@ -89,7 +90,6 @@ class ConversationDetailsPage: PageModel {
         return self
     }
 
-    
     func appParticipantToConversation() throws -> SelectParticipantsPage {
         addParticipantsButton.tap()
         return try SelectParticipantsPage()
@@ -101,13 +101,13 @@ class ConversationDetailsPage: PageModel {
         clearButtonOnBottomSheet.waitToDisappear()
         return try ConversationDetailsPage()
     }
-    
+
     @discardableResult
     func leaveConversation() throws -> ConversationDetailsPage {
         leaveConversationButtonOnBottomSheet.waitAndTap()
         return try ConversationDetailsPage()
     }
-    
+
     @discardableResult
     func leaveAndClearConversation() throws -> ConversationDetailsPage {
         leaveAndClearConversationButtonOnBottomSheet.waitAndTap()
@@ -117,7 +117,7 @@ class ConversationDetailsPage: PageModel {
     var clearButtonOnBottomSheet: XCUIElement {
         app.buttons[Locators.ConversationsPage.clearButtonOnBottomSheet.rawValue].firstMatch
     }
-    
+
     var leaveConversationButtonOnBottomSheet: XCUIElement {
         app.buttons[Locators.ConversationsPage.leaveButtonOnBottomSheet.rawValue].firstMatch
     }
@@ -125,5 +125,5 @@ class ConversationDetailsPage: PageModel {
     var leaveAndClearConversationButtonOnBottomSheet: XCUIElement {
         app.buttons[Locators.ConversationsPage.leaveAndClearButtonOnBottomSheet.rawValue].firstMatch
     }
-    
+
 }

--- a/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
+++ b/wire-ios/WireUITests/Pages/ConversationDetailsPage.swift
@@ -22,9 +22,13 @@ import XCTest
 class ConversationDetailsPage: PageModel {
 
     override var pageMainElement: XCUIElement {
-        addParticipantsButton
+        navigationTitleView
     }
 
+    var navigationTitleView: XCUIElement {
+        app.descendants(matching: .any)[Locators.ConversationDetailsPage.title.rawValue].firstMatch
+    }
+    
     var addParticipantsButton: XCUIElement {
         app.descendants(matching: .button)[Locators.ConversationDetailsPage.addParticipantsButton.rawValue].firstMatch
     }
@@ -45,6 +49,10 @@ class ConversationDetailsPage: PageModel {
         app.buttons.matching(identifier: Locators.ConversationDetailsActions.clearContent.rawValue).element(boundBy: 0)
     }
 
+    var leaveConversationOptionConversationDetailsButton: XCUIElement {
+        app.buttons.matching(identifier: Locators.ConversationDetailsActions.leaveConversation.rawValue).element(boundBy: 0)
+    }
+    
     var userCells: XCUIElementQuery {
         app.staticTexts.matching(identifier: Locators.ConversationDetailsPage.userCellName.rawValue)
     }
@@ -76,6 +84,12 @@ class ConversationDetailsPage: PageModel {
         return self
     }
 
+    func leaveOptionsConversationDetails() throws -> Self {
+        leaveConversationOptionConversationDetailsButton.tap()
+        return self
+    }
+
+    
     func appParticipantToConversation() throws -> SelectParticipantsPage {
         addParticipantsButton.tap()
         return try SelectParticipantsPage()
@@ -87,9 +101,19 @@ class ConversationDetailsPage: PageModel {
         clearButtonOnBottomSheet.waitToDisappear()
         return try ConversationDetailsPage()
     }
+    
+    @discardableResult
+    func leaveConversation() throws -> ConversationDetailsPage {
+        leaveConversationButtonOnBottomSheet.waitAndTap()
+        return try ConversationDetailsPage()
+    }
 
     var clearButtonOnBottomSheet: XCUIElement {
         app.buttons[Locators.ConversationsPage.clearButtonOnBottomSheet.rawValue].firstMatch
+    }
+    
+    var leaveConversationButtonOnBottomSheet: XCUIElement {
+        app.buttons[Locators.ConversationsPage.leaveButtonOnBottomSheet.rawValue].firstMatch
     }
 
 }

--- a/wire-ios/WireUITests/Pages/LoginPage.swift
+++ b/wire-ios/WireUITests/Pages/LoginPage.swift
@@ -31,7 +31,7 @@ class LoginPage: PageModel {
     }
 
     var nextButton: XCUIElement {
-        app.descendants(matching: .any)[Locators.WelcomePage.nextButton.rawValue].firstMatch
+        app.descendants(matching: .any)[Locators.LoginPage.nextButton.rawValue].firstMatch
     }
 
     var emailField: XCUIElement {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24661" title="WPB-24661" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24661</a>  [iOS] As a only group admin, I can leave the group conversation and group has no admin
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Following #4480, the logic for leaving a conversation got mixed up. This PR fixes it and add two UI tests:
- leave and clear a conversation
- leave a conversation as an admin

### Testing

Add automated tests

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
