### PR TITLE
fix: revert "chore: remove session manager completion handlers (#4301)" - WPB-23401

### DIFF
--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+AuthenticationStatusDelegate.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+AuthenticationStatusDelegate.swift
@@ -32,9 +32,7 @@ extension SessionManager: ZMAuthenticationStatusDelegate {
     }
 
     public func authenticationWasRequested() {
-        Task {
-            await addAccount()
-        }
+        addAccount()
     }
 
     public func loginCodeRequestDidFail(_ error: Error!) {
@@ -46,11 +44,9 @@ extension SessionManager: ZMAuthenticationStatusDelegate {
     }
 
     public func companyLoginCodeDidBecomeAvailable(_ uuid: UUID!) {
-        Task {
-            await addAccount(userInfo: [
-                SessionManager.companyLoginCodeKey: uuid ?? UUID(),
-                SessionManager.companyLoginRequestTimestampKey: Date()
-            ])
-        }
+        addAccount(userInfo: [
+            SessionManager.companyLoginCodeKey: uuid ?? UUID(),
+            SessionManager.companyLoginRequestTimestampKey: Date()
+        ])
     }
 }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+EncryptionAtRest.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+EncryptionAtRest.swift
@@ -28,20 +28,22 @@ extension SessionManager: UserSessionEncryptionAtRestDelegate {
         let sharedContainerURL = sharedContainerURL
 
         delegate?.sessionManagerWillMigrateAccount(userSessionCanBeTornDown: { [weak self] in
-            Task {
-                await self?.tearDownBackgroundSession(for: account.userIdentifier)
+            self?.tearDownBackgroundSession(for: account.userIdentifier) {
                 self?.setActiveUserSession(nil)
-                do {
-                    try await CoreDataStack.migrateLocalStorage(
-                        accountIdentifier: account.userIdentifier,
-                        applicationContainer: sharedContainerURL,
-                        migration: onReady
-                    )
-                } catch {
-                    WireLogger.ear.error("failed to migrate account: \(error)")
-                }
+                Task {
+                    do {
+                        try await CoreDataStack.migrateLocalStorage(
+                            accountIdentifier: account.userIdentifier,
+                            applicationContainer: sharedContainerURL,
+                            migration: onReady
+                        )
 
-                _ = await self?.loadSession(for: account)
+                    } catch {
+                        WireLogger.ear.error("failed to migrate account: \(error)")
+                    }
+
+                    _ = await self?.loadSession(for: account)
+                }
             }
         })
     }

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager+Push.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager+Push.swift
@@ -77,7 +77,7 @@ extension SessionManager: UNUserNotificationCenterDelegate {
         // route to user session
         do {
             let userSession = try await loadSession(userInfo: response.notification.userInfo)
-            return await userSession.userNotificationCenter(center, didReceive: response)
+            await userSession.userNotificationCenter(center, didReceive: response)
         } catch let error as NSError {
             let errorString = error.safeForLoggingDescription
             let responseString = response.safeForLoggingDescription
@@ -117,17 +117,21 @@ extension SessionManager: UNUserNotificationCenterDelegate {
         return try await withSession(for: account)
     }
 
-    fileprivate func activateAccount(for session: ZMUserSession) async {
+    fileprivate func activateAccount(for session: ZMUserSession, completion: @escaping () -> Void) {
         if session == activeUserSession {
+            completion()
             return
         }
 
         var foundSession = false
-        for (accountId, backgroundSession) in backgroundUserSessions {
-            if session == backgroundSession, let account = accountManager.account(with: accountId) {
-                _ = await select(account)
+        backgroundUserSessions.forEach { accountId, backgroundSession in
+            if session == backgroundSession, let account = self.accountManager.account(with: accountId) {
+
+                self.select(account, completion: { _ in
+                    completion()
+                })
                 foundSession = true
-                break
+                return
             }
         }
 
@@ -148,16 +152,14 @@ public extension SessionManager {
             return
         }
 
-        Task {
-            await activateAccount(for: session)
-            presentationDelegate?.showConversation(conversation, at: message)
+        activateAccount(for: session) {
+            self.presentationDelegate?.showConversation(conversation, at: message)
         }
     }
 
     func showConversationList(in session: ZMUserSession) {
-        Task {
-            await activateAccount(for: session)
-            presentationDelegate?.showConversationList()
+        activateAccount(for: session) {
+            self.presentationDelegate?.showConversationList()
         }
     }
 

--- a/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
+++ b/wire-ios-sync-engine/Source/SessionManager/SessionManager.swift
@@ -76,6 +76,11 @@ public protocol SessionManagerDelegate: AnyObject, SessionActivationObserver {
         error: Error?,
         userSessionCanBeTornDown: (() -> Void)?
     )
+    func sessionManagerWillOpenAccount(
+        _ account: Account,
+        from selectedAccount: Account?,
+        userSessionCanBeTornDown: @escaping () -> Void
+    )
     func sessionManagerWillMigrateAccount(userSessionCanBeTornDown: @escaping () -> Void)
 
     func sessionManagerDidFailToLoadSession(
@@ -706,40 +711,71 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     /// Select the account to be the active account.
-    @MainActor
-    public func select(_ account: Account) async -> ZMUserSession? {
+    /// - completion: runs when the user session was loaded
+    /// - tearDownCompletion: runs when the UI no longer holds any references to the previous user session.
+    public func select(
+        _ account: Account,
+        completion: ((ZMUserSession?) -> Void)? = nil,
+        tearDownCompletion: (() -> Void)? = nil
+    ) {
         guard !isSelectingAccount else {
-            return nil
+            completion?(nil)
+            return
         }
 
-        let isConfirmed = await confirmSwitchingAccount()
-        guard isConfirmed else {
-            return nil
+        confirmSwitchingAccount { [weak self] isConfirmed in
+
+            guard isConfirmed else {
+                completion?(nil)
+                return
+            }
+
+            self?.isSelectingAccount = true
+            let selectedAccount = self?.accountManager.selectedAccount
+
+            guard let delegate = self?.delegate else {
+                completion?(nil)
+                return
+            }
+            delegate.sessionManagerWillOpenAccount(
+                account,
+                from: selectedAccount,
+                userSessionCanBeTornDown: { [weak self] in
+                    self?.setActiveUserSession(nil)
+                    tearDownCompletion?()
+
+                    Task { @MainActor [weak self] in
+                        guard let self else {
+                            completion?(nil)
+                            return
+                        }
+
+                        accountManager.select(account)
+                        let session = await loadSession(for: account)
+                        isSelectingAccount = false
+
+                        if let session {
+                            completion?(session)
+                        } else {
+                            completion?(nil)
+                        }
+                    }
+                }
+            )
         }
-
-        isSelectingAccount = true
-        setActiveUserSession(nil)
-        accountManager.select(account)
-        let session = await loadSession(for: account)
-        isSelectingAccount = false
-
-        return session
     }
 
-    @MainActor
-    public func addAccount(userInfo: [String: Any]? = nil) async {
-        let isConfirmed = await confirmSwitchingAccount()
-        guard isConfirmed, let delegate else { return }
-
-        let error = NSError(userSessionErrorCode: .addAccountRequested, userInfo: userInfo)
-        await withCheckedContinuation { continuation in
-            delegate.sessionManagerWillLogout(
+    public func addAccount(userInfo: [String: Any]? = nil, completion: (() -> Void)? = nil) {
+        confirmSwitchingAccount { [weak self] isConfirmed in
+            guard isConfirmed else { return }
+            let error = NSError(userSessionErrorCode: .addAccountRequested, userInfo: userInfo)
+            self?.delegate?.sessionManagerWillLogout(
                 accountID: nil,
                 environment: nil,
                 error: error
             ) { [weak self] in
                 self?.setActiveUserSession(nil)
-                continuation.resume()
+                completion?()
             }
         }
     }
@@ -766,10 +802,9 @@ public final class SessionManager: NSObject, SessionManagerType {
         WireLogger.sessionManager.debug("Deleting account \(account.userIdentifier)...")
         if let secondAccount = accountManager.inactiveAccounts.first {
             // Deleted an account but we can switch to another account
-            Task {
-                _ = await select(secondAccount)
-                tearDownSessionAndDelete(account: account, eraseData: eraseData)
-            }
+            select(secondAccount, tearDownCompletion: { [weak self] in
+                self?.tearDownSessionAndDelete(account: account, eraseData: eraseData)
+            })
         } else if accountManager.selectedAccount != account {
             // Deleted an inactive account, there's no need notify the UI
             tearDownSessionAndDelete(account: account, eraseData: eraseData)
@@ -784,10 +819,9 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     fileprivate func tearDownSessionAndDelete(account: Account, eraseData: Bool) {
-        Task {
-            await tearDownBackgroundSession(for: account.userIdentifier)
+        tearDownBackgroundSession(for: account.userIdentifier) {
             if eraseData {
-                deleteAccountData(for: account)
+                self.deleteAccountData(for: account)
             }
         }
     }
@@ -803,9 +837,7 @@ public final class SessionManager: NSObject, SessionManagerType {
             if accountSession == activeSession {
                 logoutCurrentSession(deleteCookie: true, deleteAccount: false, error: error)
             } else {
-                Task {
-                    await tearDownBackgroundSession(for: account.userIdentifier)
-                }
+                tearDownBackgroundSession(for: account.userIdentifier)
             }
         }
     }
@@ -1091,24 +1123,27 @@ public final class SessionManager: NSObject, SessionManagerType {
     }
 
     /// The active user session will be torn down and the app goes into migration state.
-    @MainActor
-    public func prepareForRestoreWithMigration() async {
+    public func prepareForRestoreWithMigration(completion: @escaping () -> Void) {
         guard let delegate else {
             WireLogger.sessionManager.debug("SessionManager.delegate is nil, aborting migration preparation")
-            return
+            return completion()
         }
 
         WireLogger.sessionManager.debug("SessionManager.delegate.sessionManagerWillMigrateAccount ...")
-        await delegate.sessionManagerWillMigrateAccount()
+        delegate.sessionManagerWillMigrateAccount { [self] in
 
-        WireLogger.sessionManager.debug("... userSessionCanBeTornDown { ... }")
+            WireLogger.sessionManager.debug("... userSessionCanBeTornDown { ... }")
 
-        if let accountID = activeUserSession?.account.userIdentifier {
-            await tearDownBackgroundSession(for: accountID)
-            setActiveUserSession(nil)
-            accountTokens.removeValue(forKey: accountID)
-        } else {
-            setActiveUserSession(nil)
+            if let accountID = activeUserSession?.account.userIdentifier {
+                tearDownBackgroundSession(for: accountID) { [self] in
+                    setActiveUserSession(nil)
+                    accountTokens.removeValue(forKey: accountID)
+                    completion()
+                }
+            } else {
+                setActiveUserSession(nil)
+                completion()
+            }
         }
     }
 
@@ -1275,24 +1310,23 @@ public final class SessionManager: NSObject, SessionManagerType {
         notifyNewUserSessionCreated(newSession)
     }
 
-    @MainActor
-    func tearDownBackgroundSession(for accountId: UUID) async {
+    func tearDownBackgroundSession(for accountId: UUID, completion: (() -> Void)? = nil) {
         guard let userSession = backgroundUserSessions[accountId] else {
             WireLogger.sessionManager
                 .error("No session to tear down for \(accountId), known sessions: \(backgroundUserSessions)")
+            completion?()
             return
         }
         tearDownObservers(account: accountId)
         state.withLockUnchecked { $0.backgroundUserSessions[accountId] = nil }
 
         dispatchGroup.enter()
-        await withCheckedContinuation { continuation in
-            userSession.close(deleteCookie: false) { [weak self] in
-                self?.notifyUserSessionDestroyed(accountId)
-                continuation.resume()
-                self?.dispatchGroup.leave()
-            }
+        userSession.close(deleteCookie: false) { [weak self] in
+            self?.notifyUserSessionDestroyed(accountId)
+            completion?()
+            self?.dispatchGroup.leave()
         }
+
     }
 
     // Tears down and releases all background user sessions.
@@ -1303,10 +1337,8 @@ public final class SessionManager: NSObject, SessionManagerType {
             }
         }
 
-        Task {
-            for key in backgroundSessions.keys {
-                await tearDownBackgroundSession(for: key)
-            }
+        backgroundSessions.keys.forEach {
+            tearDownBackgroundSession(for: $0)
         }
     }
 
@@ -1841,28 +1873,22 @@ extension SessionManager: NotificationContext {
 
 public extension SessionManager {
 
-    @MainActor
-    func confirmSwitchingAccount() async -> Bool {
+    func confirmSwitchingAccount(completion: @escaping (_ isConfirmed: Bool) -> Void) {
         guard
             let switchingDelegate,
             let activeUserSession,
             activeUserSession.isCallOngoing
         else {
             // no confirmation to show if no call is ongoing
-            return true
+            return completion(true)
         }
 
-        let confirmed = await withCheckedContinuation { continuation in
-            switchingDelegate.confirmSwitchingAccount { confirmed in
-                continuation.resume(returning: confirmed)
+        switchingDelegate.confirmSwitchingAccount { confirmed in
+            if confirmed {
+                activeUserSession.callCenter?.endAllCalls()
             }
+            completion(confirmed)
         }
-
-        if confirmed {
-            activeUserSession.callCenter?.endAllCalls()
-        }
-
-        return confirmed
     }
 }
 

--- a/wire-ios-sync-engine/Source/Use cases/ImportBackupUseCase/SessionManager+importBackupUseCase.swift
+++ b/wire-ios-sync-engine/Source/Use cases/ImportBackupUseCase/SessionManager+importBackupUseCase.swift
@@ -50,12 +50,17 @@ private struct ImportBackupAppStateUpdater: ImportBackupAppStateUpdaterProtocol 
 
     @MainActor
     func reportMigrationNeeded() async {
-        await sessionManager.prepareForRestoreWithMigration()
+        await withCheckedContinuation { continuation in
+            sessionManager.prepareForRestoreWithMigration(completion: continuation.resume)
+        }
     }
 
     @MainActor
     func selectAccountAndTriggerSlowSync(_ account: Account) async {
-        guard let userSession = await sessionManager.select(account) else { return }
+        let userSession = await withCheckedContinuation { continuation in
+            sessionManager.select(account, completion: { continuation.resume(returning: $0) })
+        }
+        guard let userSession else { return }
         do {
             try await userSession.syncAgent?.performInitialSync()
         } catch {

--- a/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios-sync-engine/Support/Sourcery/generated/AutoMockable.generated.swift
@@ -806,6 +806,21 @@ public class MockSessionManagerDelegate: SessionManagerDelegate {
         mock(accountID, environment, error, userSessionCanBeTornDown)
     }
 
+    // MARK: - sessionManagerWillOpenAccount
+
+    public var sessionManagerWillOpenAccountFromUserSessionCanBeTornDown_Invocations: [(account: Account, selectedAccount: Account?, userSessionCanBeTornDown: () -> Void)] = []
+    public var sessionManagerWillOpenAccountFromUserSessionCanBeTornDown_MockMethod: ((Account, Account?, @escaping () -> Void) -> Void)?
+
+    public func sessionManagerWillOpenAccount(_ account: Account, from selectedAccount: Account?, userSessionCanBeTornDown: @escaping () -> Void) {
+        sessionManagerWillOpenAccountFromUserSessionCanBeTornDown_Invocations.append((account: account, selectedAccount: selectedAccount, userSessionCanBeTornDown: userSessionCanBeTornDown))
+
+        guard let mock = sessionManagerWillOpenAccountFromUserSessionCanBeTornDown_MockMethod else {
+            fatalError("no mock for `sessionManagerWillOpenAccountFromUserSessionCanBeTornDown`")
+        }
+
+        mock(account, selectedAccount, userSessionCanBeTornDown)
+    }
+
     // MARK: - sessionManagerWillMigrateAccount
 
     public var sessionManagerWillMigrateAccountUserSessionCanBeTornDown_Invocations: [() -> Void] = []

--- a/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
+++ b/wire-ios/Tests/Sourcery/generated/AutoMockable.generated.swift
@@ -72,16 +72,31 @@ class MockAccountSelector: AccountSelector {
     // MARK: - switchTo
 
     var switchToAccount_Invocations: [Account] = []
-    var switchToAccount_MockMethod: ((Account) async -> Void)?
+    var switchToAccount_MockMethod: ((Account) -> Void)?
 
-    func switchTo(account: Account) async {
+    func switchTo(account: Account) {
         switchToAccount_Invocations.append(account)
 
         guard let mock = switchToAccount_MockMethod else {
             fatalError("no mock for `switchToAccount`")
         }
 
-        await mock(account)
+        mock(account)
+    }
+
+    // MARK: - switchTo
+
+    var switchToAccountCompletion_Invocations: [(account: Account, completion: ((UserSession?) -> Void)?)] = []
+    var switchToAccountCompletion_MockMethod: ((Account, ((UserSession?) -> Void)?) -> Void)?
+
+    func switchTo(account: Account, completion: ((UserSession?) -> Void)?) {
+        switchToAccountCompletion_Invocations.append((account: account, completion: completion))
+
+        guard let mock = switchToAccountCompletion_MockMethod else {
+            fatalError("no mock for `switchToAccountCompletion`")
+        }
+
+        mock(account, completion)
     }
 
 }

--- a/wire-ios/Wire-iOS Tests/AppStateCalculatorTests.swift
+++ b/wire-ios/Wire-iOS Tests/AppStateCalculatorTests.swift
@@ -98,8 +98,9 @@ final class AppStateCalculatorTests: XCTestCase {
     func testThatAppStateChanges_OnWillMigrateAccount() {
 
         // GIVEN
-        let userSession = UserSessionMock()
-        sut.testHelper_setAppState(.authenticated(userSession))
+        let account = Account(userName: "dummy", userIdentifier: UUID())
+        let selectedAccount = Account(userName: "selectedDummy", userIdentifier: UUID())
+        sut.testHelper_setAppState(.loading(account: account, from: selectedAccount))
         sut.applicationDidBecomeActive()
 
         // WHEN

--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -252,6 +252,8 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             )
         case .headless:
             showLaunchScreen(completion: completion)
+        case .loading:
+            completion()
         case let .locked(userSession):
             screenCurtainWindow.userSession = userSession
             showAppLock(userSession: userSession, completion: completion)

--- a/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
+++ b/wire-ios/Wire-iOS/Sources/AppStateCalculator.swift
@@ -32,6 +32,7 @@ enum AppState: Equatable {
     case certificateEnrollmentRequired
     case databaseFailure(reason: Error)
     case migrating
+    case loading(account: Account, from: Account?)
     case syncFailure(error: any Error, onRetry: () -> Void)
 
     static func == (lhs: AppState, rhs: AppState) -> Bool {
@@ -40,8 +41,8 @@ enum AppState: Equatable {
             true
         case (.locked, .locked):
             true
-        case let (.authenticated(userSession1), .authenticated(userSession2)):
-            userSession1 === userSession2
+        case (.authenticated, .authenticated):
+            true
         case let (.unauthenticated(id1, env1, error1), .unauthenticated(id2, env2, error2)):
             id1 == id2 &&
                 env1 == env2 &&
@@ -56,6 +57,8 @@ enum AppState: Equatable {
             true
         case (migrating, migrating):
             true
+        case let (loading(accountTo1, accountFrom1), loading(accountTo2, accountFrom2)):
+            accountTo1 == accountTo2 && accountFrom1 == accountFrom2
         case (.retryStart, .retryStart):
             true
         default:
@@ -88,6 +91,8 @@ extension AppState: CustomDebugStringConvertible {
             "databaseFailure: \(reason)"
         case .migrating:
             "migrating"
+        case .loading:
+            "loading"
         case let .syncFailure(error, _):
             "syncFailure: \(error.localizedDescription)"
         }
@@ -117,6 +122,8 @@ extension AppState: SafeForLoggingStringConvertible {
             "databaseFailure \(reason)"
         case .migrating:
             "migrating"
+        case let .loading(account, from):
+            "loading account: \(account.userIdentifier.safeForLoggingDescription), from: \(from?.userIdentifier.safeForLoggingDescription ?? "<nil>")"
         case let .syncFailure(error, _):
             "syncFailure \(error.localizedDescription)"
         }
@@ -172,12 +179,6 @@ final class AppStateCalculator {
         to appState: AppState,
         completion: (() -> Void)? = nil
     ) {
-        guard let delegate else {
-            fatalInternal("AppStateCalculator has no delegate")
-            completion?()
-            return
-        }
-
         guard hasEnteredForeground  else {
             pendingAppState = appState
             completion?()
@@ -196,7 +197,7 @@ final class AppStateCalculator {
             "transitioning to app state \(appState.safeForLoggingDescription)",
             attributes: .safePublic
         )
-        delegate.appStateCalculator(self, didCalculate: appState) {
+        delegate?.appStateCalculator(self, didCalculate: appState) {
             completion?()
         }
     }
@@ -300,6 +301,21 @@ extension AppStateCalculator: SessionManagerDelegate {
 
     func sessionManagerWillMigrateAccount(userSessionCanBeTornDown: @escaping () -> Void) {
         transition(to: .migrating, completion: userSessionCanBeTornDown)
+    }
+
+    func sessionManagerWillOpenAccount(
+        _ account: Account,
+        from selectedAccount: Account?,
+        userSessionCanBeTornDown: @escaping () -> Void
+    ) {
+        let appState: AppState = .loading(
+            account: account,
+            from: selectedAccount
+        )
+        transition(
+            to: appState,
+            completion: userSessionCanBeTornDown
+        )
     }
 
     func sessionManagerDidChangeActiveUserSession(userSession: ZMUserSession) {

--- a/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/AuthenticationInterfaceBuilder.swift
@@ -307,9 +307,7 @@ final class AuthenticationInterfaceBuilder {
         let accounts = (SessionManager.shared?.accountManager.accounts ?? [])
             .map { account in
                 account.toUIModel { [weak self] in
-                    Task {
-                        await self?.accountSelector?.switchTo(account: account)
-                    }
+                    self?.accountSelector?.switchTo(account: account)
                 }
             }
         let preferredAPIVersion = BackendInfo.preferredAPIVersion.flatMap {

--- a/wire-ios/Wire-iOS/Sources/Authentication/Helpers/ObservableSessionManager.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Helpers/ObservableSessionManager.swift
@@ -54,7 +54,7 @@ protocol ObservableSessionManager: SessionManagerType {
     func delete(account: Account, eraseData: Bool)
 
     /// Add a new account.
-    func addAccount(userInfo: [String: Any]?) async
+    func addAccount(userInfo: [String: Any]?, completion: (() -> Void)?)
 }
 
 extension SessionManager: ObservableSessionManager {}

--- a/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Interface/ViewControllers/AuthenticationHostingController.swift
@@ -84,10 +84,9 @@ final class AuthenticationHostingController<Content: View>: UIHostingController<
             return
         }
 
-        Task {
-            _ = await sessionManager.select(account)
+        sessionManager.select(account, completion: { _ in
             completion?()
-        }
+        })
     }
 
     @available(*, unavailable)

--- a/wire-ios/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/Authentication/Landing/LandingViewController.swift
@@ -554,9 +554,7 @@ final class LandingViewController: AuthenticationStepViewController {
 
     private func cancelButtonTapped() {
         guard let account = SessionManager.shared?.firstAuthenticatedAccount else { return }
-        Task {
-            _ = await SessionManager.shared!.select(account)
-        }
+        SessionManager.shared!.select(account)
     }
 
     // MARK: - AuthenticationCoordinatedViewController

--- a/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/URLActionRouter.swift
@@ -215,8 +215,7 @@ extension URLActionRouter: PresentationDelegate {
             if DeveloperFlag.useWireAuthentication.isOn {
                 if let sessionManager, sessionManager.activeUserSession?.isLoggedIn == true {
                     // allows switching backend from current session
-                    Task {
-                        await sessionManager.addAccount()
+                    sessionManager.addAccount {
                         decisionHandler(SecurityFlags.customBackend.isEnabled)
                     }
                 } else {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Blacklist/BlockerViewController.swift
@@ -162,9 +162,7 @@ final class BlockerViewController: LaunchImageViewController {
                     title: Strings.retry,
                     style: .cancel,
                     handler: { _ in
-                        Task {
-                            _ = await sessionManager.select(account)
-                        }
+                        sessionManager.select(account)
                     }
                 )
             )
@@ -451,9 +449,7 @@ extension BlockerViewController {
     }
 
     private func handleSwitch(to account: Account) {
-        Task {
-            await sessionManager?.switchTo(account: account)
-        }
+        sessionManager?.switchTo(account: account)
     }
 
     private func handleLogout() {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelector/AccountSelector.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelector/AccountSelector.swift
@@ -23,6 +23,15 @@ protocol AccountSelector {
 
     var currentAccount: Account? { get }
 
-    func switchTo(account: Account) async
+    func switchTo(account: Account)
+    func switchTo(account: Account, completion: ((UserSession?) -> Void)?)
+
+}
+
+extension AccountSelector {
+
+    func switchTo(account: Account) {
+        switchTo(account: account, completion: .none)
+    }
 
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelector/SessionManager+AccountSelector.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/AccountSelector/SessionManager+AccountSelector.swift
@@ -24,7 +24,7 @@ extension SessionManager: AccountSelector {
         accountManager.selectedAccount
     }
 
-    public func switchTo(account: Account) async {
-        _ = await select(account)
+    public func switchTo(account: Account, completion: (((any UserSession)?) -> Void)?) {
+        select(account, completion: completion, tearDownCompletion: {})
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/SelfProfile/SelfProfileViewController.swift
@@ -419,9 +419,7 @@ final class SelfProfileViewController: UIViewController {
             if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
                 appDelegate.mediaPlaybackManager?.stop()
             }
-            Task {
-                await self.accountSelector?.switchTo(account: account)
-            }
+            self.accountSelector?.switchTo(account: account)
         }
     }
 }

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Settings/CellDescriptors/SettingsCellDescriptorFactory.swift
@@ -84,9 +84,7 @@ struct SettingsCellDescriptorFactory {
                 let count = sessionManager?.accountManager.numberOfAccounts,
                 let maxNumberAccounts = sessionManager?.maxNumberAccounts,
                 count < maxNumberAccounts {
-                Task {
-                    await sessionManager?.addAccount()
-                }
+                sessionManager?.addAccount()
             } else {
                 if let controller = UIApplication.shared.topmostViewController(onlyFullScreen: false) {
                     let alert = UIAlertController(


### PR DESCRIPTION
<!--do not remove the jira markers to link tickets automatically -->
<!--jira-description-action-hidden-marker-start-->

<!--jira-description-action-hidden-marker-end-->

### Issue

This PR reverts #4301 (commit 37f4909c777d4d848da5447297633760e9068c60).

This revert was much easier than I expected. There were only a few very minor merge conflicts to solve.

- Conflicts:
    - wire-ios-sync-engine/Source/SessionManager/SessionManager+EncryptionAtRest.swift 
    - wire-ios-sync-engine/Source/SessionManager/SessionManager.swift

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [x] Adds/updates automated tests.