### PR TITLE
fix: keep camera roll visible on drafts interactions - WPB-25555

### DIFF
--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+Camera.swift
@@ -167,7 +167,9 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
             asset: .video(url: url),
             onConfirm: { [unowned self] _ in
                 dismiss(animated: true)
-                if !useWireDrive() {
+                if useWireDrive() {
+                    showCamera()
+                } else {
                     uploadFiles(at: [url])
                 }
             },
@@ -217,6 +219,8 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
                     }
 
                     if self.useWireDrive() {
+                        self.showCamera()
+
                         if isFromCamera || editedImage != nil {
                             self.uploadDraft(
                                 data: dataToSend,
@@ -239,9 +243,7 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
             },
             onCancel: { [weak self] in
                 self?.dismiss(animated: true) {
-                    self?.mode = .camera
-                    self?.inputBar.textView
-                        .becomeFirstResponder()
+                    self?.showCamera()
                 }
             }
         )
@@ -255,6 +257,11 @@ extension ConversationInputBarViewController: CameraKeyboardViewControllerDelega
 
         view.window?.endEditing(true)
         present(confirmImageViewController, animated: true)
+    }
+
+    func showCamera() {
+        mode = .camera
+        inputBar.textView.becomeFirstResponder()
     }
 
     private func executeWithCameraRollPermission(_ closure: @escaping (_ success: Bool) -> Void) {

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePickerDriveConversation.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController+ImagePickerDriveConversation.swift
@@ -25,6 +25,7 @@ extension ConversationInputBarViewController: PHPickerViewControllerDelegate {
 
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
+        showCamera()
 
         for result in results {
             let localIdentifier = result.assetIdentifier

--- a/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
+++ b/wire-ios/Wire-iOS/Sources/UserInterface/Conversation/InputBar/ConversationInputBarViewController/ConversationInputBarViewController.swift
@@ -1095,6 +1095,12 @@ extension ConversationInputBarViewController: UIGestureRecognizerDelegate {
     }
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        let didTouchWireDriveAttachments = touch.view?.isDescendant(of: inputBar.attachmentsContainer) == true
+        // discards gesture, already handled by `AttachmentsCarouselItemView`
+        if didTouchWireDriveAttachments {
+            return false
+        }
+
         if singleTapGestureRecognizer == gestureRecognizer {
             return true
         }
@@ -1149,9 +1155,15 @@ extension ConversationInputBarViewController: UIGestureRecognizerDelegate {
                         showConfirmationForVideo(url: draft.assetURL)
                     }
                 },
-                onRemove: { [deleteDraftUseCase] item in
+                onRemove: { [attachmentsCarouselViewModel, deleteDraftUseCase] item in
+                    guard let draft = attachmentsCarouselViewModel.draft(for: item),
+                          let localIdentifier = draft.localIdentifier else { return }
+
                     Task.detached {
                         try? await deleteDraftUseCase.invoke(nodeID: item.id)
+                        await self.cameraKeyboardViewController?.deselectItem(
+                            withLocalIdentifier: localIdentifier
+                        )
                     }
                 },
                 onRetry: { [retryUploadDraftUseCase] item in


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-25555" title="WPB-25555" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-25555</a>  [iOS] Interacting with a draft preview (tap, remove) closes the custom gallery
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

As part of the multiple media selection, we noticed that legacy behavior dismisses the camera roll - going back to its default mode (`.textInput`) - in various cases:
- selecting an asset in the camera roll
- selecting an asset on  the native gallery picker
- tapping on a draft
- removing a draft

Now that user is able to interact with multiple media at once, it certainly provides bad UX where the user needs to manually click again on the camera icon button every time he wants to manage his drafts.

 This PR attempts to fix this behavior by keeping the camera roll visible automatically.

### Testing

- select camera icon button
- select a draft
- tap on / remove a draft
- open native gallery picker, select a draft

Observe that camera roll remains visible so user no longer has to manually click on the camera icon button every time he's managing his drafts.

### Checklist

- [ ] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [ ] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
