### PR TITLE
fix: issue regarding priority inversion in expiring activities - WPB-24585

### DIFF
--- a/WireFoundation/Sources/WireUtilitiesPackage/ExpiringActivityRegistration/ExpiringActivityManager.swift
+++ b/WireFoundation/Sources/WireUtilitiesPackage/ExpiringActivityRegistration/ExpiringActivityManager.swift
@@ -95,7 +95,10 @@ actor ExpiringActivityManager {
             }
         }
 
-        Task.detached { [self] in
+        // Use .userInitiated priority to match the QoS of the thread that
+        // performExpiringActivity uses for its handler, avoiding priority inversion
+        // on the semaphore.
+        Task.detached(priority: .userInitiated) { [self] in
             _ = try? await task.value
             logger.debug("Task finished [reason: \(reason)]")
             await taskDidFinish(generation: trackGeneration)

--- a/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
+++ b/WireNetwork/Sources/WireNetwork/Models/API/APIVersion.swift
@@ -52,7 +52,7 @@ public enum APIVersion: UInt, CaseIterable, Comparable, Sendable {
     /// as production ready.
 
     public static let productionVersions: Set<Self> = [
-        .v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8, .v9, .v10, .v11, .v12, .v13, .v14
+        .v0, .v1, .v2, .v3, .v4, .v5, .v6, .v7, .v8, .v9, .v10, .v11, .v12, .v13, .v14, .v15
     ]
 
     /// API versions currently under development and not suitable for production


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24585" title="WPB-24585" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24585</a>  [iOS] Crash on ExpiringActivityManager
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove the jira markers to link tickets automatically -->

### Issue

This PR fixes a priority issue in `ExpiringActivityManager` the debugger warns about:

```
Thread Performance Checker: Thread running at User-initiated quality-of-service      
class waiting on a lower QoS thread running at Default quality-of-service class. Investigate ways to avoid priority           
inversions
```

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
