### PR TITLE
fix: failing to build app due to a newly added parameter - WPB-24695

### DIFF
--- a/wire-ios/WireUITests/Helper/NetworkStack.swift
+++ b/wire-ios/WireUITests/Helper/NetworkStack.swift
@@ -51,11 +51,12 @@ final class NetworkStack {
     )
 
     lazy var apiNetworkService: NetworkService = {
-        let service = NetworkService(baseURL: backendEnvironment.url, serverTrustValidator: serverTrustValidator)
         let config = urlSessionConfigurationFactory.makeRESTAPISessionConfiguration()
-        let session = URLSession(configuration: config, delegate: service, delegateQueue: nil)
-        service.configure(with: session)
-        return service
+        return NetworkService(
+            baseURL: backendEnvironment.url,
+            urlSessionConfiguration: config,
+            serverTrustValidator: serverTrustValidator
+        )
     }()
 
     private lazy var serverTrustValidator = ServerTrustValidator(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24695" title="WPB-24695" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24695</a>  [iOS] Fix critical flow failures
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

On develop, build fails due to 
`[21:27:00]: ▸ 	Missing argument for parameter 'urlSessionConfiguration' in call`

https://github.com/wireapp/wire-ios/actions/runs/24264322373/job/70855635363

### Testing
Able to build and tests are running fine on local

<img width="1971" height="1678" alt="image" src="https://github.com/user-attachments/assets/f1ce6b0e-fdb1-4b09-821e-033fdd3166e4" />

Note: The above tests failing due to https://wearezeta.atlassian.net/browse/WPB-24701 and callingTests is flaky where it takes sometimes too much time on hetzner side to join the call and initiate. 
---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
