### PR TITLE
fix: prevent main app from blocking notification extension - WPB-23511

### DIFF
--- a/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/IncrementalSyncV2.swift
@@ -328,7 +328,7 @@ public struct IncrementalSyncV2: LiveSyncProtocol {
         var storedEnvelopes: [(UpdateEventEnvelope, Int64)] = []
 
         // decrypt
-        try await coreCryptoProvider.coreCrypto().transaction { coreCryptoContext in
+        try await coreCryptoProvider.coreCrypto().extendedTransaction { coreCryptoContext in
             for envelope in envelopes {
 
                 if DeveloperFlag.ignoreIncomingEvents.isOn {

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsSync.swift
@@ -94,7 +94,7 @@ public struct PullPendingUpdateEventsSync: PullPendingUpdateEventsSyncProtocol {
             var lastEnvelopeID: UUID?
 
             // We are decrypting the batch within one core crypto transaction
-            try await coreCryptoProvider.coreCrypto().transaction { context in
+            try await coreCryptoProvider.coreCrypto().extendedTransaction { context in
                 WireLogger.sync.debug(
                     "decrypting batch of \(envelopes.count) envelopes",
                     attributes: .safePublic

--- a/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsV2Sync.swift
+++ b/WireDomain/Sources/WireDomain/Synchronization/PullPendingUpdateEventsV2Sync.swift
@@ -134,7 +134,7 @@ public struct PullPendingUpdateEventsSyncV2: PullPendingUpdateEventsSyncV2Protoc
         var storedEnvelopes: [(UpdateEventEnvelope, Int64)] = []
 
         // decrypt
-        try await coreCryptoProvider.coreCrypto().transaction { coreCryptoContext in
+        try await coreCryptoProvider.coreCrypto().extendedTransaction { coreCryptoContext in
             for envelope in envelopes {
                 var envelope = envelope
                 envelope.events = await decryptEnvelope(envelope, in: coreCryptoContext)

--- a/WireFoundation/Sources/WireUtilitiesPackage/ExpiringActivityRegistration/withExpiringActivity.swift
+++ b/WireFoundation/Sources/WireUtilitiesPackage/ExpiringActivityRegistration/withExpiringActivity.swift
@@ -45,10 +45,10 @@ func withExpiringActivity(
 
 // MARK: - Throwing
 
-public func withExpiringActivity(
+public func withExpiringActivity<T>(
     reason: String,
-    block: @escaping @Sendable () async throws -> Void
-) async throws {
+    block: @escaping @Sendable () async throws -> T
+) async throws -> T where T: Sendable {
     try await withExpiringActivity(
         performer: ExpiringActivityProcessInfoWrapper(),
         reason: reason,
@@ -56,14 +56,14 @@ public func withExpiringActivity(
     )
 }
 
-func withExpiringActivity(
+func withExpiringActivity<T>(
     performer: some ExpiringActivityPerformerProtocol,
     reason: String,
-    block: @escaping @Sendable () async throws -> Void
-) async throws {
+    block: @escaping @Sendable () async throws -> T
+) async throws -> T where T: Sendable {
     let task = Task(operation: block)
     performer.performTaskCancellationAsExpiringActivity(reason: reason, task: task)
-    try await withTaskCancellationHandler {
+    return try await withTaskCancellationHandler {
         try await task.value
     } onCancel: {
         task.cancel()

--- a/wire-ios-data-model/Source/Core Crypto/CoreCryptoProvider.swift
+++ b/wire-ios-data-model/Source/Core Crypto/CoreCryptoProvider.swift
@@ -20,6 +20,17 @@ import Foundation
 import WireCoreCrypto
 import WireFoundation
 import WireLogging
+import WireUtilitiesPackage
+
+public extension CoreCryptoProtocol {
+
+    func extendedTransaction<T>(block: @escaping (any CoreCryptoContextProtocol) async throws -> T) async throws -> T {
+        try await withExpiringActivity(reason: "cc transation") {
+            try await self.transaction(block)
+        }
+    }
+
+}
 
 // sourcery: AutoMockable
 public protocol CoreCryptoProviderProtocol {
@@ -106,7 +117,7 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
         WireLogger.mls.info("Initialising MLS client with basic credentials")
         let defaultCiphersuite = await featureRespository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
         let coreCrypto = try await coreCrypto()
-        _ = try await coreCrypto.transaction { context in
+        _ = try await coreCrypto.extendedTransaction { context in
             try await context.mlsInit(
                 clientId: .init(bytes: mlsClientID.data),
                 ciphersuites: [defaultCiphersuite],
@@ -122,7 +133,7 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
     ) async throws -> CRLsDistributionPoints? {
         WireLogger.mls.info("Initialising MLS client from end-to-end identity enrollment")
         let coreCrypto = try await coreCrypto()
-        return try await coreCrypto.transaction { context in
+        return try await coreCrypto.extendedTransaction { context in
             let crlsDistributionPoints = try await context.e2eiMlsInitOnly(
                 enrollment: enrollment,
                 certificateChain: certificateChain,
@@ -254,7 +265,7 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
             attributes: .safePublic
         )
 
-        try await coreCrypto.transaction {
+        try await coreCrypto.extendedTransaction {
             WireLogger.coreCrypto.debug(
                 "proteus init",
                 attributes: .safePublic
@@ -297,7 +308,7 @@ public actor CoreCryptoProvider: CoreCryptoProviderProtocol {
                 "core crypto transaction...",
                 attributes: .safePublic
             )
-            try await coreCrypto.transaction {
+            try await coreCrypto.extendedTransaction {
                 WireLogger.coreCrypto.debug(
                     "mls init",
                     attributes: .safePublic

--- a/wire-ios-data-model/Source/E2EIdentity/E2EISetupService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2EISetupService.swift
@@ -71,19 +71,19 @@ public final class E2EISetupService: E2EISetupServiceInterface {
     // MARK: - Public interface
 
     public func isTrustAnchorRegistered() async throws -> Bool {
-        try await coreCryptoProvider.coreCrypto().transaction { context in
+        try await coreCryptoProvider.coreCrypto().extendedTransaction { context in
             try await context.e2eiIsPkiEnvSetup()
         }
     }
 
     public func registerTrustAnchor(_ trustAnchor: String) async throws {
-        try await coreCryptoProvider.coreCrypto().transaction { context in
+        try await coreCryptoProvider.coreCrypto().extendedTransaction { context in
             try await context.e2eiRegisterAcmeCa(trustAnchorPem: trustAnchor)
         }
     }
 
     public func registerFederationCertificate(_ certificate: String) async throws {
-        try await coreCryptoProvider.coreCrypto().transaction { context in
+        _ = try await coreCryptoProvider.coreCrypto().extendedTransaction { context in
             try await context.e2eiRegisterIntermediateCa(certPem: certificate)
         }
     }
@@ -121,7 +121,7 @@ public final class E2EISetupService: E2EISetupServiceInterface {
         let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
         let expirySec = expirySec ?? UInt32(TimeInterval.oneDay * 90)
 
-        return try await coreCrypto.transaction {
+        return try await coreCrypto.extendedTransaction {
             if isUpgradingClient {
                 let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: ciphersuite)
                 if e2eiIsEnabled {

--- a/wire-ios-data-model/Source/E2EIdentity/E2EIVerificationStatusService.swift
+++ b/wire-ios-data-model/Source/E2EIdentity/E2EIVerificationStatusService.swift
@@ -69,7 +69,7 @@ public final class E2EIVerificationStatusService: E2EIVerificationStatusServiceI
 
     public func getConversationStatus(groupID: MLSGroupID) async throws -> MLSVerificationStatus {
         do {
-            return try await coreCrypto.transaction {
+            return try await coreCrypto.extendedTransaction {
                 try await $0.e2eiConversationState(conversationId: groupID.conversationId).toMLSVerificationStatus()
             }
         } catch {

--- a/wire-ios-data-model/Source/MLS/CreateMLSGroupUseCase.swift
+++ b/wire-ios-data-model/Source/MLS/CreateMLSGroupUseCase.swift
@@ -88,7 +88,7 @@ extension CreateMLSGroupUseCase {
         // the external senders is the same as the parent, otherwise we
         // won't be able to decrypt external remove proposals from the
         // owning domain.
-        let externalSenders = try await coreCrypto.transaction {
+        let externalSenders = try await coreCrypto.extendedTransaction {
             [try await $0.getExternalSender(conversationId: parentGroupID.conversationId)]
         }
 
@@ -136,7 +136,7 @@ extension CreateMLSGroupUseCase {
                 custom: .init(keyRotationSpan: nil, wirePolicy: nil)
             )
 
-            try await coreCrypto.transaction {
+            try await coreCrypto.extendedTransaction {
                 let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: ciphersuite.coreCryptoCipherSuite)
                 try await $0.createConversation(
                     conversationId: groupID.conversationId,

--- a/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
+++ b/wire-ios-data-model/Source/MLS/MLSActionExecutor.swift
@@ -211,7 +211,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
         if let context {
             try await processWelcomeMessageInternal(message, context: context)
         } else {
-            try await coreCrypto.transaction { context in
+            try await coreCrypto.extendedTransaction { context in
                 try await self.processWelcomeMessageInternal(message, context: context)
             }
         }
@@ -240,7 +240,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             do {
                 WireLogger.mls.info("adding members to group...", attributes: groupID.safeAttributes)
 
-                let crlNewDistributionPoints = try await coreCrypto.transaction {
+                let crlNewDistributionPoints = try await coreCrypto.extendedTransaction {
                     try await $0.addClientsToConversation(
                         conversationId: groupID.conversationId,
                         keyPackages: invitees.compactMap(\.coreCryptoKeyPackage)
@@ -269,7 +269,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("removing clients from group...", attributes: groupID.safeAttributes)
-                return try await coreCrypto.transaction {
+                return try await coreCrypto.extendedTransaction {
                     try await $0.removeClientsFromConversation(
                         conversationId: groupID.conversationId,
                         clients: clients
@@ -290,7 +290,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("updating key material for group...", attributes: groupID.safeAttributes)
-                return try await coreCrypto.transaction {
+                return try await coreCrypto.extendedTransaction {
                     try await $0.updateKeyingMaterial(conversationId: groupID.conversationId)
                 }
             } catch {
@@ -308,7 +308,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
         try await performNonReentrant(groupID: groupID) {
             do {
                 WireLogger.mls.info("committing pending proposals for group", attributes: groupID.safeAttributes)
-                try await coreCrypto.transaction {
+                try await coreCrypto.extendedTransaction {
                     try await $0.commitPendingProposals(conversationId: groupID.conversationId)
                 }
                 WireLogger.mls
@@ -329,7 +329,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             do {
                 WireLogger.mls.info("joining group via external commit", attributes: groupID.safeAttributes)
                 let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
-                let conversationInitBundle = try await coreCrypto.transaction {
+                let conversationInitBundle = try await coreCrypto.extendedTransaction {
                     let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: ciphersuite)
                     return try await $0.joinByExternalCommit(
                         groupInfo: GroupInfo(bytes: groupInfo),
@@ -365,7 +365,7 @@ public actor MLSActionExecutor: MLSActionExecutorProtocol {
             try await decryptMessageInternal(message, in: groupID, context: context)
         } else {
             try await performNonReentrant(groupID: groupID) {
-                try await coreCrypto.transaction {
+                try await coreCrypto.extendedTransaction {
                     try await self.decryptMessageInternal(message, in: groupID, context: $0)
                 }
             }

--- a/wire-ios-data-model/Source/MLS/MLSEncryptionService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSEncryptionService.swift
@@ -75,7 +75,7 @@ public final class MLSEncryptionService: MLSEncryptionServiceInterface {
     ) async throws -> Data {
         do {
             WireLogger.mls.debug("encrypting message (\(message.count) bytes) for group (\(groupID))")
-            return try await coreCrypto.transaction { try await $0.encryptMessage(
+            return try await coreCrypto.extendedTransaction { try await $0.encryptMessage(
                 conversationId: groupID.conversationId,
                 message: message
             ) }

--- a/wire-ios-data-model/Source/MLS/MLSService.swift
+++ b/wire-ios-data-model/Source/MLS/MLSService.swift
@@ -180,7 +180,7 @@ public final class MLSService: MLSServiceInterface {
     }
 
     public func epoch(for groupID: MLSGroupID) async throws -> UInt64 {
-        try await coreCrypto.transaction {
+        try await coreCrypto.extendedTransaction {
             let exists = try? await $0.conversationExists(conversationId: groupID.conversationId)
             if exists == true {
                 return try await $0.conversationEpoch(conversationId: groupID.conversationId)
@@ -201,7 +201,7 @@ public final class MLSService: MLSServiceInterface {
 
             let keyLength: UInt32 = 32
 
-            return try await coreCrypto.transaction {
+            return try await coreCrypto.extendedTransaction {
                 let epoch = try await $0.conversationEpoch(conversationId: subconversationGroupID.conversationId)
 
                 let secretKey = try await $0.exportSecretKey(
@@ -237,7 +237,7 @@ public final class MLSService: MLSServiceInterface {
 
     public func subconversationMembers(for subconversationGroupID: MLSGroupID) async throws -> [MLSClientID] {
         do {
-            return try await coreCrypto.transaction {
+            return try await coreCrypto.extendedTransaction {
                 try await $0.getClientIds(conversationId: subconversationGroupID.conversationId).compactMap {
                     MLSClientID(data: $0.copyBytes())
                 }
@@ -568,7 +568,7 @@ public final class MLSService: MLSServiceInterface {
         logger.info("wiping group", attributes: groupID.safeAttributes)
 
         do {
-            try await coreCrypto.transaction { [self] in
+            try await coreCrypto.extendedTransaction { [self] in
                 guard try await $0.conversationExists(
                     conversationId: groupID.conversationId
                 ) else {
@@ -654,7 +654,7 @@ public final class MLSService: MLSServiceInterface {
             }
 
             let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
-            let estimatedLocalKeyPackageCount = try await coreCrypto.transaction {
+            let estimatedLocalKeyPackageCount = try await coreCrypto.extendedTransaction {
                 try await $0.clientValidKeypackagesCount(ciphersuite: ciphersuite, credentialType: .basic)
             }
             let shouldCountRemainingKeyPackages = estimatedLocalKeyPackageCount < halfOfTargetUnclaimedKeyPackageCount
@@ -711,7 +711,7 @@ public final class MLSService: MLSServiceInterface {
 
         do {
             let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
-            keyPackages = try await coreCrypto.transaction {
+            keyPackages = try await coreCrypto.extendedTransaction {
                 let e2eiIsEnabled = try await $0.e2eiIsEnabled(ciphersuite: ciphersuite)
                 return try await $0.clientKeypackages(
                     ciphersuite: ciphersuite,
@@ -762,7 +762,7 @@ public final class MLSService: MLSServiceInterface {
     }
 
     public func externalSenderKey(groupID: MLSGroupID) async throws -> Data {
-        try await coreCrypto.transaction { coreCrypto in
+        try await coreCrypto.extendedTransaction { coreCrypto in
             try await coreCrypto.getExternalSender(conversationId: groupID.conversationId)
         }.copyBytes()
     }
@@ -770,7 +770,7 @@ public final class MLSService: MLSServiceInterface {
     public func conversationExists(groupID: MLSGroupID) async throws -> Bool {
 
         logger.info("checking if group (\(groupID)) exists...")
-        let result = try await coreCrypto.transaction { coreCrypto in
+        let result = try await coreCrypto.extendedTransaction { coreCrypto in
             try await coreCrypto.conversationExists(conversationId: groupID.conversationId)
         }
         logger.info("... group (\(groupID)) " + (result ? "exists!" : "does not exist!"))
@@ -1161,7 +1161,7 @@ public final class MLSService: MLSServiceInterface {
     private func outOfSyncConversations(in context: NSManagedObjectContext) async throws
         -> [OutOfSyncConversationInfo] {
 
-        let conversations = try await coreCrypto.transaction { coreCrypto in
+        let conversations = try await coreCrypto.extendedTransaction { coreCrypto in
 
             let allMLSConversations = await context.perform { ZMConversation.fetchMLSConversations(in: context) }
 
@@ -1232,7 +1232,7 @@ public final class MLSService: MLSServiceInterface {
         subgroup: MLSSubgroup?,
         context: NSManagedObjectContext
     ) async throws -> Bool {
-        try await coreCrypto.transaction {
+        try await coreCrypto.extendedTransaction {
             await self.isConversationOutOfSync(
                 conversation,
                 subgroup: subgroup,
@@ -1823,7 +1823,7 @@ public final class MLSService: MLSServiceInterface {
                 parentGroupID: parentGroupID
             )
 
-            try await coreCrypto.transaction {
+            try await coreCrypto.extendedTransaction {
                 try await $0.wipeConversation(conversationId: subconversationGroupID.conversationId)
             }
         } catch {

--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -60,7 +60,7 @@ public final class ProteusService: ProteusServiceInterface {
         }
 
         do {
-            try await coreCrypto.transaction { try await $0.proteusSessionFromPrekey(
+            try await coreCrypto.extendedTransaction { try await $0.proteusSessionFromPrekey(
                 sessionId: id.rawValue,
                 prekey: prekeyData
             ) }
@@ -80,7 +80,7 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("deleting session")
 
         do {
-            try await coreCrypto.transaction { try await $0.proteusSessionDelete(sessionId: id.rawValue) }
+            try await coreCrypto.extendedTransaction { try await $0.proteusSessionDelete(sessionId: id.rawValue) }
         } catch {
             logger.error("failed to delete session: \(String(describing: error))")
             throw DeleteSessionError.failedToDeleteSession
@@ -98,7 +98,7 @@ public final class ProteusService: ProteusServiceInterface {
 
     func saveSession(id: ProteusSessionID) async throws {
         do {
-            try await coreCrypto.transaction { try await $0.proteusSessionSave(sessionId: id.rawValue) }
+            try await coreCrypto.extendedTransaction { try await $0.proteusSessionSave(sessionId: id.rawValue) }
         } catch {
             // swiftlint:disable:next todo_requires_jira_link
             // TODO: Log error
@@ -112,7 +112,7 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("checking if session exists")
 
         do {
-            return try await coreCrypto.transaction { try await $0.proteusSessionExists(sessionId: id.rawValue) }
+            return try await coreCrypto.extendedTransaction { try await $0.proteusSessionExists(sessionId: id.rawValue) }
         } catch {
             logger.error("failed to check if session exists \(String(describing: error))")
             return false
@@ -155,7 +155,7 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("encrypting data")
 
         do {
-            return try await coreCrypto.transaction {
+            return try await coreCrypto.extendedTransaction {
                 try await $0.proteusEncrypt(
                     sessionId: id.rawValue,
                     plaintext: data
@@ -175,7 +175,7 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("encrypting data batch")
 
         do {
-            return try await coreCrypto.transaction {
+            return try await coreCrypto.extendedTransaction {
                 try await $0.proteusEncryptBatched(
                     sessions: sessions.map(\.rawValue),
                     plaintext: data
@@ -222,7 +222,7 @@ public final class ProteusService: ProteusServiceInterface {
         if let context {
             try await decryptInternal(data: data, forSession: id, context: context)
         } else {
-            try await coreCrypto.transaction { context in
+            try await coreCrypto.extendedTransaction { context in
                 try await self.decryptInternal(data: data, forSession: id, context: context)
             }
         }
@@ -283,7 +283,7 @@ public final class ProteusService: ProteusServiceInterface {
     public func generatePrekey(id: UInt16) async throws -> String {
         do {
             return try await coreCrypto
-                .transaction { try await $0.proteusNewPrekey(prekeyId: id).base64EncodedString() }
+                .extendedTransaction { try await $0.proteusNewPrekey(prekeyId: id).base64EncodedString() }
         } catch {
             throw PrekeyError.failedToGeneratePrekey
         }
@@ -292,7 +292,7 @@ public final class ProteusService: ProteusServiceInterface {
     public func lastPrekey() async throws -> String {
         logger.info("getting last resort prekey")
         do {
-            return try await coreCrypto.transaction { try await $0.proteusLastResortPrekey().base64EncodedString() }
+            return try await coreCrypto.extendedTransaction { try await $0.proteusLastResortPrekey().base64EncodedString() }
         } catch {
             logger.error("failed to get last resort prekey: \(String(describing: error))")
             throw PrekeyError.failedToGetLastPrekey
@@ -301,7 +301,7 @@ public final class ProteusService: ProteusServiceInterface {
 
     public var lastPrekeyID: UInt16 {
         get async {
-            let lastPrekeyID = try? await coreCrypto.transaction { try $0.proteusLastResortPrekeyId() }
+            let lastPrekeyID = try? await coreCrypto.extendedTransaction { try $0.proteusLastResortPrekeyId() }
             return lastPrekeyID ?? UInt16.max
         }
     }
@@ -352,7 +352,7 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("fetching local fingerprint")
 
         do {
-            return try await coreCrypto.transaction { try await $0.proteusFingerprint() }
+            return try await coreCrypto.extendedTransaction { try await $0.proteusFingerprint() }
         } catch {
             logger.error("failed to fetch local fingerprint: \(String(describing: error))")
             throw FingerprintError.failedToGetLocalFingerprint
@@ -363,7 +363,7 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("fetching remote fingerprint")
 
         do {
-            return try await coreCrypto.transaction { try await $0.proteusFingerprintRemote(sessionId: id.rawValue) }
+            return try await coreCrypto.extendedTransaction { try await $0.proteusFingerprintRemote(sessionId: id.rawValue) }
         } catch {
             logger.error("failed to fetch remote fingerprint: \(String(describing: error))")
             throw FingerprintError.failedToGetRemoteFingerprint
@@ -378,7 +378,7 @@ public final class ProteusService: ProteusServiceInterface {
         }
 
         do {
-            return try await coreCrypto.transaction { try $0.proteusFingerprintPrekeybundle(prekey: prekeyData) }
+            return try await coreCrypto.extendedTransaction { try $0.proteusFingerprintPrekeybundle(prekey: prekeyData) }
         } catch {
             logger.error("failed to get fingerprint from prekey: \(String(describing: error))")
             throw FingerprintError.failedToGetFingerprintFromPrekey

--- a/wire-ios-data-model/Source/Proteus/ProteusService.swift
+++ b/wire-ios-data-model/Source/Proteus/ProteusService.swift
@@ -112,7 +112,8 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("checking if session exists")
 
         do {
-            return try await coreCrypto.extendedTransaction { try await $0.proteusSessionExists(sessionId: id.rawValue) }
+            return try await coreCrypto
+                .extendedTransaction { try await $0.proteusSessionExists(sessionId: id.rawValue) }
         } catch {
             logger.error("failed to check if session exists \(String(describing: error))")
             return false
@@ -292,7 +293,8 @@ public final class ProteusService: ProteusServiceInterface {
     public func lastPrekey() async throws -> String {
         logger.info("getting last resort prekey")
         do {
-            return try await coreCrypto.extendedTransaction { try await $0.proteusLastResortPrekey().base64EncodedString() }
+            return try await coreCrypto
+                .extendedTransaction { try await $0.proteusLastResortPrekey().base64EncodedString() }
         } catch {
             logger.error("failed to get last resort prekey: \(String(describing: error))")
             throw PrekeyError.failedToGetLastPrekey
@@ -363,7 +365,8 @@ public final class ProteusService: ProteusServiceInterface {
         logger.info("fetching remote fingerprint")
 
         do {
-            return try await coreCrypto.extendedTransaction { try await $0.proteusFingerprintRemote(sessionId: id.rawValue) }
+            return try await coreCrypto
+                .extendedTransaction { try await $0.proteusFingerprintRemote(sessionId: id.rawValue) }
         } catch {
             logger.error("failed to fetch remote fingerprint: \(String(describing: error))")
             throw FingerprintError.failedToGetRemoteFingerprint
@@ -378,7 +381,8 @@ public final class ProteusService: ProteusServiceInterface {
         }
 
         do {
-            return try await coreCrypto.extendedTransaction { try $0.proteusFingerprintPrekeybundle(prekey: prekeyData) }
+            return try await coreCrypto
+                .extendedTransaction { try $0.proteusFingerprintPrekeybundle(prekey: prekeyData) }
         } catch {
             logger.error("failed to get fingerprint from prekey: \(String(describing: error))")
             throw FingerprintError.failedToGetFingerprintFromPrekey

--- a/wire-ios-data-model/Source/UseCases/IsUserE2EICertifiedUseCase.swift
+++ b/wire-ios-data-model/Source/UseCases/IsUserE2EICertifiedUseCase.swift
@@ -70,7 +70,7 @@ public struct IsUserE2EICertifiedUseCase: IsUserE2EICertifiedUseCaseProtocol {
 
         // make the call to Core Crypto
         let coreCrypto = try await coreCryptoProvider.coreCrypto()
-        let userIdentities = try await coreCrypto.transaction { context in
+        let userIdentities = try await coreCrypto.extendedTransaction { context in
             // get MLS group members
             let allUserIdentities = try await context.getUserIdentities(
                 conversationId: mlsGroupID.conversationId,

--- a/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
+++ b/wire-ios-data-model/WireDataModel.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0176B8812E7AE25B005D448B /* WireLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 0176B8802E7AE25B005D448B /* WireLogging */; };
 		01D2B7A32D64A8F50030D28D /* WireCoreCrypto in Frameworks */ = {isa = PBXBuildFile; productRef = 01D2B7A22D64A8F50030D28D /* WireCoreCrypto */; };
 		1657FA9A2D9C2EB800A7B337 /* WireCoreCryptoUniffi in Frameworks */ = {isa = PBXBuildFile; productRef = 1657FA992D9C2EB800A7B337 /* WireCoreCryptoUniffi */; };
+		34A4F28F2F8FBC4B006FA043 /* WireUtilitiesPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 34A4F28E2F8FBC4B006FA043 /* WireUtilitiesPackage */; };
 		34DC44B52E01C210004D5DD5 /* WireNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = 34DC44B42E01C210004D5DD5 /* WireNetwork */; };
 		5902AC752DA92365000A8F7F /* WireFoundationSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 5902AC742DA92365000A8F7F /* WireFoundationSupport */; };
 		591B6E4C2C8B09C6009F8A7B /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9C9A66E1CAD77930039E10C /* CoreData.framework */; };
@@ -189,6 +190,7 @@
 				E6707E902BBD683F00469D57 /* PINCache in Frameworks */,
 				59B48C5C2C89CBBD00EA7999 /* WireFoundation in Frameworks */,
 				EE8DA9702954A03E00F58B79 /* WireImages.framework in Frameworks */,
+				34A4F28F2F8FBC4B006FA043 /* WireUtilitiesPackage in Frameworks */,
 				59537CDB2CFF8F2B00920B59 /* WireLogging in Frameworks */,
 				EE8DA96A2954A03100F58B79 /* WireTransport.framework in Frameworks */,
 				01D2B7A32D64A8F50030D28D /* WireCoreCrypto in Frameworks */,
@@ -347,6 +349,7 @@
 				59506A872E2E61BD0051B07A /* SwiftProtobuf */,
 				5950B0342E2EA1070051B07A /* GenericMessageProtocol */,
 				CBB648A42E33D18900FA52AA /* WireData */,
+				34A4F28E2F8FBC4B006FA043 /* WireUtilitiesPackage */,
 			);
 			productName = WireDataModel;
 			productReference = F9C9A4FC1CAD5DF10039E10C /* WireDataModel.framework */;
@@ -918,6 +921,10 @@
 		1657FA992D9C2EB800A7B337 /* WireCoreCryptoUniffi */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WireCoreCryptoUniffi;
+		};
+		34A4F28E2F8FBC4B006FA043 /* WireUtilitiesPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = WireUtilitiesPackage;
 		};
 		34DC44B42E01C210004D5DD5 /* WireNetwork */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/wire-ios-request-strategy/Sources/E2EIdentity/E2EIKeyPackageRotator.swift
+++ b/wire-ios-request-strategy/Sources/E2EIdentity/E2EIKeyPackageRotator.swift
@@ -85,7 +85,7 @@ public class E2EIKeyPackageRotator: E2EIKeyPackageRotating {
             throw Error.invalidIdentity
         }
 
-        let crlNewDistributionPoints = try await coreCrypto.transaction { context in
+        let crlNewDistributionPoints = try await coreCrypto.extendedTransaction { context in
             try await context.saveX509Credential(
                 enrollment: enrollment,
                 certificateChain: certificateChain
@@ -117,7 +117,7 @@ public class E2EIKeyPackageRotator: E2EIKeyPackageRotating {
             return mlsGroupIDs
         }
 
-        try await coreCrypto.transaction { context in
+        try await coreCrypto.extendedTransaction { context in
             for groupID in mlsConversationsToMigrate {
                 do {
                     try await context.e2eiRotate(conversationId: groupID.conversationId)
@@ -144,7 +144,7 @@ public class E2EIKeyPackageRotator: E2EIKeyPackageRotating {
             throw Error.invalidCiphersuite
         }
 
-        try await coreCrypto.transaction { coreCryptoContext in
+        try await coreCrypto.extendedTransaction { coreCryptoContext in
             try await coreCryptoContext.deleteStaleKeyPackages(
                 ciphersuite: ciphersuite.coreCryptoCipherSuite
             )

--- a/wire-ios-sync-engine/Source/E2EI/CRL/CertificateRevocationListsChecker.swift
+++ b/wire-ios-sync-engine/Source/E2EI/CRL/CertificateRevocationListsChecker.swift
@@ -131,7 +131,7 @@ public class CertificateRevocationListsChecker: CertificateRevocationListsChecki
                 let crlData = try await crlAPI.getRevocationList(from: crlURL)
 
                 // register the CRL with core crypto
-                let registration = try await coreCrypto.transaction {
+                let registration = try await coreCrypto.extendedTransaction {
                     try await $0.e2eiRegisterCrl(crlDp: distributionPoint.absoluteString, crlDer: crlData)
                 }
 

--- a/wire-ios-sync-engine/Source/Use cases/CheckOneOnOneConversationIsReadyUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/CheckOneOnOneConversationIsReadyUseCase.swift
@@ -88,7 +88,7 @@ struct CheckOneOnOneConversationIsReadyUseCase: CheckOneOnOneConversationIsReady
     // MARK: - Helpers
 
     private func isMLSConversationEstablished(groupID: MLSGroupID) async throws -> Bool {
-        try await coreCryptoProvider.coreCrypto().transaction {
+        try await coreCryptoProvider.coreCrypto().extendedTransaction {
             try await $0.conversationExists(conversationId: groupID.conversationId)
         }
     }

--- a/wire-ios-sync-engine/Source/Use cases/GetE2eIdentityCertificatesUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/GetE2eIdentityCertificatesUseCase.swift
@@ -127,7 +127,7 @@ public final class GetE2eIdentityCertificatesUseCase: GetE2eIdentityCertificates
         conversationId: WireCoreCryptoUniffi.ConversationId,
         clientIDs: [WireCoreCryptoUniffi.ClientId]
     ) async throws -> [WireIdentity] {
-        try await coreCrypto.transaction {
+        try await coreCrypto.extendedTransaction {
             try await $0.getDeviceIdentities(
                 conversationId: conversationId,
                 deviceIds: clientIDs

--- a/wire-ios-sync-engine/Source/Use cases/GetIsE2EIdentityEnabledUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/GetIsE2EIdentityEnabledUseCase.swift
@@ -39,7 +39,7 @@ public final class GetIsE2EIdentityEnabledUseCase: GetIsE2EIdentityEnabledUseCas
     public func invoke() async throws -> Bool {
         let ciphersuite = await featureRepository.fetchMLS().config.defaultCipherSuite.coreCryptoCipherSuite
         let coreCrypto = try await coreCryptoProvider.coreCrypto()
-        return try await coreCrypto.transaction {
+        return try await coreCrypto.extendedTransaction {
             try await $0.e2eiIsEnabled(ciphersuite: ciphersuite)
         }
     }

--- a/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_2.swift
+++ b/wire-ios-sync-engine/Source/UserSession/ZMUserSession/AppVersionMigrations/AppVersionMigration_4_12_2.swift
@@ -42,7 +42,7 @@ struct AppVersionMigration_4_12_2: AppVersionMigration {
 
         for mlsGroupID in mlsGroupIDs {
 
-            try await coreCrypto.transaction { ccContext in
+            try await coreCrypto.extendedTransaction { ccContext in
                 let epoch: UInt64 = if try await ccContext
                     .conversationExists(conversationId: mlsGroupID.conversationId) {
                     UInt64(try await ccContext.conversationEpoch(conversationId: mlsGroupID.conversationId))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-23511" title="WPB-23511" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-23511</a>  [iOS] NSE is often getting stuck and expiring
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue
It's been observed that the Notification Service Extension (NSE) sometimes gets stuck and expires after 30 seconds of activity. Once this occurs, it typically repeats for every push received by the NSE until the main app is opened. 

After some thorough investigation, I found that the NSE gets stuck waiting on a Core Crypto transaction. There is a Core Crypto instance in both the main app and the NSE and to ensure that there is safe access to shared mutable state, Core Crypto internally uses file locks to make the transaction blocks are executed sequentially. The problem is that if the main app starts a CC transaction and then goes to the background before the transaction completes then execution would freeze while the lock is acquired and wouldn't be released. At the same time the push channel is closed and so new events will be delivered as pushes to the NSE which would be stuck indefinitely waiting for the lock to be released.

The solution is to ensure that all CC transactions can complete even before the app is suspended, which we can achieve by wrapping all transactions inside expiring activates. This ensures that even when we go to the background the file lock will be released and allow the NSE to run.

Changes include:
- modify the expiring activity function to return the wrapped task's result
- add an `extendedTransaction` function to Core Crypto that performs a transaction in an expiring activity
- use the `extentedTransaction` 


### Testing

The best way to verify this fix is to let it run in beta for a little while and observe how many NSE expirations occur.

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
