### PR TITLE
fix: backporting testiny integration to 4.17 - WPB-24719

### DIFF
--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -19,12 +19,17 @@ on:
       run_critical_flows:
         type: boolean
         required: true
-      notify:
+      testiny_run_name:
+        type: string
+        required: false
+        default: ''
+     notify:
         type: string
         required: true
         default: 'failure' # values: always | failure | never
 
-    secrets:
+        
+     secrets:
       ZENKINS_USERNAME:
         required: true
       DD_API_KEY:
@@ -153,6 +158,32 @@ jobs:
         if: ${{ inputs.run_critical_flows }}
         run: |
           bundle exec fastlane run_uitests
+
+
+      - name: Upload XCResult results to Testiny
+        if: ${{ always() && inputs.run_critical_flows && inputs.testiny_run_name }}
+        shell: bash
+        env:
+          TESTINY_RUN_NAME: ${{ inputs.testiny_run_name }}
+        run: |
+          set -euo pipefail
+          TESTINY_API_KEY="$(op read 'op://Test Automation/TESTINY_API_KEY_IOS/password')"
+          echo "::add-mask::$TESTINY_API_KEY"
+          export TESTINY_API_KEY
+
+          # Find a xcresult bundle produced by the run
+          XCRESULT="$(find artifacts -type d -name '*.xcresult' | head -n 1)"
+          if [ -z "$XCRESULT" ]; then
+            echo "[ERROR] No .xcresult found under artifacts/"
+            exit 1
+          fi
+
+          echo "[INFO] Using xcresult: $XCRESULT"
+
+          python3 ./scripts/send_xcresult_to_testiny.py \
+            --xcresult "$XCRESULT" \
+            --run-name "$TESTINY_RUN_NAME" \
+            --require-existing-run
 
       - name: "Test all selected frameworks"
         if: ${{ inputs.test_dependencies || inputs.all }}

--- a/.github/workflows/_reusable_run_tests.yml
+++ b/.github/workflows/_reusable_run_tests.yml
@@ -23,13 +23,12 @@ on:
         type: string
         required: false
         default: ''
-     notify:
+      notify:
         type: string
         required: true
         default: 'failure' # values: always | failure | never
 
-        
-     secrets:
+    secrets:
       ZENKINS_USERNAME:
         required: true
       DD_API_KEY:

--- a/.github/workflows/critical_flows.yaml
+++ b/.github/workflows/critical_flows.yaml
@@ -2,6 +2,11 @@ name: Critical Flows
 
 on:
   workflow_dispatch:
+    inputs:
+      testiny_run_name:
+        description: "Testiny test run name: paste the exact run name from Testiny"
+        required: false
+        type: string
   push:
     branches:
       - 'develop'
@@ -21,5 +26,5 @@ jobs:
       notify_secret: WIRE_IOS_QA_WEBHOOK
       test_dependencies: false
       run_critical_flows: true
-      notify: always
+      testiny_run_name: ${{ inputs.testiny_run_name }}
     secrets: inherit

--- a/.github/workflows/critical_flows.yaml
+++ b/.github/workflows/critical_flows.yaml
@@ -26,5 +26,6 @@ jobs:
       notify_secret: WIRE_IOS_QA_WEBHOOK
       test_dependencies: false
       run_critical_flows: true
+      notify: always
       testiny_run_name: ${{ inputs.testiny_run_name }}
     secrets: inherit

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -77,6 +77,14 @@ custom_rules:
     message: "Add JIRA reference to TODOs and FIX MEs like [WPB-680]."
     severity: warning
 
+  xcuitest_requires_testiny_tc_id:
+    name: "XCUITest requires Testiny TC ID"
+    included:
+      - "WireUITests"
+    regex: '^\s*func\s+test(?![A-Za-z0-9_]*_TC_\d+(?:_\d+)*)[A-Za-z0-9_]*\s*\('
+    message: "WireUITests test methods must include a Testiny TC ID suffix, for example: testLogin_TC_1234"
+    severity: error
+
 excluded:
   - "**/.build"
   - "**/AutoMockable.generated.swift"

--- a/scripts/send_xcresult_to_testiny.py
+++ b/scripts/send_xcresult_to_testiny.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+
+"""
+Upload XCUITest results to Testiny via REST API.
+
+How it works
+- Reads an .xcresult
+- Extracts Testiny case IDs from test names using the pattern: _TC_<id>[_<id>...]
+  Examples:
+    test_Login_TC_1234()            -> TC-1234
+    test_Login_TC_1234_1111_2222()  -> TC-1234, TC-1111, TC-2222
+- Finds a Testiny test run by title and updates the matching test cases with PASSED/FAILED/SKIPPED
+
+Usage
+  python3 send_xcresult_to_testiny.py --xcresult <path>.xcresult --run-name "My Run" [--require-existing-run]
+
+Environment
+  TESTINY_API_KEY     Required. Testiny API key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+TESTINY_BASE_URL = "https://app.testiny.io/api/v1"
+TESTINY_API_KEY = os.environ.get("TESTINY_API_KEY")
+PROJECT_FIELD: Dict = {"project_id": 7} #IOS
+
+@dataclass
+class FlatTest:
+    name: str
+    status: str
+    tc_keys: List[str] = field(default_factory=list)
+
+@dataclass
+class PendingResult:
+    run_id: int
+    test_case_id: int
+    status: str
+
+
+def extract_tc_keys(test_name: str) -> List[str]:
+    """
+    Extract all TC IDs from function name.
+    Supports:
+        test_TC_1234
+        test_TC_1234_1111_2222
+        test_TC_1234_TC_1111_TC_2222
+        test_TC_1234_1111_TC_2222
+    """
+    matches = re.findall(r'_TC_(\d+)', test_name, re.IGNORECASE)
+    if not matches:
+        return []
+
+    seen = set()
+    keys: List[str] = []
+    for m in matches:
+        if m not in seen:
+            seen.add(m)
+            keys.append(f"TC-{m}")
+
+    return keys
+
+
+STATUS_MAP = {
+    "Success": "PASSED",
+    "Failure": "FAILED",
+    "Skipped": "SKIPPED",
+    "Expected Failure": "FAILED",
+    "Error": "FAILED",
+    "Passed": "PASSED",
+    "Failed": "FAILED",
+    "passed": "PASSED",
+    "failed": "FAILED",
+    "skipped": "SKIPPED",
+    "error": "FAILED",
+}
+
+
+
+def map_status(raw: str) -> str:
+    status = STATUS_MAP.get(raw)
+    if status is None:
+        print(f"[WARN] Unrecognised test status '{raw}', defaulting to NOTRUN")
+        return "NOTRUN"
+    return status
+
+def execute_xcresulttool(*args: str) -> dict:
+    cmd = ["xcrun", "xcresulttool"] + list(args)
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if r.returncode != 0:
+        raise RuntimeError(f"xcresulttool error:\n{r.stderr.strip()}")
+    return json.loads(r.stdout)
+
+def collect_test_nodes_new_api(root: dict, tests: list):
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if not isinstance(node, dict):
+            continue
+        if node.get("nodeType") == "Test Case":
+            name = node.get("name", "").rstrip("()")
+            result = node.get("result", "unknown")
+            tests.append({"name": name, "status": result})
+        stack.extend(node.get("children", []))
+
+
+def parse_xcresult_new_api(path: str) -> List[FlatTest]:
+    print("[INFO] Using Xcode 16+ xcresulttool API")
+    data = execute_xcresulttool("get", "test-results", "tests", "--path", path)
+    raw = []
+    for node in data.get("testNodes", []):
+        collect_test_nodes_new_api(node, raw)
+    return build_flat_test_models(raw)
+
+
+def collect_test_nodes_legacy(root, tests):
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, list):
+            stack.extend(node)
+            continue
+        if not isinstance(node, dict):
+            continue
+        if node.get("_type", {}).get("_name") == "ActionTestMetadata":
+            identifier = node.get("identifier", {}).get("_value", "")
+            status = node.get("testStatus", {}).get("_value", "")
+            if identifier:
+                func = identifier.split("/")[-1].rstrip("()")
+                tests.append({"name": func, "status": status})
+        stack.extend(
+            v for k, v in node.items()
+            if k not in ("_type", "_value") and isinstance(v, (dict, list))
+        )
+
+def parse_xcresult_legacy(path: str) -> List[FlatTest]:
+    print("[INFO] Using legacy xcresulttool API")
+    top = execute_xcresulttool("get", "--legacy", "--format", "json", "--path", path)
+
+    raw = []
+    collect_test_nodes_legacy(top, raw)
+    return build_flat_test_models(raw)
+
+def parse_xcresult(path: str) -> List[FlatTest]:
+    print(f"[INFO] Parsing XCResult: {path}")
+
+    probe = subprocess.run(
+        ["xcrun", "xcresulttool", "get", "test-results", "--help"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=30,
+    )
+
+    if probe.returncode == 0:
+        try:
+            return parse_xcresult_new_api(path)
+        except Exception as e:
+            print(f"[WARN] New API failed ({e}), falling back to legacy")
+
+    return parse_xcresult_legacy(path)
+
+
+def parse_junit_xml(path: str) -> List[FlatTest]:
+    print(f"[INFO] Parsing JUnit XML: {path}")
+    tree = ET.parse(path)
+    root = tree.getroot()
+
+    raw = []
+    for tc in root.iter("testcase"):
+        name = tc.get("name", "").rstrip("()")
+        if tc.find("failure") is not None or tc.find("error") is not None:
+            status = "Failure"
+        elif tc.find("skipped") is not None:
+            status = "Skipped"
+        else:
+            status = "Success"
+        raw.append({"name": name, "status": status})
+
+    return build_flat_test_models(raw)
+
+
+def build_flat_test_models(raw: list) -> List[FlatTest]:
+    return [
+        FlatTest(
+            name=t["name"],
+            status=t["status"],
+            tc_keys=extract_tc_keys(t["name"])
+        )
+        for t in raw
+    ]
+
+
+def call_testiny_api(method: str, endpoint: str, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        f"{TESTINY_BASE_URL}{endpoint}",
+        data=data,
+        headers={"Content-Type": "application/json", "X-Api-Key": TESTINY_API_KEY},
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(
+            f"Testiny {method} {endpoint} -> {e.code}: {e.read().decode()}"
+        )
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error calling {endpoint}: {e.reason}")
+
+def append_ci_summary(run_id: int, run_name: str) -> None:
+    github_server = os.environ.get("GITHUB_SERVER_URL")
+    github_repo = os.environ.get("GITHUB_REPOSITORY")
+    github_run_id = os.environ.get("GITHUB_RUN_ID")
+    github_run_number = os.environ.get("GITHUB_RUN_NUMBER")
+
+    if not github_server or not github_repo or not github_run_id:
+        return
+
+    build_url = f"{github_server}/{github_repo}/actions/runs/{github_run_id}"
+
+    try:
+        run = call_testiny_api("GET", f"/testrun/{run_id}")
+        description = run.get("description")
+
+        try:
+            doc = json.loads(description) if description else {"t": "slate", "v": 1, "c": []}
+        except Exception:
+            doc = {"t": "slate", "v": 1, "c": []}
+
+        link_label = f"{run_name}"
+        if github_run_number:
+            link_label += f" #{github_run_number}"
+        link_label += ": "
+
+        doc["c"].append({
+            "t": "p",
+            "children": [
+                {"text": link_label},
+                {"t": "a", "url": build_url, "children": [{"text": build_url}]},
+                {"text": ""}
+            ]
+        })
+
+        call_testiny_api(
+            "PUT",
+            f"/testrun/{run_id}?force=true",
+            {"description": json.dumps(doc)}
+        )
+
+    except Exception as e:
+        print(f"[WARN] Could not update Testiny run description: {e}")
+
+# Find an existing run by the provided name
+def resolve_run(title: str, require_existing: bool) -> int:
+    found = call_testiny_api("POST", "/testrun/find", {"filter": {"title": title, **PROJECT_FIELD}})
+
+    if found.get("data"):
+        if len(found["data"]) > 1:
+            print(f"[WARN] Multiple runs named '{title}', using the first match")
+        run_id = found["data"][0]["id"]
+        print(f"[OK] Found existing run '{title}' (ID {run_id})")
+        return run_id
+
+    if require_existing:
+        raise RuntimeError(f"Run '{title}' not found and --require-existing-run set")
+
+    print(f"[INFO] Creating test run '{title}'")
+    run = call_testiny_api("POST", "/testrun", {"title": title, **PROJECT_FIELD})
+    return run["id"]
+
+
+def find_testiny_id(tc_key: str) -> int | None:
+    numeric = re.sub(r'^TC-', '', tc_key, flags=re.IGNORECASE)
+    if not numeric.isdigit():
+        return None
+    try:
+        tc = call_testiny_api("GET", f"/testcase/{numeric}")
+        return tc["id"]
+    except Exception:
+        return None
+
+
+def bulk_send(results: List[PendingResult]) -> None:
+    payload = [
+        {
+            "ids": {"testcase_id": r.test_case_id, "testrun_id": r.run_id},
+            "mapped": {"result_status": r.status, "assigned_to": "OWNER"},
+        }
+        for r in results
+    ]
+    call_testiny_api("POST", "/testrun/mapping/bulk/testcase:testrun?op=add_or_update", payload)
+
+
+def resolve_test_cases(tests: List[FlatTest], run_id: int):
+    results_to_upload = []
+    skipped_no_tag = 0
+    skipped_missing = 0
+
+    for t in tests:
+        if not t.tc_keys:
+            skipped_no_tag += 1
+            continue
+
+        status = map_status(t.status)
+
+        for key in t.tc_keys:
+            tc_id = find_testiny_id(key)
+            if tc_id is None:
+                print(f"[WARN] {key} not found in Testiny")
+                skipped_missing += 1
+                continue
+
+            results_to_upload.append(PendingResult(run_id, tc_id, status))
+
+    return results_to_upload, skipped_no_tag, skipped_missing
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Send XCUITest results to Testiny.")
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--xcresult")
+    src.add_argument("--junit")
+    p.add_argument("--run-name", required=True)
+    p.add_argument("--require-existing-run", action="store_true")
+    return p.parse_args()
+
+def main():
+    args = parse_args()
+
+    if not TESTINY_API_KEY:
+        sys.exit("TESTINY_API_KEY not set")
+
+    if args.xcresult:
+        if not os.path.exists(args.xcresult):
+            sys.exit("XCResult not found")
+        tests = parse_xcresult(args.xcresult)
+    else:
+        if not os.path.exists(args.junit):
+            sys.exit("JUnit not found")
+        tests = parse_junit_xml(args.junit)
+
+    print(f"[INFO] {len(tests)} test(s) loaded")
+
+    run_id = resolve_run(args.run_name, args.require_existing_run)
+
+    pending, skipped_no_tag, skipped_missing = resolve_test_cases(tests, run_id)
+
+    dedup = {}
+    for r in pending:
+        dedup[f"{r.test_case_id}:{r.run_id}"] = r
+
+    final = list(dedup.values())
+
+    exit_code = 0
+    if final:
+        print(f"[INFO] Sending {len(final)} result(s)")
+        try:
+            bulk_send(final)
+            print("[OK] Upload successful")
+        except Exception as e:
+            print(f"[ERROR] Upload failed: {e}", file=sys.stderr)
+            exit_code = 1
+    else:
+        print("[INFO] No results to send")
+
+    append_ci_summary(run_id, args.run_name)
+    sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()

--- a/wire-ios/WireUITests/AccountManagementTests.swift
+++ b/wire-ios/WireUITests/AccountManagementTests.swift
@@ -23,9 +23,8 @@ final class AccountManagementTests: WireUITestCase {
 
     var teamMember: UserInfo!
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8588
     @MainActor
-    func test_Account_Management_Lock_With_Passcode() async throws {
+    func testAccountManagementLockWithPasscode_TC_8950() async throws {
 
         let passcode = UserGenerator.generateAppPasscode()
 
@@ -48,9 +47,8 @@ final class AccountManagementTests: WireUITestCase {
 
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8796
     @MainActor
-    func test_Account_Management_Update_Email_Reset_password() async throws {
+    func testAccountManagementUpdateEmailAndResetPassword_TC_8933_TC_8931() async throws {
 
         let updatedUserDetails = UserGenerator.generateUniqueUserInfo()
 

--- a/wire-ios/WireUITests/BackupRestoreHistoryTests.swift
+++ b/wire-ios/WireUITests/BackupRestoreHistoryTests.swift
@@ -21,9 +21,8 @@ import XCTest
 
 final class BackupRestoreHistoryTests: WireUITestCase {
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8582
     @MainActor
-    func test_CreateBackupAndRestoreHistory() async throws {
+    func testCreateBackupAndRestoreHistory_TC_8928_TC_8930_TC_8805() async throws {
         let groupName = UserGenerator.generateRandomGroupName()
         let messageFromOwner = UserGenerator.generateRandomMessage()
         let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()

--- a/wire-ios/WireUITests/ConversationTests.swift
+++ b/wire-ios/WireUITests/ConversationTests.swift
@@ -21,7 +21,7 @@ import XCTest
 final class ConversationTests: WireUITestCase {
 
     @MainActor
-    func testClearContent() async throws {
+    func testClearContent_TC_9488() async throws {
         let stagingTeam = try await userHelper.registerTeam(withMemberCount: 2)
         let userA = try XCTUnwrap(stagingTeam.teamMembers.first)
         let userB = try XCTUnwrap(stagingTeam.teamMembers.last)

--- a/wire-ios/WireUITests/FederationTests.swift
+++ b/wire-ios/WireUITests/FederationTests.swift
@@ -21,7 +21,7 @@ import XCTest
 final class FederationTests: WireUITestCase {
 
     @MainActor
-    func testConnectFederatedUsers() async throws {
+    func testConnectFederatedUsers_TC_9459() async throws {
 
         defer {
             BackendContext.current = .staging

--- a/wire-ios/WireUITests/MultiBackendSupportTests.swift
+++ b/wire-ios/WireUITests/MultiBackendSupportTests.swift
@@ -44,9 +44,8 @@ final class MultiBackendSupportTests: WireUITestCase {
         return (accountPage, user)
     }
 
-    /// testniy: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8797
     @MainActor
-    func test_Add_MultiBackend_Accounts() async throws {
+    func testAddMultiBackendAccounts_TC_8940() async throws {
 
         defer { BackendContext.current = .staging }
 

--- a/wire-ios/WireUITests/PersonalUserTests.swift
+++ b/wire-ios/WireUITests/PersonalUserTests.swift
@@ -20,9 +20,8 @@ import XCTest
 
 final class PersonalUsersTests: WireUITestCase {
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8587
     @MainActor
-    func test_Register_asPersonalUser() async throws {
+    func testRegisterAsPersonalUser_TC_8971() async throws {
         let user = UserGenerator.generateUniqueUserInfo()
 
         let welcomePage = try WelcomePage()
@@ -58,9 +57,8 @@ final class PersonalUsersTests: WireUITestCase {
         XCTAssertEqual(accountPage.getEmail(), user.email, "Email didn't contain \(user.email)")
     }
 
-    /// testiny:  https://app.testiny.io/IOS/testcases/tcf/1286/tc/8799
     @MainActor
-    func test_Login_asExistingPersonalUser() async throws {
+    func testLoginAsExistingPersonalUser_TC_8804() async throws {
         let user = try await userHelper.createPersonalUser()
 
         let firstTimePage = try app.loginUser(email: user.email, password: user.password)
@@ -71,9 +69,8 @@ final class PersonalUsersTests: WireUITestCase {
             .enterPassword(user.password)
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8798
     @MainActor
-    func test_PersonalAccountLifecycle() async throws {
+    func testPersonalAccountLifecycle_TC_8807_TC_8810_TC_8819_TC_8826_TC_8867_TC_9450() async throws {
         let userA = try await userHelper.createPersonalUser()
         let userB = try await userHelper.createPersonalUser()
         let messageFromUserB = "Hello from \(userB.name)"
@@ -137,9 +134,8 @@ final class PersonalUsersTests: WireUITestCase {
         XCTAssertNotEqual(accountNameUserA, accountNameUserB, "Account name didn't change after deleting")
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1389/tc/8869
     @MainActor
-    func test_AddConversationAsFavourite() async throws {
+    func test_AddConversationAsFavourite_TC_8869() async throws {
         let groupName = UserGenerator.generateRandomGroupName()
         let (teamOwner, _, _, _) = try await userHelper
             .registerTeam(
@@ -159,9 +155,8 @@ final class PersonalUsersTests: WireUITestCase {
         )
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1389/tc/8874
     @MainActor
-    func test_FilterConversationByFavourite() async throws {
+    func test_FilterConversationByFavourite_TC_8874() async throws {
         let groupName = UserGenerator.generateRandomGroupName()
         let (teamOwner, _, _, _) = try await userHelper
             .registerTeam(

--- a/wire-ios/WireUITests/ShareExtensionTests.swift
+++ b/wire-ios/WireUITests/ShareExtensionTests.swift
@@ -49,9 +49,8 @@ final class ShareExtensionTests: WireUITestCase {
         }
     }
 
-    // TestCase: https://app.testiny.io/IOS/testplans/tp/109/tc/8199
     @MainActor
-    func test_ShareImageOnetoOne() async throws {
+    func testShareImageOnetoOne_TC_8915() async throws {
 
         let user1 = try await userHelper.createPersonalUser()
         let user2 = try await userHelper.createPersonalUser()
@@ -76,9 +75,8 @@ final class ShareExtensionTests: WireUITestCase {
         )
     }
 
-    // TestCase: https://app.testiny.io/IOS/testplans/tp/109/tc/8200
     @MainActor
-    func test_ShareImageToGroupConversation() async throws {
+    func testShareImageToGroupConversation_TC_8919() async throws {
 
         let groupName = UserGenerator.generateRandomGroupName()
 

--- a/wire-ios/WireUITests/TeamManageTests.swift
+++ b/wire-ios/WireUITests/TeamManageTests.swift
@@ -21,9 +21,8 @@ import XCTest
 
 final class TeamManageTests: WireUITestCase {
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1299/tc/8625
     @MainActor
-    func test_Migrate_PersonalUserToTeam() async throws {
+    func testMigratePersonalUserToTeam_TC_9452() async throws {
         let user = try await userHelper.createPersonalUser()
 
         let conversationPage = try app.loginUser(email: user.email, password: user.password)
@@ -42,9 +41,8 @@ final class TeamManageTests: WireUITestCase {
         XCTAssertTrue(userProfilePage.manageTeamButton.exists, "Manage Team button is not visible")
     }
 
-    /// testiny:  https://app.testiny.io/IOS/testcases/tcf/1287/tc/8800
     @MainActor
-    func test_PersonalUser_InvitedToTeam() async throws {
+    func testPersonalUserInvitedToTeam_TC_9453() async throws {
         let teamOwner = try await userHelper.createPersonalUser()
         let teamID = try await userHelper.upgradePersonalToTeam(
             teamName: teamOwner.teamName
@@ -75,10 +73,8 @@ final class TeamManageTests: WireUITestCase {
             .enterPassword(memberUser.password)
     }
 
-    ///  testiny: https://app.testiny.io/IOS/testcases/tcf/1287/tc/8579
     @MainActor
-    func test_TeamOwner_GroupCreatedAndSendMessage() async throws {
-
+    func testTeamOwnerGroupCreatedAndSendMessage_TC_9454() async throws {
         let groupName = UserGenerator.generateRandomGroupName()
         let messageFromOwner = UserGenerator.generateRandomMessage()
 
@@ -105,9 +101,8 @@ final class TeamManageTests: WireUITestCase {
         )
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1302/tc/8656
     @MainActor
-    func test_GroupAdmin_RemoveAndAddParticipantFromGroup() async throws {
+    func testGroupAdminRemoveAndAddParticipantFromGroup_TC_9455() async throws {
 
         let groupName = UserGenerator.generateRandomGroupName()
         let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
@@ -165,9 +160,8 @@ final class TeamManageTests: WireUITestCase {
     }
 
     /// [WPB-3772] Bug: Opening an archived conversation unarchives it
-    /// testiny: https://app.testiny.io/IOS/testcases/tc/8563
     @MainActor
-    func test_ArchivedConversationUnarchivesWhenOpened() async throws {
+    func testArchivedConversationUnarchivesWhenOpened_TC_8872() async throws {
         let groupName = UserGenerator.generateRandomGroupName()
 
         let (_, teamOwner) = try await userHelper.registerUserAsTeamOwner()
@@ -192,9 +186,8 @@ final class TeamManageTests: WireUITestCase {
         XCTAssertTrue(archivedConversationPage.conversationExists(withName: groupName))
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1389/tc/8865/
     @MainActor
-    func test_MentionUserInGroup() async throws {
+    func testMentionUserInGroup_TC_8865() async throws {
 
         let (teamOwner, teamMembers, _, _) = try await userHelper
             .registerTeam(

--- a/wire-ios/WireUITests/WireAuthenticationTests.swift
+++ b/wire-ios/WireUITests/WireAuthenticationTests.swift
@@ -25,7 +25,7 @@ final class WireAuthenticationTests: WireUITestCase {
     }
 
     @MainActor
-    func test_Login_withWrongEmail_NextIsDisabled() throws {
+    func testLoginWithWrongEmail_NextIsDisabled_TC_9457() throws {
 
         let welcomePage = try WelcomePage()
             .typeEmailOrSSO("notAnEmail.com")
@@ -34,7 +34,7 @@ final class WireAuthenticationTests: WireUITestCase {
     }
 
     @MainActor
-    func test_Login_withoutPassword_NextIsDisabled() throws {
+    func testLoginWithoutPassword_NextIsDisabled_TC_9457() throws {
 
         let loginPage = try WelcomePage()
             .enterEmailOrSSO(LoginCredentials.email)

--- a/wire-ios/WireUITests/WireDriveTests.swift
+++ b/wire-ios/WireUITests/WireDriveTests.swift
@@ -31,9 +31,8 @@ final class WireDriveTests: WireUITestCase {
         XCTAssertTrue(activeConversationPage.sharedDriveButton.exists)
     }
 
-    /// testiny: https://app.testiny.io/IOS/testcases/tcf/1389/tc/8955/
     @MainActor
-    func test_CreateGroupConversationWithDrive() async throws {
+    func test_CreateGroupConversationWithDrive_TC_8955() async throws {
 
         let groupName = UserGenerator.generateRandomGroupName()
 

--- a/wire-ios/WireUITests/ZCallingTests.swift
+++ b/wire-ios/WireUITests/ZCallingTests.swift
@@ -89,10 +89,9 @@ final class ZCallingTests: WireUITestCase {
         return ongoingCallPage
     }
 
-    /// Testiny : https://app.testiny.io/IOS/testcases/tc/8801
     /// Team Owner create group conversation and initiate a group call with members
     @MainActor
-    func test_MultipleUsersJoiningGroupCall() async throws {
+    func testMultipleUsersJoiningGroupCall_TC_8910_TC_8880() async throws {
         do {
 
             let teamAndGroupCallSetup = try await makeTeamAndGroupCallSetup(memberCount: 3)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24719" title="WPB-24719" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24719</a>  [iOS] Backport Testiny integration to 4.17
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

**Need to backport Testiny Integration from develop to 4.17**

### Testing

Ran here o this branch and worked fine: 
https://github.com/wireapp/wire-ios/actions/runs/24442339806
Number 637
<img width="1019" height="740" alt="image" src="https://github.com/user-attachments/assets/6a87cb91-3bfb-4881-bad5-d9c9fe0bf86c" />


---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
