### PR TITLE
feat: re-create folder structure locally when offline - WPB-24437

### DIFF
--- a/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetRepository.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetRepository.swift
@@ -67,9 +67,9 @@ package final class WireDriveLocalAssetRepository: WireDriveLocalAssetRepository
     @MainActor
     package func offlineAssets(
         conversationName: String?,
-        filePath: String?
+        assetsPath: String?
     ) async throws -> [WireMessagingDomain.WireDriveLocalAsset] {
-        try await store.offlineAssets(conversationName: conversationName, filePath: filePath)
+        try await store.offlineAssets(conversationName: conversationName, assetsPath: assetsPath)
     }
 
     /// Refreshes the local asset metadata for a given `nodeID` and deletes any cached file if necessary.

--- a/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetRepository.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetRepository.swift
@@ -65,8 +65,11 @@ package final class WireDriveLocalAssetRepository: WireDriveLocalAssetRepository
     }
 
     @MainActor
-    package func offlineAssets(conversationName: String?) async throws -> [WireMessagingDomain.WireDriveLocalAsset] {
-        try await store.offlineAssets(conversationName: conversationName)
+    package func offlineAssets(
+        conversationName: String?,
+        filePath: String?
+    ) async throws -> [WireMessagingDomain.WireDriveLocalAsset] {
+        try await store.offlineAssets(conversationName: conversationName, filePath: filePath)
     }
 
     /// Refreshes the local asset metadata for a given `nodeID` and deletes any cached file if necessary.

--- a/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetStore.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetStore.swift
@@ -48,13 +48,13 @@ package final class WireDriveLocalAssetStore: WireDriveLocalAssetStoreProtocol {
 
     package func offlineAssets(
         conversationName: String?,
-        filePath: String?
+        assetsPath: String?
     ) async throws -> [WireMessagingDomain.WireDriveLocalAsset] {
         let context = contextProvider.newBackgroundContext()
         return try await context.perform {
             let managedAssets = try context.fetchLocalOfflineAssets(
                 conversationName: conversationName,
-                filePath: filePath
+                assetsPath: assetsPath
             )
 
             return managedAssets.compactMap { managed in
@@ -201,7 +201,7 @@ private extension NSManagedObjectContext {
         return try fetch(request).first
     }
 
-    func fetchLocalOfflineAssets(conversationName: String?, filePath: String?) throws -> [ManagedLocalAsset] {
+    func fetchLocalOfflineAssets(conversationName: String?, assetsPath: String?) throws -> [ManagedLocalAsset] {
         let request = ManagedLocalAsset.fetchRequest() as! NSFetchRequest<ManagedLocalAsset>
         let isAvailableOfflinePredicate = NSPredicate(format: "isAvailableOffline == YES")
         let isDownloadedPredicate =
@@ -217,8 +217,8 @@ private extension NSManagedObjectContext {
             predicates.append(NSPredicate(format: "conversationName == %@", conversationName))
         }
 
-        if let filePath {
-            predicates.append(NSPredicate(format: "path CONTAINS %@", filePath))
+        if let assetsPath {
+            predicates.append(NSPredicate(format: "path BEGINSWITH %@", assetsPath))
         }
 
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)

--- a/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetStore.swift
+++ b/WireMessaging/Sources/WireMessagingData/WireDrive/WireDriveLocalAssetStore.swift
@@ -46,10 +46,16 @@ package final class WireDriveLocalAssetStore: WireDriveLocalAssetStoreProtocol {
         }
     }
 
-    package func offlineAssets(conversationName: String?) async throws -> [WireMessagingDomain.WireDriveLocalAsset] {
+    package func offlineAssets(
+        conversationName: String?,
+        filePath: String?
+    ) async throws -> [WireMessagingDomain.WireDriveLocalAsset] {
         let context = contextProvider.newBackgroundContext()
         return try await context.perform {
-            let managedAssets = try context.fetchLocalOfflineAssets(conversationName: conversationName)
+            let managedAssets = try context.fetchLocalOfflineAssets(
+                conversationName: conversationName,
+                filePath: filePath
+            )
 
             return managedAssets.compactMap { managed in
                 let cacheKey = WireDriveLocalAsset.cacheKey(
@@ -195,7 +201,7 @@ private extension NSManagedObjectContext {
         return try fetch(request).first
     }
 
-    func fetchLocalOfflineAssets(conversationName: String?) throws -> [ManagedLocalAsset] {
+    func fetchLocalOfflineAssets(conversationName: String?, filePath: String?) throws -> [ManagedLocalAsset] {
         let request = ManagedLocalAsset.fetchRequest() as! NSFetchRequest<ManagedLocalAsset>
         let isAvailableOfflinePredicate = NSPredicate(format: "isAvailableOffline == YES")
         let isDownloadedPredicate =
@@ -209,6 +215,10 @@ private extension NSManagedObjectContext {
 
         if let conversationName {
             predicates.append(NSPredicate(format: "conversationName == %@", conversationName))
+        }
+
+        if let filePath {
+            predicates.append(NSPredicate(format: "path CONTAINS %@", filePath))
         }
 
         request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetRepositoryProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetRepositoryProtocol.swift
@@ -28,9 +28,10 @@ package protocol WireDriveLocalAssetRepositoryProtocol: Sendable {
     @MainActor
     func asset(nodeID: UUID) throws -> WireDriveLocalAsset?
 
-    /// Returns offline available local assets for a given conversation or for all conversations if nil.
+    /// Returns offline `WireDriveLocalAsset` objects for a given path or conversation.
+    /// If both parameters are `nil`, all offline assets are returned.
     @MainActor
-    func offlineAssets(conversationName: String?, filePath: String?) async throws
+    func offlineAssets(conversationName: String?, assetsPath: String?) async throws
         -> [WireMessagingDomain.WireDriveLocalAsset]
 
     /// Refreshes the local asset metadata for a given `nodeID` and deletes any cached file if necessary.

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetRepositoryProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetRepositoryProtocol.swift
@@ -30,7 +30,8 @@ package protocol WireDriveLocalAssetRepositoryProtocol: Sendable {
 
     /// Returns offline available local assets for a given conversation or for all conversations if nil.
     @MainActor
-    func offlineAssets(conversationName: String?) async throws -> [WireMessagingDomain.WireDriveLocalAsset]
+    func offlineAssets(conversationName: String?, filePath: String?) async throws
+        -> [WireMessagingDomain.WireDriveLocalAsset]
 
     /// Refreshes the local asset metadata for a given `nodeID` and deletes any cached file if necessary.
     ///

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetStoreProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetStoreProtocol.swift
@@ -26,8 +26,9 @@ package protocol WireDriveLocalAssetStoreProtocol: Sendable {
     /// Returns the `WireDriveLocalAsset` for a given `nodeID` or `nil`.
     func asset(nodeID: UUID) throws -> WireDriveLocalAsset?
 
-    /// Returns offline available local assets for a given conversation or for all conversations if nil.
-    func offlineAssets(conversationName: String?, filePath: String?) async throws
+    /// Returns offline `WireDriveLocalAsset` objects for a given path or conversation.
+    /// If both parameters are `nil`, all offline assets are returned.
+    func offlineAssets(conversationName: String?, assetsPath: String?) async throws
         -> [WireMessagingDomain.WireDriveLocalAsset]
 
     /// Updates an existing `WireDriveLocalAsset` or creates a new one if none exists with its `nodeID`.

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetStoreProtocol.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/Protocols/WireDriveLocalAssetStoreProtocol.swift
@@ -27,7 +27,8 @@ package protocol WireDriveLocalAssetStoreProtocol: Sendable {
     func asset(nodeID: UUID) throws -> WireDriveLocalAsset?
 
     /// Returns offline available local assets for a given conversation or for all conversations if nil.
-    func offlineAssets(conversationName: String?) async throws -> [WireMessagingDomain.WireDriveLocalAsset]
+    func offlineAssets(conversationName: String?, filePath: String?) async throws
+        -> [WireMessagingDomain.WireDriveLocalAsset]
 
     /// Updates an existing `WireDriveLocalAsset` or creates a new one if none exists with its `nodeID`.
     func upsertAsset(_ asset: WireDriveLocalAsset) throws

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveFetchOfflineAvailableAssetsUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveFetchOfflineAvailableAssetsUseCase.swift
@@ -27,7 +27,7 @@ package struct WireDriveFetchOfflineAvailableAssetsUseCase {
         self.localAssetRepository = localAssetRepository
     }
 
-    package func invoke(conversationName: String?) async throws -> [WireDriveLocalAsset] {
-        try await localAssetRepository.offlineAssets(conversationName: conversationName)
+    package func invoke(conversationName: String?, filePath: String?) async throws -> [WireDriveLocalAsset] {
+        try await localAssetRepository.offlineAssets(conversationName: conversationName, filePath: filePath)
     }
 }

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveFetchOfflineAvailableAssetsUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveFetchOfflineAvailableAssetsUseCase.swift
@@ -27,7 +27,7 @@ package struct WireDriveFetchOfflineAvailableAssetsUseCase {
         self.localAssetRepository = localAssetRepository
     }
 
-    package func invoke(conversationName: String?, filePath: String?) async throws -> [WireDriveLocalAsset] {
-        try await localAssetRepository.offlineAssets(conversationName: conversationName, filePath: filePath)
+    package func invoke(conversationName: String?, assetsPath: String?) async throws -> [WireDriveLocalAsset] {
+        try await localAssetRepository.offlineAssets(conversationName: conversationName, assetsPath: assetsPath)
     }
 }

--- a/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveMoveNodeUseCase.swift
+++ b/WireMessaging/Sources/WireMessagingDomain/WireDrive/UseCases/WireDriveMoveNodeUseCase.swift
@@ -19,17 +19,21 @@
 package import Foundation
 
 /// Moves a `WireDriveNode` on the server.
+@MainActor
 package struct WireDriveMoveNodeUseCase {
 
     private let nodesRepository: any WireDriveNodesRepositoryProtocol
+    private let localAssetRepository: any WireDriveLocalAssetRepositoryProtocol
 
     package init(
-        nodesRepository: any WireDriveNodesRepositoryProtocol
+        nodesRepository: any WireDriveNodesRepositoryProtocol,
+        localAssetRepository: any WireDriveLocalAssetRepositoryProtocol
     ) {
         self.nodesRepository = nodesRepository
+        self.localAssetRepository = localAssetRepository
     }
 
-    /// Moves a `WireCellNode` on the server.
+    /// Moves a `WireCellNode` on the server and updates the local asset with the new path.
     ///
     /// - Parameters:
     ///  - nodeID: The ID of the node to move.
@@ -39,6 +43,13 @@ package struct WireDriveMoveNodeUseCase {
         containerPath: String
     ) async throws {
         try await nodesRepository.moveNode(nodeID: nodeID, newContainerPath: containerPath)
+
+        if var localAsset = try localAssetRepository.asset(nodeID: nodeID),
+           let node = try await nodesRepository.getNode(id: nodeID) {
+            localAsset.path = node.path
+            try localAssetRepository.updateAsset(localAsset)
+        }
+
     }
 
 }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/NetworkMonitor.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Common/NetworkMonitor.swift
@@ -43,7 +43,7 @@ package final class NetworkMonitor: Observable, ObservableObject {
         monitor: any NWPathMonitoring = NWPathMonitor(),
     ) {
         self.monitor = monitor
-        
+
         subject
             .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
             .receive(on: DispatchQueue.main)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesContentView.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesContentView.swift
@@ -118,7 +118,7 @@ package struct FilesContentView<Toolbar: ToolbarContent, Sheet: View>: View {
                 }
             )
         }
-        .onChange(of: viewModel.networkStatus) { oldValue, newValue in
+        .onChange(of: viewModel.networkStatus) { _, newValue in
             if newValue != nil {
                 Task {
                     await viewModel.reload(refreshing: true)

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesPreviewHelpers.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesPreviewHelpers.swift
@@ -333,7 +333,10 @@ private final class PreviewLocalAssetRepository: WireDriveLocalAssetRepositoryPr
         publishers.values.compactMap(\.value)
     }
 
-    func offlineAssets(conversationName: String?) throws -> [WireMessagingDomain.WireDriveLocalAsset] {
+    func offlineAssets(
+        conversationName: String?,
+        filePath: String?
+    ) throws -> [WireMessagingDomain.WireDriveLocalAsset] {
         publishers.values.compactMap(\.value).filter(\.isAvailableOffline)
     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesPreviewHelpers.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesPreviewHelpers.swift
@@ -335,7 +335,7 @@ private final class PreviewLocalAssetRepository: WireDriveLocalAssetRepositoryPr
 
     func offlineAssets(
         conversationName: String?,
-        filePath: String?
+        assetsPath: String?
     ) throws -> [WireMessagingDomain.WireDriveLocalAsset] {
         publishers.values.compactMap(\.value).filter(\.isAvailableOffline)
     }

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
@@ -671,7 +671,7 @@ package final class FilesViewModel: ObservableObject {
         do {
             let offlineAssets = try await useCases.getOfflineAvailableAssets.invoke(
                 conversationName: cellName != nil ? conversations.first?.name : nil,
-                filePath: navigationPath.last?.filePath
+                assetsPath: navigationPath.last?.filePath
             )
 
             let items: [FilesViewItem] = offlineAssets.map { asset in
@@ -683,8 +683,9 @@ package final class FilesViewModel: ObservableObject {
                     let baseComponents = basePath.split(separator: "/")
                     let fullComponents = fullPath.split(separator: "/")
 
-                    // no more folders.
-                    if fullComponents.count == baseComponents.count + 1 {
+                    let noMoreFolders = fullComponents.count == baseComponents.count + 1
+                    
+                    if noMoreFolders {
                         return nil
                     }
 

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
@@ -272,7 +272,7 @@ package final class FilesViewModel: ObservableObject {
     var networkStatus: NetworkMonitor.NetworkStatus? {
         networkMonitor.currentStatus
     }
-    
+
     var isOffline: Bool {
         networkMonitor.currentStatus == .disconnected
     }
@@ -430,7 +430,10 @@ package final class FilesViewModel: ObservableObject {
                 },
                 nodesRepository: nodesRepository,
                 localAssetRepository: assetRepository,
-                moveNodeUseCase: WireDriveMoveNodeUseCase(nodesRepository: nodesRepository),
+                moveNodeUseCase: WireDriveMoveNodeUseCase(
+                    nodesRepository: nodesRepository,
+                    localAssetRepository: assetRepository
+                ),
                 createFileUseCase: useCases.createFile
             )
         )
@@ -667,24 +670,56 @@ package final class FilesViewModel: ObservableObject {
     private func loadOfflineFiles() async {
         do {
             let offlineAssets = try await useCases.getOfflineAvailableAssets.invoke(
-                conversationName: cellName != nil ? conversations.first?.name : nil
+                conversationName: cellName != nil ? conversations.first?.name : nil,
+                filePath: navigationPath.last?.filePath
             )
 
             let items: [FilesViewItem] = offlineAssets.map { asset in
                 let fileUrl = URL(fileURLWithPath: asset.path)
-                let fileName = fileUrl.lastPathComponent
                 let fileExtension = fileUrl.pathExtension
                 let fileType = UTType(filenameExtension: fileExtension)
+
+                func nextFolderPath(from fullPath: String, basePath: String) -> String? {
+                    let baseComponents = basePath.split(separator: "/")
+                    let fullComponents = fullPath.split(separator: "/")
+
+                    // no more folders.
+                    if fullComponents.count == baseComponents.count + 1 {
+                        return nil
+                    }
+
+                    guard fullComponents.starts(with: baseComponents) else {
+                        return nil
+                    }
+
+                    let nextCount = baseComponents.count + 1
+                    let nextComponents = fullComponents.prefix(nextCount)
+                    return nextComponents.joined(separator: "/") + "/"
+                }
+
+                let basePath = navigationPath.last?.filePath ?? asset.path.split(separator: "/").prefix(1).joined()
+                let nextFolderPath = isBrowsing ? nil : nextFolderPath(from: asset.path, basePath: basePath)
+
+                let filekind: FilesViewItem.Kind = if nextFolderPath != nil {
+                    .folder
+                } else {
+                    .file
+                }
+                let filepath: String = if let nextFolderPath {
+                    nextFolderPath
+                } else {
+                    asset.path
+                }
 
                 return .init(
                     id: asset.nodeID,
                     eTag: asset.eTag,
-                    kind: .file,
-                    name: fileName,
-                    filePath: asset.path,
+                    kind: filekind,
+                    name: URL(fileURLWithPath: filepath).lastPathComponent,
+                    filePath: filepath,
                     ownedBy: asset.ownerName,
                     modifiedAt: asset.modified,
-                    icon: .make(type: fileType, fileExtension: fileExtension),
+                    icon: filekind == .folder ? .folder : .make(type: fileType, fileExtension: fileExtension),
                     tags: [], // change later if we want to show tags in offline mode.
                     isEditable: false, // change later if we want to edit files in offline mode.
                     publicLinkID: nil, // change later if we want to be able to share a public link in offline mode.
@@ -692,17 +727,24 @@ package final class FilesViewModel: ObservableObject {
                     size: asset.size
                 )
             }
-            
+
             let itemsWithCreationDates: [(item: FilesViewItem, creationDate: Date)] = await items.asyncMap { item in
                 let url = try? await useCases.getAsset.invoke(nodeID: item.id, eTag: item.eTag)
                 let creationDate = (try? url?.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? Date()
                 return (item: item, creationDate: creationDate)
             }
-            
+
             let sortedItems = itemsWithCreationDates.sorted { lhs, rhs in
                 lhs.creationDate.compare(rhs.creationDate) == .orderedDescending
             }
             .map(\.item)
+            .reduce(into: [FilesViewItem]()) { result, item in
+                let isDuplicate = result.map(\.filePath).contains(item.filePath) // removes duplicated folders
+
+                if !isDuplicate {
+                    result.append(item)
+                }
+            }
 
             state = .received(items: sortedItems)
         } catch {

--- a/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
+++ b/WireMessaging/Sources/WireMessagingUI/WireDrive/Components/Files/FilesViewModel.swift
@@ -684,7 +684,7 @@ package final class FilesViewModel: ObservableObject {
                     let fullComponents = fullPath.split(separator: "/")
 
                     let noMoreFolders = fullComponents.count == baseComponents.count + 1
-                    
+
                     if noMoreFolders {
                         return nil
                     }

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
@@ -47,7 +47,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
             self?.storeBacking[asset.nodeID] = asset
         }
 
-        store.offlineAssetsConversationNameFilePath_MockMethod = { [weak self] conversationName, _ in
+        store.offlineAssetsConversationNameAssetsPath_MockMethod = { [weak self] conversationName, _ in
             if let conversationName {
                 return self?.storeBacking.map(\.value).filter { $0.conversationName == conversationName } ?? []
             } else {
@@ -63,7 +63,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
         try assets.forEach(store.upsertAsset)
 
         // when
-        let availableAssets = try await sut.invoke(conversationName: nil, filePath: nil)
+        let availableAssets = try await sut.invoke(conversationName: nil, assetsPath: nil)
 
         // then
         #expect(availableAssets.count == assets.count)
@@ -82,7 +82,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
         try assets.forEach(store.upsertAsset)
 
         // when
-        let availableAssets = try await sut.invoke(conversationName: "Test", filePath: nil)
+        let availableAssets = try await sut.invoke(conversationName: "Test", assetsPath: nil)
 
         // then
         #expect(availableAssets.count == 2)

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
@@ -46,7 +46,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
         store.upsertAsset_MockMethod = { [weak self] asset in
             self?.storeBacking[asset.nodeID] = asset
         }
-        
+
         store.offlineAssetsConversationName_MockMethod = { [weak self] conversationName in
             if let conversationName {
                 return self?.storeBacking.map(\.value).filter { $0.conversationName == conversationName } ?? []
@@ -68,11 +68,17 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
         // then
         #expect(availableAssets.count == assets.count)
     }
-    
+
     @Test
     func `It retrieves available offline assets for a given conversation locally`() async throws {
         // given
-        let assets = [WireDriveLocalAsset.fixture(conversationName: "Test"), .fixture(conversationName: "Test"), .fixture(), .fixture(), .fixture()]
+        let assets = [
+            WireDriveLocalAsset.fixture(conversationName: "Test"),
+            .fixture(conversationName: "Test"),
+            .fixture(),
+            .fixture(),
+            .fixture()
+        ]
         try assets.forEach(store.upsertAsset)
 
         // when

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
@@ -47,7 +47,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
             self?.storeBacking[asset.nodeID] = asset
         }
 
-        store.offlineAssetsConversationName_MockMethod = { [weak self] conversationName in
+        store.offlineAssetsConversationNameFilePath_MockMethod = { [weak self] conversationName, filePath in
             if let conversationName {
                 return self?.storeBacking.map(\.value).filter { $0.conversationName == conversationName } ?? []
             } else {
@@ -63,7 +63,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
         try assets.forEach(store.upsertAsset)
 
         // when
-        let availableAssets = try await sut.invoke(conversationName: nil)
+        let availableAssets = try await sut.invoke(conversationName: nil, filePath: nil)
 
         // then
         #expect(availableAssets.count == assets.count)
@@ -82,7 +82,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
         try assets.forEach(store.upsertAsset)
 
         // when
-        let availableAssets = try await sut.invoke(conversationName: "Test")
+        let availableAssets = try await sut.invoke(conversationName: "Test", filePath: nil)
 
         // then
         #expect(availableAssets.count == 2)

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/ImplementationTests/UseCases/WireDriveFetchOfflineAvailableAssetsUseCaseTests.swift
@@ -47,7 +47,7 @@ final class WireDriveFetchOfflineAvailableAssetsUseCaseTests {
             self?.storeBacking[asset.nodeID] = asset
         }
 
-        store.offlineAssetsConversationNameFilePath_MockMethod = { [weak self] conversationName, filePath in
+        store.offlineAssetsConversationNameFilePath_MockMethod = { [weak self] conversationName, _ in
             if let conversationName {
                 return self?.storeBacking.map(\.value).filter { $0.conversationName == conversationName } ?? []
             } else {

--- a/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewModelTests.swift
+++ b/WireMessaging/Tests/WireMessagingTests/WireDrive/UITests/Components/Files/FilesViewModelTests.swift
@@ -18,8 +18,8 @@
 
 import Combine
 import Foundation
-import Testing
 import Network
+import Testing
 import WireMessagingDomain
 
 @testable import WireMessagingDomainSupport
@@ -45,7 +45,7 @@ final class FilesViewModelTests {
 
         let editingURLRepository = MockWireDriveEditingURLRepositoryProtocol()
         editingURLRepository.getEditorURLId_MockValue = nil
-        
+
         networkMonitor.currentStatus = .connected
 
         self.sut = FilesViewModel(
@@ -601,7 +601,7 @@ final class FilesViewModelTests {
         let now = Date()
 
         networkMonitor.currentStatus = .disconnected
-        
+
         sut.state = .received(items: [
             FilesViewItem(
                 id: nodeA.id,
@@ -627,6 +627,6 @@ final class FilesViewModelTests {
 
 private final class MockNWPathMonitoring: NWPathMonitoring {
     var pathUpdateHandler: (@Sendable (NWPath) -> Void)?
-    
+
     func start(queue: DispatchQueue) {}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24437" title="WPB-24437" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24437</a>  [iOS] Fetch and display the assets available offline when connection is down
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

This PR re-constructs the folder structure locally in offline mode using the asset path to keep a consistent UI with the online mode (which is BE driven). 
Also, local asset path is now being updated when moving a node to a folder otherwise it will not have a correct path when re-constructing the folder structure.

### Testing

Do the following to prepare for testing:

1) Make a file available offline (flat, no folders)
2) Make a file available offline then move it to a folder
3) Create multiple nested folders and move files inside those various folders, then make the them available offline

Switch to plane mode and ensure the file/folder stucture is preserved for each of these files in the shared drive screen.
In the drive tab, folders should not show up as files are flattened.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
