### PR TITLE
fix: too many login requests - WPB-24616

### DIFF
--- a/.github/workflows/_reusable_app_release.yml
+++ b/.github/workflows/_reusable_app_release.yml
@@ -20,7 +20,7 @@ on:
         default: false
       produce_debug_builds:
         type: boolean
-        required: true
+        required: false
         default: false
 
     secrets:

--- a/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
+++ b/wire-ios-sync-engine/Source/Synchronization/Transcoders/ZMLoginTranscoder.m
@@ -94,7 +94,6 @@ NSTimeInterval DefaultPendingValidationLoginAttemptInterval = 5;
     }
 
     if(authenticationStatus.currentPhase == ZMAuthenticationPhaseLoginWithEmail) {
-        [self.timedDownstreamSync readyForNextRequestIfNotBusy];
         request = [self.timedDownstreamSync nextRequestForAPIVersion:apiVersion];
     }
 

--- a/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
+++ b/wire-ios-sync-engine/Tests/Source/Synchronization/Transcoders/ZMLoginTranscoderTests.m
@@ -254,9 +254,31 @@ extern NSTimeInterval DefaultPendingValidationLoginAttemptInterval;
 {
     // when
     ZMTransportRequest *request = [self.sut nextRequestForAPIVersion:APIVersionV0];
-    
+
     // then
     XCTAssertNil(request);
+}
+
+- (void)testThatItDoesNotGenerateADuplicateLoginRequestInTheRaceWindowWhileFirstIsInFlight
+{
+    // given
+    [self.authenticationStatus prepareForLoginWithCredentials:self.testEmailCredentials];
+    ZMTransportRequest *firstRequest = [self.sut nextRequestForAPIVersion:APIVersionV0];
+    XCTAssertNotNil(firstRequest);
+
+    // Simulate the race window in ZMSingleRequestSync.processResponse: where currentRequest
+    // is set to nil before status transitions to Completed. On a concurrent thread,
+    // nextRequestForAPIVersion: can be called in this window. Without the fix, the former
+    // readyForNextRequestIfNotBusy call would see currentRequest == nil, force status back
+    // to Ready, and generate a second login request — causing the first response to be
+    // dropped via the requestUniqueCounter mismatch and the access token to be lost.
+    [self.sut.timedDownstreamSync setValue:nil forKey:@"currentRequest"];
+
+    // when
+    ZMTransportRequest *secondRequest = [self.sut nextRequestForAPIVersion:APIVersionV0];
+
+    // then
+    XCTAssertNil(secondRequest);
 }
 
 - (void)testThatItDoesNotGenerateALoginRequestWhenTheUserSessionIsLoggedIn


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24616" title="WPB-24616" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-24616</a>  [iOS] Release iOS v3.120.9
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Two login requests could be sent concurrently, causing the access token from the first successful login to be silently dropped.

**Root cause**

`ZMLoginTranscoder.nextRequestForAPIVersion:` called `readyForNextRequestIfNotBusy` on  `timedDownstreamSync` immediately before requesting a new request. 

In `ZMSingleRequestSync.processResponse:`, `currentRequest` is cleared (nil) before status is set to Completed.  In that window, the transport scheduler (on a different thread) could call nextRequestForAPIVersion: on the login transcoder, see `currentRequest == nil`, and re-ready the sync — resetting status to Ready and  incrementing `requestUniqueCounter`. This caused a second login request to be generated while the first  was completing, and the first request's success response to be dropped via the counter mismatch check,  leaving the access token unstored.

**Solution**

Remove the `readyForNextRequestIfNotBusy` call from `nextRequestForAPIVersion:`. The sync is already ready at initialization (`ZMTimedSingleRequestSync` calls `readyForNextRequest` in its initializer) and is  re-readied by `setTimeInterval:0` in `didReceiveResponse:` after every response, so forcing it ready on  every request tick was both redundant and racy.

### Testing

  1. Log in with an account on a backend that requires email verification (2FA)
  2. Complete the login flow including the email verification code step.
  3. Verify in network logs that only a single `POST /login?persist=true` is sent at each stage of the flow
  (no duplicate login requests).
  4. Verify that login succeeds and the session is established without being stuck or requiring a manual
  retry.

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
