### PR TITLE
fix: ignore `NSURLErrorCancelled` in `SyncAgent` - WPB-24826

### DIFF
--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -137,7 +137,7 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
                 }
             } catch is CancellationError {
                 // ignore error
-            } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+            } catch URLError.cancelled {
                 // ignore error, this is a result of cancelling the sync while a `URLSessionDataTask` is in progress,
                 // we treat it the same as a `CancellationError`
             } catch {

--- a/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
+++ b/wire-ios-sync-engine/Source/Synchronization/SyncAgent.swift
@@ -137,6 +137,9 @@ final class SyncAgent: NSObject, SyncAgentProtocol {
                 }
             } catch is CancellationError {
                 // ignore error
+            } catch let error as NSError where error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
+                // ignore error, this is a result of cancelling the sync while a `URLSessionDataTask` is in progress,
+                // we treat it the same as a `CancellationError`
             } catch {
                 delegate?.syncAgentDidFailSyncing(
                     self,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24826" title="WPB-24826" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24826</a>  [iOS] Filter out `NSURLErrorCancelled` errors triggered by cancelling incremental sync
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

ignore `NSURLErrorCancelled` in the `SyncAgent` 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

