### PR TITLE
fix: app state transition deadlock - WPB-24530 🍒

### DIFF
--- a/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
+++ b/wire-ios/Wire-iOS/Sources/AppRootRouter.swift
@@ -251,6 +251,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             showAppLock(userSession: userSession, completion: completion)
         case let .syncFailure(error, onRetry):
             presentSyncErrorAlert(error: error, onRetry: onRetry)
+            appStateTransitionGroup.leave()
         }
     }
 
@@ -268,9 +269,8 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             UIAlertAction(
                 title: L10n.Localizable.Content.System.FailedtosendMessage.retry, // reusing retry string
                 style: .default
-            ) { [weak self] _ in
+            ) { _ in
                 onRetry()
-                self?.appStateTransitionGroup.leave()
             }
         )
 
@@ -278,9 +278,7 @@ extension AppRootRouter: AppStateCalculatorDelegate {
             UIAlertAction(
                 title: L10n.Localizable.General.cancel,
                 style: .destructive
-            ) { [weak self] _ in
-                self?.appStateTransitionGroup.leave()
-            }
+            ) { _ in }
         )
 
         rootViewController.present(alert, animated: true)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24530" title="WPB-24530" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24530</a>  [iOS] This message can not be displayed shown when phone is locked for a while
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->


### Issue

cherry-pick from https://github.com/wireapp/wire-ios/pull/4566

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

