### PR TITLE
fix: missed call localization issue - WPB-22560

### DIFF
--- a/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
+++ b/wire-ios/Wire-iOS/Generated/Strings+Generated.swift
@@ -2145,9 +2145,9 @@ internal enum L10n {
             return L10n.tr("Localizable", "content.system.call.missed-call", p1, fallback: "Plural format key: \"%#@missed_call@\"")
           }
           internal enum MissedCall {
-            /// Plural format key: "%#@missed_call_from@ %2$@"
-            internal static func groups(_ p1: Int, _ p2: Any) -> String {
-              return L10n.tr("Localizable", "content.system.call.missed-call.groups", p1, String(describing: p2), fallback: "Plural format key: \"%#@missed_call_from@ %2$@\"")
+            /// Plural format key: "%#@missed_call_from@"
+            internal static func groups(_ p1: Int) -> String {
+              return L10n.tr("Localizable", "content.system.call.missed-call.groups", p1, fallback: "Plural format key: \"%#@missed_call_from@\"")
             }
           }
         }

--- a/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/Base.lproj/Localizable.stringsdict
@@ -308,7 +308,7 @@
 			<key>one</key>
 			<string>Missed call</string>
 			<key>other</key>
-			<string>Missed calls</string>
+			<string>Missed calls (%d)</string>
 		</dict>
 	</dict>
 	<key>content.system.federation_termination.participants_removed</key>
@@ -330,7 +330,7 @@
 	<key>content.system.call.missed-call.groups</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@missed_call_from@ %2$@</string>
+		<string>%#@missed_call_from@</string>
 		<key>missed_call_from</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -338,9 +338,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Missed call from</string>
+			<string>Missed call from %2$@</string>
 			<key>other</key>
-			<string>Missed calls from</string>
+			<string>Missed calls from %2$@ (%d)</string>
 		</dict>
 	</dict>
 	<key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/ar.lproj/Localizable.stringsdict
@@ -411,22 +411,14 @@
       <string>%#@missed_call@</string>
       <key>missed_call</key>
       <dict>
-        <key>zero</key>
-        <string>Missed calls</string>
         <key>NSStringFormatSpecTypeKey</key>
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>مكالمة فائتة</string>
-        <key>two</key>
-        <string>Missed calls</string>
-        <key>few</key>
-        <string>Missed calls</string>
-        <key>many</key>
-        <string>Missed calls</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Missed calls</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -456,25 +448,17 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%2$@ %#@missed_call_from@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
-        <key>zero</key>
-        <string>Missed calls from %2$@</string>
         <key>NSStringFormatSpecTypeKey</key>
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
         <string>Missed call from %2$@</string>
-        <key>two</key>
-        <string>Missed call from %2$@</string>
-        <key>few</key>
-        <string>Missed call from %2$@</string>
-        <key>many</key>
-        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Missed call from %2$@</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/da.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Ubesvarede opkald</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Missed calls</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Missed call from</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Missed calls from</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/de.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Verpasster Anruf</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Verpasste Anrufe</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Verpasster Anruf von</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Verpasste Anrufe von</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/es.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Llamada perdida</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Llamadas perdidas</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Llamada perdida de</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Llamadas perdidas de</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/et.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Vastamata kõne</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Vastamata kõned</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Vastamata kõne kasutajalt</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Vastamata kõned kasutajalt</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/fi.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Vastaamaton puhelu</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Missed calls</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Missed call from</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Missed calls from</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/fr.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Appel manqué</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Appels manqués</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Appel manqué de</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Appels manqués de</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/it.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Chiamata senza risposta</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Chiamate senza risposta</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Chiamata persa da</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Chiamate perse da</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/ja.lproj/Localizable.stringsdict
@@ -245,8 +245,10 @@
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
+        <key>one</key>
+        <string>Missed call</string>
         <key>other</key>
-        <string>不在着信</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -266,15 +268,17 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%2$@ %#@missed_call_from@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
+        <key>one</key>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>からの不在着信</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/lt.lproj/Localizable.stringsdict
@@ -348,13 +348,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Praleistas skambutis</string>
-        <key>few</key>
-        <string>Praleisti skambučiai</string>
-        <key>many</key>
-        <string>Praleisti skambučiai</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Praleisti skambučiai</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -380,7 +376,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -388,13 +384,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Skambino</string>
-        <key>few</key>
-        <string>Skambino</string>
-        <key>many</key>
-        <string>Skambino</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Skambino</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/nl.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Gemiste oproep</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Missed calls</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Missed call from</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Missed calls from</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/pl.lproj/Localizable.stringsdict
@@ -348,13 +348,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Nieodebrane połączenie</string>
-        <key>few</key>
-        <string>Nieodebrane połączenia</string>
-        <key>many</key>
-        <string>Nieodebrane połączenia</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Nieodebrane połączenia</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -380,7 +376,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -388,13 +384,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Nieodebrana rozmowa od</string>
-        <key>few</key>
-        <string>Nieodebrane rozmowy od</string>
-        <key>many</key>
-        <string>Nieodebrane rozmowy od</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Nieodebrane rozmowy od</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/pt-BR.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Chamada não atendida</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Chamadas Perdidas</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Chamada perdida de</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Chamadas perdidas de</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/ru.lproj/Localizable.stringsdict
@@ -348,13 +348,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Пропущенный вызов</string>
-        <key>few</key>
-        <string>Пропущенных вызова</string>
-        <key>many</key>
-        <string>Пропущенных вызовов</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Пропущенных вызовов</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -380,7 +376,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -388,13 +384,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Пропущенный вызов от</string>
-        <key>few</key>
-        <string>Пропущенные вызовы от</string>
-        <key>many</key>
-        <string>Пропущенные вызовы от</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Пропущенные вызовы от</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/sl.lproj/Localizable.stringsdict
@@ -348,13 +348,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Zgrešen klic</string>
-        <key>two</key>
-        <string>Missed calls</string>
-        <key>few</key>
-        <string>Missed calls</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Missed calls</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -380,7 +376,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -388,13 +384,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Missed call from</string>
-        <key>two</key>
-        <string>Missed calls from</string>
-        <key>few</key>
-        <string>Missed calls from</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Missed calls from</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/tr.lproj/Localizable.stringsdict
@@ -280,9 +280,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Cevapsız arama</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Cevapsız aramalar</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -304,7 +304,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%2$@ %#@missed_call_from@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -312,9 +312,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>kişisinden cevapsız çağrı</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>kişisinden cevapsız çağrılar</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/uk.lproj/Localizable.stringsdict
@@ -348,13 +348,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Пропущений дзвінок</string>
-        <key>few</key>
-        <string>Пропущені дзвінки</string>
-        <key>many</key>
-        <string>Пропущених дзвінків</string>
+        <string>Missed call</string>
         <key>other</key>
-        <string>Пропущених дзвінків</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -380,7 +376,7 @@
     <key>content.system.call.missed-call.groups</key>
     <dict>
       <key>NSStringLocalizedFormatKey</key>
-      <string>%#@missed_call_from@ %2$@</string>
+      <string>%#@missed_call_from@</string>
       <key>missed_call_from</key>
       <dict>
         <key>NSStringFormatSpecTypeKey</key>
@@ -388,13 +384,9 @@
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
         <key>one</key>
-        <string>Пропущений дзвінок від</string>
-        <key>few</key>
-        <string>Пропущені дзвінки від</string>
-        <key>many</key>
-        <string>Пропущених дзвінків від</string>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>Пропущених дзвінків від</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hans.lproj/Localizable.stringsdict
@@ -245,8 +245,10 @@
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
+        <key>one</key>
+        <string>Missed call</string>
         <key>other</key>
-        <string>未接来电</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -273,8 +275,10 @@
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
+        <key>one</key>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>来自 %2$@ 的未接来电</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.stringsdict
+++ b/wire-ios/Wire-iOS/Resources/Localization/zh-Hant.lproj/Localizable.stringsdict
@@ -245,8 +245,10 @@
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
+        <key>one</key>
+        <string>Missed call</string>
         <key>other</key>
-        <string>未接來電</string>
+        <string>Missed calls (%d)</string>
       </dict>
     </dict>
     <key>content.system.federation_termination.participants_removed</key>
@@ -273,8 +275,10 @@
         <string>NSStringPluralRuleType</string>
         <key>NSStringFormatValueTypeKey</key>
         <string>d</string>
+        <key>one</key>
+        <string>Missed call from %2$@</string>
         <key>other</key>
-        <string>錯過%2$@的來電</string>
+        <string>Missed calls from %2$@ (%d)</string>
       </dict>
     </dict>
     <key>registration.password.rules.min_length</key>

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMissedCallSystemMessageViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMissedCallSystemMessageViewModel.swift
@@ -50,12 +50,11 @@ struct ConversationMissedCallSystemMessageViewModel {
 
         let senderName = sender.name ?? ""
 
-        let finalText: String
-        if message.conversationLike?.conversationType == .group {
+        let finalText: String = if message.conversationLike?.conversationType == .group {
             // SwiftGen does not support this localized string.
-            finalText = "content.system.call.missed-call.groups".localized(args: numberOfCalls, senderName)
+            "content.system.call.missed-call.groups".localized(args: numberOfCalls, senderName)
         } else {
-            finalText = L10n.Localizable.Content.System.Call.missedCall(numberOfCalls)
+            L10n.Localizable.Content.System.Call.missedCall(numberOfCalls)
         }
 
         return NSAttributedString(

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMissedCallSystemMessageViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationMissedCallSystemMessageViewModel.swift
@@ -48,12 +48,15 @@ struct ConversationMissedCallSystemMessageViewModel {
         let numberOfCalls = systemMessageData.childMessages.count + 1
         typealias Call = L10n.Localizable.Content.System.Call
 
-        let isGroup = message.conversationLike?.conversationType == .group
         let senderName = sender.name ?? ""
 
-        let counterSuffix = numberOfCalls > 1 ? " (\(numberOfCalls))" : ""
-        let finalText = (isGroup ? Call.MissedCall.groups(numberOfCalls, senderName) : Call.missedCall(numberOfCalls)) +
-            counterSuffix
+        let finalText: String
+        if message.conversationLike?.conversationType == .group {
+            // SwiftGen does not support this localized string.
+            finalText = "content.system.call.missed-call.groups".localized(args: numberOfCalls, senderName)
+        } else {
+            finalText = L10n.Localizable.Content.System.Call.missedCall(numberOfCalls)
+        }
 
         return NSAttributedString(
             string: finalText,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22560" title="WPB-22560" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-22560</a>  [iOS] Misaligned tick mark shown agains missed call system message on opening the keyboard
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR fixes some localization issues that were worked on in https://github.com/wireapp/wire-ios/pull/4486 to allow for correct localization in many languages.

https://github.com/wireapp/wire-ios/pull/4486 moved positional arguments to the localization key which I think was incorrect because  the position of those arguments is language dependent.

This PR also removes logic related to pluralization out of the code to the stringsdict where it belongs. As the format has changed.

I've updated the related content for all languages to English as the format has changed and they will need to be re-localized.

### Testing

Test single & multiple missed calls in 1:1 and group conversations: There should be one of the following system messages:

| Number of missed calls | 1:1 | Group |
| --- | --- | --- |
| 1 | Missed call | Missed call from John Appleseed |
| 3 | Missed calls (3) | Missed calls from John Appleseed (2) |

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
