### PR TITLE
fix: locators for critical flow in 4.16.2 run - WPB-24695

### DIFF
--- a/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
+++ b/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
@@ -19,7 +19,7 @@
 protocol AutoPrefixedEnum: RawRepresentable, CaseIterable where RawValue == String {}
 
 extension AutoPrefixedEnum {
-    // TODO: WPB-24694
+    // TODO: [WPB-24694]
     public var rawValue: String { "\(self)" }
 
     public init?(rawValue: String) {

--- a/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
+++ b/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
@@ -19,7 +19,8 @@
 protocol AutoPrefixedEnum: RawRepresentable, CaseIterable where RawValue == String {}
 
 extension AutoPrefixedEnum {
-    public var rawValue: String { "\(Self.self).\(self)" }
+    // TODO: https://wearezeta.atlassian.net/browse/WPB-24694
+    public var rawValue: String { "\(self)" }
 
     public init?(rawValue: String) {
         guard let match = Self.allCases.first(where: { $0.rawValue == rawValue }) else { return nil }

--- a/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
+++ b/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
@@ -19,7 +19,7 @@
 protocol AutoPrefixedEnum: RawRepresentable, CaseIterable where RawValue == String {}
 
 extension AutoPrefixedEnum {
-    // TODO: [WPB-24694]
+    // TODO: [WPB-24694] need to update app locators based on this file
     public var rawValue: String { "\(self)" }
 
     public init?(rawValue: String) {

--- a/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
+++ b/WireUI/Sources/WireLocators/AutoPrefixedEnum.swift
@@ -19,7 +19,7 @@
 protocol AutoPrefixedEnum: RawRepresentable, CaseIterable where RawValue == String {}
 
 extension AutoPrefixedEnum {
-    // TODO: https://wearezeta.atlassian.net/browse/WPB-24694
+    // TODO: WPB-24694
     public var rawValue: String { "\(self)" }
 
     public init?(rawValue: String) {


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

Locators issue for few tests : https://github.com/wireapp/wire-ios/actions/runs/24251445510/job/70811629270

### Testing


locally ran all tests fine
<img width="1640" height="1838" alt="image" src="https://github.com/user-attachments/assets/cefe2e1a-b748-46f5-a9e1-0e98c3b5a374" />



---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
