### PR TITLE
fix: crash when removing user on conversation header - WPB-25593

### DIFF
--- a/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
+++ b/WireDomain/Sources/WireDomain/Repositories/Message/MessageLocalStore.swift
@@ -980,7 +980,7 @@ public final class MessageLocalStore: MessageLocalStoreProtocol {
 
     private func createSystemMessage(
         messageType: ZMSystemMessageType,
-        sender: ZMUser,
+        sender: ZMUser?,
         users: Set<ZMUser>? = nil,
         addedUsers: Set<ZMUser> = Set(),
         clients: Set<UserClient>? = nil,

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Internal.h
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+Internal.h
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_END
 @property (readonly, nonatomic, nonnull) NSMutableSet<ZMMessage *> *mutableMessages;
 @property (readonly, nonatomic, nonnull) NSSet<ZMMessage *> *hiddenMessages;
 @property (readonly, nonatomic) enum ZMConnectionStatus relatedConnectionState; // This is a computed property, needed for snapshoting
-@property (nonatomic, nonnull) ZMUser *creator;
+@property (nonatomic, nullable) ZMUser *creator;
 @property (nonatomic, nullable) NSDate *lastModifiedDate;
 @property (nonatomic) ZMConversationType conversationType;
 @property (nonatomic, readonly) BOOL isSelfConversation;

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SecurityLevel.swift
@@ -677,7 +677,7 @@ extension ZMConversation {
     @discardableResult
     func appendSystemMessage(
         type: ZMSystemMessageType,
-        sender: ZMUser,
+        sender: ZMUser?,
         users: Set<ZMUser>?,
         addedUsers: Set<ZMUser> = Set(),
         clients: Set<UserClient>?,

--- a/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
+++ b/wire-ios-data-model/Source/Model/Conversation/ZMConversation+SystemMessages.swift
@@ -70,7 +70,7 @@ public extension ZMConversation {
         )
     }
 
-    func appendFailedToAddUsersSystemMessage(users: Set<ZMUser>, sender: ZMUser, at timestamp: Date) {
+    func appendFailedToAddUsersSystemMessage(users: Set<ZMUser>, sender: ZMUser?, at timestamp: Date) {
         appendSystemMessage(
             type: .failedToAddParticipants,
             sender: sender,

--- a/wire-ios-data-model/Source/Public/ZMConversation.h
+++ b/wire-ios-data-model/Source/Public/ZMConversation.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(int16_t, ZMConversationListIndicator) {
 @property (readonly, nonatomic, nullable) NSDate *lastModifiedDate;
 @property (readonly, nonatomic, nonnull) NSSet<ZMMessage *> *allMessages;
 @property (readonly, nonatomic, nonnull) NSArray<ZMUser *> *sortedActiveParticipants;
-@property (readonly, nonatomic, nonnull) ZMUser *creator;
+@property (readonly, nonatomic, nullable) ZMUser *creator;
 @property (nonatomic, readonly) BOOL isPendingConnectionConversation;
 @property (nonatomic, readonly) NSUInteger estimatedUnreadCount;
 @property (nonatomic, readonly) NSUInteger estimatedUnreadSelfMentionCount;

--- a/wire-ios-data-model/Tests/Model/Observer/SnapshotCenterTests.swift
+++ b/wire-ios-data-model/Tests/Model/Observer/SnapshotCenterTests.swift
@@ -97,7 +97,7 @@ class SnapshotCenterTests: BaseZMMessageTests {
         XCTAssertEqual(snapshot.toManyRelationships, expectedToManyRelationships)
     }
 
-    func testThatItSnapshotsSetValues() {
+    func testThatItSnapshotsSetValues() throws {
         // given
         let conv = ZMConversation.insertNewObject(in: uiMOC)
         conv.conversationType = .group
@@ -163,7 +163,7 @@ class SnapshotCenterTests: BaseZMMessageTests {
         ]
 
         let expectedToOneRelationships: [String: NSManagedObjectID] =
-            ["creator": conv.creator.objectID]
+            ["creator": try XCTUnwrap(conv.creator?.objectID)]
 
         expectedAttributes.forEach {
             XCTAssertEqual(snapshot.attributes[$0] ?? nil, $1, "values for \($0) don't match")

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationStartedSystemMessageCellDescription.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/Cells/ConfigurationMessageCell/Components/ConversationStartedSystemMessageCellDescription.swift
@@ -94,15 +94,16 @@ final class ConversationStartedSystemMessageCellDescription: NSObject, Conversat
         let iconColor = IconColors.backgroundDefault
         let isChannel = conversation.isChannel
 
-        let creator: UserType = conversation.creator
-        let senderName = creator.isSelfUser
+        let creator: (any UserType)? = conversation.creator
+        let creatorIsSelfUser = creator?.isSelfUser ?? false
+        let senderName = creatorIsSelfUser
             ? L10n.Localizable.Content.System.youNominative
-            : (creator.name ?? L10n.Localizable.Conversation.Status.someone)
+            : (creator?.name ?? L10n.Localizable.Conversation.Status.someone)
 
         // Heading (only for named conversations)
         let heading: NSAttributedString?
         if let name = conversation.displayName, !name.isEmpty {
-            let headingText = switch (isChannel, creator.isSelfUser) {
+            let headingText = switch (isChannel, creatorIsSelfUser) {
             case (true, true):
                 L10n.Localizable.Content.System.Channel.WithName.titleYou(senderName)
             case (true, false):
@@ -121,12 +122,12 @@ final class ConversationStartedSystemMessageCellDescription: NSObject, Conversat
         }
 
         // Participants excluding creator, with self user placed last
-        let creatorObjectID = conversation.creator.objectID
+        let creatorObjectID = conversation.creator?.objectID
         let participantsExcludingCreator = conversation.sortedActiveParticipantsUserTypes.filter { participant in
-            guard let zmUser = participant as? ZMUser else { return true }
+            guard let creatorObjectID, let zmUser = participant as? ZMUser else { return true }
             return zmUser.objectID != creatorObjectID
         }
-        let hasSelf = !creator.isSelfUser && participantsExcludingCreator.contains(where: \.isSelfUser)
+        let hasSelf = !creatorIsSelfUser && participantsExcludingCreator.contains(where: \.isSelfUser)
         var names = participantsExcludingCreator
             .filter { !$0.isSelfUser }
             .compactMap(\.name)
@@ -143,7 +144,7 @@ final class ConversationStartedSystemMessageCellDescription: NSObject, Conversat
                 .isEmpty ? nil :
                 "\(L10n.Localizable.Content.System.Conversation.WithName.participants) \(participantsString)" && font &&
                 textColor
-        } else if creator.isSelfUser {
+        } else if creatorIsSelfUser {
             L10n.Localizable.Content.System.Conversation.You.started(senderName, participantsString)
                 && font && textColor
         } else {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/GroupConversationHeaderView.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/Content/GroupConversationHeaderView.swift
@@ -97,9 +97,11 @@ final class GroupConversationHeaderView: UIView {
 
         // TODO: [WPB-18464] the sender might need to be changed to reflect the user
         // that changed the depth of the history, maybe it goes back to the conversation cells, not sure.
-        if conversation.isChannel, let channelHistoryDepth = conversation.channelHistoryDepth {
+        if conversation.isChannel,
+           let channelHistoryDepth = conversation.channelHistoryDepth,
+           let creator = conversation.creator {
             let historyCell = ConversationChannelHistoryDepthSystemMessageCellDescription(
-                sender: conversation.creator,
+                sender: creator,
                 historyDepth: channelHistoryDepth,
                 isNewConversation: true
             )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25593" title="WPB-25593" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-25593</a>  [iOS][XCUITest] Exception while deleting user for UITest
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

Fixes a crash `(EXC_BAD_ACCESS in swift_getObjectType)` that occurs when entering a 1:1 conversation whose other participant has been deleted (e.g., team member removed). Root cause: ZMConversation.creator was annotated nonnull in the ObjC header, but the CoreData model has always declared the relationship as Optional with a Nullify delete rule — so when the destination User row is removed, creator is set to nil by the store. The annotation was a lie the model never honored, and the resulting nil leaked into Swift code typed as non-optional. The protocol upcast in `ConversationStartedSystemMessageCellDescription.makeConfiguration(from:) `then crashed reading the type metadata at address 0x0.

**Changes**

- Annotation fix at the source. ZMConversation.creator is now nullable in ZMConversation.h and ZMConversation+Internal.h. This aligns the
  Swift/ObjC surface with what the CoreData model has always promised.
- Propagate the optional through system-message helpers instead of fabricating a fallback sender, since the creator is not always self:
   - `ZMConversation.appendSystemMessage(sender:)` and `appendFailedToAddUsersSystemMessage(sender:)` now accept ZMUser? (underlying
  ZMSystemMessage.sender was already optional).
   - `MessageLocalStore.createSystemMessage(sender:)` now accepts ZMUser? and forwards the optional creator unchanged for `.newConversationCreated` and `.receiptModeIsOn`.
- Crash site: `ConversationStartedSystemMessageCellDescription.makeConfiguration(from:)` now safely reads conversation.creator, falling back to the existing "someone" string when nil.
- Channel history depth row in `GroupConversationHeaderView` is skipped when the creator is gone (the row text is meaningless without a sender).
- Test: `SnapshotCenterTests.testThatItSnapshotsSetValues` updated to try XCTUnwrap the now-optional creator?.objectID.

### Testing

- Run `RemoveUserTests.testUserDeletedForPersonalUser_TC_9490` and `testRemoveTeamMemberAndConversationListUpdated_TC_9491` — they should no longer crash while inside the 1:1 conversation when the other user is deleted.
- Sanity-check group conversations: opening a normal group still renders the "started the conversation" header.

**Note:** because the other user gets deleted, the conversation.creator is then nil and the app will render a Group header instead of 1:1

---

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
