### PR TITLE
fix: certificate enrollment view not displayed by developer tools - WPB-24270

### DIFF
--- a/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperE2ei/DeveloperE2eiViewModel.swift
+++ b/wire-ios/Wire-iOS/Sources/Developer/DeveloperTools/DeveloperE2ei/DeveloperE2eiViewModel.swift
@@ -50,7 +50,7 @@ final class DeveloperE2eiViewModel: ObservableObject {
     func enrollCertificate() {
         guard
             let session = userSession,
-            let topmostViewController = UIApplication.shared.topmostViewController()
+            let topmostViewController = UIApplication.shared.topmostViewController(onlyFullScreen: false)
         else { return }
 
         let e2eiCertificateUseCase = session.enrollE2EICertificate as? EnrollE2EICertificateUseCase


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24270" title="WPB-24270" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24270</a>  [iOS] Certificate Expiration debug tool not working anymore on bund-next environments
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove the jira markers to link tickets automatically -->


### Issue

The certificate enrollment view is not being displayed by the developer tools menu when tapping on the `enroll` button.

### Cause

The developer tools sheet has `modalPresentationStyle != .fullScreen`, so the while loop in `topmostViewController` stops one level too early and returns the parent VC — not the developer tools VC. However, the parent VC already has a `presentedViewController` (the developer tools sheet), so `present()` fails silently.

This only affects builds that have `SecurityFlags.useEmbeddedIDPUserAgent` evaluate to `true`, because in this case `WebViewUserAgent` is used. It relies on a `targetViewController` to be presented. That target VC is the one captured by `topmostViewController()`

Builds with  `SecurityFlags.useEmbeddedIDPUserAgent`  evaluating to `false` rely on `OIDExternalUserAgentIOS`, which uses the window directly, instead of a target VC.

### Solution

use `topmostViewController(onlyFullScreen: false)` to find and use the developer tools sheet as target VC

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.


