### PR TITLE
revert: fix: links aren't shared via share extension - WPB-24816

### DIFF
--- a/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
+++ b/wire-ios/Wire-iOS Share Extension/Sources/View Controllers/ShareExtensionViewController.swift
@@ -162,12 +162,12 @@ final class ShareExtensionViewController: SLComposeServiceViewController {
         currentAccount = accountManager?.selectedAccount
         ExtensionBackupExcluder.exclude()
 
-        if let sortedAttachments = extensionContext?.attachments.sorted {
-            attachments = sortedAttachments
-        }
-
         Task { @MainActor in
             await updateAccount(currentAccount)
+
+            if let sortedAttachments = extensionContext?.attachments.sorted {
+                attachments = sortedAttachments
+            }
         }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24816" title="WPB-24816" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24816</a>  [iOS] [Share ext] Sharing website from Safari doesn't include link
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

This reverts commit 4c98afb6c8f964de1f15e4c3a8d28c633d92501a.

<!--do not remove the jira markers to link tickets automatically -->


### Issue
Reverting #4663 as it did not pass QA. 

---

### Checklist

- [x] Title contains a reference JIRA issue number like `[WPB-XXX]`.
- [x] Description is filled and free of optional paragraphs.
- [ ] Adds/updates automated tests.

---

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_
- [ ] Make sure you use the API for UI elements that support large fonts.
- [ ] All colors are taken from WireDesign.ColorTheme or constructed using WireDesign.BaseColorPalette.
- [ ] New UI elements have Accessibility strings for VoiceOver.
